### PR TITLE
fix: use valid keywords for perfgate-paired

### DIFF
--- a/crates/perfgate-paired/Cargo.toml
+++ b/crates/perfgate-paired/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Paired benchmarking statistics for A/B comparison"
-keywords = ["paired", "benchmarking", "statistics", "a/b-testing"]
+keywords = ["paired", "benchmarking", "statistics", "ab-testing"]
 categories = ["mathematics", "development-tools"]
 
 [dependencies]


### PR DESCRIPTION
Replaces 'a/b-testing' with 'ab-testing' to satisfy crates.io validation rules.