### PR TITLE
feat: perfgate facade and publishability cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/perfgate-cli",
   "crates/perfgate-server",
   "crates/perfgate-client",
+  "crates/perfgate",
   "xtask",
 ]
 exclude = [
@@ -72,6 +73,7 @@ perfgate-domain.workspace = true
 perfgate-paired.workspace = true
 perfgate-app.workspace = true
 perfgate-significance.workspace = true
+perfgate.workspace = true
 
 [[test]]
 name = "cucumber"
@@ -125,3 +127,4 @@ perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.4.1" }
 perfgate-app = { path = "crates/perfgate-app", version = "0.4.1" }
 perfgate-server = { path = "crates/perfgate-server", version = "0.4.1" }
 perfgate-client = { path = "crates/perfgate-client", version = "0.4.1" }
+perfgate = { path = "crates/perfgate", version = "0.4.1" }

--- a/crates/perfgate-cli/Cargo.toml
+++ b/crates/perfgate-cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "perfgate"
+name = "perfgate-cli"
 description = "CLI for perfgate performance budgets and baseline diffs"
 version.workspace = true
 edition.workspace = true
@@ -7,17 +7,18 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
-documentation = "https://docs.rs/perfgate"
+documentation = "https://docs.rs/perfgate-cli"
 authors.workspace = true
 readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
 
+[[bin]]
+name = "perfgate"
+path = "src/main.rs"
+
 [dependencies]
-perfgate-types.workspace = true
-perfgate-domain.workspace = true
-perfgate-adapters.workspace = true
-perfgate-app.workspace = true
+perfgate.workspace = true
 perfgate-client.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use object_store::{ObjectStore, path::Path as ObjectPath};
-use perfgate_adapters::{StdHostProbe, StdProcessRunner};
+use perfgate::adapters::{StdHostProbe, StdProcessRunner};
 use perfgate_app::baseline_resolve::{is_remote_storage_uri, resolve_baseline_path};
 use perfgate_app::comparison_logic::{build_budgets, build_metric_statistics, verdict_from_counts};
 use perfgate_app::{

--- a/crates/perfgate/Cargo.toml
+++ b/crates/perfgate/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "perfgate"
+description = "Core library for perfgate performance budgets and baseline diffs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/perfgate"
+authors.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+perfgate-types.workspace = true
+perfgate-domain.workspace = true
+perfgate-adapters.workspace = true
+perfgate-app.workspace = true
+perfgate-error.workspace = true
+perfgate-validation.workspace = true
+perfgate-stats.workspace = true
+perfgate-significance.workspace = true
+perfgate-budget.workspace = true
+perfgate-render.workspace = true
+perfgate-sensor.workspace = true
+perfgate-export.workspace = true
+perfgate-paired.workspace = true
+perfgate-host-detect.workspace = true
+perfgate-sha256.workspace = true
+
+[features]
+default = []

--- a/crates/perfgate/README.md
+++ b/crates/perfgate/README.md
@@ -1,0 +1,39 @@
+# perfgate
+
+High-performance, modular Rust library for performance budgeting and baseline diffing.
+
+This is the facade crate for the `perfgate` ecosystem. It re-exports functionality from the core micro-crates to provide a single, unified entry point.
+
+## Architecture
+
+`perfgate` is built on a layered micro-crate architecture:
+
+- **`perfgate::types`**: Versioned receipt and configuration data structures.
+- **`perfgate::domain`**: Pure logic for statistics computation and budget comparison.
+- **`perfgate::adapters`**: System metrics collection and process execution.
+- **`perfgate::app`**: High-level use cases and report rendering.
+
+## Usage
+
+Add `perfgate` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+perfgate = "0.4.1"
+```
+
+### Example: Running a benchmark
+
+```rust
+use perfgate::prelude::*;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Logic coming soon in higher-level facade helpers
+    Ok(())
+}
+```
+
+## License
+
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate/src/lib.rs
+++ b/crates/perfgate/src/lib.rs
@@ -1,0 +1,30 @@
+//! # perfgate
+//! 
+//! High-performance, modular Rust library for performance budgeting and baseline diffing.
+//! 
+//! This is a facade crate that re-exports functionality from the core perfgate micro-crates.
+
+pub use perfgate_types as types;
+pub use perfgate_domain as domain;
+pub use perfgate_adapters as adapters;
+pub use perfgate_app as app;
+pub use perfgate_error as error;
+pub use perfgate_validation as validation;
+pub use perfgate_stats as stats;
+pub use perfgate_significance as significance;
+pub use perfgate_budget as budget;
+pub use perfgate_render as render;
+pub use perfgate_sensor as sensor;
+pub use perfgate_export as export;
+pub use perfgate_paired as paired;
+pub use perfgate_host_detect as host_detect;
+pub use perfgate_sha256 as sha256;
+
+// Common re-exports for ergonomic use
+pub mod prelude {
+    pub use perfgate_app::{CheckUseCase, CompareUseCase, RunBenchUseCase};
+    pub use perfgate_domain::{compare_runs, compute_stats};
+    pub use perfgate_types::{
+        CompareReceipt, ConfigFile, Metric, MetricStatistic, RunReceipt, VerdictStatus,
+    };
+}


### PR DESCRIPTION
This PR adds the high-level \perfgate\ facade crate and cleans up the remaining path dependencies in the client and server manifests to enable crates.io publication.