### PR TITLE
ci: deduplicate workload wrappers (Phase 2)

### DIFF
--- a/.ci/perf/check-no-baseline.sh
+++ b/.ci/perf/check-no-baseline.sh
@@ -1,28 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hardened wrapper for check-no-baseline benchmark.
+source "$(dirname "$0")/lib.sh"
 
-if [ -f "./target/release/perfgate" ]; then
-  BIN="./target/release/perfgate"
-elif [ -f "./target/release/perfgate.exe" ]; then
-  BIN="./target/release/perfgate.exe"
-else
-  echo "perfgate binary not found" >&2
-  exit 1
-fi
+BIN=$(perfgate_bin)
+OUT_DIR=$(make_tempdir)
 
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
-
-set +e
-"$BIN" check \
+allow_policy_exit "$BIN" check \
   --config .ci/fixtures/check/perfgate.toml \
   --bench test-no-baseline \
   --out-dir "$OUT_DIR" \
   >/dev/null
-status=$?
-set -e
-
-case "$status" in
-  0|2|3) exit 0 ;;
-  *) exit "$status" ;;
-esac

--- a/.ci/perf/check-single.sh
+++ b/.ci/perf/check-single.sh
@@ -1,28 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hardened wrapper for single check benchmark.
+source "$(dirname "$0")/lib.sh"
 
-if [ -f "./target/release/perfgate" ]; then
-  BIN="./target/release/perfgate"
-elif [ -f "./target/release/perfgate.exe" ]; then
-  BIN="./target/release/perfgate.exe"
-else
-  echo "perfgate binary not found" >&2
-  exit 1
-fi
+BIN=$(perfgate_bin)
+OUT_DIR=$(make_tempdir)
 
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
-
-set +e
-"$BIN" check \
+allow_policy_exit "$BIN" check \
   --config .ci/fixtures/check/perfgate.toml \
   --bench test-bench \
   --out-dir "$OUT_DIR" \
   >/dev/null
-status=$?
-set -e
-
-case "$status" in
-  0|2|3) exit 0 ;;
-  *) exit "$status" ;;
-esac

--- a/.ci/perf/compare-large.sh
+++ b/.ci/perf/compare-large.sh
@@ -1,28 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hardened wrapper for large comparison benchmark.
+source "$(dirname "$0")/lib.sh"
 
-if [ -f "./target/release/perfgate" ]; then
-  BIN="./target/release/perfgate"
-elif [ -f "./target/release/perfgate.exe" ]; then
-  BIN="./target/release/perfgate.exe"
-else
-  echo "perfgate binary not found" >&2
-  exit 1
-fi
+BIN=$(perfgate_bin)
+OUT_DIR=$(make_tempdir)
 
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
-
-set +e
-"$BIN" compare \
+allow_policy_exit "$BIN" compare \
   --baseline .ci/fixtures/compare/large-baseline.json \
   --current .ci/fixtures/compare/large-current.json \
   --out "$OUT_DIR/out.json" \
   >/dev/null
-status=$?
-set -e
-
-case "$status" in
-  0|2|3) exit 0 ;;
-  *) exit "$status" ;;
-esac

--- a/.ci/perf/compare-small.sh
+++ b/.ci/perf/compare-small.sh
@@ -1,28 +1,12 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hardened wrapper for small comparison benchmark.
+source "$(dirname "$0")/lib.sh"
 
-if [ -f "./target/release/perfgate" ]; then
-  BIN="./target/release/perfgate"
-elif [ -f "./target/release/perfgate.exe" ]; then
-  BIN="./target/release/perfgate.exe"
-else
-  echo "perfgate binary not found" >&2
-  exit 1
-fi
+BIN=$(perfgate_bin)
+OUT_DIR=$(make_tempdir)
 
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
-
-set +e
-"$BIN" compare \
+allow_policy_exit "$BIN" compare \
   --baseline .ci/fixtures/compare/small-baseline.json \
   --current .ci/fixtures/compare/small-current.json \
   --out "$OUT_DIR/out.json" \
   >/dev/null
-status=$?
-set -e
-
-case "$status" in
-  0|2|3) exit 0 ;;
-  *) exit "$status" ;;
-esac

--- a/.ci/perf/lib.sh
+++ b/.ci/perf/lib.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolves the path to the perfgate release binary.
+perfgate_bin() {
+  if [ -f "./target/release/perfgate" ]; then
+    printf '%s\n' "./target/release/perfgate"
+  elif [ -f "./target/release/perfgate.exe" ]; then
+    printf '%s\n' "./target/release/perfgate.exe"
+  else
+    echo "perfgate binary not found" >&2
+    exit 1
+  fi
+}
+
+# Creates a temporary directory and sets up a trap to remove it on exit.
+# Outputs the path to the created directory.
+make_tempdir() {
+  local dir
+  dir="$(mktemp -d)"
+  trap 'rm -rf "$dir"' EXIT
+  printf '%s\n' "$dir"
+}
+
+# Executes a command and allows policy-driven exit codes (0, 2, 3).
+# Any other exit code will cause the script to exit with that status.
+allow_policy_exit() {
+  set +e
+  "$@"
+  local status=$?
+  set -e
+  case "$status" in
+    0|2|3) return 0 ;;
+    *) return "$status" ;;
+  esac
+}

--- a/.ci/perf/render-md.sh
+++ b/.ci/perf/render-md.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hardened wrapper for markdown rendering benchmark.
+source "$(dirname "$0")/lib.sh"
 
-if [ -f "./target/release/perfgate" ]; then
-  BIN="./target/release/perfgate"
-elif [ -f "./target/release/perfgate.exe" ]; then
-  BIN="./target/release/perfgate.exe"
-else
-  echo "perfgate binary not found" >&2
-  exit 1
-fi
-
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
+BIN=$(perfgate_bin)
+OUT_DIR=$(make_tempdir)
 
 "$BIN" md \
   --compare .ci/fixtures/compare/compare-receipt.json \

--- a/.ci/perf/render-report.sh
+++ b/.ci/perf/render-report.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Hardened wrapper for cockpit report rendering benchmark.
+source "$(dirname "$0")/lib.sh"
 
-if [ -f "./target/release/perfgate" ]; then
-  BIN="./target/release/perfgate"
-elif [ -f "./target/release/perfgate.exe" ]; then
-  BIN="./target/release/perfgate.exe"
-else
-  echo "perfgate binary not found" >&2
-  exit 1
-fi
-
-OUT_DIR="$(mktemp -d)"
-trap 'rm -rf "$OUT_DIR"' EXIT
+BIN=$(perfgate_bin)
+OUT_DIR=$(make_tempdir)
 
 "$BIN" report \
   --compare .ci/fixtures/compare/compare-receipt.json \


### PR DESCRIPTION
This PR implements Phase 2 of the self-dogfooding hardening:

### Deduplicated Wrappers
- **Shared Library**: Introduces \.ci/perf/lib.sh\ to centralize binary resolution, tempdir management, and exit classification.
- **Robustness**: Uses \llow_policy_exit\ to ensure only expected \perfgate\ exit codes (0, 2, 3) are allowed, while catching actual runtime crashes or setup failures.