### PR TITLE
fix: correct test expectations for RunCommand error struct change

### DIFF
--- a/crates/perfgate-adapters/src/lib.rs
+++ b/crates/perfgate-adapters/src/lib.rs
@@ -1304,7 +1304,7 @@ mod tests {
 
     /// Non-existent command returns AdapterError::Other (not EmptyArgv).
     #[test]
-    fn nonexistent_command_returns_other_error() {
+    fn nonexistent_command_returns_run_command_error() {
         let runner = StdProcessRunner;
         let spec = CommandSpec {
             argv: vec!["__perfgate_nonexistent_cmd_xyz__".into()],
@@ -1316,8 +1316,8 @@ mod tests {
 
         let err = runner.run(&spec).unwrap_err();
         assert!(
-            matches!(err, AdapterError::Other(_)),
-            "Expected AdapterError::Other for missing binary, got: {err:?}",
+            matches!(err, AdapterError::RunCommand { .. }),
+            "Expected AdapterError::RunCommand for missing binary, got: {err:?}",
         );
     }
 

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 229
 expression: "help_output(&[\"--help\"])"
 ---
 Perf budgets and baseline diffs for CI / PR bots
@@ -18,6 +17,7 @@ Commands:
   check Config-driven one-command workflow
   paired Run paired benchmark: interleave baseline and current commands for reduced noise
   baseline Manage baselines on the baseline server
+  summary Summarize one or more compare receipts in a terminal table
   help Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/integration/error_propagation.rs
+++ b/tests/integration/error_propagation.rs
@@ -203,7 +203,7 @@ fn io_error_display_messages() {
             reason: "spawn failed".to_string(),
         }
             .to_string()
-            .contains("run command")
+            .contains("failed to execute command")
     );
 }
 


### PR DESCRIPTION
This fixes tests in perfgate-adapters and perfgate-tests that were failing due to the recent refactor of the RunCommand error variant from a tuple to a struct.