### PR TITLE
fix: remove unused anyhow::Context imports

### DIFF
--- a/crates/perfgate-adapters/src/lib.rs
+++ b/crates/perfgate-adapters/src/lib.rs
@@ -6,7 +6,6 @@ mod fake;
 
 pub use fake::FakeProcessRunner;
 
-use anyhow::Context;
 use perfgate_sha256::sha256_hex;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -30,7 +30,6 @@ pub use perfgate_render::{
 // Re-export export functionality from perfgate-export for backward compatibility
 pub use perfgate_export::{CompareExportRow, ExportFormat, ExportUseCase, RunExportRow};
 
-use anyhow::Context;
 use perfgate_adapters::{CommandSpec, HostProbe, HostProbeOptions, ProcessRunner, RunResult};
 use perfgate_domain::{
     Comparison, SignificancePolicy, compare_runs, compute_stats, detect_host_mismatch,

--- a/crates/perfgate-app/src/paired.rs
+++ b/crates/perfgate-app/src/paired.rs
@@ -1,6 +1,5 @@
 //! Paired benchmark execution for perfgate.
 
-use anyhow::Context;
 use perfgate_adapters::{CommandSpec, HostProbe, HostProbeOptions, ProcessRunner};
 use perfgate_domain::compute_paired_stats;
 use perfgate_types::{


### PR DESCRIPTION
Cleans up unused anyhow::Context imports in perfgate-adapters and perfgate-app that were causing clippy warnings.