### PR TITLE
docs: add ADRs 0007-0011 for undocumented decisions

### DIFF
--- a/docs/adrs/0007-versioned-json-receipts.md
+++ b/docs/adrs/0007-versioned-json-receipts.md
@@ -1,0 +1,29 @@
+# ADR 0007: Versioned JSON Receipts
+
+## Status
+Accepted
+
+## Context
+perfgate produces artifacts at every stage of its pipeline (run, compare, report). These artifacts need to be:
+- Machine-readable for downstream tooling (CI, dashboards, export)
+- Stable enough that consumers don't break on upgrades
+- Self-describing so a reader can determine the schema without external context
+
+## Decision
+Every perfgate output file includes a `schema` field identifying its type and version:
+- `perfgate.run.v1` — raw measurement data from a benchmark execution
+- `perfgate.compare.v1` — comparison of current run against baseline
+- `perfgate.report.v1` — cockpit-compatible report envelope
+- `sensor.report.v1` — sensor integration envelope for dashboard ingestion
+
+Key design choices:
+1. **Schema field is always the first key** in the JSON object for easy identification.
+2. **Schemas are append-only** — new fields can be added to a version, but existing fields are never removed or retyped within a version.
+3. **Auto-generated schemas** via `schemars` for run, compare, and report types. The `sensor.report.v1` schema is hand-written and vendored at `contracts/schemas/` because it must remain stable for external consumers.
+4. **Conformance testing** via `xtask conform` validates all fixtures against the vendored schema in CI.
+
+## Consequences
+- Consumers can rely on `schema` field to route parsing logic.
+- Adding new metrics (e.g., `io_read_bytes`) doesn't break existing consumers.
+- Schema evolution to v2 will require a documented migration path (not yet defined).
+- The hand-written sensor schema requires manual maintenance when the report structure changes.

--- a/docs/adrs/0008-statistical-significance-gating.md
+++ b/docs/adrs/0008-statistical-significance-gating.md
@@ -1,0 +1,24 @@
+# ADR 0008: Statistical Significance for Gating
+
+## Status
+Accepted
+
+## Context
+Benchmark measurements are inherently noisy. A 5% wall-time increase might be a real regression or just environmental variance (system load, thermal throttling, background processes). Naive threshold-based gating produces false positives, leading teams to ignore performance gates entirely.
+
+## Decision
+We integrate Welch's t-test as an optional significance layer on top of threshold-based gating:
+
+1. **Thresholds remain the primary gate.** A metric must exceed its configured threshold (e.g., 20% regression) to trigger a verdict.
+2. **Significance is opt-in** via `--significance-alpha` (default: disabled). When enabled, the comparison includes p-value metadata.
+3. **`--require-significance`** makes significance a hard gate: if the sample size is too small to reach statistical significance, the verdict is suppressed (no false alarm).
+4. **Noise policy** (`ignore`, `warn`, `skip`) handles metrics with high coefficient of variation — benchmarks that are inherently unstable can be flagged and optionally excluded from gating.
+5. **Paired benchmarking** (`perfgate paired`) further reduces noise by interleaving baseline and current measurements back-to-back, canceling out environmental drift.
+
+The implementation lives in `perfgate-significance` (Welch's t-test, confidence intervals) and `perfgate-domain` (noise policy evaluation).
+
+## Consequences
+- Teams can tune their confidence level per-project, balancing sensitivity against false-positive rates.
+- The `compare` receipt includes p-value and confidence interval metadata for audit.
+- Paired mode is recommended for noisy CI environments but adds ~2x runtime.
+- The default (significance disabled) preserves backward compatibility with simple threshold gating.

--- a/docs/adrs/0009-paired-benchmarking.md
+++ b/docs/adrs/0009-paired-benchmarking.md
@@ -1,0 +1,22 @@
+# ADR 0009: Paired Benchmarking
+
+## Status
+Accepted
+
+## Context
+CI runners share infrastructure with other jobs. System load, memory pressure, and thermal state vary between runs. When baseline and current measurements happen at different times (or on different machines), environmental noise can dominate the signal, making it impossible to detect real regressions smaller than ~10-15%.
+
+## Decision
+The `perfgate paired` command runs baseline and current commands in interleaved fashion: B₁, C₁, B₂, C₂, ..., Bₙ, Cₙ. Each pair is measured back-to-back to minimize environmental variance.
+
+Key design choices:
+1. **Interleaved execution** — each baseline run is immediately followed by a current run, so both experience the same system state.
+2. **Separate commands** — baseline and current are specified as separate shell commands (`--baseline-cmd`, `--current-cmd`), allowing comparison of different binaries.
+3. **Significance-based retries** — if `--max-retries` is set, paired mode will run additional pairs when the t-test doesn't reach significance, up to the retry limit.
+4. **Standard output** — produces a `perfgate.compare.v1` receipt, compatible with all downstream commands (md, report, export).
+5. **Lives in `perfgate-paired`** — separated from `perfgate-domain` because it involves I/O (process execution), while domain is intentionally I/O-free.
+
+## Consequences
+- Sub-5% regressions become detectable in noisy CI environments.
+- Runtime roughly doubles compared to separate run+compare (two commands per pair).
+- The interleaving strategy assumes environmental noise is correlated across adjacent time intervals — this holds for load and thermals but not for all noise sources.

--- a/docs/adrs/0010-intelligent-gating-diagnostics.md
+++ b/docs/adrs/0010-intelligent-gating-diagnostics.md
@@ -1,0 +1,30 @@
+# ADR 0010: Intelligent Gating Diagnostics (Bisect, Blame, Explain)
+
+## Status
+Accepted
+
+## Context
+When a performance regression is detected, the natural next question is "why?" Traditionally this requires manual investigation: reviewing recent commits, checking dependency changes, and correlating diffs with performance deltas. This is slow and error-prone, especially for large PRs or dependency-heavy projects.
+
+## Decision
+v0.15.0 introduces three diagnostic commands that automate common investigation workflows:
+
+### `perfgate bisect`
+Wraps `git bisect` with `perfgate paired` to automatically find the commit that introduced a regression. Takes a known-good commit, a known-bad commit (default: HEAD), and an executable to benchmark.
+
+### `perfgate blame`
+Analyzes two `Cargo.lock` files (baseline vs current) to identify dependency additions, removals, and version changes. Useful for binary size regressions caused by transitive dependency bloat.
+
+### `perfgate explain`
+Generates structured diagnostic prompts from a comparison receipt. Designed to be piped into an LLM or used as a human-readable regression report. Does not call any external AI service — it produces the prompt, not the answer.
+
+Key design choices:
+1. **Each command is standalone** — they don't require the full `check` pipeline. You can run `blame` without having run `compare`.
+2. **No external dependencies** — `bisect` uses local git, `blame` parses Cargo.lock, `explain` generates text. No API calls, no network.
+3. **Output is text, not JSON** — these are diagnostic tools, not pipeline stages. They write human-readable output to stdout.
+
+## Consequences
+- Investigation time for regressions drops from hours to minutes.
+- `bisect` accuracy depends on the benchmark being deterministic enough to distinguish good from bad — noisy benchmarks may give false results.
+- `explain` output quality depends on the comparison having enough context (metrics, deltas, significance) to be useful.
+- These commands are newer and less battle-tested than the core pipeline.

--- a/docs/adrs/0011-authentication-and-multi-tenancy.md
+++ b/docs/adrs/0011-authentication-and-multi-tenancy.md
@@ -1,0 +1,34 @@
+# ADR 0011: Authentication and Multi-tenancy
+
+## Status
+Accepted
+
+## Context
+The baseline server needs to support multiple projects sharing a single instance, with access control that prevents one team from modifying another's baselines. CI runners need to authenticate without human interaction, and GitHub Actions runners need keyless authentication via OIDC tokens.
+
+## Decision
+We implement a layered auth system in `perfgate-auth` and `perfgate-server`:
+
+### API Keys
+- Keys follow the format `pg_live_<32+ alphanumeric chars>` or `pg_test_<prefix>`.
+- Each key is scoped to a role, project, and optional benchmark regex pattern.
+- Roles: `viewer` (read), `contributor` (read + write), `promoter` (+ promote), `admin` (full).
+- Keys are passed via `--api-key` flag or `PERFGATE_API_KEY` env var.
+- Server accepts keys via `--api-keys "role:key:project:benchmark_regex"` at startup.
+
+### Project Isolation
+- All baselines are namespaced by project (`--project` flag or `PERFGATE_PROJECT` env var).
+- Non-admin keys are restricted to their assigned project.
+- The `*` project scope grants access to all projects (admin only).
+
+### OIDC (GitHub Actions)
+- The server can validate GitHub Actions OIDC tokens via `--github-oidc "org/repo:project_id:role"`.
+- Repository claims are mapped directly to project IDs and roles.
+- This eliminates the need to store API keys in GitHub Secrets for Actions workflows.
+
+## Consequences
+- Single server instance can serve multiple teams/projects safely.
+- API key format validation prevents accidental use of weak keys.
+- OIDC support is currently GitHub-specific; GitLab/Okta support requires additional work.
+- No CLI for key management yet — keys are configured at server startup via flags.
+- Benchmark regex patterns must use regex syntax (`.*`), not glob syntax (`*`). This is a known friction point (#58).


### PR DESCRIPTION
## Summary

Documents 5 significant architectural decisions that were implemented but never recorded as ADRs:

- **0007: Versioned JSON Receipts** — schema naming, append-only evolution, auto-gen vs hand-written, conformance testing
- **0008: Statistical Significance for Gating** — Welch's t-test integration, noise policy, require-significance gate
- **0009: Paired Benchmarking** — interleaved execution design, significance-based retries, separation from I/O-free domain
- **0010: Intelligent Gating Diagnostics** — bisect/blame/explain trio, standalone operation, no external dependencies
- **0011: Authentication and Multi-tenancy** — API key format, role-based access, project isolation, GitHub OIDC

## Test plan
- [x] No code changes, docs only
- [x] ADR format matches existing 0001-0006 pattern