### PR TITLE
chore: crates.io publish prep (readme declarations)

### DIFF
--- a/crates/perfgate-budget/Cargo.toml
+++ b/crates/perfgate-budget/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Budget evaluation logic for performance thresholds"
+readme = "README.md"
 keywords = ["budget", "threshold", "performance"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-error/Cargo.toml
+++ b/crates/perfgate-error/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Unified error types for perfgate"
+readme = "README.md"
 keywords = ["error", "error-handling"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-export/Cargo.toml
+++ b/crates/perfgate-export/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Export formats for perfgate benchmarks (CSV, JSONL, HTML, Prometheus)"
+readme = "README.md"
 keywords = ["export", "csv", "prometheus", "benchmarking"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-fake/Cargo.toml
+++ b/crates/perfgate-fake/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Test utilities and fake implementations for perfgate testing"
+readme = "README.md"
 keywords = ["testing", "fake", "mock", "benchmarking"]
 categories = ["development-tools::testing"]
 

--- a/crates/perfgate-host-detect/Cargo.toml
+++ b/crates/perfgate-host-detect/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Host mismatch detection for benchmarking noise reduction"
+readme = "README.md"
 keywords = ["benchmarking", "host", "mismatch", "detection"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-paired/Cargo.toml
+++ b/crates/perfgate-paired/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Paired benchmarking statistics for A/B comparison"
+readme = "README.md"
 keywords = ["paired", "benchmarking", "statistics", "ab-testing"]
 categories = ["mathematics", "development-tools"]
 

--- a/crates/perfgate-sensor/Cargo.toml
+++ b/crates/perfgate-sensor/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Sensor report building for cockpit integration"
+readme = "README.md"
 keywords = ["sensor", "report", "cockpit", "integration"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-sha256/Cargo.toml
+++ b/crates/perfgate-sha256/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Minimal SHA-256 implementation for perfgate fingerprinting"
+readme = "README.md"
 keywords = ["sha256", "hash", "fingerprinting", "no-std"]
 categories = ["cryptography", "no-std"]
 

--- a/crates/perfgate-significance/Cargo.toml
+++ b/crates/perfgate-significance/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Statistical significance testing for benchmarking"
+readme = "README.md"
 keywords = ["statistics", "significance", "t-test", "benchmarking"]
 categories = ["mathematics", "development-tools"]
 

--- a/crates/perfgate-stats/Cargo.toml
+++ b/crates/perfgate-stats/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Statistical functions for benchmarking analysis"
+readme = "README.md"
 keywords = ["statistics", "median", "percentile", "benchmarking"]
 categories = ["mathematics", "development-tools"]
 

--- a/crates/perfgate-validation/Cargo.toml
+++ b/crates/perfgate-validation/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Validation functions for benchmark names and configuration"
+readme = "README.md"
 keywords = ["validation", "benchmarking", "names"]
 categories = ["development-tools"]
 


### PR DESCRIPTION
## Summary
Add `readme = "README.md"` to 11 crate Cargo.toml files that were missing it. Without this, crates.io won't display the README on the crate page.

Affected: perfgate-budget, perfgate-error, perfgate-export, perfgate-fake, perfgate-host-detect, perfgate-paired, perfgate-sensor, perfgate-sha256, perfgate-significance, perfgate-stats, perfgate-validation.

## Publish readiness
- `cargo publish --dry-run -p perfgate-error` passes
- Other crates fail dry-run because their internal deps aren't at 0.15.0 on crates.io yet (expected — must publish in dependency order)
- `perfgate-selfbench` and `xtask` have `publish = false` (correct)

## Test plan
- [x] `cargo build --all` passes
- [x] Dry-run publish passes for leaf crate