### PR TITLE
feat(server): enable SQLite WAL mode for concurrent reads

### DIFF
--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -38,8 +38,9 @@ impl SqliteStore {
             std::fs::create_dir_all(parent)?;
         }
 
+        let is_memory = path.as_os_str() == ":memory:";
         let conn = rusqlite::Connection::open(&path)?;
-        Self::configure_pragmas(&conn)?;
+        Self::configure_pragmas(&conn, is_memory)?;
 
         let store = Self {
             _path: path,
@@ -54,7 +55,7 @@ impl SqliteStore {
     /// Creates an in-memory SQLite database (for testing).
     pub fn in_memory() -> Result<Self, StoreError> {
         let conn = rusqlite::Connection::open_in_memory()?;
-        Self::configure_pragmas(&conn)?;
+        Self::configure_pragmas(&conn, true)?;
 
         let store = Self {
             _path: std::path::PathBuf::from(":memory:"),
@@ -69,11 +70,23 @@ impl SqliteStore {
     /// Configures SQLite pragmas for performance and concurrent access.
     ///
     /// - `journal_mode=WAL`: enables write-ahead logging so readers do not
-    ///   block writers and vice-versa.
+    ///   block writers and vice-versa.  Verified via the returned mode string
+    ///   so that silent fallbacks (e.g. read-only filesystem) become hard
+    ///   errors.  Skipped for in-memory databases where WAL is not applicable.
     /// - `busy_timeout=5000`: waits up to 5 seconds when the database is
     ///   locked instead of returning SQLITE_BUSY immediately.
-    fn configure_pragmas(conn: &rusqlite::Connection) -> Result<(), StoreError> {
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")?;
+    fn configure_pragmas(conn: &rusqlite::Connection, is_memory: bool) -> Result<(), StoreError> {
+        conn.execute_batch("PRAGMA busy_timeout=5000;")?;
+
+        if !is_memory {
+            let mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
+            if mode.to_lowercase() != "wal" {
+                return Err(StoreError::Other(format!(
+                    "failed to enable WAL journal mode (got '{mode}')"
+                )));
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- Enable WAL journal mode on SQLite connections for better concurrent read performance
- Set busy_timeout to handle contention gracefully

Closes #73

## Test plan
- [ ] Unit test verifies WAL mode is active
- [ ] Existing server tests pass
- [ ] clippy clean