### PR TITLE
docs: expand thin crate READMEs for crates.io

### DIFF
--- a/crates/perfgate-api/README.md
+++ b/crates/perfgate-api/README.md
@@ -2,7 +2,78 @@
 
 Common API types and models for the perfgate baseline service.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+## Overview
 
-Defines `BaselineRecord`, `BaselineVersion`, `VerdictRecord`, and related request/response
-types shared between `perfgate-server` and `perfgate-client`.
+`perfgate-api` defines the shared request/response types and data models used by
+both `perfgate-server` (the centralized Baseline Service) and `perfgate-client`
+(the client library). If you are building tooling that talks to the perfgate
+baseline service, this crate gives you the canonical wire types.
+
+## Key Types
+
+### Storage models
+
+- `BaselineRecord` — primary storage model for a baseline snapshot, including the
+  full `RunReceipt`, git metadata, tags, content hash, and soft-delete flag.
+- `BaselineVersion` — lightweight version history entry (no receipt payload).
+- `BaselineSummary` — compact listing entry with optional receipt inclusion.
+- `VerdictRecord` — recorded outcome of a benchmark execution (pass/warn/fail/skip).
+- `Project` — multi-tenancy namespace with `RetentionPolicy` and `VersioningStrategy`.
+
+### Request / response pairs
+
+| Operation | Request | Response |
+|-----------|---------|----------|
+| Upload baseline | `UploadBaselineRequest` | `UploadBaselineResponse` |
+| Promote baseline | `PromoteBaselineRequest` | `PromoteBaselineResponse` |
+| Delete baseline | -- | `DeleteBaselineResponse` |
+| List baselines | `ListBaselinesQuery` | `ListBaselinesResponse` |
+| Submit verdict | `SubmitVerdictRequest` | -- |
+| List verdicts | `ListVerdictsQuery` | `ListVerdictsResponse` |
+| Health check | -- | `HealthResponse` |
+
+### Supporting types
+
+- `BaselineSource` — how a baseline was created (`Upload`, `Promote`, `Migrate`, `Rollback`).
+- `RetentionPolicy` — configurable limits for version count, age, and preserved tags.
+- `VersioningStrategy` — auto-versioning mode (`RunId`, `Timestamp`, `GitSha`, `Manual`).
+- `PaginationInfo` — offset/limit pagination metadata for list endpoints.
+- `ApiError` — structured error response with code, message, and optional details.
+
+### Schema identifiers
+
+```text
+perfgate.baseline.v1
+perfgate.project.v1
+perfgate.verdict.v1
+```
+
+## Feature Flags
+
+- `server` — enables `axum::response::IntoResponse` impl for `ApiError`, so
+  the server crate can return API errors directly as HTTP responses.
+
+## Example
+
+```rust
+use perfgate_api::{ListBaselinesQuery, UploadBaselineRequest};
+
+// Build a filtered query with the builder API
+let query = ListBaselinesQuery::new()
+    .with_benchmark("my-bench")
+    .with_limit(10)
+    .with_receipts();
+
+// Convert to HTTP query parameters
+let params = query.to_query_params();
+```
+
+## Workspace Role
+
+`perfgate-api` sits between the core types and the network layer:
+
+`perfgate-types` -> **`perfgate-api`** -> `perfgate-server` / `perfgate-client`
+
+## License
+
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate-config/README.md
+++ b/crates/perfgate-config/README.md
@@ -2,7 +2,66 @@
 
 Configuration loading and merging logic for perfgate.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+## Overview
 
-Resolves server configuration from CLI flags, environment variables, and config files.
-Creates `BaselineClient` instances with the merged settings.
+`perfgate-config` resolves the effective perfgate configuration by merging
+values from three sources in priority order:
+
+1. **CLI flags** (highest priority)
+2. **Environment variables** (`PERFGATE_SERVER_URL`, `PERFGATE_API_KEY`, `PERFGATE_PROJECT`)
+3. **Config file** (`perfgate.toml` or `perfgate.json`)
+
+The merged result is a `ResolvedServerConfig` that can create ready-to-use
+`BaselineClient` or `FallbackClient` instances for talking to the centralized
+Baseline Service.
+
+## Key API
+
+### Functions
+
+- `load_config_file(path)` — reads a `perfgate.toml` or `perfgate.json` file
+  and deserializes it into a `ConfigFile`. Returns the default config if the
+  file does not exist.
+- `resolve_server_config(flag_url, flag_key, flag_project, file_config)` —
+  merges CLI flags with the `[baseline_server]` section of the config file,
+  producing a `ResolvedServerConfig`.
+
+### `ResolvedServerConfig`
+
+| Method | Description |
+|--------|-------------|
+| `is_configured()` | `true` when a server URL is present |
+| `create_client()` | builds a `BaselineClient` from the merged settings |
+| `create_fallback_client(dir)` | wraps the client in a `FallbackClient` that falls back to local storage |
+| `require_fallback_client(dir, msg)` | like above, but returns an error if the server is not configured |
+| `resolve_project(override)` | resolves the project name from the override, config, or returns an error |
+
+## Example
+
+```rust
+use std::path::Path;
+use perfgate_config::{load_config_file, resolve_server_config};
+
+let config = load_config_file(Path::new("perfgate.toml"))?;
+let resolved = resolve_server_config(
+    Some("https://baselines.example.com".into()),
+    None,
+    None,
+    &config.baseline_server,
+);
+
+if resolved.is_configured() {
+    let client = resolved.create_client()?;
+    // use client to upload/download baselines...
+}
+```
+
+## Workspace Role
+
+`perfgate-config` bridges configuration sources and the client library:
+
+`perfgate-types` + `perfgate-client` -> **`perfgate-config`** -> `perfgate-app` / `perfgate-cli`
+
+## License
+
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate-selfbench/README.md
+++ b/crates/perfgate-selfbench/README.md
@@ -2,7 +2,47 @@
 
 Internal benchmarking workloads for perfgate self-dogfooding.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+## Overview
 
-Provides deterministic workloads (`noop`, `cpu-fixed`, `io-fixed`, `json-read`) used by
-the CI dogfooding lanes to gate perfgate's own performance.
+`perfgate-selfbench` is a small binary crate that ships four deterministic
+workloads. These workloads are executed by perfgate's own CI dogfooding lanes
+so that perfgate can gate its own performance — eating its own dog food.
+
+The binary is invoked by `perfgate run` the same way any user benchmark would
+be, making it a realistic end-to-end test of the entire pipeline.
+
+> **Note:** This crate is `publish = false` and is not published to crates.io.
+> It exists solely for internal CI use.
+
+## Workloads
+
+| Command | What it does |
+|---------|--------------|
+| `noop` | Exits immediately. Measures baseline overhead of process spawning and measurement. |
+| `cpu-fixed` | Performs 10 million wrapping additions. Deterministic CPU-bound workload. |
+| `io-fixed` | Writes and reads back 1 MB to a temp file. Deterministic I/O-bound workload. |
+| `json-read` | Parses a JSON string (or file if a path argument is given). Exercises serde_json. |
+
+## Usage
+
+```bash
+# Run directly
+cargo run -p perfgate-selfbench -- cpu-fixed
+
+# Use with perfgate CLI for dogfooding
+cargo run -p perfgate-cli -- run \
+    --name selfbench-cpu \
+    --repeat 5 \
+    --out cpu-run.json \
+    -- cargo run -p perfgate-selfbench -- cpu-fixed
+```
+
+## Workspace Role
+
+`perfgate-selfbench` is a leaf binary used exclusively by CI:
+
+`perfgate-cli` spawns **`perfgate-selfbench`** as the benchmark command
+
+## License
+
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate-summary/README.md
+++ b/crates/perfgate-summary/README.md
@@ -2,7 +2,71 @@
 
 Summarization logic for perfgate comparison receipts.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+## Overview
 
-Aggregates multiple `CompareReceipt` files into a terminal-friendly summary table
-via the `perfgate summary` command.
+`perfgate-summary` aggregates one or more `CompareReceipt` files (produced by
+`perfgate compare`) into a compact summary table. It powers the
+`perfgate summary` CLI command, giving you a quick at-a-glance view of how
+multiple benchmarks performed in a single CI run.
+
+Glob patterns are supported, so you can point it at a directory of comparison
+files and get a unified table.
+
+## Key Types
+
+- `SummaryRequest` — input: a list of file paths or glob patterns to summarize.
+- `SummaryRow` — one row in the output table: benchmark name, verdict status,
+  wall-clock time, and percentage change.
+- `SummaryOutcome` — the complete result: a vector of rows plus a `failed` flag
+  indicating whether any benchmark had a `fail` verdict.
+- `SummaryUseCase` — the entry point that executes the summarization.
+
+## Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `SummaryUseCase::execute(request)` | Reads and parses all matching comparison receipts, extracts wall-time deltas, and returns a `SummaryOutcome` |
+| `SummaryUseCase::render_markdown(outcome)` | Renders the outcome as a Markdown table suitable for PR comments |
+
+## Example
+
+```rust
+use perfgate_summary::{SummaryRequest, SummaryUseCase};
+
+let usecase = SummaryUseCase;
+let outcome = usecase.execute(SummaryRequest {
+    files: vec!["artifacts/**/*.compare.json".to_string()],
+})?;
+
+if outcome.failed {
+    eprintln!("One or more benchmarks failed!");
+}
+
+let table = usecase.render_markdown(&outcome);
+println!("{}", table);
+```
+
+The rendered Markdown looks like:
+
+```
+| Benchmark | Status | Wall (ms) | Change |
+|-----------|--------|-----------|--------|
+| bench-a   | pass   | 42.50     | -2.1%  |
+| bench-b   | fail   | 310.00    | +15.3% |
+```
+
+## CLI Usage
+
+```bash
+perfgate summary artifacts/perfgate/compare*.json
+```
+
+## Workspace Role
+
+`perfgate-summary` is consumed by the application and CLI layers:
+
+`perfgate-types` -> **`perfgate-summary`** -> `perfgate-app` -> `perfgate-cli`
+
+## License
+
+Licensed under either Apache-2.0 or MIT.


### PR DESCRIPTION
## Summary
- Expand perfgate-api README with API types and models documentation
- Expand perfgate-config README with config loading documentation
- Expand perfgate-selfbench README with benchmarking workload documentation
- Expand perfgate-summary README with summarization documentation

Closes #59

## Test plan
- [ ] All READMEs render correctly as Markdown
- [ ] Content matches actual crate functionality