### PR TITLE
feat(server): enhance web dashboard with filtering and drill-down

### DIFF
--- a/crates/perfgate-server/assets/index.html
+++ b/crates/perfgate-server/assets/index.html
@@ -824,8 +824,9 @@
         }
 
         function verdictBadge(status) {
-            const cls = 'badge badge-' + status;
-            return '<span class="' + cls + '">' + status + '</span>';
+            const safe = escHtml(status);
+            const cls = 'badge badge-' + safe;
+            return '<span class="' + cls + '">' + safe + '</span>';
         }
 
         /* ======= API fetch ======= */
@@ -1117,13 +1118,13 @@
                     datasets: [{
                         label: metricLabels[metric] || metric,
                         data: dataPoints,
-                        borderColor: 'var(--color-primary)',
+                        borderColor: '#0366d6',
                         backgroundColor: 'rgba(3, 102, 214, 0.08)',
                         fill: true,
                         tension: 0.2,
                         pointRadius: 4,
                         pointHoverRadius: 7,
-                        pointBackgroundColor: 'var(--color-primary)',
+                        pointBackgroundColor: '#0366d6',
                         pointBorderColor: '#fff',
                         pointBorderWidth: 2
                     }]
@@ -1236,14 +1237,14 @@
             if (bench.name) {
                 html += detailItem('Bench Name', escHtml(bench.name));
             }
-            if (run.run_id) {
-                html += detailItem('Run ID', '<code>' + escHtml(run.run_id) + '</code>');
+            if (run.id) {
+                html += detailItem('Run ID', '<code>' + escHtml(run.id) + '</code>');
             }
-            if (bench.command) {
-                html += detailItem('Command', '<code>' + escHtml(bench.command) + '</code>');
+            if (bench.command && bench.command.length > 0) {
+                html += detailItem('Command', '<code>' + escHtml(bench.command.join(' ')) + '</code>');
             }
-            if (run.repeat !== undefined) {
-                html += detailItem('Repeat', run.repeat);
+            if (bench.repeat !== undefined) {
+                html += detailItem('Repeat', bench.repeat);
             }
 
             html += '</div>';


### PR DESCRIPTION
## Summary
- Add interactive filters (date range picker, metric selector dropdown, benchmark name search)
- Add verdict history panel with pass/warn/fail/skip checkbox filters
- Add run detail drill-down modal on chart point click and table row click
- Add responsive CSS grid/flex layout with media queries for mobile/tablet
- Add loading spinners for all async fetches and dismissible error banners
- Add pagination controls for baselines and verdicts lists
- Add health status indicator and API key input in header
- Improve visual design with CSS custom properties, better typography, and spacing

Closes #77

## Test plan
- [ ] Dashboard loads without errors at `/`
- [ ] Entering a project name and clicking Load fetches baselines
- [ ] Benchmark name search input filters the displayed table rows
- [ ] Date range pickers narrow results via API query params
- [ ] Metric selector changes the displayed metric column values
- [ ] Verdict checkboxes filter the verdict history table
- [ ] Clicking a baseline row navigates to benchmark detail view
- [ ] Chart metric selector switches the trend line metric
- [ ] Clicking a chart data point opens the run detail modal
- [ ] Clicking a history table row opens the run detail modal
- [ ] Modal shows full statistics, samples, metadata, and tags
- [ ] Modal closes on overlay click, X button, or Escape key
- [ ] Pagination prev/next buttons work for baselines and verdicts
- [ ] Layout adapts to mobile widths (single column, stacked filters)
- [ ] Health dot shows green/yellow/gray based on `/health` response
- [ ] API error banner appears on fetch failure and can be dismissed
- [ ] `cargo test -p perfgate-server` passes (40 tests)
- [ ] `cargo clippy -p perfgate-server --all-targets --all-features -- -D warnings` clean