### PR TITLE
feat(server): add Prometheus /metrics scrape endpoint

### DIFF
--- a/crates/perfgate-server/Cargo.toml
+++ b/crates/perfgate-server/Cargo.toml
@@ -55,6 +55,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 regex = { workspace = true }
 
+# Metrics
+metrics = "0.24.3"
+metrics-exporter-prometheus = { version = "0.18.1", default-features = false }
+
 # Additional dependencies
 sha2 = "0.10.8"
 base64 = "0.22.1"

--- a/crates/perfgate-server/src/handlers/baselines.rs
+++ b/crates/perfgate-server/src/handlers/baselines.rs
@@ -11,6 +11,7 @@ use tracing::{error, info};
 
 use crate::auth::{AuthContext, Scope, check_scope};
 use crate::error::StoreError;
+use crate::metrics;
 use crate::models::{
     ApiError, BaselineRecord, BaselineRecordExt, BaselineSource, DeleteBaselineResponse,
     ListBaselinesQuery, PromoteBaselineRequest, PromoteBaselineResponse, UploadBaselineRequest,
@@ -61,6 +62,7 @@ pub async fn upload_baseline(
 
     match store.create(&record).await {
         Ok(_) => {
+            metrics::record_baseline_upload(&project);
             info!(project = %project, benchmark = %request.benchmark, version = %version, "Baseline uploaded");
             let response = UploadBaselineResponse {
                 id: record.id.clone(),
@@ -100,11 +102,14 @@ pub async fn get_latest_baseline(
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Read)?;
 
     match store.get_latest(&project, &benchmark).await {
-        Ok(Some(record)) => Ok((
-            StatusCode::OK,
-            [(header::ETAG, record.etag())],
-            Json(record),
-        )),
+        Ok(Some(record)) => {
+            metrics::record_baseline_download(&project);
+            Ok((
+                StatusCode::OK,
+                [(header::ETAG, record.etag())],
+                Json(record),
+            ))
+        }
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
             Json(ApiError::not_found(&format!(
@@ -127,11 +132,14 @@ pub async fn get_baseline(
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Read)?;
 
     match store.get(&project, &benchmark, &version).await {
-        Ok(Some(record)) => Ok((
-            StatusCode::OK,
-            [(header::ETAG, record.etag())],
-            Json(record),
-        )),
+        Ok(Some(record)) => {
+            metrics::record_baseline_download(&project);
+            Ok((
+                StatusCode::OK,
+                [(header::ETAG, record.etag())],
+                Json(record),
+            ))
+        }
         Ok(None) => Err((
             StatusCode::NOT_FOUND,
             Json(ApiError::not_found(&format!(
@@ -155,7 +163,10 @@ pub async fn list_baselines(
     check_scope(Some(&auth_ctx), &project, None, Scope::Read)?;
 
     match store.list(&project, &query).await {
-        Ok(response) => Ok(Json(response).into_response()),
+        Ok(response) => {
+            metrics::record_storage_list();
+            Ok(Json(response).into_response())
+        }
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
@@ -171,14 +182,17 @@ pub async fn delete_baseline(
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Delete)?;
 
     match store.delete(&project, &benchmark, &version).await {
-        Ok(true) => Ok(Json(DeleteBaselineResponse {
-            deleted: true,
-            id: format!("{}/{}/{}", project, benchmark, version),
-            benchmark,
-            version,
-            deleted_at: chrono::Utc::now(),
-        })
-        .into_response()),
+        Ok(true) => {
+            metrics::record_storage_delete();
+            Ok(Json(DeleteBaselineResponse {
+                deleted: true,
+                id: format!("{}/{}/{}", project, benchmark, version),
+                benchmark,
+                version,
+                deleted_at: chrono::Utc::now(),
+            })
+            .into_response())
+        }
         Ok(false) => Err((
             StatusCode::NOT_FOUND,
             Json(ApiError::not_found(&format!(
@@ -253,17 +267,20 @@ pub async fn promote_baseline(
     );
 
     match store.create(&promoted).await {
-        Ok(_) => Ok((
-            StatusCode::CREATED,
-            Json(PromoteBaselineResponse {
-                id: promoted.id.clone(),
-                benchmark: benchmark.clone(),
-                version: request.to_version.clone(),
-                promoted_from: request.from_version.clone(),
-                promoted_at: promoted.created_at,
-                created_at: promoted.created_at,
-            }),
-        )),
+        Ok(_) => {
+            metrics::record_storage_promote();
+            Ok((
+                StatusCode::CREATED,
+                Json(PromoteBaselineResponse {
+                    id: promoted.id.clone(),
+                    benchmark: benchmark.clone(),
+                    version: request.to_version.clone(),
+                    promoted_from: request.from_version.clone(),
+                    promoted_at: promoted.created_at,
+                    created_at: promoted.created_at,
+                }),
+            ))
+        }
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -39,10 +39,12 @@
 //! | DELETE | `/projects/{project}/baselines/{benchmark}/versions/{version}` | Delete baseline |
 //! | POST | `/projects/{project}/baselines/{benchmark}/promote` | Promote version |
 //! | GET | `/health` | Health check |
+//! | GET | `/metrics` | Prometheus metrics |
 
 pub mod auth;
 pub mod error;
 pub mod handlers;
+pub mod metrics;
 pub mod models;
 pub mod oidc;
 pub mod server;

--- a/crates/perfgate-server/src/metrics.rs
+++ b/crates/perfgate-server/src/metrics.rs
@@ -1,0 +1,228 @@
+//! Prometheus metrics middleware and endpoint.
+//!
+//! This module provides:
+//! - A `/metrics` endpoint returning Prometheus text exposition format
+//! - A middleware layer that records request duration and status code
+//! - Custom counters for storage operations
+
+use std::time::Instant;
+
+use axum::{
+    body::Body,
+    extract::Request,
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use metrics::{counter, gauge, histogram};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+/// Metric name constants.
+pub mod names {
+    /// Histogram: request duration in seconds, labeled by method, path, status.
+    pub const HTTP_REQUEST_DURATION_SECONDS: &str = "http_request_duration_seconds";
+    /// Counter: total HTTP requests, labeled by method, path, status.
+    pub const HTTP_REQUESTS_TOTAL: &str = "http_requests_total";
+    /// Gauge: number of in-flight requests.
+    pub const HTTP_REQUESTS_IN_FLIGHT: &str = "http_requests_in_flight";
+    /// Counter: total baseline uploads.
+    pub const BASELINE_UPLOADS_TOTAL: &str = "perfgate_baseline_uploads_total";
+    /// Counter: total baseline downloads.
+    pub const BASELINE_DOWNLOADS_TOTAL: &str = "perfgate_baseline_downloads_total";
+    /// Counter: total storage operations, labeled by operation.
+    pub const STORAGE_OPERATIONS_TOTAL: &str = "perfgate_storage_operations_total";
+}
+
+/// Installs the Prometheus recorder and returns a handle for rendering metrics.
+///
+/// Must be called once at server startup before any metrics are recorded.
+pub fn setup_metrics_recorder() -> PrometheusHandle {
+    PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install Prometheus recorder")
+}
+
+/// Axum handler that renders collected metrics in Prometheus text exposition format.
+pub async fn metrics_handler(
+    axum::extract::State(handle): axum::extract::State<PrometheusHandle>,
+) -> impl IntoResponse {
+    let body = handle.render();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            axum::http::header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )
+        .body(Body::from(body))
+        .unwrap()
+}
+
+/// Normalizes a URI path for use as a metrics label.
+///
+/// Replaces dynamic path segments with placeholders to avoid high-cardinality labels.
+fn normalize_path(path: &str) -> String {
+    let segments: Vec<&str> = path.split('/').collect();
+    let mut normalized = Vec::with_capacity(segments.len());
+
+    let mut i = 0;
+    while i < segments.len() {
+        let seg = segments[i];
+        match seg {
+            "projects" => {
+                normalized.push("projects");
+                // Next segment is the project name -> replace with placeholder
+                if i + 1 < segments.len() {
+                    normalized.push(":project");
+                    i += 1;
+                }
+            }
+            "baselines" => {
+                normalized.push("baselines");
+                // Next segment is benchmark name -> replace with placeholder
+                if i + 1 < segments.len() && !segments[i + 1].is_empty() {
+                    let next = segments[i + 1];
+                    // Check if it's a known sub-path or a dynamic segment
+                    if next != "latest" && next != "versions" && next != "promote" {
+                        normalized.push(":benchmark");
+                        i += 1;
+                    }
+                }
+            }
+            "versions" => {
+                normalized.push("versions");
+                // Next segment is the version -> replace with placeholder
+                if i + 1 < segments.len() {
+                    normalized.push(":version");
+                    i += 1;
+                }
+            }
+            "verdicts" => {
+                normalized.push("verdicts");
+            }
+            _ => {
+                normalized.push(seg);
+            }
+        }
+        i += 1;
+    }
+
+    normalized.join("/")
+}
+
+/// Middleware that records HTTP request metrics.
+///
+/// Records:
+/// - `http_request_duration_seconds` histogram
+/// - `http_requests_total` counter
+/// - `http_requests_in_flight` gauge
+pub async fn metrics_middleware(request: Request, next: Next) -> Response {
+    let method = request.method().to_string();
+    let path = normalize_path(request.uri().path());
+
+    gauge!(names::HTTP_REQUESTS_IN_FLIGHT).increment(1);
+    let start = Instant::now();
+
+    let response = next.run(request).await;
+
+    let duration = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
+
+    let labels = [
+        ("method", method.clone()),
+        ("path", path.clone()),
+        ("status", status.clone()),
+    ];
+
+    histogram!(names::HTTP_REQUEST_DURATION_SECONDS, &labels).record(duration);
+    counter!(names::HTTP_REQUESTS_TOTAL, &labels).increment(1);
+    gauge!(names::HTTP_REQUESTS_IN_FLIGHT).decrement(1);
+
+    response
+}
+
+/// Records a successful baseline upload.
+pub fn record_baseline_upload(project: &str) {
+    counter!(names::BASELINE_UPLOADS_TOTAL, "project" => project.to_string()).increment(1);
+    counter!(names::STORAGE_OPERATIONS_TOTAL, "operation" => "upload").increment(1);
+}
+
+/// Records a successful baseline download (get/get_latest).
+pub fn record_baseline_download(project: &str) {
+    counter!(names::BASELINE_DOWNLOADS_TOTAL, "project" => project.to_string()).increment(1);
+    counter!(names::STORAGE_OPERATIONS_TOTAL, "operation" => "download").increment(1);
+}
+
+/// Records a storage list operation.
+pub fn record_storage_list() {
+    counter!(names::STORAGE_OPERATIONS_TOTAL, "operation" => "list").increment(1);
+}
+
+/// Records a storage delete operation.
+pub fn record_storage_delete() {
+    counter!(names::STORAGE_OPERATIONS_TOTAL, "operation" => "delete").increment(1);
+}
+
+/// Records a storage promote operation.
+pub fn record_storage_promote() {
+    counter!(names::STORAGE_OPERATIONS_TOTAL, "operation" => "promote").increment(1);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_path_health() {
+        assert_eq!(normalize_path("/health"), "/health");
+    }
+
+    #[test]
+    fn test_normalize_path_baselines_upload() {
+        assert_eq!(
+            normalize_path("/api/v1/projects/my-proj/baselines"),
+            "/api/v1/projects/:project/baselines"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_latest() {
+        assert_eq!(
+            normalize_path("/api/v1/projects/my-proj/baselines/my-bench/latest"),
+            "/api/v1/projects/:project/baselines/:benchmark/latest"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_version() {
+        assert_eq!(
+            normalize_path("/api/v1/projects/my-proj/baselines/my-bench/versions/v1"),
+            "/api/v1/projects/:project/baselines/:benchmark/versions/:version"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_promote() {
+        assert_eq!(
+            normalize_path("/api/v1/projects/my-proj/baselines/my-bench/promote"),
+            "/api/v1/projects/:project/baselines/:benchmark/promote"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_verdicts() {
+        assert_eq!(
+            normalize_path("/api/v1/projects/my-proj/verdicts"),
+            "/api/v1/projects/:project/verdicts"
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_metrics() {
+        assert_eq!(normalize_path("/metrics"), "/metrics");
+    }
+
+    #[test]
+    fn test_normalize_path_root() {
+        assert_eq!(normalize_path("/"), "/");
+    }
+}

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -25,10 +25,12 @@ use crate::handlers::{
     dashboard_index, delete_baseline, get_baseline, get_latest_baseline, health_check,
     list_baselines, list_verdicts, promote_baseline, static_asset, submit_verdict, upload_baseline,
 };
+use crate::metrics::{metrics_handler, metrics_middleware, setup_metrics_recorder};
 use crate::oidc::{OidcConfig, OidcProvider};
 use crate::storage::{
     ArtifactStore, BaselineStore, InMemoryStore, ObjectArtifactStore, PostgresStore, SqliteStore,
 };
+use metrics_exporter_prometheus::PrometheusHandle;
 
 /// Storage backend type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -280,6 +282,7 @@ pub(crate) fn create_router(
     store: Arc<dyn BaselineStore>,
     auth_state: AuthState,
     config: &ServerConfig,
+    prometheus_handle: Option<PrometheusHandle>,
 ) -> Router {
     // Health check (no auth required)
     let health_routes = Router::new().route("/health", get(health_check));
@@ -321,6 +324,16 @@ pub(crate) fn create_router(
         .merge(health_routes.clone())
         .nest("/api/v1", health_routes.merge(api_routes));
 
+    // Add /metrics endpoint if Prometheus handle is available
+    if let Some(handle) = prometheus_handle {
+        let metrics_routes = Router::new()
+            .route("/metrics", get(metrics_handler))
+            .with_state(handle);
+        app = app.merge(metrics_routes);
+        // Apply metrics middleware to all routes
+        app = app.layer(middleware::from_fn(metrics_middleware));
+    }
+
     // Add CORS if enabled
     if config.cors {
         app = app.layer(
@@ -360,8 +373,12 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
 
     let auth_state = AuthState::new(key_store, config.jwt.clone(), oidc_provider);
 
+    // Install Prometheus metrics recorder
+    let prometheus_handle = setup_metrics_recorder();
+    info!("Prometheus metrics enabled at /metrics");
+
     // Create router
-    let app = create_router(store.clone(), auth_state, &config);
+    let app = create_router(store.clone(), auth_state, &config, Some(prometheus_handle));
 
     // Add tracing and request ID layers
     let app = app.layer(
@@ -523,7 +540,7 @@ mod tests {
         let auth_state = AuthState::new(Arc::new(ApiKeyStore::new()), None, None);
         let config = ServerConfig::new();
 
-        let _router = create_router(store, auth_state, &config);
+        let _router = create_router(store, auth_state, &config, None);
         // Router created successfully
     }
 }

--- a/crates/perfgate-server/src/testing.rs
+++ b/crates/perfgate-server/src/testing.rs
@@ -26,7 +26,7 @@ pub async fn spawn_test_server(config: ServerConfig) -> TestServer {
         .await
         .expect("failed to create key store");
     let auth_state = AuthState::new(key_store, config.jwt.clone(), None);
-    let app = create_router(store, auth_state, &config);
+    let app = create_router(store, auth_state, &config, None);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary
- Add `/metrics` endpoint returning Prometheus text exposition format via `metrics` + `metrics-exporter-prometheus` crates
- Middleware-based instrumentation records request duration histograms, request counts by status code, and in-flight request gauge for all endpoints
- Custom counters: `perfgate_baseline_uploads_total`, `perfgate_baseline_downloads_total`, `perfgate_storage_operations_total` (by operation: upload, download, list, delete, promote)
- Path normalization replaces dynamic segments (project, benchmark, version) with placeholders to prevent high-cardinality label explosion

Closes #66

## Test plan
- [x] All 27 unit tests pass (including 8 new path normalization tests)
- [x] All 12 integration tests pass
- [x] clippy clean (`-D warnings`)
- [x] `cargo fmt` clean
- [ ] `/metrics` returns valid Prometheus text format
- [ ] Request metrics are recorded after HTTP traffic
- [ ] Custom operation counters increment on successful operations