### PR TITLE
feat(server): add audit logging for mutations and admin actions

### DIFF
--- a/crates/perfgate-api/src/lib.rs
+++ b/crates/perfgate-api/src/lib.rs
@@ -28,6 +28,9 @@ pub const PROJECT_SCHEMA_V1: &str = "perfgate.project.v1";
 /// Schema identifier for verdict records.
 pub const VERDICT_SCHEMA_V1: &str = "perfgate.verdict.v1";
 
+/// Schema identifier for audit event records.
+pub const AUDIT_SCHEMA_V1: &str = "perfgate.audit.v1";
+
 /// Source of baseline creation.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -491,6 +494,153 @@ pub struct DeleteBaselineResponse {
     pub benchmark: String,
     pub version: String,
     pub deleted_at: DateTime<Utc>,
+}
+
+// =========================================================================
+// Audit logging types
+// =========================================================================
+
+/// The action that was performed in an audit event.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditAction {
+    /// A resource was created (e.g., baseline upload)
+    Create,
+    /// A resource was updated
+    Update,
+    /// A resource was deleted (soft or hard)
+    Delete,
+    /// A baseline was promoted
+    Promote,
+}
+
+impl std::fmt::Display for AuditAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuditAction::Create => write!(f, "create"),
+            AuditAction::Update => write!(f, "update"),
+            AuditAction::Delete => write!(f, "delete"),
+            AuditAction::Promote => write!(f, "promote"),
+        }
+    }
+}
+
+impl std::str::FromStr for AuditAction {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "create" => Ok(AuditAction::Create),
+            "update" => Ok(AuditAction::Update),
+            "delete" => Ok(AuditAction::Delete),
+            "promote" => Ok(AuditAction::Promote),
+            other => Err(format!("Unknown audit action: {}", other)),
+        }
+    }
+}
+
+/// The type of resource affected by an audit event.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditResourceType {
+    /// A baseline record
+    Baseline,
+    /// An API key
+    Key,
+    /// A verdict record
+    Verdict,
+}
+
+impl std::fmt::Display for AuditResourceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuditResourceType::Baseline => write!(f, "baseline"),
+            AuditResourceType::Key => write!(f, "key"),
+            AuditResourceType::Verdict => write!(f, "verdict"),
+        }
+    }
+}
+
+impl std::str::FromStr for AuditResourceType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "baseline" => Ok(AuditResourceType::Baseline),
+            "key" => Ok(AuditResourceType::Key),
+            "verdict" => Ok(AuditResourceType::Verdict),
+            other => Err(format!("Unknown resource type: {}", other)),
+        }
+    }
+}
+
+/// An append-only audit event for tracking mutations and admin actions.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct AuditEvent {
+    /// Unique event identifier
+    pub id: String,
+    /// Timestamp of the event (RFC 3339)
+    pub timestamp: DateTime<Utc>,
+    /// Actor identity (API key ID or OIDC subject)
+    pub actor: String,
+    /// The action performed
+    pub action: AuditAction,
+    /// Type of resource affected
+    pub resource_type: AuditResourceType,
+    /// Identifier for the affected resource
+    pub resource_id: String,
+    /// Project scope
+    pub project: String,
+    /// Additional structured metadata (endpoint-specific details)
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+/// Query parameters for listing audit events.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ListAuditEventsQuery {
+    /// Filter by project
+    pub project: Option<String>,
+    /// Filter by action
+    pub action: Option<String>,
+    /// Filter by resource type
+    pub resource_type: Option<String>,
+    /// Filter by actor
+    pub actor: Option<String>,
+    /// Filter by events after this time
+    pub since: Option<DateTime<Utc>>,
+    /// Filter by events before this time
+    pub until: Option<DateTime<Utc>>,
+    /// Pagination limit
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+    /// Pagination offset
+    #[serde(default)]
+    pub offset: u64,
+}
+
+impl Default for ListAuditEventsQuery {
+    fn default() -> Self {
+        Self {
+            project: None,
+            action: None,
+            resource_type: None,
+            actor: None,
+            since: None,
+            until: None,
+            limit: default_limit(),
+            offset: 0,
+        }
+    }
+}
+
+/// Response for audit event list operation.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ListAuditEventsResponse {
+    /// The audit events matching the query
+    pub events: Vec<AuditEvent>,
+    /// Pagination metadata
+    pub pagination: PaginationInfo,
 }
 
 /// Health status of a storage backend.

--- a/crates/perfgate-server/src/handlers.rs
+++ b/crates/perfgate-server/src/handlers.rs
@@ -1,10 +1,12 @@
 //! Re-export all handlers for use in the server.
 
+mod audit;
 mod baselines;
 mod dashboard;
 mod health;
 mod verdicts;
 
+pub use audit::*;
 pub use baselines::*;
 pub use dashboard::*;
 pub use health::*;

--- a/crates/perfgate-server/src/handlers/audit.rs
+++ b/crates/perfgate-server/src/handlers/audit.rs
@@ -1,0 +1,43 @@
+//! Audit log query handler.
+
+use axum::{
+    Extension, Json,
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use tracing::error;
+
+use crate::auth::{AuthContext, Scope, check_scope};
+use crate::models::{ApiError, ListAuditEventsQuery};
+use crate::server::AppState;
+
+/// List audit events with filtering.
+///
+/// Requires `Admin` scope. Supports filtering by project, action, resource_type,
+/// actor, since, and until.
+pub async fn list_audit_events(
+    Extension(auth_ctx): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Query(query): Query<ListAuditEventsQuery>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
+    // Audit log access requires admin role. We use the actor's own project for the
+    // scope check, since audit events span projects.
+    check_scope(
+        Some(&auth_ctx),
+        &auth_ctx.api_key.project_id,
+        None,
+        Scope::Admin,
+    )?;
+
+    match state.audit.list_events(&query).await {
+        Ok(response) => Ok(Json(response)),
+        Err(e) => {
+            error!(error = %e, "Failed to list audit events");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
+    }
+}

--- a/crates/perfgate-server/src/handlers/baselines.rs
+++ b/crates/perfgate-server/src/handlers/baselines.rs
@@ -7,23 +7,23 @@ use axum::{
     response::IntoResponse,
 };
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::auth::{AuthContext, Scope, check_scope};
 use crate::error::StoreError;
 use crate::metrics;
 use crate::models::{
-    ApiError, BaselineRecord, BaselineRecordExt, BaselineSource, DeleteBaselineResponse,
-    ListBaselinesQuery, PromoteBaselineRequest, PromoteBaselineResponse, UploadBaselineRequest,
-    UploadBaselineResponse,
+    ApiError, AuditAction, AuditEvent, AuditResourceType, BaselineRecord, BaselineRecordExt,
+    BaselineSource, DeleteBaselineResponse, ListBaselinesQuery, PromoteBaselineRequest,
+    PromoteBaselineResponse, UploadBaselineRequest, UploadBaselineResponse, generate_ulid,
 };
-use crate::storage::BaselineStore;
+use crate::server::AppState;
 
 /// Upload a new baseline.
 pub async fn upload_baseline(
     Path(project): Path<String>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
     Json(request): Json<UploadBaselineRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(
@@ -60,10 +60,25 @@ pub async fn upload_baseline(
         BaselineSource::Upload,
     );
 
-    match store.create(&record).await {
+    match state.store.create(&record).await {
         Ok(_) => {
             metrics::record_baseline_upload(&project);
             info!(project = %project, benchmark = %request.benchmark, version = %version, "Baseline uploaded");
+
+            emit_audit(
+                &state.audit,
+                &auth_ctx,
+                AuditAction::Create,
+                AuditResourceType::Baseline,
+                &record.id,
+                &project,
+                serde_json::json!({
+                    "benchmark": request.benchmark,
+                    "version": version,
+                }),
+            )
+            .await;
+
             let response = UploadBaselineResponse {
                 id: record.id.clone(),
                 benchmark: request.benchmark.clone(),
@@ -97,11 +112,11 @@ pub async fn upload_baseline(
 pub async fn get_latest_baseline(
     Path((project, benchmark)): Path<(String, String)>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Read)?;
 
-    match store.get_latest(&project, &benchmark).await {
+    match state.store.get_latest(&project, &benchmark).await {
         Ok(Some(record)) => {
             metrics::record_baseline_download(&project);
             Ok((
@@ -127,11 +142,11 @@ pub async fn get_latest_baseline(
 pub async fn get_baseline(
     Path((project, benchmark, version)): Path<(String, String, String)>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Read)?;
 
-    match store.get(&project, &benchmark, &version).await {
+    match state.store.get(&project, &benchmark, &version).await {
         Ok(Some(record)) => {
             metrics::record_baseline_download(&project);
             Ok((
@@ -157,12 +172,12 @@ pub async fn get_baseline(
 pub async fn list_baselines(
     Path(project): Path<String>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
     Query(query): Query<ListBaselinesQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(Some(&auth_ctx), &project, None, Scope::Read)?;
 
-    match store.list(&project, &query).await {
+    match state.store.list(&project, &query).await {
         Ok(response) => {
             metrics::record_storage_list();
             Ok(Json(response).into_response())
@@ -177,16 +192,32 @@ pub async fn list_baselines(
 pub async fn delete_baseline(
     Path((project, benchmark, version)): Path<(String, String, String)>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Delete)?;
 
-    match store.delete(&project, &benchmark, &version).await {
+    match state.store.delete(&project, &benchmark, &version).await {
         Ok(true) => {
             metrics::record_storage_delete();
+            let resource_id = format!("{}/{}/{}", project, benchmark, version);
+
+            emit_audit(
+                &state.audit,
+                &auth_ctx,
+                AuditAction::Delete,
+                AuditResourceType::Baseline,
+                &resource_id,
+                &project,
+                serde_json::json!({
+                    "benchmark": benchmark,
+                    "version": version,
+                }),
+            )
+            .await;
+
             Ok(Json(DeleteBaselineResponse {
                 deleted: true,
-                id: format!("{}/{}/{}", project, benchmark, version),
+                id: resource_id,
                 benchmark,
                 version,
                 deleted_at: chrono::Utc::now(),
@@ -210,12 +241,16 @@ pub async fn delete_baseline(
 pub async fn promote_baseline(
     Path((project, benchmark)): Path<(String, String)>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
     Json(request): Json<PromoteBaselineRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(Some(&auth_ctx), &project, Some(&benchmark), Scope::Promote)?;
 
-    let source = match store.get(&project, &benchmark, &request.from_version).await {
+    let source = match state
+        .store
+        .get(&project, &benchmark, &request.from_version)
+        .await
+    {
         Ok(Some(record)) => record,
         Ok(None) => {
             return Err((
@@ -234,7 +269,8 @@ pub async fn promote_baseline(
         }
     };
 
-    if store
+    if state
+        .store
         .get(&project, &benchmark, &request.to_version)
         .await
         .map_err(|e| {
@@ -266,9 +302,25 @@ pub async fn promote_baseline(
         BaselineSource::Promote,
     );
 
-    match store.create(&promoted).await {
+    match state.store.create(&promoted).await {
         Ok(_) => {
             metrics::record_storage_promote();
+
+            emit_audit(
+                &state.audit,
+                &auth_ctx,
+                AuditAction::Promote,
+                AuditResourceType::Baseline,
+                &promoted.id,
+                &project,
+                serde_json::json!({
+                    "benchmark": benchmark,
+                    "from_version": request.from_version,
+                    "to_version": request.to_version,
+                }),
+            )
+            .await;
+
             Ok((
                 StatusCode::CREATED,
                 Json(PromoteBaselineResponse {
@@ -285,5 +337,31 @@ pub async fn promote_baseline(
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(ApiError::internal_error(&e.to_string())),
         )),
+    }
+}
+
+/// Emit an audit event, logging a warning if storage fails.
+async fn emit_audit(
+    audit: &Arc<dyn crate::storage::AuditStore>,
+    auth_ctx: &AuthContext,
+    action: AuditAction,
+    resource_type: AuditResourceType,
+    resource_id: &str,
+    project: &str,
+    metadata: serde_json::Value,
+) {
+    let event = AuditEvent {
+        id: generate_ulid(),
+        timestamp: chrono::Utc::now(),
+        actor: auth_ctx.api_key.id.clone(),
+        action,
+        resource_type,
+        resource_id: resource_id.to_string(),
+        project: project.to_string(),
+        metadata,
+    };
+
+    if let Err(e) = audit.log_event(&event).await {
+        warn!(error = %e, "Failed to log audit event");
     }
 }

--- a/crates/perfgate-server/src/handlers/health.rs
+++ b/crates/perfgate-server/src/handlers/health.rs
@@ -1,17 +1,17 @@
 //! Health check handlers.
 
 use axum::{Json, extract::State};
-use std::sync::Arc;
 
 use crate::models::{HealthResponse, StorageHealth as ModelStorageHealth};
-use crate::storage::{BaselineStore, StorageHealth};
+use crate::server::AppState;
+use crate::storage::StorageHealth;
 
 /// Health check endpoint.
 ///
 /// Returns server health status, storage backend health, and connection pool
 /// metrics (when using a pooled backend such as PostgreSQL).
-pub async fn health_check(State(store): State<Arc<dyn BaselineStore>>) -> Json<HealthResponse> {
-    let storage_health = match store.health_check().await {
+pub async fn health_check(State(state): State<AppState>) -> Json<HealthResponse> {
+    let storage_health = match state.store.health_check().await {
         Ok(health) => health,
         Err(_) => StorageHealth::Unhealthy,
     };
@@ -19,7 +19,7 @@ pub async fn health_check(State(store): State<Arc<dyn BaselineStore>>) -> Json<H
     let status_str = storage_health.as_str();
 
     // Collect pool metrics if the backend exposes them.
-    let pool = store.pool_metrics();
+    let pool = state.store.pool_metrics();
 
     Json(HealthResponse {
         status: if storage_health == StorageHealth::Healthy {
@@ -29,7 +29,7 @@ pub async fn health_check(State(store): State<Arc<dyn BaselineStore>>) -> Json<H
         },
         version: env!("CARGO_PKG_VERSION").to_string(),
         storage: ModelStorageHealth {
-            backend: store.backend_type().to_string(),
+            backend: state.store.backend_type().to_string(),
             status: status_str.to_string(),
         },
         pool,

--- a/crates/perfgate-server/src/handlers/verdicts.rs
+++ b/crates/perfgate-server/src/handlers/verdicts.rs
@@ -6,21 +6,20 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::auth::{AuthContext, Scope, check_scope};
 use crate::models::{
-    ApiError, ListVerdictsQuery, SubmitVerdictRequest, VERDICT_SCHEMA_V1, VerdictRecord,
-    generate_ulid,
+    ApiError, AuditAction, AuditEvent, AuditResourceType, ListVerdictsQuery, SubmitVerdictRequest,
+    VERDICT_SCHEMA_V1, VerdictRecord, generate_ulid,
 };
-use crate::storage::BaselineStore;
+use crate::server::AppState;
 
 /// Submit a new benchmark verdict.
 pub async fn submit_verdict(
     Path(project): Path<String>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
     Json(request): Json<SubmitVerdictRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(
@@ -54,7 +53,7 @@ pub async fn submit_verdict(
         created_at: chrono::Utc::now(),
     };
 
-    match store.create_verdict(&record).await {
+    match state.store.create_verdict(&record).await {
         Ok(_) => {
             info!(
                 project = %project,
@@ -62,6 +61,24 @@ pub async fn submit_verdict(
                 status = ?record.status,
                 "Verdict submitted"
             );
+
+            let audit_event = AuditEvent {
+                id: generate_ulid(),
+                timestamp: chrono::Utc::now(),
+                actor: auth_ctx.api_key.id.clone(),
+                action: AuditAction::Create,
+                resource_type: AuditResourceType::Verdict,
+                resource_id: record.id.clone(),
+                project: project.clone(),
+                metadata: serde_json::json!({
+                    "benchmark": record.benchmark,
+                    "status": format!("{:?}", record.status).to_lowercase(),
+                }),
+            };
+            if let Err(e) = state.audit.log_event(&audit_event).await {
+                warn!(error = %e, "Failed to log audit event");
+            }
+
             Ok((StatusCode::CREATED, Json(record)))
         }
         Err(e) => {
@@ -78,12 +95,12 @@ pub async fn submit_verdict(
 pub async fn list_verdicts(
     Path(project): Path<String>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn BaselineStore>>,
+    State(state): State<AppState>,
     Query(query): Query<ListVerdictsQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_scope(Some(&auth_ctx), &project, None, Scope::Read)?;
 
-    match store.list_verdicts(&project, &query).await {
+    match state.store.list_verdicts(&project, &query).await {
         Ok(response) => Ok(Json(response)),
         Err(e) => {
             error!(error = %e, "Failed to list verdicts");

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -40,6 +40,7 @@
 //! | GET | `/projects/{project}/baselines` | List baselines |
 //! | DELETE | `/projects/{project}/baselines/{benchmark}/versions/{version}` | Delete baseline |
 //! | POST | `/projects/{project}/baselines/{benchmark}/promote` | Promote version |
+//! | GET | `/audit` | List audit events (admin only) |
 //! | GET | `/health` | Health check |
 //! | GET | `/metrics` | Prometheus metrics |
 
@@ -59,8 +60,8 @@ pub use auth::{ApiKey, ApiKeyStore, AuthContext, AuthState, JwtClaims, JwtConfig
 pub use error::{AuthError, ConfigError, StoreError};
 pub use models::*;
 pub use oidc::{OidcConfig, OidcProvider};
-pub use server::{PostgresPoolConfig, ServerConfig, StorageBackend, run_server};
-pub use storage::{BaselineStore, InMemoryStore, SqliteStore, StorageHealth};
+pub use server::{AppState, PostgresPoolConfig, ServerConfig, StorageBackend, run_server};
+pub use storage::{AuditStore, BaselineStore, InMemoryStore, SqliteStore, StorageHealth};
 
 /// Server version string.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -24,14 +24,25 @@ use crate::auth::{ApiKey, ApiKeyStore, AuthState, JwtConfig, Role, auth_middlewa
 use crate::error::ConfigError;
 use crate::handlers::{
     dashboard_index, delete_baseline, get_baseline, get_latest_baseline, health_check,
-    list_baselines, list_verdicts, promote_baseline, static_asset, submit_verdict, upload_baseline,
+    list_audit_events, list_baselines, list_verdicts, promote_baseline, static_asset,
+    submit_verdict, upload_baseline,
 };
 use crate::metrics::{metrics_handler, metrics_middleware, setup_metrics_recorder};
 use crate::oidc::{OidcConfig, OidcProvider};
 use crate::storage::{
-    ArtifactStore, BaselineStore, InMemoryStore, ObjectArtifactStore, PostgresStore, SqliteStore,
+    ArtifactStore, AuditStore, BaselineStore, InMemoryStore, ObjectArtifactStore, PostgresStore,
+    SqliteStore,
 };
 use metrics_exporter_prometheus::PrometheusHandle;
+
+/// Shared application state holding all stores.
+#[derive(Clone)]
+pub struct AppState {
+    /// Baseline/verdict store
+    pub store: Arc<dyn BaselineStore>,
+    /// Audit event store
+    pub audit: Arc<dyn AuditStore>,
+}
 
 /// Storage backend type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -291,15 +302,18 @@ pub(crate) async fn create_artifacts(
 }
 
 /// Creates the storage backend based on configuration.
+///
+/// Returns both a `BaselineStore` and an `AuditStore` backed by the same backend.
 pub(crate) async fn create_storage(
     config: &ServerConfig,
-) -> Result<Arc<dyn BaselineStore>, ConfigError> {
+) -> Result<(Arc<dyn BaselineStore>, Arc<dyn AuditStore>), ConfigError> {
     let artifacts = create_artifacts(config).await?;
 
     match config.storage_backend {
         StorageBackend::Memory => {
             info!("Using in-memory storage");
-            Ok(Arc::new(InMemoryStore::new()))
+            let store = Arc::new(InMemoryStore::new());
+            Ok((store.clone(), store))
         }
         StorageBackend::Sqlite => {
             let path = config
@@ -309,7 +323,8 @@ pub(crate) async fn create_storage(
             info!(path = %path.display(), "Using SQLite storage");
             let store = SqliteStore::new(&path, artifacts)
                 .map_err(|e| ConfigError::InvalidValue(format!("Failed to open SQLite: {}", e)))?;
-            Ok(Arc::new(store))
+            let store = Arc::new(store);
+            Ok((store.clone(), store))
         }
         StorageBackend::Postgres => {
             let url = config
@@ -322,7 +337,8 @@ pub(crate) async fn create_storage(
                 .map_err(|e| {
                     ConfigError::InvalidValue(format!("Failed to connect to Postgres: {}", e))
                 })?;
-            Ok(Arc::new(store))
+            let store = Arc::new(store);
+            Ok((store.clone(), store))
         }
     }
 }
@@ -352,7 +368,7 @@ pub(crate) async fn create_key_store(
 
 /// Creates the router with all routes configured.
 pub(crate) fn create_router(
-    store: Arc<dyn BaselineStore>,
+    state: AppState,
     auth_state: AuthState,
     config: &ServerConfig,
     prometheus_handle: Option<PrometheusHandle>,
@@ -396,7 +412,9 @@ pub(crate) fn create_router(
         .route(
             "/projects/{project}/baselines/{benchmark}/promote",
             post(promote_baseline),
-        );
+        )
+        // Audit log
+        .route("/audit", get(list_audit_events));
 
     let api_routes = if config.local_mode {
         api_routes_inner
@@ -433,7 +451,7 @@ pub(crate) fn create_router(
         );
     }
 
-    app.with_state(store)
+    app.with_state(state)
 }
 
 /// Runs the HTTP server.
@@ -447,7 +465,7 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     );
 
     // Create storage
-    let store = create_storage(&config).await?;
+    let (store, audit) = create_storage(&config).await?;
 
     // Create key store
     let key_store = create_key_store(&config).await?;
@@ -466,8 +484,10 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     let prometheus_handle = setup_metrics_recorder();
     info!("Prometheus metrics enabled at /metrics");
 
+    let app_state = AppState { store, audit };
+
     // Create router
-    let app = create_router(store.clone(), auth_state, &config, Some(prometheus_handle));
+    let app = create_router(app_state, auth_state, &config, Some(prometheus_handle));
 
     // Add tracing and request ID layers
     let app = app.layer(
@@ -581,7 +601,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_storage_memory() {
         let config = ServerConfig::new().storage_backend(StorageBackend::Memory);
-        let storage = create_storage(&config).await.unwrap();
+        let (storage, _audit) = create_storage(&config).await.unwrap();
         assert_eq!(storage.backend_type(), "memory");
     }
 
@@ -590,7 +610,7 @@ mod tests {
         let config = ServerConfig::new()
             .storage_backend(StorageBackend::Sqlite)
             .sqlite_path(":memory:");
-        let storage = create_storage(&config).await.unwrap();
+        let (storage, _audit) = create_storage(&config).await.unwrap();
         assert_eq!(storage.backend_type(), "sqlite");
     }
 
@@ -628,8 +648,12 @@ mod tests {
         let store = Arc::new(InMemoryStore::new());
         let auth_state = AuthState::new(Arc::new(ApiKeyStore::new()), None, None);
         let config = ServerConfig::new();
+        let app_state = AppState {
+            store: store.clone(),
+            audit: store,
+        };
 
-        let _router = create_router(store, auth_state, &config, None);
+        let _router = create_router(app_state, auth_state, &config, None);
         // Router created successfully
     }
 

--- a/crates/perfgate-server/src/storage/memory.rs
+++ b/crates/perfgate-server/src/storage/memory.rs
@@ -5,11 +5,12 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use super::{BaselineStore, StorageHealth};
+use super::{AuditStore, BaselineStore, StorageHealth};
 use crate::error::StoreError;
 use crate::models::{
-    BaselineRecord, BaselineSummary, BaselineVersion, ListBaselinesQuery, ListBaselinesResponse,
-    ListVerdictsQuery, ListVerdictsResponse, PaginationInfo, VerdictRecord,
+    AuditEvent, BaselineRecord, BaselineSummary, BaselineVersion, ListAuditEventsQuery,
+    ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse, ListVerdictsQuery,
+    ListVerdictsResponse, PaginationInfo, VerdictRecord,
 };
 
 /// In-memory storage backend for baselines.
@@ -18,6 +19,7 @@ pub struct InMemoryStore {
     #[allow(clippy::type_complexity)]
     baselines: Arc<RwLock<BTreeMap<(String, String, String), BaselineRecord>>>,
     verdicts: Arc<RwLock<Vec<VerdictRecord>>>,
+    audit_events: Arc<RwLock<Vec<AuditEvent>>>,
 }
 
 impl InMemoryStore {
@@ -26,6 +28,7 @@ impl InMemoryStore {
         Self {
             baselines: Arc::new(RwLock::new(BTreeMap::new())),
             verdicts: Arc::new(RwLock::new(Vec::new())),
+            audit_events: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
@@ -328,6 +331,86 @@ impl BaselineStore for InMemoryStore {
 
         Ok(ListVerdictsResponse {
             verdicts: paginated,
+            pagination: PaginationInfo {
+                total,
+                limit: query.limit,
+                offset: query.offset,
+                has_more,
+            },
+        })
+    }
+}
+
+#[async_trait]
+impl AuditStore for InMemoryStore {
+    async fn log_event(&self, event: &AuditEvent) -> Result<(), StoreError> {
+        let mut events = self.audit_events.write().await;
+        events.push(event.clone());
+        Ok(())
+    }
+
+    async fn list_events(
+        &self,
+        query: &ListAuditEventsQuery,
+    ) -> Result<ListAuditEventsResponse, StoreError> {
+        let events = self.audit_events.read().await;
+
+        let mut filtered: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                if let Some(ref project) = query.project
+                    && &e.project != project
+                {
+                    return false;
+                }
+
+                if let Some(ref action) = query.action
+                    && e.action.to_string() != *action
+                {
+                    return false;
+                }
+
+                if let Some(ref resource_type) = query.resource_type
+                    && e.resource_type.to_string() != *resource_type
+                {
+                    return false;
+                }
+
+                if let Some(ref actor) = query.actor
+                    && &e.actor != actor
+                {
+                    return false;
+                }
+
+                if let Some(since) = query.since
+                    && e.timestamp < since
+                {
+                    return false;
+                }
+
+                if let Some(until) = query.until
+                    && e.timestamp > until
+                {
+                    return false;
+                }
+
+                true
+            })
+            .cloned()
+            .collect();
+
+        filtered.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+        let total = filtered.len() as u64;
+        let offset = query.offset as usize;
+        let limit = query.limit as usize;
+
+        let paginated: Vec<_> = filtered.into_iter().skip(offset).take(limit).collect();
+
+        let has_more = (offset + paginated.len()) < total as usize;
+
+        Ok(ListAuditEventsResponse {
+            events: paginated,
             pagination: PaginationInfo {
                 total,
                 limit: query.limit,

--- a/crates/perfgate-server/src/storage/mod.rs
+++ b/crates/perfgate-server/src/storage/mod.rs
@@ -15,8 +15,9 @@ pub use sqlite::SqliteStore;
 
 use crate::error::StoreError;
 use crate::models::{
-    BaselineRecord, BaselineVersion, ListBaselinesQuery, ListBaselinesResponse, ListVerdictsQuery,
-    ListVerdictsResponse, PoolMetrics, VerdictRecord,
+    AuditEvent, BaselineRecord, BaselineVersion, ListAuditEventsQuery, ListAuditEventsResponse,
+    ListBaselinesQuery, ListBaselinesResponse, ListVerdictsQuery, ListVerdictsResponse,
+    PoolMetrics, VerdictRecord,
 };
 use async_trait::async_trait;
 
@@ -113,6 +114,22 @@ pub trait BaselineStore: Send + Sync {
         project: &str,
         query: &ListVerdictsQuery,
     ) -> Result<ListVerdictsResponse, StoreError>;
+}
+
+/// Trait for append-only audit event storage.
+///
+/// This trait abstracts audit log persistence, allowing different backends
+/// to store and query audit events.
+#[async_trait]
+pub trait AuditStore: Send + Sync {
+    /// Appends a new audit event to the log.
+    async fn log_event(&self, event: &AuditEvent) -> Result<(), StoreError>;
+
+    /// Lists audit events with optional filtering.
+    async fn list_events(
+        &self,
+        query: &ListAuditEventsQuery,
+    ) -> Result<ListAuditEventsResponse, StoreError>;
 }
 
 /// Storage backend health status.

--- a/crates/perfgate-server/src/storage/postgres.rs
+++ b/crates/perfgate-server/src/storage/postgres.rs
@@ -3,10 +3,11 @@
 //! This module provides a robust, asynchronous PostgreSQL backend for storing
 //! and querying perfgate baseline records using sqlx.
 
-use super::{ArtifactStore, BaselineStore, StorageHealth};
+use super::{ArtifactStore, AuditStore, BaselineStore, StorageHealth};
 use crate::error::StoreError;
 use crate::models::{
-    BaselineRecord, BaselineSource, BaselineVersion, ListBaselinesQuery, ListBaselinesResponse,
+    AuditAction, AuditEvent, AuditResourceType, BaselineRecord, BaselineSource, BaselineVersion,
+    ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse,
     ListVerdictsQuery, ListVerdictsResponse, PaginationInfo, VerdictRecord,
 };
 use crate::server::PostgresPoolConfig;
@@ -205,6 +206,26 @@ impl PostgresStore {
 
             CREATE INDEX IF NOT EXISTS idx_verdicts_created_at
             ON verdicts(created_at);
+
+            CREATE TABLE IF NOT EXISTS audit_events (
+                id VARCHAR(64) PRIMARY KEY,
+                timestamp TIMESTAMPTZ NOT NULL,
+                actor VARCHAR(255) NOT NULL,
+                action VARCHAR(32) NOT NULL,
+                resource_type VARCHAR(32) NOT NULL,
+                resource_id VARCHAR(255) NOT NULL,
+                project VARCHAR(255) NOT NULL,
+                metadata JSONB NOT NULL DEFAULT '{}'
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_audit_events_project
+            ON audit_events(project);
+
+            CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp
+            ON audit_events(timestamp DESC);
+
+            CREATE INDEX IF NOT EXISTS idx_audit_events_action
+            ON audit_events(action);
         "#;
 
         sqlx::query(sql)
@@ -770,6 +791,147 @@ impl PostgresStore {
             git_ref: row.get("git_ref"),
             git_sha: row.get("git_sha"),
             created_at: row.get("created_at"),
+        })
+    }
+}
+
+#[async_trait]
+impl AuditStore for PostgresStore {
+    async fn log_event(&self, event: &AuditEvent) -> Result<(), StoreError> {
+        let metadata_json =
+            serde_json::to_value(&event.metadata).map_err(StoreError::SerializationError)?;
+
+        let sql = r#"
+            INSERT INTO audit_events (
+                id, timestamp, actor, action, resource_type, resource_id, project, metadata
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        "#;
+
+        sqlx::query(sql)
+            .bind(&event.id)
+            .bind(event.timestamp)
+            .bind(&event.actor)
+            .bind(event.action.to_string())
+            .bind(event.resource_type.to_string())
+            .bind(&event.resource_id)
+            .bind(&event.project)
+            .bind(metadata_json)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn list_events(
+        &self,
+        query: &ListAuditEventsQuery,
+    ) -> Result<ListAuditEventsResponse, StoreError> {
+        let mut sql = "SELECT * FROM audit_events WHERE TRUE".to_string();
+        let mut params_count = 0;
+
+        if query.project.is_some() {
+            params_count += 1;
+            sql.push_str(&format!(" AND project = ${}", params_count));
+        }
+        if query.action.is_some() {
+            params_count += 1;
+            sql.push_str(&format!(" AND action = ${}", params_count));
+        }
+        if query.resource_type.is_some() {
+            params_count += 1;
+            sql.push_str(&format!(" AND resource_type = ${}", params_count));
+        }
+        if query.actor.is_some() {
+            params_count += 1;
+            sql.push_str(&format!(" AND actor = ${}", params_count));
+        }
+        if query.since.is_some() {
+            params_count += 1;
+            sql.push_str(&format!(" AND timestamp >= ${}", params_count));
+        }
+        if query.until.is_some() {
+            params_count += 1;
+            sql.push_str(&format!(" AND timestamp <= ${}", params_count));
+        }
+
+        sql.push_str(" ORDER BY timestamp DESC");
+
+        params_count += 1;
+        sql.push_str(&format!(" LIMIT ${}", params_count));
+        params_count += 1;
+        sql.push_str(&format!(" OFFSET ${}", params_count));
+
+        let mut q = sqlx::query(&sql);
+
+        if let Some(ref project) = query.project {
+            q = q.bind(project);
+        }
+        if let Some(ref action) = query.action {
+            q = q.bind(action);
+        }
+        if let Some(ref resource_type) = query.resource_type {
+            q = q.bind(resource_type);
+        }
+        if let Some(ref actor) = query.actor {
+            q = q.bind(actor);
+        }
+        if let Some(ref since) = query.since {
+            q = q.bind(since);
+        }
+        if let Some(ref until) = query.until {
+            q = q.bind(until);
+        }
+
+        q = q.bind(query.limit as i64);
+        q = q.bind(query.offset as i64);
+
+        let rows = q
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+
+        let mut events = Vec::with_capacity(rows.len());
+        for row in rows {
+            let action_str: String = row.get("action");
+            let action = action_str
+                .parse::<AuditAction>()
+                .unwrap_or(AuditAction::Create);
+
+            let resource_type_str: String = row.get("resource_type");
+            let resource_type = resource_type_str
+                .parse::<AuditResourceType>()
+                .unwrap_or(AuditResourceType::Baseline);
+
+            let metadata_json: serde_json::Value = row.get("metadata");
+
+            events.push(AuditEvent {
+                id: row.get("id"),
+                timestamp: row.get("timestamp"),
+                actor: row.get("actor"),
+                action,
+                resource_type,
+                resource_id: row.get("resource_id"),
+                project: row.get("project"),
+                metadata: metadata_json,
+            });
+        }
+
+        // Total count
+        let count_sql = "SELECT COUNT(*) FROM audit_events WHERE TRUE";
+        let total: i64 = sqlx::query_scalar(count_sql)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+
+        Ok(ListAuditEventsResponse {
+            events,
+            pagination: PaginationInfo {
+                total: total as u64,
+                offset: query.offset,
+                limit: query.limit,
+                has_more: (query.offset + query.limit as u64) < total as u64,
+            },
         })
     }
 }

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -5,10 +5,11 @@ use rusqlite::{OptionalExtension, params};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use super::{ArtifactStore, BaselineStore, StorageHealth};
+use super::{ArtifactStore, AuditStore, BaselineStore, StorageHealth};
 use crate::error::StoreError;
 use crate::models::{
-    BaselineRecord, BaselineSource, BaselineVersion, ListBaselinesQuery, ListBaselinesResponse,
+    AuditAction, AuditEvent, AuditResourceType, BaselineRecord, BaselineSource, BaselineVersion,
+    ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse,
     ListVerdictsQuery, ListVerdictsResponse, PaginationInfo, VerdictRecord,
 };
 use perfgate_types::{VerdictCounts, VerdictStatus};
@@ -139,6 +140,20 @@ impl SqliteStore {
             );
             CREATE INDEX IF NOT EXISTS idx_verdicts_project_benchmark ON verdicts(project, benchmark);
             CREATE INDEX IF NOT EXISTS idx_verdicts_created_at ON verdicts(created_at DESC);
+
+            CREATE TABLE IF NOT EXISTS audit_events (
+                id TEXT PRIMARY KEY,
+                timestamp TEXT NOT NULL,
+                actor TEXT NOT NULL,
+                action TEXT NOT NULL,
+                resource_type TEXT NOT NULL,
+                resource_id TEXT NOT NULL,
+                project TEXT NOT NULL,
+                metadata TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_events_project ON audit_events(project);
+            CREATE INDEX IF NOT EXISTS idx_audit_events_timestamp ON audit_events(timestamp DESC);
+            CREATE INDEX IF NOT EXISTS idx_audit_events_action ON audit_events(action);
             "#,
         )?;
         Ok(())
@@ -656,6 +671,157 @@ impl SqliteStore {
     }
 }
 
+#[async_trait]
+impl AuditStore for SqliteStore {
+    async fn log_event(&self, event: &AuditEvent) -> Result<(), StoreError> {
+        let metadata_json =
+            serde_json::to_string(&event.metadata).map_err(StoreError::SerializationError)?;
+
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| StoreError::LockError(e.to_string()))?;
+        conn.execute(
+            r#"
+            INSERT INTO audit_events (
+                id, timestamp, actor, action, resource_type, resource_id, project, metadata
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            "#,
+            params![
+                event.id,
+                event.timestamp.to_rfc3339(),
+                event.actor,
+                event.action.to_string(),
+                event.resource_type.to_string(),
+                event.resource_id,
+                event.project,
+                metadata_json,
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    async fn list_events(
+        &self,
+        query: &ListAuditEventsQuery,
+    ) -> Result<ListAuditEventsResponse, StoreError> {
+        let mut sql = "SELECT * FROM audit_events WHERE 1=1".to_string();
+        let mut params_vec: Vec<rusqlite::types::Value> = Vec::new();
+
+        if let Some(ref project) = query.project {
+            sql.push_str(" AND project = ?");
+            params_vec.push(project.clone().into());
+        }
+
+        if let Some(ref action) = query.action {
+            sql.push_str(" AND action = ?");
+            params_vec.push(action.clone().into());
+        }
+
+        if let Some(ref resource_type) = query.resource_type {
+            sql.push_str(" AND resource_type = ?");
+            params_vec.push(resource_type.clone().into());
+        }
+
+        if let Some(ref actor) = query.actor {
+            sql.push_str(" AND actor = ?");
+            params_vec.push(actor.clone().into());
+        }
+
+        if let Some(ref since) = query.since {
+            sql.push_str(" AND timestamp >= ?");
+            params_vec.push(since.to_rfc3339().into());
+        }
+
+        if let Some(ref until) = query.until {
+            sql.push_str(" AND timestamp <= ?");
+            params_vec.push(until.to_rfc3339().into());
+        }
+
+        // Count before pagination
+        let count_sql = format!("SELECT COUNT(*) FROM ({})", sql);
+
+        sql.push_str(" ORDER BY timestamp DESC LIMIT ? OFFSET ?");
+        params_vec.push((query.limit as i64).into());
+        params_vec.push((query.offset as i64).into());
+
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| StoreError::LockError(e.to_string()))?;
+
+        // Get total (without LIMIT/OFFSET params)
+        let count_params: Vec<rusqlite::types::Value> =
+            params_vec[..params_vec.len().saturating_sub(2)].to_vec();
+        let total: i64 = conn
+            .query_row(
+                &count_sql,
+                rusqlite::params_from_iter(count_params.iter()),
+                |row| row.get(0),
+            )
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(params_vec.iter()), |row| {
+                Self::row_to_audit_event(row)
+            })
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+
+        let mut events = Vec::new();
+        for row in rows {
+            events.push(row?);
+        }
+
+        Ok(ListAuditEventsResponse {
+            events,
+            pagination: PaginationInfo {
+                total: total as u64,
+                offset: query.offset,
+                limit: query.limit,
+                has_more: (query.offset + query.limit as u64) < total as u64,
+            },
+        })
+    }
+}
+
+impl SqliteStore {
+    fn row_to_audit_event(row: &rusqlite::Row) -> Result<AuditEvent, rusqlite::Error> {
+        let timestamp_str: String = row.get(1)?;
+        let timestamp = chrono::DateTime::parse_from_rfc3339(&timestamp_str)
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(|_| chrono::Utc::now());
+
+        let action_str: String = row.get(3)?;
+        let action = action_str
+            .parse::<AuditAction>()
+            .unwrap_or(AuditAction::Create);
+
+        let resource_type_str: String = row.get(4)?;
+        let resource_type = resource_type_str
+            .parse::<AuditResourceType>()
+            .unwrap_or(AuditResourceType::Baseline);
+
+        let metadata_json: String = row.get(7)?;
+        let metadata: serde_json::Value = serde_json::from_str(&metadata_json)
+            .unwrap_or(serde_json::Value::Object(Default::default()));
+
+        Ok(AuditEvent {
+            id: row.get(0)?,
+            timestamp,
+            actor: row.get(2)?,
+            action,
+            resource_type,
+            resource_id: row.get(5)?,
+            project: row.get(6)?,
+            metadata,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -766,5 +932,111 @@ mod tests {
             .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
             .unwrap();
         assert_eq!(busy_timeout, 5000);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_audit_log_event_and_list() {
+        use crate::models::{ListAuditEventsQuery, generate_ulid};
+
+        let store = SqliteStore::in_memory().unwrap();
+
+        let event = AuditEvent {
+            id: generate_ulid(),
+            timestamp: chrono::Utc::now(),
+            actor: "key-abc".to_string(),
+            action: AuditAction::Create,
+            resource_type: AuditResourceType::Baseline,
+            resource_id: "my-project/my-bench/v1".to_string(),
+            project: "my-project".to_string(),
+            metadata: serde_json::json!({"benchmark": "my-bench"}),
+        };
+
+        store.log_event(&event).await.unwrap();
+
+        // List all
+        let query = ListAuditEventsQuery::default();
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 1);
+        assert_eq!(result.events[0].actor, "key-abc");
+        assert_eq!(result.events[0].action, AuditAction::Create);
+        assert_eq!(result.events[0].resource_type, AuditResourceType::Baseline);
+
+        // Filter by project
+        let query = ListAuditEventsQuery {
+            project: Some("my-project".to_string()),
+            ..Default::default()
+        };
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 1);
+
+        // Filter by wrong project
+        let query = ListAuditEventsQuery {
+            project: Some("other-project".to_string()),
+            ..Default::default()
+        };
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 0);
+
+        // Filter by action
+        let query = ListAuditEventsQuery {
+            action: Some("create".to_string()),
+            ..Default::default()
+        };
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 1);
+
+        let query = ListAuditEventsQuery {
+            action: Some("delete".to_string()),
+            ..Default::default()
+        };
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_audit_log_multiple_events() {
+        use crate::models::{ListAuditEventsQuery, generate_ulid};
+
+        let store = SqliteStore::in_memory().unwrap();
+
+        for i in 0..5 {
+            let event = AuditEvent {
+                id: generate_ulid(),
+                timestamp: chrono::Utc::now(),
+                actor: format!("key-{}", i),
+                action: if i % 2 == 0 {
+                    AuditAction::Create
+                } else {
+                    AuditAction::Delete
+                },
+                resource_type: AuditResourceType::Baseline,
+                resource_id: format!("resource-{}", i),
+                project: "proj".to_string(),
+                metadata: serde_json::json!({}),
+            };
+            store.log_event(&event).await.unwrap();
+        }
+
+        let query = ListAuditEventsQuery::default();
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 5);
+        assert_eq!(result.pagination.total, 5);
+
+        // Pagination
+        let query = ListAuditEventsQuery {
+            limit: 2,
+            ..Default::default()
+        };
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 2);
+        assert!(result.pagination.has_more);
+
+        // Filter by action
+        let query = ListAuditEventsQuery {
+            action: Some("create".to_string()),
+            ..Default::default()
+        };
+        let result = store.list_events(&query).await.unwrap();
+        assert_eq!(result.events.len(), 3); // indices 0, 2, 4
     }
 }

--- a/crates/perfgate-server/src/testing.rs
+++ b/crates/perfgate-server/src/testing.rs
@@ -5,7 +5,7 @@
 use tokio::net::TcpListener;
 
 use crate::auth::AuthState;
-use crate::server::{ServerConfig, create_key_store, create_router, create_storage};
+use crate::server::{AppState, ServerConfig, create_key_store, create_router, create_storage};
 
 /// A running test server.
 pub struct TestServer {
@@ -19,14 +19,15 @@ pub struct TestServer {
 
 /// Spawns a real perfgate server on a random port for testing.
 pub async fn spawn_test_server(config: ServerConfig) -> TestServer {
-    let store = create_storage(&config)
+    let (store, audit) = create_storage(&config)
         .await
         .expect("failed to create storage");
     let key_store = create_key_store(&config)
         .await
         .expect("failed to create key store");
     let auth_state = AuthState::new(key_store, config.jwt.clone(), None);
-    let app = create_router(store, auth_state, &config, None);
+    let app_state = AppState { store, audit };
+    let app = create_router(app_state, auth_state, &config, None);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary
- Add `AuditEvent` type with actor, action, resource, timestamp, and metadata fields
- Add append-only `AuditStore` trait and `audit_events` table for SQLite/PostgreSQL
- Log all baseline mutations (upload/create, promote, delete) and verdict submissions
- Add `GET /api/v1/audit` endpoint with filtering by project, action, resource_type, actor, since, until
- Admin-only access via `Scope::Admin` check
- Introduce `AppState` struct to carry both `BaselineStore` and `AuditStore` through handlers

Closes #68

## Test plan
- [x] Audit events logged on baseline operations (tested via SQLite in-memory store)
- [x] Audit query endpoint returns filtered results (unit tests for SQLite store)
- [x] Pagination works correctly for audit event listing
- [x] Existing tests pass (all 42 tests green)
- [x] clippy clean (`-D warnings`)
- [x] cargo fmt check passes