### PR TITLE
feat(auth): add GitLab CI OIDC support

### DIFF
--- a/crates/perfgate-server/src/auth.rs
+++ b/crates/perfgate-server/src/auth.rs
@@ -19,7 +19,7 @@ use tokio::sync::RwLock;
 use tracing::warn;
 
 use crate::models::ApiError;
-use crate::oidc::OidcProvider;
+use crate::oidc::OidcRegistry;
 use crate::storage::KeyStore;
 
 /// JWT validation settings.
@@ -91,17 +91,13 @@ pub struct AuthState {
     /// Optional JWT validation settings.
     pub jwt: Option<JwtConfig>,
 
-    /// Optional OIDC provider.
-    pub oidc: Option<OidcProvider>,
+    /// OIDC provider registry (may contain zero or more providers).
+    pub oidc: OidcRegistry,
 }
 
 impl AuthState {
     /// Creates auth state from a key store and optional JWT/OIDC configuration.
-    pub fn new(
-        key_store: Arc<ApiKeyStore>,
-        jwt: Option<JwtConfig>,
-        oidc: Option<OidcProvider>,
-    ) -> Self {
+    pub fn new(key_store: Arc<ApiKeyStore>, jwt: Option<JwtConfig>, oidc: OidcRegistry) -> Self {
         Self {
             key_store,
             persistent_key_store: None,
@@ -293,9 +289,9 @@ async fn authenticate_jwt(
                 });
             }
             Err(e) => {
-                // If we don't have an OIDC provider, fail here.
+                // If we don't have OIDC providers, fail here.
                 // Otherwise, fall through to OIDC.
-                if auth_state.oidc.is_none() {
+                if !auth_state.oidc.has_providers() {
                     match &e {
                         AuthError::ExpiredToken => warn!("Expired JWT token"),
                         AuthError::InvalidToken(_) => warn!("Invalid JWT token"),
@@ -307,9 +303,9 @@ async fn authenticate_jwt(
         }
     }
 
-    // Try OIDC provider if available
-    if let Some(oidc) = &auth_state.oidc {
-        match oidc.validate_token(token).await {
+    // Try OIDC providers if any are configured
+    if auth_state.oidc.has_providers() {
+        match auth_state.oidc.validate_token(token).await {
             Ok(api_key) => {
                 return Ok(AuthContext {
                     api_key,
@@ -562,7 +558,7 @@ mod tests {
             )
             .await;
 
-        let response = auth_test_router(AuthState::new(store, None, None))
+        let response = auth_test_router(AuthState::new(store, None, Default::default()))
             .oneshot(
                 Request::builder()
                     .uri("/protected")
@@ -587,7 +583,7 @@ mod tests {
         let response = auth_test_router(AuthState::new(
             Arc::new(ApiKeyStore::new()),
             Some(test_jwt_config()),
-            None,
+            Default::default(),
         ))
         .oneshot(
             Request::builder()
@@ -610,16 +606,20 @@ mod tests {
         );
         let token = create_test_token(&claims);
 
-        let response = auth_test_router(AuthState::new(Arc::new(ApiKeyStore::new()), None, None))
-            .oneshot(
-                Request::builder()
-                    .uri("/protected")
-                    .header(header::AUTHORIZATION, format!("Token {}", token))
-                    .body(axum::body::Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        let response = auth_test_router(AuthState::new(
+            Arc::new(ApiKeyStore::new()),
+            None,
+            Default::default(),
+        ))
+        .oneshot(
+            Request::builder()
+                .uri("/protected")
+                .header(header::AUTHORIZATION, format!("Token {}", token))
+                .body(axum::body::Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }

--- a/crates/perfgate-server/src/bin/perfgate-server.rs
+++ b/crates/perfgate-server/src/bin/perfgate-server.rs
@@ -14,6 +14,19 @@
 //!
 //! # Add API keys
 //! perfgate-server --api-keys admin:pg_live_abc123...,viewer:pg_live_def456...
+//!
+//! # GitHub Actions OIDC
+//! perfgate-server --github-oidc EffortlessMetrics/perfgate:perfgate-oss:contributor
+//!
+//! # GitLab CI OIDC (gitlab.com)
+//! perfgate-server --gitlab-oidc mygroup/myproject:my-project:contributor
+//!
+//! # GitLab CI OIDC (self-managed)
+//! perfgate-server --gitlab-oidc mygroup/myproject:my-project:contributor \
+//!     --gitlab-oidc-issuer https://gitlab.example.com
+//!
+//! # Custom OIDC provider
+//! perfgate-server --oidc-provider issuer=https://auth.example.com,jwks_url=https://auth.example.com/.well-known/jwks.json,audience=perfgate,claim=team_slug,mapping=platform-team:my-project:contributor
 //! ```
 
 use clap::Parser;
@@ -24,7 +37,6 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use perfgate_server::{
     JwtConfig, OidcConfig, PostgresPoolConfig, Role, ServerConfig, StorageBackend, run_server,
 };
-use std::collections::HashMap;
 use std::time::Duration;
 
 /// perfgate baseline service server.
@@ -101,6 +113,26 @@ struct Args {
     #[arg(long, default_value = "perfgate")]
     github_oidc_audience: String,
 
+    /// GitLab CI OIDC mapping in format "group/project:project_id:role" (can be specified multiple times).
+    /// Example: --gitlab-oidc mygroup/myproject:my-project:contributor
+    #[arg(long = "gitlab-oidc")]
+    gitlab_oidc: Vec<String>,
+
+    /// Expected audience for GitLab OIDC tokens.
+    #[arg(long, default_value = "perfgate")]
+    gitlab_oidc_audience: String,
+
+    /// GitLab issuer URL for self-managed instances (default: https://gitlab.com).
+    #[arg(long, default_value = "https://gitlab.com")]
+    gitlab_oidc_issuer: String,
+
+    /// Custom OIDC provider in format
+    /// "issuer=URL,jwks_url=URL,audience=AUD,claim=FIELD,mapping=IDENTITY:PROJECT:ROLE".
+    /// The `mapping` key can be repeated by passing --oidc-provider multiple times with the same
+    /// issuer or by using semicolons: "...,mapping=id1:proj1:role1;id2:proj2:role2".
+    #[arg(long = "oidc-provider")]
+    oidc_provider: Vec<String>,
+
     /// Disable CORS
     #[arg(long)]
     no_cors: bool,
@@ -137,18 +169,7 @@ fn parse_api_key(s: &str) -> Result<ApiKeyConfigArg, String> {
         ));
     }
 
-    let role = match parts[0].to_lowercase().as_str() {
-        "admin" => Role::Admin,
-        "promoter" => Role::Promoter,
-        "contributor" => Role::Contributor,
-        "viewer" => Role::Viewer,
-        _ => {
-            return Err(format!(
-                "Unknown role '{}'. Expected: admin, promoter, contributor, viewer",
-                parts[0]
-            ));
-        }
-    };
+    let role = parse_role(parts[0])?;
 
     let key = parts[1].to_string();
     let project = parts.get(2).unwrap_or(&"default").to_string();
@@ -166,6 +187,36 @@ fn parse_api_key(s: &str) -> Result<ApiKeyConfigArg, String> {
         project,
         benchmark_regex,
     })
+}
+
+/// Parses a role string (case-insensitive).
+fn parse_role(s: &str) -> Result<Role, String> {
+    match s.to_lowercase().as_str() {
+        "admin" => Ok(Role::Admin),
+        "promoter" => Ok(Role::Promoter),
+        "contributor" => Ok(Role::Contributor),
+        "viewer" => Ok(Role::Viewer),
+        _ => Err(format!(
+            "Unknown role '{}'. Expected: admin, promoter, contributor, viewer",
+            s
+        )),
+    }
+}
+
+/// Parses an OIDC identity mapping "identity:project_id:role".
+fn parse_oidc_mapping(mapping: &str, flag_name: &str) -> Result<(String, String, Role), String> {
+    let parts: Vec<&str> = mapping.split(':').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "Invalid {} format '{}'. Expected 'identity:project_id:role'",
+            flag_name, mapping
+        ));
+    }
+    let identity = parts[0].to_string();
+    let project = parts[1].to_string();
+    let role = parse_role(parts[2])
+        .map_err(|e| format!("In {} mapping '{}': {}", flag_name, mapping, e))?;
+    Ok((identity, project, role))
 }
 
 /// Initializes the logging system.
@@ -242,35 +293,36 @@ async fn main() {
         config = config.scoped_api_key(cfg.key, cfg.role, cfg.project, cfg.benchmark_regex);
     }
 
+    // ----- GitHub OIDC -----
     if !args.github_oidc.is_empty() {
-        let mut repo_mappings = HashMap::new();
-        for mapping in args.github_oidc {
-            let parts: Vec<&str> = mapping.split(':').collect();
-            if parts.len() != 3 {
-                panic!(
-                    "Invalid github-oidc format '{}'. Expected 'org/repo:project_id:role'",
-                    mapping
-                );
-            }
-            let repo = parts[0].to_string();
-            let project = parts[1].to_string();
-            let role = match parts[2].to_lowercase().as_str() {
-                "admin" => Role::Admin,
-                "promoter" => Role::Promoter,
-                "contributor" => Role::Contributor,
-                "viewer" => Role::Viewer,
-                _ => panic!("Unknown role '{}' in github-oidc mapping", parts[2]),
-            };
-            repo_mappings.insert(repo, (project, role));
+        let mut oidc_config = OidcConfig::github(&args.github_oidc_audience);
+        for mapping in &args.github_oidc {
+            let (identity, project, role) =
+                parse_oidc_mapping(mapping, "--github-oidc").unwrap_or_else(|e| panic!("{}", e));
+            oidc_config = oidc_config.add_mapping(identity, project, role);
         }
-
-        let oidc_config = OidcConfig {
-            jwks_url: "https://token.actions.githubusercontent.com/.well-known/jwks".to_string(),
-            issuer: "https://token.actions.githubusercontent.com".to_string(),
-            audience: args.github_oidc_audience,
-            repo_mappings,
-        };
         config = config.oidc(oidc_config);
+    }
+
+    // ----- GitLab OIDC -----
+    if !args.gitlab_oidc.is_empty() {
+        let mut oidc_config = if args.gitlab_oidc_issuer == "https://gitlab.com" {
+            OidcConfig::gitlab(&args.gitlab_oidc_audience)
+        } else {
+            OidcConfig::gitlab_custom(&args.gitlab_oidc_issuer, &args.gitlab_oidc_audience)
+        };
+        for mapping in &args.gitlab_oidc {
+            let (identity, project, role) =
+                parse_oidc_mapping(mapping, "--gitlab-oidc").unwrap_or_else(|e| panic!("{}", e));
+            oidc_config = oidc_config.add_mapping(identity, project, role);
+        }
+        config = config.oidc(oidc_config);
+    }
+
+    // ----- Custom OIDC providers -----
+    for provider_spec in &args.oidc_provider {
+        config = config
+            .oidc(parse_custom_oidc_provider(provider_spec).unwrap_or_else(|e| panic!("{}", e)));
     }
 
     if let Some(secret) = args.jwt_secret {
@@ -295,6 +347,55 @@ async fn main() {
         eprintln!("Server error: {}", e);
         std::process::exit(1);
     }
+}
+
+/// Parses a custom OIDC provider specification from the CLI.
+///
+/// Format: `issuer=URL,jwks_url=URL,audience=AUD,claim=FIELD,mapping=ID:PROJ:ROLE[;ID2:PROJ2:ROLE2]`
+fn parse_custom_oidc_provider(spec: &str) -> Result<OidcConfig, String> {
+    let mut issuer = None;
+    let mut jwks_url = None;
+    let mut audience = None;
+    let mut claim = None;
+    let mut mappings: Vec<(String, String, Role)> = Vec::new();
+
+    for part in spec.split(',') {
+        if let Some(val) = part.strip_prefix("issuer=") {
+            issuer = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("jwks_url=") {
+            jwks_url = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("audience=") {
+            audience = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("claim=") {
+            claim = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("mapping=") {
+            // Support semicolon-separated multiple mappings
+            for m in val.split(';') {
+                mappings.push(parse_oidc_mapping(m, "--oidc-provider mapping")?);
+            }
+        } else {
+            return Err(format!(
+                "Unknown key in --oidc-provider: '{}'. Expected issuer=, jwks_url=, audience=, claim=, mapping=",
+                part
+            ));
+        }
+    }
+
+    let issuer = issuer.ok_or("Missing 'issuer=' in --oidc-provider")?;
+    let jwks_url = jwks_url.ok_or("Missing 'jwks_url=' in --oidc-provider")?;
+    let audience = audience.ok_or("Missing 'audience=' in --oidc-provider")?;
+    let claim = claim.ok_or("Missing 'claim=' in --oidc-provider")?;
+
+    if mappings.is_empty() {
+        return Err("Missing 'mapping=' in --oidc-provider".to_string());
+    }
+
+    let mut config = OidcConfig::custom(issuer, jwks_url, audience, claim);
+    for (identity, project, role) in mappings {
+        config = config.add_mapping(identity, project, role);
+    }
+
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -437,5 +538,117 @@ mod tests {
         assert_eq!(args.jwt_secret, Some("super-secret".to_string()));
         assert_eq!(args.jwt_issuer, Some("perfgate".to_string()));
         assert_eq!(args.jwt_audience, Some("perfgate-api".to_string()));
+    }
+
+    #[test]
+    fn test_cli_args_gitlab_oidc() {
+        let args = Args::try_parse_from([
+            "perfgate-server",
+            "--gitlab-oidc",
+            "mygroup/myproject:my-project:contributor",
+        ])
+        .unwrap();
+
+        assert_eq!(args.gitlab_oidc.len(), 1);
+        assert_eq!(
+            args.gitlab_oidc[0],
+            "mygroup/myproject:my-project:contributor"
+        );
+        assert_eq!(args.gitlab_oidc_issuer, "https://gitlab.com");
+        assert_eq!(args.gitlab_oidc_audience, "perfgate");
+    }
+
+    #[test]
+    fn test_cli_args_gitlab_oidc_self_managed() {
+        let args = Args::try_parse_from([
+            "perfgate-server",
+            "--gitlab-oidc",
+            "team/repo:internal:admin",
+            "--gitlab-oidc-issuer",
+            "https://gitlab.example.com",
+            "--gitlab-oidc-audience",
+            "my-service",
+        ])
+        .unwrap();
+
+        assert_eq!(args.gitlab_oidc.len(), 1);
+        assert_eq!(args.gitlab_oidc_issuer, "https://gitlab.example.com");
+        assert_eq!(args.gitlab_oidc_audience, "my-service");
+    }
+
+    #[test]
+    fn test_cli_args_oidc_provider() {
+        let args = Args::try_parse_from([
+            "perfgate-server",
+            "--oidc-provider",
+            "issuer=https://auth.example.com,jwks_url=https://auth.example.com/jwks,audience=perfgate,claim=org_id,mapping=my-org:proj:contributor",
+        ])
+        .unwrap();
+
+        assert_eq!(args.oidc_provider.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_oidc_mapping_valid() {
+        let (identity, project, role) =
+            parse_oidc_mapping("org/repo:my-proj:contributor", "--github-oidc").unwrap();
+        assert_eq!(identity, "org/repo");
+        assert_eq!(project, "my-proj");
+        assert_eq!(role, Role::Contributor);
+    }
+
+    #[test]
+    fn test_parse_oidc_mapping_invalid() {
+        assert!(parse_oidc_mapping("bad-format", "--test").is_err());
+        assert!(parse_oidc_mapping("a:b:badrole", "--test").is_err());
+        assert!(parse_oidc_mapping("a:b:c:d", "--test").is_err());
+    }
+
+    #[test]
+    fn test_parse_custom_oidc_provider_valid() {
+        let config = parse_custom_oidc_provider(
+            "issuer=https://auth.example.com,jwks_url=https://auth.example.com/jwks,audience=perfgate,claim=team_slug,mapping=platform:proj:contributor",
+        ).unwrap();
+
+        assert_eq!(config.issuer, "https://auth.example.com");
+        assert_eq!(config.jwks_url, "https://auth.example.com/jwks");
+        assert_eq!(config.audience, "perfgate");
+        assert_eq!(config.repo_mappings.len(), 1);
+        assert!(config.repo_mappings.contains_key("platform"));
+    }
+
+    #[test]
+    fn test_parse_custom_oidc_provider_multiple_mappings() {
+        let config = parse_custom_oidc_provider(
+            "issuer=https://auth.example.com,jwks_url=https://auth.example.com/jwks,audience=perfgate,claim=team,mapping=team-a:proj-a:viewer;team-b:proj-b:admin",
+        ).unwrap();
+
+        assert_eq!(config.repo_mappings.len(), 2);
+        assert!(config.repo_mappings.contains_key("team-a"));
+        assert!(config.repo_mappings.contains_key("team-b"));
+    }
+
+    #[test]
+    fn test_parse_custom_oidc_provider_missing_fields() {
+        // Missing issuer
+        assert!(
+            parse_custom_oidc_provider("jwks_url=u,audience=a,claim=c,mapping=i:p:admin").is_err()
+        );
+        // Missing claim
+        assert!(
+            parse_custom_oidc_provider("issuer=i,jwks_url=u,audience=a,mapping=i:p:admin").is_err()
+        );
+        // Missing mapping
+        assert!(parse_custom_oidc_provider("issuer=i,jwks_url=u,audience=a,claim=c").is_err());
+    }
+
+    #[test]
+    fn test_parse_custom_oidc_provider_unknown_key() {
+        assert!(
+            parse_custom_oidc_provider(
+                "issuer=i,jwks_url=u,audience=a,claim=c,mapping=i:p:admin,unknown=val"
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -59,7 +59,7 @@ pub mod testing;
 pub use auth::{ApiKey, ApiKeyStore, AuthContext, AuthState, JwtClaims, JwtConfig, Role, Scope};
 pub use error::{AuthError, ConfigError, StoreError};
 pub use models::*;
-pub use oidc::{OidcConfig, OidcProvider};
+pub use oidc::{OidcConfig, OidcProvider, OidcProviderType, OidcRegistry};
 pub use server::{AppState, PostgresPoolConfig, ServerConfig, StorageBackend, run_server};
 pub use storage::{
     AuditStore, BaselineStore, InMemoryKeyStore, InMemoryStore, KeyRecord, KeyStore,

--- a/crates/perfgate-server/src/oidc.rs
+++ b/crates/perfgate-server/src/oidc.rs
@@ -1,4 +1,9 @@
 //! OIDC authentication support for perfgate-server.
+//!
+//! Supports multiple OIDC providers:
+//! - **GitHub Actions**: Maps `repository` claim to project/role.
+//! - **GitLab CI**: Maps `project_path` claim to project/role.
+//! - **Custom providers**: Configurable issuer, JWKS URL, and claim field.
 
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header, jwk::JwkSet};
 use perfgate_auth::{ApiKey, Role};
@@ -10,24 +15,119 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
-/// OIDC configuration.
+// ---------------------------------------------------------------------------
+// Provider types
+// ---------------------------------------------------------------------------
+
+/// Identifies which OIDC provider issued the token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OidcProviderType {
+    /// GitHub Actions (`https://token.actions.githubusercontent.com`)
+    GitHub,
+    /// GitLab CI (`https://gitlab.com` or a self-managed instance)
+    GitLab,
+    /// A custom OIDC provider with a user-specified claim field.
+    Custom {
+        /// The JWT claim field that identifies the subject for mapping
+        /// (e.g. `"project_path"`, `"repository"`, `"sub"`).
+        claim_field: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// OIDC configuration for a single provider instance.
 #[derive(Debug, Clone)]
 pub struct OidcConfig {
-    /// URL to fetch JWKS from (e.g. `https://token.actions.githubusercontent.com/.well-known/jwks.json`)
+    /// URL to fetch JWKS from
+    /// (e.g. `https://token.actions.githubusercontent.com/.well-known/jwks`)
     pub jwks_url: String,
 
-    /// Expected issuer (e.g. `https://token.actions.githubusercontent.com`)
+    /// Expected issuer
+    /// (e.g. `https://token.actions.githubusercontent.com`)
     pub issuer: String,
 
     /// Expected audience
     pub audience: String,
 
-    /// Mapping from GitHub repository to project ID and Role.
-    /// E.g. "org/repo" -> ("project-id", Role::Contributor)
+    /// Mapping from the identity claim value to (project_id, Role).
+    ///
+    /// For GitHub the key is `org/repo`, for GitLab it is `group/project`,
+    /// for custom providers it is whatever the configured claim field yields.
     pub repo_mappings: HashMap<String, (String, Role)>,
+
+    /// The provider type driving claim extraction.
+    pub provider_type: OidcProviderType,
 }
 
-/// A provider that periodically fetches JWKS and validates tokens.
+impl OidcConfig {
+    /// Creates a GitHub Actions OIDC configuration.
+    pub fn github(audience: impl Into<String>) -> Self {
+        Self {
+            jwks_url: "https://token.actions.githubusercontent.com/.well-known/jwks".to_string(),
+            issuer: "https://token.actions.githubusercontent.com".to_string(),
+            audience: audience.into(),
+            repo_mappings: HashMap::new(),
+            provider_type: OidcProviderType::GitHub,
+        }
+    }
+
+    /// Creates a GitLab CI OIDC configuration for `gitlab.com`.
+    pub fn gitlab(audience: impl Into<String>) -> Self {
+        Self::gitlab_custom("https://gitlab.com", audience)
+    }
+
+    /// Creates a GitLab CI OIDC configuration for a self-managed instance.
+    pub fn gitlab_custom(issuer: impl Into<String>, audience: impl Into<String>) -> Self {
+        let issuer = issuer.into();
+        let jwks_url = format!("{}/-/jwks", issuer.trim_end_matches('/'));
+        Self {
+            jwks_url,
+            issuer,
+            audience: audience.into(),
+            repo_mappings: HashMap::new(),
+            provider_type: OidcProviderType::GitLab,
+        }
+    }
+
+    /// Creates a custom provider OIDC configuration.
+    pub fn custom(
+        issuer: impl Into<String>,
+        jwks_url: impl Into<String>,
+        audience: impl Into<String>,
+        claim_field: impl Into<String>,
+    ) -> Self {
+        Self {
+            jwks_url: jwks_url.into(),
+            issuer: issuer.into(),
+            audience: audience.into(),
+            repo_mappings: HashMap::new(),
+            provider_type: OidcProviderType::Custom {
+                claim_field: claim_field.into(),
+            },
+        }
+    }
+
+    /// Adds a mapping entry.
+    pub fn add_mapping(
+        mut self,
+        identity: impl Into<String>,
+        project_id: impl Into<String>,
+        role: Role,
+    ) -> Self {
+        self.repo_mappings
+            .insert(identity.into(), (project_id.into(), role));
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Provider runtime
+// ---------------------------------------------------------------------------
+
+/// A provider that fetches JWKS and validates tokens from a single issuer.
 #[derive(Clone)]
 pub struct OidcProvider {
     config: OidcConfig,
@@ -40,11 +140,57 @@ pub struct OidcProvider {
 #[derive(Debug, Deserialize)]
 struct GithubClaims {
     iss: String,
-    aud: String,
+    aud: StringOrVec,
     sub: String,
     repository: String,
     exp: u64,
     iat: Option<u64>,
+}
+
+/// GitLab CI OIDC claims.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct GitLabClaims {
+    iss: String,
+    aud: StringOrVec,
+    sub: String,
+    /// Full path of the project (e.g. `mygroup/myproject`).
+    project_path: String,
+    /// Namespace path (e.g. `mygroup`).
+    #[serde(default)]
+    namespace_path: Option<String>,
+    /// Git ref (e.g. `main`).
+    #[serde(rename = "ref")]
+    #[serde(default)]
+    git_ref: Option<String>,
+    /// Pipeline source (e.g. `push`, `web`, `schedule`).
+    #[serde(default)]
+    pipeline_source: Option<String>,
+    exp: u64,
+    iat: Option<u64>,
+}
+
+/// Generic claims used by custom providers.
+/// We deserialize the full payload as a map and then extract the configured claim.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct GenericClaims {
+    iss: String,
+    sub: String,
+    exp: u64,
+    iat: Option<u64>,
+    /// All remaining fields captured for claim extraction.
+    #[serde(flatten)]
+    extra: HashMap<String, serde_json::Value>,
+}
+
+/// Helper: some OIDC providers encode `aud` as a string, others as an array.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum StringOrVec {
+    Single(String),
+    Multiple(Vec<String>),
 }
 
 impl OidcProvider {
@@ -70,6 +216,26 @@ impl OidcProvider {
         }
 
         Ok(provider)
+    }
+
+    /// Creates a provider with pre-loaded JWKS (for testing).
+    #[cfg(test)]
+    pub(crate) fn with_jwks(config: OidcConfig, jwks: JwkSet) -> Self {
+        Self {
+            config,
+            jwks: Arc::new(RwLock::new(Some(jwks))),
+            client: Client::new(),
+        }
+    }
+
+    /// Returns the issuer URL for this provider.
+    pub fn issuer(&self) -> &str {
+        &self.config.issuer
+    }
+
+    /// Returns the provider type.
+    pub fn provider_type(&self) -> &OidcProviderType {
+        &self.config.provider_type
     }
 
     /// Refreshes the JWKS from the configured URL.
@@ -101,7 +267,7 @@ impl OidcProvider {
         Ok(())
     }
 
-    /// Validates an OIDC token and returns the corresponding mapped ApiKey.
+    /// Validates an OIDC token and returns the corresponding mapped [`ApiKey`].
     pub async fn validate_token(&self, token: &str) -> Result<ApiKey, AuthError> {
         let header = decode_header(token).map_err(|e| AuthError::InvalidToken(e.to_string()))?;
 
@@ -109,7 +275,7 @@ impl OidcProvider {
             .kid
             .ok_or_else(|| AuthError::InvalidToken("Missing 'kid' in token header".to_string()))?;
 
-        // Extract decoding key
+        // Extract decoding key from JWKS cache
         let decoding_key = {
             let cache = self.jwks.read().await;
             let jwks = cache
@@ -137,17 +303,30 @@ impl OidcProvider {
         validation.set_issuer(&[&self.config.issuer]);
         validation.set_audience(&[&self.config.audience]);
 
+        match &self.config.provider_type {
+            OidcProviderType::GitHub => self.validate_github(token, &decoding_key, &validation),
+            OidcProviderType::GitLab => self.validate_gitlab(token, &decoding_key, &validation),
+            OidcProviderType::Custom { claim_field } => {
+                let field = claim_field.clone();
+                self.validate_custom(token, &decoding_key, &validation, &field)
+            }
+        }
+    }
+
+    fn validate_github(
+        &self,
+        token: &str,
+        key: &DecodingKey,
+        validation: &Validation,
+    ) -> Result<ApiKey, AuthError> {
         let token_data =
-            decode::<GithubClaims>(token, &decoding_key, &validation).map_err(|e| {
-                match e.kind() {
-                    jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::ExpiredToken,
-                    _ => AuthError::InvalidToken(e.to_string()),
-                }
+            decode::<GithubClaims>(token, key, validation).map_err(|e| match e.kind() {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::ExpiredToken,
+                _ => AuthError::InvalidToken(e.to_string()),
             })?;
 
         let claims = token_data.claims;
 
-        // Map repository to project and role
         let (project_id, role) = self
             .config
             .repo_mappings
@@ -159,24 +338,686 @@ impl OidcProvider {
                 ))
             })?;
 
-        let expires_at = chrono::DateTime::<chrono::Utc>::from_timestamp(claims.exp as i64, 0)
-            .unwrap_or_else(chrono::Utc::now);
+        Ok(build_api_key(
+            &claims.sub,
+            &format!("GitHub Actions ({})", claims.repository),
+            project_id,
+            *role,
+            claims.exp,
+            claims.iat,
+        ))
+    }
 
-        let created_at = claims
-            .iat
-            .and_then(|iat| chrono::DateTime::<chrono::Utc>::from_timestamp(iat as i64, 0))
-            .unwrap_or_else(chrono::Utc::now);
+    fn validate_gitlab(
+        &self,
+        token: &str,
+        key: &DecodingKey,
+        validation: &Validation,
+    ) -> Result<ApiKey, AuthError> {
+        let token_data =
+            decode::<GitLabClaims>(token, key, validation).map_err(|e| match e.kind() {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::ExpiredToken,
+                _ => AuthError::InvalidToken(e.to_string()),
+            })?;
 
-        Ok(ApiKey {
-            id: format!("oidc:{}", claims.sub),
-            name: format!("GitHub Actions ({})", claims.repository),
-            project_id: project_id.clone(),
-            scopes: role.allowed_scopes(),
-            role: *role,
-            benchmark_regex: None,
-            expires_at: Some(expires_at),
-            created_at,
-            last_used_at: None,
-        })
+        let claims = token_data.claims;
+
+        let (project_id, role) = self
+            .config
+            .repo_mappings
+            .get(&claims.project_path)
+            .ok_or_else(|| {
+                AuthError::InvalidToken(format!(
+                    "Project '{}' is not authorized",
+                    claims.project_path
+                ))
+            })?;
+
+        Ok(build_api_key(
+            &claims.sub,
+            &format!("GitLab CI ({})", claims.project_path),
+            project_id,
+            *role,
+            claims.exp,
+            claims.iat,
+        ))
+    }
+
+    fn validate_custom(
+        &self,
+        token: &str,
+        key: &DecodingKey,
+        validation: &Validation,
+        claim_field: &str,
+    ) -> Result<ApiKey, AuthError> {
+        let token_data =
+            decode::<GenericClaims>(token, key, validation).map_err(|e| match e.kind() {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::ExpiredToken,
+                _ => AuthError::InvalidToken(e.to_string()),
+            })?;
+
+        let claims = token_data.claims;
+
+        // Extract the mapping key from the configured claim field.
+        // First check `sub` (standard claim), then look in `extra`.
+        let identity = if claim_field == "sub" {
+            claims.sub.clone()
+        } else {
+            claims
+                .extra
+                .get(claim_field)
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    AuthError::InvalidToken(format!("Claim '{}' not found in token", claim_field))
+                })?
+        };
+
+        let (project_id, role) = self.config.repo_mappings.get(&identity).ok_or_else(|| {
+            AuthError::InvalidToken(format!(
+                "Identity '{}' (from claim '{}') is not authorized",
+                identity, claim_field
+            ))
+        })?;
+
+        let provider_name = self
+            .config
+            .issuer
+            .split("//")
+            .nth(1)
+            .unwrap_or(&self.config.issuer);
+
+        Ok(build_api_key(
+            &claims.sub,
+            &format!("OIDC {} ({})", provider_name, identity),
+            project_id,
+            *role,
+            claims.exp,
+            claims.iat,
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-provider registry
+// ---------------------------------------------------------------------------
+
+/// A registry of multiple [`OidcProvider`]s that tries each one in turn.
+#[derive(Clone, Default)]
+pub struct OidcRegistry {
+    providers: Vec<OidcProvider>,
+}
+
+impl OidcRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self {
+            providers: Vec::new(),
+        }
+    }
+
+    /// Adds a provider to the registry.
+    pub fn add(&mut self, provider: OidcProvider) {
+        self.providers.push(provider);
+    }
+
+    /// Returns `true` when at least one provider is registered.
+    pub fn has_providers(&self) -> bool {
+        !self.providers.is_empty()
+    }
+
+    /// Validates a token against all registered providers, returning the first
+    /// successful result. If no provider succeeds, returns the last error.
+    pub async fn validate_token(&self, token: &str) -> Result<ApiKey, AuthError> {
+        let mut last_err = AuthError::InvalidToken("No OIDC providers configured".to_string());
+
+        for provider in &self.providers {
+            match provider.validate_token(token).await {
+                Ok(api_key) => return Ok(api_key),
+                Err(e) => {
+                    debug!(
+                        issuer = %provider.issuer(),
+                        error = %e,
+                        "OIDC provider did not accept token"
+                    );
+                    last_err = e;
+                }
+            }
+        }
+
+        Err(last_err)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_api_key(
+    sub: &str,
+    name: &str,
+    project_id: &str,
+    role: Role,
+    exp: u64,
+    iat: Option<u64>,
+) -> ApiKey {
+    let expires_at = chrono::DateTime::<chrono::Utc>::from_timestamp(exp as i64, 0)
+        .unwrap_or_else(chrono::Utc::now);
+
+    let created_at = iat
+        .and_then(|iat| chrono::DateTime::<chrono::Utc>::from_timestamp(iat as i64, 0))
+        .unwrap_or_else(chrono::Utc::now);
+
+    ApiKey {
+        id: format!("oidc:{}", sub),
+        name: name.to_string(),
+        project_id: project_id.to_string(),
+        scopes: role.allowed_scopes(),
+        role,
+        benchmark_regex: None,
+        expires_at: Some(expires_at),
+        created_at,
+        last_used_at: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::jwk::{
+        AlgorithmParameters, CommonParameters, Jwk, KeyAlgorithm, PublicKeyUse, RSAKeyParameters,
+    };
+    use jsonwebtoken::{EncodingKey, Header, encode};
+
+    // A pre-generated 2048-bit RSA PKCS#8 private key for tests.
+    const TEST_RSA_PRIVATE_PEM: &[u8] = b"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDZybnf96nsNBgF
+xV6bk/KoV1uJopbXHX4VYeYgp7llS8WpvkKjFzyoWowsmkhdlh934lI1cHEJPtdl
+UlczdEgkhyro8aKRO1f6cdg8csH9Vj+Zyf1gavGDpHXLOfsjykLDpDfpb2GZ+6pr
+uGuattFYF/vWDrwUx4lWRwCfRrCL4gW3A2i+uhUT/weJ5bvzOe/mXlF1VAw6+Bxb
+FjjsBoupkMk9JXEQRl5/yMksrVIN2E8Wd7K7mcscUuXV42gBiQ2EJGC3Xz7jqzlx
+LAb4EI+EeUXhEo5EA2mS897jzGU3QDxMOw8RdGgQLqpVx2zUozsYvYdcunf5yZhp
+Hrg+XtBNAgMBAAECggEAAbTiU7cNBEZcl0hwvRLPn+DNLrxIPiCPIHXEYiZllWxB
+lCwdOWFlgaYJFYXYVmnyGhcGvJ1flWGZf8PYxuZZ6UddgkJUpskNcSmYfKL02DGh
+pFFRsw39qNv3JQ+I+oiLe2L7Z7mCtdO7HVI/0ISjfmd/hrHKUYHpUMYIYx/alza7
+fFfBLxgjqwIM5wYL8WOrM7E6axsA7eFjj5Uad2nhgpRImTG0oLR49R0ldN8lYKZ6
+4cbD27JS7vw716PgHGT2S+JTh3+6dFyty/DkL6S3+pUVPbQUbhCQLQMVzf5QhI0J
+fDbdWXzF3fgBk9+uXHLIv9Spa9h+1/dv/2v8UMcMdQKBgQD9PivmY/Tcu8Sz3Rij
+blJ8b41jcmzlgx3bLh55b//3iY/GBMT67rRqOGFEEoC+EGrfQ72voWYr+XFb/qf7
+DoX6jfncGL1LSCDaS5BCc9Ekf9VX0Q56otF/12mpu8g5aYBDhJSd8JUcFtck+Dxz
+1Y6dTwtGG0720NTRE7Xy/N+wSwKBgQDcKLx2vOdIFkuAaXv+YUvxZ0jJDAcscNEm
+/wwGpcV+u3TBlqrfEEymfkca9YdoFoOO9u4g32EIe1k3ya/VxUuZxJhjiMBtpgh1
+CymYHEp7i4U/Sa5zRMulmuq8NZj3ZJANi8rSqHJ+UJiv+ofRu2Tdve9xuBpzMskz
+ZV6RqpaSxwKBgDc71itb5c43DgIE2RjcORV25ymnjWTJojtp5a+q4/NDh54y8Bui
+8KqyPVSxjG7n+cdUaQzjcPtqXnUoJ880LbimOrbslmzTAIdcL8yuohEJ6KhMqpHI
+7VSq0Rr6IAOVpSoUwq1oCb2kpawkkFrbW02oLddOoXxns+MeH3MuAEPdAoGAVlIi
+kuu+QyV6tP6m/zZm8F/uyeVNar9RQlj9/h1BMk+Nl9nbZVqesykP+CIM1WL+ci+f
+boQnJ4w1jwolR0v0OHY8ycn0qQlQh5O420s8aPRrakUZgViYAHadUu4w688iLC2D
+eNVTDvPK6jTwy+sNwWOXXp8wv7pJ6Tz1t2eLYkECgYB4tKuGpV4i2f2Ve5BNfAwQ
+Pct5tSWlUCbHRgaZ3hno6pR/WVs4HP6LmaA1pdwLL+3qG84OP3ARUzELEGRnNVT5
++/xobF/tDl7gdKvRSFhOF08mxg7evm5yRt+GGkX1+SA3St3queXDAVG6NtrKju5j
+ggQxRhTX+ObL3zkIJahzUA==
+-----END PRIVATE KEY-----";
+
+    // The corresponding public key modulus (base64url, no padding).
+    const TEST_RSA_N: &str = "2cm53_ep7DQYBcVem5PyqFdbiaKW1x1-FWHmIKe5ZUvFqb5Coxc8qFqMLJpIXZYfd-JSNXBxCT7XZVJXM3RIJIcq6PGikTtX-nHYPHLB_VY_mcn9YGrxg6R1yzn7I8pCw6Q36W9hmfuqa7hrmrbRWBf71g68FMeJVkcAn0awi-IFtwNovroVE_8HieW78znv5l5RdVQMOvgcWxY47AaLqZDJPSVxEEZef8jJLK1SDdhPFneyu5nLHFLl1eNoAYkNhCRgt18-46s5cSwG-BCPhHlF4RKORANpkvPe48xlN0A8TDsPEXRoEC6qVcds1KM7GL2HXLp3-cmYaR64Pl7QTQ";
+
+    // Public exponent (65537 in base64url).
+    const TEST_RSA_E: &str = "AQAB";
+
+    /// Helper: return (encoding_key, jwk_set) for test token signing and verification.
+    fn test_rsa_keys(kid: &str) -> (EncodingKey, JwkSet) {
+        let encoding_key = EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_PEM).unwrap();
+
+        let jwk = Jwk {
+            common: CommonParameters {
+                public_key_use: Some(PublicKeyUse::Signature),
+                key_operations: None,
+                key_algorithm: Some(KeyAlgorithm::RS256),
+                key_id: Some(kid.to_string()),
+                x509_url: None,
+                x509_chain: None,
+                x509_sha1_fingerprint: None,
+                x509_sha256_fingerprint: None,
+            },
+            algorithm: AlgorithmParameters::RSA(RSAKeyParameters {
+                key_type: Default::default(),
+                n: TEST_RSA_N.to_string(),
+                e: TEST_RSA_E.to_string(),
+            }),
+        };
+
+        let jwks = JwkSet { keys: vec![jwk] };
+
+        (encoding_key, jwks)
+    }
+
+    fn encode_github_token(encoding_key: &EncodingKey, kid: &str, repo: &str) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+
+        let now = chrono::Utc::now().timestamp() as u64;
+        let claims = serde_json::json!({
+            "iss": "https://token.actions.githubusercontent.com",
+            "aud": "perfgate",
+            "sub": "repo:org/repo:ref:refs/heads/main",
+            "repository": repo,
+            "exp": now + 300,
+            "iat": now,
+        });
+
+        encode(&header, &claims, encoding_key).unwrap()
+    }
+
+    fn encode_gitlab_token(
+        encoding_key: &EncodingKey,
+        kid: &str,
+        project_path: &str,
+        issuer: &str,
+    ) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+
+        let now = chrono::Utc::now().timestamp() as u64;
+        let claims = serde_json::json!({
+            "iss": issuer,
+            "aud": "perfgate",
+            "sub": format!("project_path:{}:ref_type:branch:ref:main", project_path),
+            "project_path": project_path,
+            "namespace_path": project_path.split('/').next().unwrap_or(""),
+            "ref": "main",
+            "pipeline_source": "push",
+            "exp": now + 300,
+            "iat": now,
+        });
+
+        encode(&header, &claims, encoding_key).unwrap()
+    }
+
+    fn encode_custom_token(
+        encoding_key: &EncodingKey,
+        kid: &str,
+        issuer: &str,
+        claim_field: &str,
+        claim_value: &str,
+    ) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+
+        let now = chrono::Utc::now().timestamp() as u64;
+        let claims = serde_json::json!({
+            "iss": issuer,
+            "aud": "perfgate",
+            "sub": format!("custom:{}", claim_value),
+            claim_field: claim_value,
+            "exp": now + 300,
+            "iat": now,
+        });
+
+        encode(&header, &claims, encoding_key).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // GitHub provider tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_github_oidc_valid_token() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::github("perfgate").add_mapping(
+            "EffortlessMetrics/perfgate",
+            "perfgate-oss",
+            Role::Contributor,
+        );
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_github_token(&enc, kid, "EffortlessMetrics/perfgate");
+
+        let api_key = provider.validate_token(&token).await.unwrap();
+        assert_eq!(api_key.project_id, "perfgate-oss");
+        assert_eq!(api_key.role, Role::Contributor);
+        assert!(api_key.id.starts_with("oidc:"));
+        assert!(api_key.name.contains("GitHub Actions"));
+        assert!(api_key.name.contains("EffortlessMetrics/perfgate"));
+    }
+
+    #[tokio::test]
+    async fn test_github_oidc_unauthorized_repo() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::github("perfgate").add_mapping(
+            "EffortlessMetrics/perfgate",
+            "perfgate-oss",
+            Role::Contributor,
+        );
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_github_token(&enc, kid, "evil-org/evil-repo");
+
+        let err = provider.validate_token(&token).await.unwrap_err();
+        match err {
+            AuthError::InvalidToken(msg) => {
+                assert!(msg.contains("not authorized"), "got: {}", msg);
+            }
+            other => panic!("Expected InvalidToken, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_github_oidc_unknown_kid() {
+        let kid = "test-key-1";
+        let (enc, _jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::github("perfgate").add_mapping("org/repo", "proj", Role::Viewer);
+
+        // Use a different kid to create the JWKS
+        let (_enc2, other_jwks) = test_rsa_keys("different-key");
+        let provider = OidcProvider::with_jwks(config, other_jwks);
+        let token = encode_github_token(&enc, kid, "org/repo");
+
+        let err = provider.validate_token(&token).await.unwrap_err();
+        match err {
+            AuthError::InvalidToken(msg) => {
+                assert!(msg.contains("not found in JWKS"), "got: {}", msg);
+            }
+            other => panic!("Expected InvalidToken, got: {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // GitLab provider tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_gitlab_oidc_valid_token() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::gitlab("perfgate").add_mapping(
+            "mygroup/myproject",
+            "myproject-prod",
+            Role::Promoter,
+        );
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_gitlab_token(&enc, kid, "mygroup/myproject", "https://gitlab.com");
+
+        let api_key = provider.validate_token(&token).await.unwrap();
+        assert_eq!(api_key.project_id, "myproject-prod");
+        assert_eq!(api_key.role, Role::Promoter);
+        assert!(api_key.id.starts_with("oidc:"));
+        assert!(api_key.name.contains("GitLab CI"));
+        assert!(api_key.name.contains("mygroup/myproject"));
+    }
+
+    #[tokio::test]
+    async fn test_gitlab_oidc_self_managed() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let issuer = "https://gitlab.example.com";
+        let config = OidcConfig::gitlab_custom(issuer, "perfgate").add_mapping(
+            "team/repo",
+            "internal-proj",
+            Role::Admin,
+        );
+
+        assert_eq!(config.jwks_url, "https://gitlab.example.com/-/jwks");
+        assert_eq!(config.issuer, issuer);
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_gitlab_token(&enc, kid, "team/repo", issuer);
+
+        let api_key = provider.validate_token(&token).await.unwrap();
+        assert_eq!(api_key.project_id, "internal-proj");
+        assert_eq!(api_key.role, Role::Admin);
+    }
+
+    #[tokio::test]
+    async fn test_gitlab_oidc_unauthorized_project() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config =
+            OidcConfig::gitlab("perfgate").add_mapping("mygroup/myproject", "proj", Role::Viewer);
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_gitlab_token(&enc, kid, "evil/project", "https://gitlab.com");
+
+        let err = provider.validate_token(&token).await.unwrap_err();
+        match err {
+            AuthError::InvalidToken(msg) => {
+                assert!(msg.contains("not authorized"), "got: {}", msg);
+            }
+            other => panic!("Expected InvalidToken, got: {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Custom provider tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_custom_oidc_valid_token() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::custom(
+            "https://auth.example.com",
+            "https://auth.example.com/.well-known/jwks.json",
+            "perfgate",
+            "team_slug",
+        )
+        .add_mapping("platform-team", "platform-proj", Role::Contributor);
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_custom_token(
+            &enc,
+            kid,
+            "https://auth.example.com",
+            "team_slug",
+            "platform-team",
+        );
+
+        let api_key = provider.validate_token(&token).await.unwrap();
+        assert_eq!(api_key.project_id, "platform-proj");
+        assert_eq!(api_key.role, Role::Contributor);
+        assert!(api_key.name.contains("auth.example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_custom_oidc_missing_claim() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::custom(
+            "https://auth.example.com",
+            "https://auth.example.com/.well-known/jwks.json",
+            "perfgate",
+            "nonexistent_claim",
+        )
+        .add_mapping("val", "proj", Role::Viewer);
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        // The token has "team_slug" but not "nonexistent_claim"
+        let token = encode_custom_token(&enc, kid, "https://auth.example.com", "team_slug", "val");
+
+        let err = provider.validate_token(&token).await.unwrap_err();
+        match err {
+            AuthError::InvalidToken(msg) => {
+                assert!(msg.contains("not found in token"), "got: {}", msg);
+            }
+            other => panic!("Expected InvalidToken, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_custom_oidc_sub_claim() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        let config = OidcConfig::custom(
+            "https://auth.example.com",
+            "https://auth.example.com/.well-known/jwks.json",
+            "perfgate",
+            "sub",
+        )
+        .add_mapping("custom:my-identity", "sub-proj", Role::Viewer);
+
+        let provider = OidcProvider::with_jwks(config, jwks);
+        let token = encode_custom_token(
+            &enc,
+            kid,
+            "https://auth.example.com",
+            "team_slug",
+            "my-identity",
+        );
+
+        let api_key = provider.validate_token(&token).await.unwrap();
+        assert_eq!(api_key.project_id, "sub-proj");
+        assert_eq!(api_key.role, Role::Viewer);
+    }
+
+    // -----------------------------------------------------------------------
+    // Registry tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_registry_tries_all_providers() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        // Provider 1: GitHub (won't match a GitLab token)
+        let github_config =
+            OidcConfig::github("perfgate").add_mapping("org/repo", "gh-proj", Role::Viewer);
+
+        // Provider 2: GitLab (will match)
+        let gitlab_config = OidcConfig::gitlab("perfgate").add_mapping(
+            "mygroup/myproject",
+            "gl-proj",
+            Role::Contributor,
+        );
+
+        let mut registry = OidcRegistry::new();
+        registry.add(OidcProvider::with_jwks(github_config, jwks.clone()));
+        registry.add(OidcProvider::with_jwks(gitlab_config, jwks));
+
+        // A GitLab-style token should be picked up by the second provider
+        let token = encode_gitlab_token(&enc, kid, "mygroup/myproject", "https://gitlab.com");
+
+        let api_key = registry.validate_token(&token).await.unwrap();
+        assert_eq!(api_key.project_id, "gl-proj");
+        assert_eq!(api_key.role, Role::Contributor);
+    }
+
+    #[tokio::test]
+    async fn test_registry_no_providers() {
+        let registry = OidcRegistry::new();
+        assert!(!registry.has_providers());
+
+        let err = registry.validate_token("some.jwt.token").await.unwrap_err();
+        match err {
+            AuthError::InvalidToken(msg) => {
+                assert!(msg.contains("No OIDC providers"), "got: {}", msg);
+            }
+            other => panic!("Expected InvalidToken, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_registry_returns_last_error_when_all_fail() {
+        let kid = "test-key-1";
+        let (enc, jwks) = test_rsa_keys(kid);
+
+        // Both providers will reject because the repo/project doesn't match
+        let github_config =
+            OidcConfig::github("perfgate").add_mapping("org/repo", "proj", Role::Viewer);
+        let gitlab_config =
+            OidcConfig::gitlab("perfgate").add_mapping("group/project", "proj", Role::Viewer);
+
+        let mut registry = OidcRegistry::new();
+        registry.add(OidcProvider::with_jwks(github_config, jwks.clone()));
+        registry.add(OidcProvider::with_jwks(gitlab_config, jwks));
+
+        let token = encode_github_token(&enc, kid, "unknown/repo");
+
+        let err = registry.validate_token(&token).await.unwrap_err();
+        assert!(matches!(err, AuthError::InvalidToken(_)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Config builder tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_github_config_defaults() {
+        let config = OidcConfig::github("perfgate");
+        assert_eq!(
+            config.jwks_url,
+            "https://token.actions.githubusercontent.com/.well-known/jwks"
+        );
+        assert_eq!(config.issuer, "https://token.actions.githubusercontent.com");
+        assert_eq!(config.audience, "perfgate");
+        assert_eq!(config.provider_type, OidcProviderType::GitHub);
+        assert!(config.repo_mappings.is_empty());
+    }
+
+    #[test]
+    fn test_gitlab_config_defaults() {
+        let config = OidcConfig::gitlab("perfgate");
+        assert_eq!(config.jwks_url, "https://gitlab.com/-/jwks");
+        assert_eq!(config.issuer, "https://gitlab.com");
+        assert_eq!(config.audience, "perfgate");
+        assert_eq!(config.provider_type, OidcProviderType::GitLab);
+    }
+
+    #[test]
+    fn test_gitlab_custom_config_trailing_slash() {
+        let config = OidcConfig::gitlab_custom("https://gitlab.example.com/", "perfgate");
+        assert_eq!(config.jwks_url, "https://gitlab.example.com/-/jwks");
+        assert_eq!(config.issuer, "https://gitlab.example.com/");
+    }
+
+    #[test]
+    fn test_custom_config() {
+        let config = OidcConfig::custom(
+            "https://auth.example.com",
+            "https://auth.example.com/jwks",
+            "my-audience",
+            "org_id",
+        );
+        assert_eq!(config.issuer, "https://auth.example.com");
+        assert_eq!(config.jwks_url, "https://auth.example.com/jwks");
+        assert_eq!(config.audience, "my-audience");
+        assert_eq!(
+            config.provider_type,
+            OidcProviderType::Custom {
+                claim_field: "org_id".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn test_config_add_mapping() {
+        let config = OidcConfig::github("aud")
+            .add_mapping("org/repo1", "proj1", Role::Viewer)
+            .add_mapping("org/repo2", "proj2", Role::Admin);
+
+        assert_eq!(config.repo_mappings.len(), 2);
+        assert_eq!(
+            config.repo_mappings.get("org/repo1"),
+            Some(&("proj1".to_string(), Role::Viewer))
+        );
+        assert_eq!(
+            config.repo_mappings.get("org/repo2"),
+            Some(&("proj2".to_string(), Role::Admin))
+        );
     }
 }

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -28,7 +28,7 @@ use crate::handlers::{
     static_asset, submit_verdict, upload_baseline,
 };
 use crate::metrics::{metrics_handler, metrics_middleware, setup_metrics_recorder};
-use crate::oidc::{OidcConfig, OidcProvider};
+use crate::oidc::{OidcConfig, OidcProvider, OidcRegistry};
 use crate::storage::{
     ArtifactStore, AuditStore, BaselineStore, InMemoryKeyStore, InMemoryStore, KeyStore,
     ObjectArtifactStore, PostgresStore, SqliteKeyStore, SqliteStore,
@@ -159,8 +159,8 @@ pub struct ServerConfig {
     /// Optional JWT validation settings.
     pub jwt: Option<JwtConfig>,
 
-    /// Optional OIDC configuration.
-    pub oidc: Option<OidcConfig>,
+    /// OIDC provider configurations (GitHub, GitLab, custom).
+    pub oidc_configs: Vec<OidcConfig>,
 
     /// Enable CORS for all origins
     pub cors: bool,
@@ -183,7 +183,7 @@ impl Default for ServerConfig {
             artifacts_url: None,
             api_keys: vec![],
             jwt: None,
-            oidc: None,
+            oidc_configs: vec![],
             cors: true,
             timeout_seconds: 30,
             local_mode: false,
@@ -264,9 +264,11 @@ impl ServerConfig {
         self
     }
 
-    /// Configures OIDC authentication.
+    /// Adds an OIDC provider configuration.
+    ///
+    /// Multiple providers can be registered (e.g. GitHub + GitLab).
     pub fn oidc(mut self, config: OidcConfig) -> Self {
-        self.oidc = Some(config);
+        self.oidc_configs.push(config);
         self
     }
 
@@ -525,15 +527,15 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     // Create in-memory key store (for CLI-provided keys)
     let key_store = create_key_store(&config).await?;
 
-    let mut oidc_provider = None;
-    if let Some(oidc_cfg) = config.oidc.clone() {
-        let provider = OidcProvider::new(oidc_cfg)
+    let mut oidc_registry = OidcRegistry::new();
+    for oidc_cfg in &config.oidc_configs {
+        let provider = OidcProvider::new(oidc_cfg.clone())
             .await
             .map_err(|e| e.to_string())?;
-        oidc_provider = Some(provider);
+        oidc_registry.add(provider);
     }
 
-    let auth_state = AuthState::new(key_store, config.jwt.clone(), oidc_provider)
+    let auth_state = AuthState::new(key_store, config.jwt.clone(), oidc_registry)
         .with_persistent_key_store(persistent_key_store.clone());
 
     // Install Prometheus metrics recorder
@@ -709,7 +711,7 @@ mod tests {
     async fn test_router_creation() {
         let store = Arc::new(InMemoryStore::new());
         let persistent_key_store: Arc<dyn KeyStore> = Arc::new(InMemoryKeyStore::new());
-        let auth_state = AuthState::new(Arc::new(ApiKeyStore::new()), None, None);
+        let auth_state = AuthState::new(Arc::new(ApiKeyStore::new()), None, Default::default());
         let config = ServerConfig::new();
         let app_state = AppState {
             store: store.clone(),

--- a/crates/perfgate-server/src/testing.rs
+++ b/crates/perfgate-server/src/testing.rs
@@ -28,7 +28,7 @@ pub async fn spawn_test_server(config: ServerConfig) -> TestServer {
         .await
         .expect("failed to create key store");
     let persistent_key_store: Arc<dyn KeyStore> = Arc::new(InMemoryKeyStore::new());
-    let auth_state = AuthState::new(key_store, config.jwt.clone(), None)
+    let auth_state = AuthState::new(key_store, config.jwt.clone(), Default::default())
         .with_persistent_key_store(persistent_key_store.clone());
     let app_state = AppState { store, audit };
     let app = create_router(app_state, persistent_key_store, auth_state, &config, None);


### PR DESCRIPTION
## Summary
- Add GitLab CI OIDC token validation alongside existing GitHub Actions support, with `--gitlab-oidc` CLI flag and `--gitlab-oidc-issuer` for self-managed instances
- Introduce `OidcRegistry` multi-provider architecture so GitHub + GitLab (or custom) OIDC can coexist on the same server
- Add generic `--oidc-provider` CLI flag for custom OIDC providers with configurable issuer, JWKS URL, audience, claim field, and identity mappings
- 17 new unit tests with mock RSA JWT tokens covering all provider types, error paths, and the registry fallthrough behavior

Closes #72

## Test plan
- [x] GitLab JWT tokens are validated correctly (maps `project_path` claim)
- [x] Self-managed GitLab instances work with `--gitlab-oidc-issuer`
- [x] Custom OIDC providers work with configurable claim fields
- [x] Claim mapping produces correct project/role for all provider types
- [x] Unauthorized projects/repos are rejected
- [x] GitHub OIDC still works (no regression, existing tests pass)
- [x] Multi-provider registry tries all providers and returns first match
- [x] All 66 tests pass (`cargo test -p perfgate-server`)
- [x] clippy clean (`cargo clippy -p perfgate-server --all-targets --all-features -- -D warnings`)
- [x] fmt clean (`cargo fmt --all`)