### PR TITLE
feat(server): add S3/GCS retention and lifecycle policies

### DIFF
--- a/crates/perfgate-server/src/bin/perfgate-server.rs
+++ b/crates/perfgate-server/src/bin/perfgate-server.rs
@@ -148,6 +148,15 @@ struct Args {
     /// Log format: json, pretty
     #[arg(long, default_value = "json")]
     log_format: String,
+
+    /// Artifact retention period in days. Objects older than this are
+    /// automatically cleaned up. 0 = no automatic cleanup (default).
+    #[arg(long, default_value_t = 0)]
+    retention_days: u64,
+
+    /// Hours between background cleanup passes (default: 1).
+    #[arg(long, default_value_t = 1)]
+    cleanup_interval_hours: u64,
 }
 
 /// Helper struct for parsing API key CLI arguments.
@@ -263,7 +272,9 @@ async fn main() {
         .bind(bind_addr.to_string())
         .unwrap_or_else(|_| panic!("Invalid bind address"))
         .storage_backend(storage_backend)
-        .cors(!args.no_cors);
+        .cors(!args.no_cors)
+        .retention_days(args.retention_days)
+        .cleanup_interval_hours(args.cleanup_interval_hours);
 
     // Set database path for SQLite
     if storage_backend == StorageBackend::Sqlite {
@@ -464,6 +475,8 @@ mod tests {
         assert_eq!(args.port, 8080);
         assert_eq!(args.storage_type, "memory");
         assert!(!args.no_cors);
+        assert_eq!(args.retention_days, 0);
+        assert_eq!(args.cleanup_interval_hours, 1);
         // Verify default pool parameters
         assert_eq!(args.pg_max_connections, 10);
         assert_eq!(args.pg_min_connections, 2);
@@ -650,5 +663,20 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn test_cli_args_retention() {
+        let args = Args::try_parse_from([
+            "perfgate-server",
+            "--retention-days",
+            "30",
+            "--cleanup-interval-hours",
+            "6",
+        ])
+        .unwrap();
+
+        assert_eq!(args.retention_days, 30);
+        assert_eq!(args.cleanup_interval_hours, 6);
     }
 }

--- a/crates/perfgate-server/src/cleanup.rs
+++ b/crates/perfgate-server/src/cleanup.rs
@@ -1,0 +1,272 @@
+//! Background artifact cleanup for retention policy enforcement.
+//!
+//! When `--retention-days` is set to a non-zero value, a background task
+//! periodically scans the artifact store and removes objects older than
+//! the configured retention period.
+
+use crate::storage::ArtifactStore;
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+/// Result of a cleanup operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CleanupResult {
+    /// Number of objects scanned.
+    pub scanned: u64,
+    /// Number of objects deleted.
+    pub deleted: u64,
+    /// Number of objects that failed to delete.
+    pub errors: u64,
+    /// The retention cutoff timestamp used.
+    pub cutoff: String,
+}
+
+/// Runs a single cleanup pass against the artifact store.
+///
+/// Deletes all objects whose `last_modified` timestamp is older than
+/// `retention_days` days from now.
+pub async fn run_cleanup(
+    store: &dyn ArtifactStore,
+    retention_days: u64,
+) -> Result<CleanupResult, String> {
+    let cutoff = Utc::now() - Duration::days(retention_days as i64);
+    info!(
+        retention_days = retention_days,
+        cutoff = %cutoff,
+        "Starting artifact cleanup"
+    );
+
+    let objects = store
+        .list(None)
+        .await
+        .map_err(|e| format!("Failed to list objects: {}", e))?;
+
+    let scanned = objects.len() as u64;
+    let mut deleted = 0u64;
+    let mut errors = 0u64;
+
+    for obj in &objects {
+        if obj.last_modified < cutoff {
+            match store.delete(&obj.path).await {
+                Ok(()) => {
+                    deleted += 1;
+                    info!(
+                        path = %obj.path,
+                        last_modified = %obj.last_modified,
+                        "Deleted expired artifact"
+                    );
+                }
+                Err(e) => {
+                    errors += 1;
+                    warn!(
+                        path = %obj.path,
+                        error = %e,
+                        "Failed to delete expired artifact"
+                    );
+                }
+            }
+        }
+    }
+
+    let result = CleanupResult {
+        scanned,
+        deleted,
+        errors,
+        cutoff: cutoff.to_rfc3339(),
+    };
+
+    info!(
+        scanned = result.scanned,
+        deleted = result.deleted,
+        errors = result.errors,
+        "Artifact cleanup completed"
+    );
+
+    Ok(result)
+}
+
+/// Spawns a background task that runs cleanup periodically.
+///
+/// The task runs every `interval_hours` hours. It is designed to be
+/// cancelled via the tokio cancellation token / task abort.
+pub fn spawn_cleanup_task(
+    store: Arc<dyn ArtifactStore>,
+    retention_days: u64,
+    interval_hours: u64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let interval = std::time::Duration::from_secs(interval_hours * 3600);
+        info!(
+            retention_days = retention_days,
+            interval_hours = interval_hours,
+            "Background cleanup task started"
+        );
+
+        loop {
+            tokio::time::sleep(interval).await;
+
+            match run_cleanup(store.as_ref(), retention_days).await {
+                Ok(result) => {
+                    info!(
+                        deleted = result.deleted,
+                        scanned = result.scanned,
+                        "Background cleanup pass completed"
+                    );
+                }
+                Err(e) => {
+                    error!(error = %e, "Background cleanup pass failed");
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::StoreError;
+    use crate::storage::ArtifactMeta;
+    use async_trait::async_trait;
+    use chrono::{Duration, Utc};
+    use std::sync::Mutex;
+
+    /// A simple in-memory artifact store for testing cleanup logic.
+    #[derive(Debug)]
+    struct MockArtifactStore {
+        objects: Mutex<Vec<ArtifactMeta>>,
+        deleted: Mutex<Vec<String>>,
+    }
+
+    impl MockArtifactStore {
+        fn new(objects: Vec<ArtifactMeta>) -> Self {
+            Self {
+                objects: Mutex::new(objects),
+                deleted: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn deleted_paths(&self) -> Vec<String> {
+            self.deleted.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl ArtifactStore for MockArtifactStore {
+        async fn put(&self, _path: &str, _data: Vec<u8>) -> Result<(), StoreError> {
+            Ok(())
+        }
+
+        async fn get(&self, _path: &str) -> Result<Vec<u8>, StoreError> {
+            Ok(vec![])
+        }
+
+        async fn delete(&self, path: &str) -> Result<(), StoreError> {
+            let mut deleted = self.deleted.lock().unwrap();
+            deleted.push(path.to_string());
+            Ok(())
+        }
+
+        async fn list(&self, _prefix: Option<&str>) -> Result<Vec<ArtifactMeta>, StoreError> {
+            let objects = self.objects.lock().unwrap();
+            Ok(objects.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_deletes_expired_objects() {
+        let now = Utc::now();
+        let objects = vec![
+            ArtifactMeta {
+                path: "old-receipt.json".to_string(),
+                last_modified: now - Duration::days(10),
+                size: 1024,
+            },
+            ArtifactMeta {
+                path: "recent-receipt.json".to_string(),
+                last_modified: now - Duration::days(1),
+                size: 2048,
+            },
+            ArtifactMeta {
+                path: "ancient-receipt.json".to_string(),
+                last_modified: now - Duration::days(100),
+                size: 512,
+            },
+        ];
+
+        let store = MockArtifactStore::new(objects);
+        let result = run_cleanup(&store, 7).await.unwrap();
+
+        assert_eq!(result.scanned, 3);
+        assert_eq!(result.deleted, 2);
+        assert_eq!(result.errors, 0);
+
+        let deleted = store.deleted_paths();
+        assert!(deleted.contains(&"old-receipt.json".to_string()));
+        assert!(deleted.contains(&"ancient-receipt.json".to_string()));
+        assert!(!deleted.contains(&"recent-receipt.json".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_no_expired_objects() {
+        let now = Utc::now();
+        let objects = vec![ArtifactMeta {
+            path: "fresh.json".to_string(),
+            last_modified: now - Duration::hours(1),
+            size: 100,
+        }];
+
+        let store = MockArtifactStore::new(objects);
+        let result = run_cleanup(&store, 30).await.unwrap();
+
+        assert_eq!(result.scanned, 1);
+        assert_eq!(result.deleted, 0);
+        assert_eq!(result.errors, 0);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_empty_store() {
+        let store = MockArtifactStore::new(vec![]);
+        let result = run_cleanup(&store, 7).await.unwrap();
+
+        assert_eq!(result.scanned, 0);
+        assert_eq!(result.deleted, 0);
+        assert_eq!(result.errors, 0);
+    }
+
+    /// Test that delete errors are counted but don't abort the scan.
+    #[tokio::test]
+    async fn test_cleanup_handles_delete_errors() {
+        /// A store that fails on delete for a specific path.
+        #[derive(Debug)]
+        struct FailingDeleteStore;
+
+        #[async_trait]
+        impl ArtifactStore for FailingDeleteStore {
+            async fn put(&self, _path: &str, _data: Vec<u8>) -> Result<(), StoreError> {
+                Ok(())
+            }
+            async fn get(&self, _path: &str) -> Result<Vec<u8>, StoreError> {
+                Ok(vec![])
+            }
+            async fn delete(&self, _path: &str) -> Result<(), StoreError> {
+                Err(StoreError::Other("permission denied".to_string()))
+            }
+            async fn list(&self, _prefix: Option<&str>) -> Result<Vec<ArtifactMeta>, StoreError> {
+                Ok(vec![ArtifactMeta {
+                    path: "locked.json".to_string(),
+                    last_modified: Utc::now() - Duration::days(30),
+                    size: 100,
+                }])
+            }
+        }
+
+        let store = FailingDeleteStore;
+        let result = run_cleanup(&store, 7).await.unwrap();
+
+        assert_eq!(result.scanned, 1);
+        assert_eq!(result.deleted, 0);
+        assert_eq!(result.errors, 1);
+    }
+}

--- a/crates/perfgate-server/src/handlers.rs
+++ b/crates/perfgate-server/src/handlers.rs
@@ -1,5 +1,6 @@
 //! Re-export all handlers for use in the server.
 
+pub mod admin;
 mod audit;
 mod baselines;
 mod dashboard;
@@ -7,6 +8,7 @@ mod health;
 mod keys;
 mod verdicts;
 
+pub use admin::*;
 pub use audit::*;
 pub use baselines::*;
 pub use dashboard::*;

--- a/crates/perfgate-server/src/handlers/admin.rs
+++ b/crates/perfgate-server/src/handlers/admin.rs
@@ -1,0 +1,94 @@
+//! Admin handlers for server management operations.
+
+use axum::{Extension, Json, extract::Query, http::StatusCode, response::IntoResponse};
+use serde::Deserialize;
+use std::sync::Arc;
+use tracing::{error, info};
+
+use crate::auth::{AuthContext, Scope, check_scope};
+use crate::cleanup::run_cleanup;
+use crate::models::ApiError;
+use crate::storage::ArtifactStore;
+
+/// Query parameters for the admin cleanup endpoint.
+#[derive(Debug, Deserialize)]
+pub struct CleanupQuery {
+    /// Remove objects older than this many days.
+    pub older_than_days: Option<u64>,
+}
+
+/// `DELETE /api/v1/admin/cleanup?older_than_days=N`
+///
+/// Triggers an immediate cleanup of expired artifacts. Requires admin scope.
+/// If `older_than_days` is not specified, defaults to the server's
+/// configured retention period. Returns 400 if no retention period is
+/// available.
+pub async fn admin_cleanup(
+    Extension(auth_ctx): Extension<AuthContext>,
+    Extension(artifact_store): Extension<Option<Arc<dyn ArtifactStore>>>,
+    Extension(default_retention): Extension<DefaultRetentionDays>,
+    Query(query): Query<CleanupQuery>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
+    // Admin-only: use a synthetic "admin" project check.
+    // The `Scope::Admin` check ensures only admin-role keys can call this.
+    check_scope(
+        Some(&auth_ctx),
+        &auth_ctx.api_key.project_id,
+        None,
+        Scope::Admin,
+    )?;
+
+    let store = match artifact_store {
+        Some(s) => s,
+        None => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ApiError::bad_request(
+                    "No artifact store configured; cleanup requires S3/GCS/Azure object storage",
+                )),
+            ));
+        }
+    };
+
+    let days = query.older_than_days.or(Some(default_retention.0));
+    let days = match days {
+        Some(d) if d > 0 => d,
+        _ => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ApiError::bad_request(
+                    "older_than_days must be > 0, or --retention-days must be configured",
+                )),
+            ));
+        }
+    };
+
+    info!(
+        older_than_days = days,
+        triggered_by = %auth_ctx.api_key.id,
+        "Admin cleanup triggered"
+    );
+
+    match run_cleanup(store.as_ref(), days).await {
+        Ok(result) => {
+            info!(
+                deleted = result.deleted,
+                scanned = result.scanned,
+                "Admin cleanup completed"
+            );
+            Ok((StatusCode::OK, Json(result)))
+        }
+        Err(e) => {
+            error!(error = %e, "Admin cleanup failed");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e)),
+            ))
+        }
+    }
+}
+
+/// Newtype wrapper for the server's default retention days, used as an
+/// Axum extension so the handler can fall back to it.
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultRetentionDays(pub u64);

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -45,6 +45,7 @@
 //! | GET | `/metrics` | Prometheus metrics |
 
 pub mod auth;
+pub mod cleanup;
 pub mod error;
 pub mod handlers;
 pub mod metrics;

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -21,11 +21,12 @@ use tower_http::{
 use tracing::info;
 
 use crate::auth::{ApiKey, ApiKeyStore, AuthState, JwtConfig, Role, auth_middleware};
+use crate::cleanup::spawn_cleanup_task;
 use crate::error::ConfigError;
 use crate::handlers::{
-    create_key, dashboard_index, delete_baseline, get_baseline, get_latest_baseline, health_check,
-    list_audit_events, list_baselines, list_keys, list_verdicts, promote_baseline, revoke_key,
-    static_asset, submit_verdict, upload_baseline,
+    DefaultRetentionDays, admin_cleanup, create_key, dashboard_index, delete_baseline,
+    get_baseline, get_latest_baseline, health_check, list_audit_events, list_baselines, list_keys,
+    list_verdicts, promote_baseline, revoke_key, static_asset, submit_verdict, upload_baseline,
 };
 use crate::metrics::{metrics_handler, metrics_middleware, setup_metrics_recorder};
 use crate::oidc::{OidcConfig, OidcProvider, OidcRegistry};
@@ -170,6 +171,12 @@ pub struct ServerConfig {
 
     /// Local mode: disable authentication for single-user local use.
     pub local_mode: bool,
+
+    /// Artifact retention period in days (0 = no cleanup).
+    pub retention_days: u64,
+
+    /// Interval between background cleanup passes (in hours).
+    pub cleanup_interval_hours: u64,
 }
 
 impl Default for ServerConfig {
@@ -187,6 +194,8 @@ impl Default for ServerConfig {
             cors: true,
             timeout_seconds: 30,
             local_mode: false,
+            retention_days: 0,
+            cleanup_interval_hours: 1,
         }
     }
 }
@@ -283,6 +292,18 @@ impl ServerConfig {
         self.local_mode = enabled;
         self
     }
+
+    /// Sets the artifact retention period in days. 0 means no cleanup.
+    pub fn retention_days(mut self, days: u64) -> Self {
+        self.retention_days = days;
+        self
+    }
+
+    /// Sets the interval (in hours) between background cleanup passes.
+    pub fn cleanup_interval_hours(mut self, hours: u64) -> Self {
+        self.cleanup_interval_hours = hours;
+        self
+    }
 }
 
 /// Creates the artifact storage based on configuration.
@@ -310,7 +331,14 @@ pub(crate) async fn create_storage(
     config: &ServerConfig,
 ) -> Result<(Arc<dyn BaselineStore>, Arc<dyn AuditStore>), ConfigError> {
     let artifacts = create_artifacts(config).await?;
+    create_storage_with_artifacts(config, artifacts).await
+}
 
+/// Creates the storage backend with a pre-built artifact store.
+pub(crate) async fn create_storage_with_artifacts(
+    config: &ServerConfig,
+    artifacts: Option<Arc<dyn ArtifactStore>>,
+) -> Result<(Arc<dyn BaselineStore>, Arc<dyn AuditStore>), ConfigError> {
     match config.storage_backend {
         StorageBackend::Memory => {
             info!("Using in-memory storage");
@@ -397,6 +425,7 @@ pub(crate) fn create_persistent_key_store(
 pub(crate) fn create_router(
     state: AppState,
     persistent_key_store: Arc<dyn KeyStore>,
+    artifact_store: Option<Arc<dyn ArtifactStore>>,
     auth_state: AuthState,
     config: &ServerConfig,
     prometheus_handle: Option<PrometheusHandle>,
@@ -424,6 +453,16 @@ pub(crate) fn create_router(
         .route("/keys", get(list_keys))
         .route("/keys/{id}", delete(revoke_key))
         .with_state(persistent_key_store)
+        .layer(middleware::from_fn_with_state(
+            auth_state.clone(),
+            auth_middleware,
+        ));
+
+    // Admin routes (require admin auth, never skipped even in local mode)
+    let admin_routes = Router::new()
+        .route("/admin/cleanup", delete(admin_cleanup))
+        .layer(axum::Extension(artifact_store.clone()))
+        .layer(axum::Extension(DefaultRetentionDays(config.retention_days)))
         .layer(middleware::from_fn_with_state(
             auth_state.clone(),
             auth_middleware,
@@ -470,7 +509,8 @@ pub(crate) fn create_router(
             health_routes
                 .merge(info_routes)
                 .merge(api_routes)
-                .merge(key_routes),
+                .merge(key_routes)
+                .merge(admin_routes),
         );
 
     // Add /metrics endpoint if Prometheus handle is available
@@ -503,11 +543,15 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     info!(
         bind = %config.bind,
         backend = ?config.storage_backend,
+        retention_days = config.retention_days,
         "Starting perfgate server"
     );
 
+    // Create artifact store (shared between baseline store and cleanup)
+    let artifact_store = create_artifacts(&config).await?;
+
     // Create storage
-    let (store, audit) = create_storage(&config).await?;
+    let (store, audit) = create_storage_with_artifacts(&config, artifact_store.clone()).await?;
 
     // Create the persistent key store (shares SQLite connection when applicable)
     let sqlite_conn = if config.storage_backend == StorageBackend::Sqlite {
@@ -538,6 +582,29 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     let auth_state = AuthState::new(key_store, config.jwt.clone(), oidc_registry)
         .with_persistent_key_store(persistent_key_store.clone());
 
+    // Spawn background cleanup task if retention is configured
+    let cleanup_handle = if config.retention_days > 0 {
+        if let Some(ref art_store) = artifact_store {
+            info!(
+                retention_days = config.retention_days,
+                interval_hours = config.cleanup_interval_hours,
+                "Spawning background artifact cleanup task"
+            );
+            Some(spawn_cleanup_task(
+                art_store.clone(),
+                config.retention_days,
+                config.cleanup_interval_hours,
+            ))
+        } else {
+            info!(
+                "Retention policy configured but no artifact store available; skipping background cleanup"
+            );
+            None
+        }
+    } else {
+        None
+    };
+
     // Install Prometheus metrics recorder
     let prometheus_handle = setup_metrics_recorder();
     info!("Prometheus metrics enabled at /metrics");
@@ -548,6 +615,7 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     let app = create_router(
         app_state,
         persistent_key_store.clone(),
+        artifact_store,
         auth_state,
         &config,
         Some(prometheus_handle),
@@ -570,6 +638,11 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
         .await?;
+
+    // Abort cleanup task on shutdown
+    if let Some(handle) = cleanup_handle {
+        handle.abort();
+    }
 
     info!("Server shutdown complete");
     Ok(())
@@ -718,7 +791,14 @@ mod tests {
             audit: store,
         };
 
-        let _router = create_router(app_state, persistent_key_store, auth_state, &config, None);
+        let _router = create_router(
+            app_state,
+            persistent_key_store,
+            None,
+            auth_state,
+            &config,
+            None,
+        );
         // Router created successfully
     }
 

--- a/crates/perfgate-server/src/storage/artifacts.rs
+++ b/crates/perfgate-server/src/storage/artifacts.rs
@@ -1,8 +1,9 @@
 //! Artifact storage implementations using object_store.
 
-use super::ArtifactStore;
+use super::{ArtifactMeta, ArtifactStore};
 use crate::error::StoreError;
 use async_trait::async_trait;
+use futures::TryStreamExt;
 use object_store::{ObjectStore, path::Path};
 use std::sync::Arc;
 
@@ -53,5 +54,24 @@ impl ArtifactStore for ObjectArtifactStore {
             .await
             .map_err(|e| StoreError::Other(format!("ObjectStore delete failed: {}", e)))?;
         Ok(())
+    }
+
+    async fn list(&self, prefix: Option<&str>) -> Result<Vec<ArtifactMeta>, StoreError> {
+        let prefix = prefix.map(Path::from);
+        let stream = self.inner.list(prefix.as_ref());
+
+        let objects: Vec<_> = stream
+            .try_collect()
+            .await
+            .map_err(|e| StoreError::Other(format!("ObjectStore list failed: {}", e)))?;
+
+        Ok(objects
+            .into_iter()
+            .map(|meta| ArtifactMeta {
+                path: meta.location.to_string(),
+                last_modified: meta.last_modified,
+                size: meta.size as u64,
+            })
+            .collect())
     }
 }

--- a/crates/perfgate-server/src/storage/mod.rs
+++ b/crates/perfgate-server/src/storage/mod.rs
@@ -22,6 +22,18 @@ use crate::models::{
     PoolMetrics, VerdictRecord,
 };
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+
+/// Metadata for a stored artifact object.
+#[derive(Debug, Clone)]
+pub struct ArtifactMeta {
+    /// Object path/key.
+    pub path: String,
+    /// Last-modified timestamp (if available from the backend).
+    pub last_modified: DateTime<Utc>,
+    /// Size in bytes.
+    pub size: u64,
+}
 
 /// Trait for storing raw artifacts (receipts).
 #[async_trait]
@@ -34,6 +46,9 @@ pub trait ArtifactStore: std::fmt::Debug + Send + Sync {
 
     /// Deletes an artifact from the given path.
     async fn delete(&self, path: &str) -> Result<(), StoreError>;
+
+    /// Lists all objects under the given prefix, returning their metadata.
+    async fn list(&self, prefix: Option<&str>) -> Result<Vec<ArtifactMeta>, StoreError>;
 }
 
 /// Trait for baseline storage operations.

--- a/crates/perfgate-server/src/testing.rs
+++ b/crates/perfgate-server/src/testing.rs
@@ -31,7 +31,14 @@ pub async fn spawn_test_server(config: ServerConfig) -> TestServer {
     let auth_state = AuthState::new(key_store, config.jwt.clone(), Default::default())
         .with_persistent_key_store(persistent_key_store.clone());
     let app_state = AppState { store, audit };
-    let app = create_router(app_state, persistent_key_store, auth_state, &config, None);
+    let app = create_router(
+        app_state,
+        persistent_key_store,
+        None,
+        auth_state,
+        &config,
+        None,
+    );
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();


### PR DESCRIPTION
## Summary
- Add `--retention-days` CLI flag for automatic artifact cleanup (default: 0 = disabled)
- Background tokio task periodically scans and removes expired objects from S3/GCS/Azure stores
- Admin-only `DELETE /api/v1/admin/cleanup?older_than_days=N` endpoint for manual cleanup
- Extend `ArtifactStore` trait with `list()` method and `ArtifactMeta` type

Closes #67

## Test plan
- [x] Server starts with `--retention-days` flag (CLI args test)
- [x] Background cleanup task spawns when retention > 0 and artifact store is configured
- [x] Cleanup correctly deletes expired objects and preserves fresh ones (4 unit tests)
- [x] Cleanup handles delete errors gracefully without aborting scan
- [x] Admin cleanup endpoint requires admin scope
- [x] All existing tests pass (45 total, 43 run + 2 ignored)
- [x] `cargo clippy` clean (no warnings)
- [x] `cargo fmt` clean