### PR TITLE
feat: smarter noise policy with adaptive retries and CV threshold

### DIFF
--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -116,6 +116,9 @@ pub struct CheckOutcome {
 
     /// Exit code to use (0=pass, 2=fail, 3=warn with fail-on-warn).
     pub exit_code: i32,
+
+    /// Suggestion to use paired mode due to high noise (CV > 0.30).
+    pub suggest_paired: bool,
 }
 
 /// Use case for running a config-driven check.
@@ -270,6 +273,15 @@ impl<R: ProcessRunner + Clone, H: HostProbe + Clone, C: Clock + Clone> CheckUseC
             (false, 0)
         };
 
+        // 8. Check for high CV and suggest paired mode
+        let suggest_paired = detect_high_cv(&run_receipt);
+        if suggest_paired {
+            warnings.push(
+                "high noise detected (CV > 30%): consider using `perfgate paired` for more reliable results"
+                    .to_string(),
+            );
+        }
+
         Ok(CheckOutcome {
             run_receipt,
             run_path,
@@ -282,6 +294,7 @@ impl<R: ProcessRunner + Clone, H: HostProbe + Clone, C: Clock + Clone> CheckUseC
             warnings,
             failed,
             exit_code,
+            suggest_paired,
         })
     }
 
@@ -533,6 +546,14 @@ fn build_no_baseline_report(run: &RunReceipt) -> PerfgateReport {
             total_count: 1,
         },
     }
+}
+
+/// Detect high coefficient of variation in run receipt wall_ms.
+///
+/// Returns true if the wall_ms CV exceeds 0.30 (30%), which indicates
+/// the benchmark environment is noisy and paired mode would give better results.
+fn detect_high_cv(run: &RunReceipt) -> bool {
+    run.stats.wall_ms.cv().map(|cv| cv > 0.30).unwrap_or(false)
 }
 
 /// Render markdown for the case when there is no baseline.

--- a/crates/perfgate-app/src/paired.rs
+++ b/crates/perfgate-app/src/paired.rs
@@ -1,10 +1,10 @@
 //! Paired benchmark execution for perfgate.
 
 use perfgate_adapters::{CommandSpec, HostProbe, HostProbeOptions, ProcessRunner};
-use perfgate_domain::compute_paired_stats;
+use perfgate_domain::{compute_paired_cv, compute_paired_stats};
 use perfgate_types::{
-    PAIRED_SCHEMA_V1, PairedBenchMeta, PairedRunReceipt, PairedSample, PairedSampleHalf, RunMeta,
-    SignificancePolicy, ToolInfo,
+    NoiseDiagnostics, NoiseLevel, PAIRED_SCHEMA_V1, PairedBenchMeta, PairedRunReceipt,
+    PairedSample, PairedSampleHalf, RunMeta, SignificancePolicy, ToolInfo,
 };
 use std::path::PathBuf;
 use std::time::Duration;
@@ -30,6 +30,10 @@ pub struct PairedRunRequest {
     pub require_significance: bool,
     pub max_retries: u32,
     pub fail_on_regression: Option<f64>,
+    /// CV threshold for early termination. If the coefficient of variation of
+    /// the wall-time differences exceeds this value, retries are aborted because
+    /// the benchmark is too noisy for significance to be achievable.
+    pub cv_threshold: Option<f64>,
 }
 
 #[derive(Debug, Clone)]
@@ -100,8 +104,9 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> PairedRunUseCase<R, H, C> {
             min_samples: req.significance_min_samples,
         };
 
-        // Retry logic for significance
-        let mut retries_done = 0;
+        // Retry logic for significance with adaptive sample sizing and CV-based early termination
+        let mut retries_done: u32 = 0;
+        let mut early_termination = false;
         loop {
             let stats = compute_paired_stats(&samples, req.work_units, Some(&significance_policy))?;
             let significance_reached = stats
@@ -116,16 +121,34 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> PairedRunUseCase<R, H, C> {
                 break;
             }
 
-            // Not significant, and we have retries left - run one more pair
+            // Check CV threshold for early termination
+            if let Some(cv_thresh) = req.cv_threshold {
+                let cv = compute_paired_cv(&samples);
+                if cv > cv_thresh {
+                    early_termination = true;
+                    reasons.push(format!(
+                        "early termination: CV {:.3} exceeds threshold {:.3}, benchmark too noisy for retries",
+                        cv, cv_thresh
+                    ));
+                    break;
+                }
+            }
+
+            // Adaptive sample sizing: each retry collects more pairs (1.5x growth)
+            // Retry 1: 1 pair, Retry 2: 2 pairs, Retry 3: 3 pairs, ...
+            let extra_pairs = ((retries_done as f64 + 1.0) * 1.5).ceil() as u32;
             retries_done += 1;
-            self.run_pair(
-                req.warmup + pairs_collected,
-                false,
-                &req,
-                &mut samples,
-                &mut reasons,
-            )?;
-            pairs_collected += 1;
+
+            for _ in 0..extra_pairs {
+                self.run_pair(
+                    req.warmup + pairs_collected,
+                    false,
+                    &req,
+                    &mut samples,
+                    &mut reasons,
+                )?;
+                pairs_collected += 1;
+            }
         }
 
         // Update bench metadata if we collected more samples than originally requested
@@ -133,6 +156,19 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> PairedRunUseCase<R, H, C> {
 
         let stats = compute_paired_stats(&samples, req.work_units, Some(&significance_policy))?;
         let ended_at = self.clock.now_rfc3339();
+
+        // Build noise diagnostics when retries were configured
+        let noise_diagnostics = if req.max_retries > 0 {
+            let cv = compute_paired_cv(&samples);
+            Some(NoiseDiagnostics {
+                cv,
+                noise_level: NoiseLevel::from_cv(cv),
+                retries_used: retries_done,
+                early_termination,
+            })
+        } else {
+            None
+        };
 
         let receipt = PairedRunReceipt {
             schema: PAIRED_SCHEMA_V1.to_string(),
@@ -146,6 +182,7 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> PairedRunUseCase<R, H, C> {
             bench,
             samples,
             stats,
+            noise_diagnostics,
         };
 
         if let Some(threshold_pct) = req.fail_on_regression {
@@ -444,6 +481,7 @@ mod tests {
                 require_significance: false,
                 max_retries: 0,
                 fail_on_regression: None,
+                cv_threshold: None,
             })
             .expect("paired run should succeed");
 
@@ -531,6 +569,7 @@ mod tests {
                 require_significance: false,
                 max_retries: 0,
                 fail_on_regression: None,
+                cv_threshold: None,
             })
             .expect("paired run should succeed");
 
@@ -583,6 +622,7 @@ mod tests {
                 require_significance: false,
                 max_retries: 0,
                 fail_on_regression: None,
+                cv_threshold: None,
             })
             .unwrap_err();
 
@@ -642,6 +682,7 @@ mod tests {
                 require_significance: false,
                 max_retries: 0,
                 fail_on_regression: None,
+                cv_threshold: None,
             })
             .expect("paired run should succeed");
 
@@ -656,16 +697,11 @@ mod tests {
     fn paired_run_retries_until_significance() {
         // We want to simulate:
         // Initial run (2 pairs): not significant
-        // Retry 1 (1 pair): now significant (or reached max retries)
+        // Adaptive retries collect increasing pairs until significance
 
-        // Wall diffs:
-        // Pair 1: 100 - 100 = 0
-        // Pair 2: 100 - 100 = 0
-        // (Mean = 0, StdDev = 0 -> not significant if alpha is tight or we need more samples)
-        // Wait, if StdDev is 0 it MIGHT be significant depending on the test.
-        // Actually compute_paired_stats uses Welch's t-test on the diffs.
-
-        // Let's just use a large enough StdDev to ensure not significant initially.
+        // Wall diffs: initially ambiguous, later consistently positive.
+        // Retry 1 collects ceil((0+1)*1.5) = 2 pairs, Retry 2 = 3 pairs, etc.
+        // Provide enough runs for multiple retries.
         let runs = vec![
             // Pair 1 (diff 0)
             run_result(100, 0, false, None, b"", b""),
@@ -673,7 +709,27 @@ mod tests {
             // Pair 2 (diff 10)
             run_result(100, 0, false, None, b"", b""),
             run_result(110, 0, false, None, b"", b""),
-            // Pair 3 (diff 10) - Should be collected because of retry
+            // Retry 1: 2 extra pairs (diff 10 each)
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            // Retry 2: 3 extra pairs (diff 10 each)
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            // Retry 3: 5 extra pairs (diff 10 each) - just in case
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
             run_result(100, 0, false, None, b"", b""),
             run_result(110, 0, false, None, b"", b""),
         ];
@@ -718,6 +774,7 @@ mod tests {
                 require_significance: true,
                 max_retries: 5, // Allow up to 5 retries
                 fail_on_regression: None,
+                cv_threshold: None,
             })
             .expect("paired run should succeed");
 
@@ -726,6 +783,154 @@ mod tests {
         assert_eq!(
             outcome.receipt.bench.repeat,
             outcome.receipt.samples.len() as u32
+        );
+
+        // Noise diagnostics should be present because max_retries > 0
+        let diag = outcome
+            .receipt
+            .noise_diagnostics
+            .expect("should have noise diagnostics");
+        assert!(diag.retries_used > 0);
+        assert!(!diag.early_termination);
+    }
+
+    #[test]
+    fn paired_run_cv_threshold_early_termination() {
+        // Simulate very noisy data: large variance in diffs
+        // Pair 1: diff = -50, Pair 2: diff = +60 => high CV
+        let runs = vec![
+            // Pair 1
+            run_result(200, 0, false, None, b"", b""),
+            run_result(150, 0, false, None, b"", b""),
+            // Pair 2
+            run_result(100, 0, false, None, b"", b""),
+            run_result(160, 0, false, None, b"", b""),
+            // Extra pair should NOT be consumed because CV threshold triggers early exit
+            // But we provide extras just in case the retry runs one more batch
+            run_result(100, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+            run_result(100, 0, false, None, b"", b""),
+        ];
+
+        let runner = TestRunner::new(runs);
+        let host = HostInfo {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            cpu_count: None,
+            memory_bytes: None,
+            hostname_hash: None,
+        };
+        let host_probe = TestHostProbe::new(host);
+        let clock = TestClock::new("2024-01-01T00:00:00Z");
+
+        let usecase = PairedRunUseCase::new(
+            runner,
+            host_probe,
+            clock,
+            ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        );
+
+        let outcome = usecase
+            .execute(PairedRunRequest {
+                name: "noisy-bench".to_string(),
+                cwd: None,
+                baseline_command: vec!["true".to_string()],
+                current_command: vec!["true".to_string()],
+                repeat: 2,
+                warmup: 0,
+                work_units: None,
+                timeout: None,
+                env: vec![],
+                output_cap_bytes: 1024,
+                allow_nonzero: false,
+                include_hostname_hash: false,
+                significance_alpha: Some(0.05),
+                significance_min_samples: Some(2),
+                require_significance: true,
+                max_retries: 5,
+                fail_on_regression: None,
+                cv_threshold: Some(0.5),
+            })
+            .expect("paired run should succeed");
+
+        let diag = outcome
+            .receipt
+            .noise_diagnostics
+            .expect("should have noise diagnostics");
+        // Early termination should have kicked in
+        assert!(diag.early_termination);
+        assert!(diag.cv > 0.5);
+        assert_eq!(diag.noise_level, perfgate_types::NoiseLevel::High);
+
+        // Should have a reason about early termination
+        assert!(
+            outcome
+                .reasons
+                .iter()
+                .any(|r| r.contains("early termination")),
+            "expected early termination reason, got: {:?}",
+            outcome.reasons
+        );
+    }
+
+    #[test]
+    fn paired_run_no_retries_no_noise_diagnostics() {
+        let runs = vec![
+            run_result(100, 0, false, None, b"", b""),
+            run_result(110, 0, false, None, b"", b""),
+        ];
+
+        let runner = TestRunner::new(runs);
+        let host = HostInfo {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            cpu_count: None,
+            memory_bytes: None,
+            hostname_hash: None,
+        };
+        let host_probe = TestHostProbe::new(host);
+        let clock = TestClock::new("2024-01-01T00:00:00Z");
+
+        let usecase = PairedRunUseCase::new(
+            runner,
+            host_probe,
+            clock,
+            ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        );
+
+        let outcome = usecase
+            .execute(PairedRunRequest {
+                name: "simple-bench".to_string(),
+                cwd: None,
+                baseline_command: vec!["true".to_string()],
+                current_command: vec!["true".to_string()],
+                repeat: 1,
+                warmup: 0,
+                work_units: None,
+                timeout: None,
+                env: vec![],
+                output_cap_bytes: 1024,
+                allow_nonzero: false,
+                include_hostname_hash: false,
+                significance_alpha: None,
+                significance_min_samples: None,
+                require_significance: false,
+                max_retries: 0,
+                fail_on_regression: None,
+                cv_threshold: None,
+            })
+            .expect("paired run should succeed");
+
+        assert!(
+            outcome.receipt.noise_diagnostics.is_none(),
+            "should not have noise diagnostics when max_retries=0"
         );
     }
 }

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -668,6 +668,12 @@ pub struct PairedArgs {
     #[arg(long, default_value_t = 0)]
     pub max_retries: u32,
 
+    /// CV threshold for early termination of retries.
+    /// If the coefficient of variation of wall-time differences exceeds this value,
+    /// retries are aborted because the benchmark is too noisy. Default: 0.5 (50%).
+    #[arg(long)]
+    pub cv_threshold: Option<f64>,
+
     /// Fail the command (exit code 2) if a regression exceeds this percentage (e.g., 5.0 for 5%).
     #[arg(long)]
     pub fail_on_regression: Option<f64>,
@@ -1345,6 +1351,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 significance_alpha,
                 significance_min_samples,
                 max_retries,
+                cv_threshold,
                 fail_on_regression,
                 out,
                 pretty,
@@ -1390,6 +1397,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 require_significance,
                 max_retries,
                 fail_on_regression,
+                cv_threshold,
             })?;
 
             write_json(&out, &outcome.receipt, pretty)?;
@@ -3264,6 +3272,7 @@ mod tests {
             warnings: Vec::new(),
             failed: false,
             exit_code: 0,
+            suggest_paired: false,
         };
 
         write_check_artifacts(&outcome, false).unwrap();
@@ -3322,6 +3331,7 @@ mod tests {
             warnings: Vec::new(),
             failed: false,
             exit_code: 0,
+            suggest_paired: false,
         };
 
         write_check_artifacts(&outcome, false).unwrap();

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -8,7 +8,7 @@ mod paired;
 pub use blame::{
     BinaryBlame, DependencyChange, DependencyChangeType, compare_lockfiles, parse_lockfile,
 };
-pub use paired::{PairedComparison, compare_paired_stats, compute_paired_stats};
+pub use paired::{PairedComparison, compare_paired_stats, compute_paired_cv, compute_paired_stats};
 
 pub use perfgate_host_detect::detect_host_mismatch;
 

--- a/crates/perfgate-domain/src/paired.rs
+++ b/crates/perfgate-domain/src/paired.rs
@@ -3,7 +3,7 @@
 //! This module re-exports from `perfgate_paired` for backward compatibility.
 
 pub use perfgate_paired::{
-    PairedComparison, PairedError, compare_paired_stats, compute_paired_stats,
+    PairedComparison, PairedError, compare_paired_stats, compute_paired_cv, compute_paired_stats,
 };
 
 use crate::DomainError;

--- a/crates/perfgate-paired/src/lib.rs
+++ b/crates/perfgate-paired/src/lib.rs
@@ -234,6 +234,28 @@ pub fn summarize_paired_diffs(
     })
 }
 
+/// Compute the coefficient of variation (CV) of the wall-time differences
+/// from a set of paired samples (excluding warmups).
+///
+/// CV = std_dev / |mean|. Returns 0.0 if mean is zero (no variation detectable).
+pub fn compute_paired_cv(samples: &[PairedSample]) -> f64 {
+    let measured: Vec<f64> = samples
+        .iter()
+        .filter(|s| !s.warmup)
+        .map(|s| s.wall_diff_ms as f64)
+        .collect();
+    if measured.is_empty() {
+        return 0.0;
+    }
+    let n = measured.len() as f64;
+    let mean = measured.iter().sum::<f64>() / n;
+    if mean.abs() < f64::EPSILON {
+        return 0.0;
+    }
+    let variance = measured.iter().map(|d| (d - mean).powi(2)).sum::<f64>() / n;
+    variance.sqrt() / mean.abs()
+}
+
 /// Result of comparing paired statistics, including significance testing.
 ///
 /// # Examples
@@ -954,6 +976,66 @@ mod tests {
             let comparison = compare_paired_stats(&stats);
             assert!((comparison.pct_change - 0.00001).abs() < 0.000001);
         }
+    }
+
+    #[test]
+    fn test_compute_paired_cv_empty_samples() {
+        let samples: Vec<PairedSample> = vec![];
+        assert_eq!(compute_paired_cv(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_compute_paired_cv_no_variance() {
+        let samples = vec![
+            paired_sample(0, false, 100, 110),
+            paired_sample(1, false, 100, 110),
+            paired_sample(2, false, 100, 110),
+        ];
+        assert_eq!(compute_paired_cv(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_compute_paired_cv_with_variance() {
+        // Diffs: 10, 20, 30 => mean=20, stddev=sqrt(200/3)~=8.165
+        // CV = 8.165/20 = 0.408
+        let samples = vec![
+            paired_sample(0, false, 100, 110),
+            paired_sample(1, false, 100, 120),
+            paired_sample(2, false, 100, 130),
+        ];
+        let cv = compute_paired_cv(&samples);
+        assert!((cv - 0.4082).abs() < 0.01, "expected CV ~0.408, got {}", cv);
+    }
+
+    #[test]
+    fn test_compute_paired_cv_skips_warmup() {
+        let samples = vec![
+            paired_sample(0, true, 100, 1000), // warmup, should be ignored
+            paired_sample(1, false, 100, 110),
+            paired_sample(2, false, 100, 110),
+        ];
+        assert_eq!(compute_paired_cv(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_compute_paired_cv_zero_mean() {
+        // Diffs: -10, +10 => mean=0 => CV should be 0 (avoid division by zero)
+        let samples = vec![
+            paired_sample(0, false, 110, 100),
+            paired_sample(1, false, 100, 110),
+        ];
+        assert_eq!(compute_paired_cv(&samples), 0.0);
+    }
+
+    #[test]
+    fn test_compute_paired_cv_high_noise() {
+        // Diffs: -50, +60 => mean=5, stddev large => high CV
+        let samples = vec![
+            paired_sample(0, false, 200, 150),
+            paired_sample(1, false, 100, 160),
+        ];
+        let cv = compute_paired_cv(&samples);
+        assert!(cv > 1.0, "expected very high CV, got {}", cv);
     }
 }
 

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -24,8 +24,8 @@ mod defaults_config;
 mod paired;
 
 pub use paired::{
-    PAIRED_SCHEMA_V1, PairedBenchMeta, PairedDiffSummary, PairedRunReceipt, PairedSample,
-    PairedSampleHalf, PairedStats,
+    NoiseDiagnostics, NoiseLevel, PAIRED_SCHEMA_V1, PairedBenchMeta, PairedDiffSummary,
+    PairedRunReceipt, PairedSample, PairedSampleHalf, PairedStats,
 };
 
 pub use defaults_config::*;

--- a/crates/perfgate-types/src/paired.rs
+++ b/crates/perfgate-types/src/paired.rs
@@ -3,6 +3,7 @@
 use crate::{F64Summary, RunMeta, Significance, ToolInfo, U64Summary};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 pub const PAIRED_SCHEMA_V1: &str = "perfgate.paired.v1";
 
@@ -82,6 +83,56 @@ pub struct PairedStats {
     pub throughput_diff_per_s: Option<PairedDiffSummary>,
 }
 
+/// Noise level classification for paired benchmark results.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum NoiseLevel {
+    /// CV <= 0.10 (10%)
+    Low,
+    /// 0.10 < CV <= 0.30 (30%)
+    Moderate,
+    /// CV > 0.30
+    High,
+}
+
+impl NoiseLevel {
+    /// Classify a coefficient of variation into a noise level.
+    pub fn from_cv(cv: f64) -> Self {
+        if cv <= 0.10 {
+            NoiseLevel::Low
+        } else if cv <= 0.30 {
+            NoiseLevel::Moderate
+        } else {
+            NoiseLevel::High
+        }
+    }
+}
+
+impl fmt::Display for NoiseLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            NoiseLevel::Low => write!(f, "low"),
+            NoiseLevel::Moderate => write!(f, "moderate"),
+            NoiseLevel::High => write!(f, "high"),
+        }
+    }
+}
+
+/// Diagnostics about noise in paired benchmark measurements.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct NoiseDiagnostics {
+    /// Coefficient of variation of the wall-time differences.
+    pub cv: f64,
+    /// Classified noise level.
+    pub noise_level: NoiseLevel,
+    /// Number of retries used to achieve significance.
+    pub retries_used: u32,
+    /// Whether the retry loop terminated early due to excessive CV.
+    pub early_termination: bool,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct PairedRunReceipt {
@@ -91,6 +142,9 @@ pub struct PairedRunReceipt {
     pub bench: PairedBenchMeta,
     pub samples: Vec<PairedSample>,
     pub stats: PairedStats,
+    /// Noise diagnostics from the paired run (present when retries were configured).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub noise_diagnostics: Option<NoiseDiagnostics>,
 }
 
 #[cfg(test)]
@@ -168,6 +222,7 @@ mod tests {
                 current_throughput_per_s: None,
                 throughput_diff_per_s: None,
             },
+            noise_diagnostics: None,
         }
     }
 
@@ -198,5 +253,60 @@ mod tests {
         assert!(sample["baseline"].get("max_rss_kb").is_none());
         assert!(sample["baseline"].get("stdout").is_none());
         assert!(sample["baseline"].get("stderr").is_none());
+
+        assert!(json.get("noise_diagnostics").is_none());
+    }
+
+    #[test]
+    fn noise_level_from_cv_classifies_correctly() {
+        assert_eq!(NoiseLevel::from_cv(0.0), NoiseLevel::Low);
+        assert_eq!(NoiseLevel::from_cv(0.05), NoiseLevel::Low);
+        assert_eq!(NoiseLevel::from_cv(0.10), NoiseLevel::Low);
+        assert_eq!(NoiseLevel::from_cv(0.15), NoiseLevel::Moderate);
+        assert_eq!(NoiseLevel::from_cv(0.30), NoiseLevel::Moderate);
+        assert_eq!(NoiseLevel::from_cv(0.31), NoiseLevel::High);
+        assert_eq!(NoiseLevel::from_cv(0.50), NoiseLevel::High);
+        assert_eq!(NoiseLevel::from_cv(1.0), NoiseLevel::High);
+    }
+
+    #[test]
+    fn noise_level_display() {
+        assert_eq!(NoiseLevel::Low.to_string(), "low");
+        assert_eq!(NoiseLevel::Moderate.to_string(), "moderate");
+        assert_eq!(NoiseLevel::High.to_string(), "high");
+    }
+
+    #[test]
+    fn noise_diagnostics_json_round_trip() {
+        let diag = NoiseDiagnostics {
+            cv: 0.25,
+            noise_level: NoiseLevel::Moderate,
+            retries_used: 2,
+            early_termination: false,
+        };
+        let json = serde_json::to_string(&diag).unwrap();
+        let decoded: NoiseDiagnostics = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.cv, 0.25);
+        assert_eq!(decoded.noise_level, NoiseLevel::Moderate);
+        assert_eq!(decoded.retries_used, 2);
+        assert!(!decoded.early_termination);
+    }
+
+    #[test]
+    fn paired_receipt_with_noise_diagnostics_round_trip() {
+        let mut receipt = make_receipt();
+        receipt.noise_diagnostics = Some(NoiseDiagnostics {
+            cv: 0.60,
+            noise_level: NoiseLevel::High,
+            retries_used: 3,
+            early_termination: true,
+        });
+        let json = serde_json::to_string(&receipt).unwrap();
+        let decoded: PairedRunReceipt = serde_json::from_str(&json).unwrap();
+        let diag = decoded.noise_diagnostics.expect("should have diagnostics");
+        assert_eq!(diag.cv, 0.60);
+        assert_eq!(diag.noise_level, NoiseLevel::High);
+        assert_eq!(diag.retries_used, 3);
+        assert!(diag.early_termination);
     }
 }

--- a/tests/integration/cross_crate_pipeline.rs
+++ b/tests/integration/cross_crate_pipeline.rs
@@ -510,6 +510,7 @@ fn paired_receipt_json_roundtrip() {
             current_throughput_per_s: None,
             throughput_diff_per_s: None,
         },
+        noise_diagnostics: None,
     };
 
     let json = serde_json::to_string_pretty(&receipt).unwrap();


### PR DESCRIPTION
## Summary
- Add `--cv-threshold` for early termination on hopelessly noisy benchmarks
- Adaptive sample size increase on paired retries (1.5x growth per retry)
- Noise diagnostics (`NoiseDiagnostics`) in paired run receipts with CV, noise level, retries used, and early termination flag
- Suggest paired mode when standalone `check` detects high CV (> 30%)

Closes #78

## Test plan
- [x] Early termination triggers when CV exceeds threshold
- [x] Sample size increases on retry (adaptive sizing)
- [x] Noise diagnostics appear in receipt when retries configured
- [x] Noise diagnostics omitted from receipt when max_retries=0
- [x] NoiseLevel classification (low/moderate/high) is correct
- [x] compute_paired_cv handles edge cases (empty, zero mean, warmup filtering)
- [x] Existing tests pass (all 900+ tests across workspace)
- [x] clippy clean
- [x] Integration test updated for new PairedRunReceipt field