### PR TITLE
docs: modernize core crate READMEs (types, domain, stats)

### DIFF
--- a/crates/perfgate-domain/README.md
+++ b/crates/perfgate-domain/README.md
@@ -1,31 +1,76 @@
 # perfgate-domain
 
-Pure, I/O-free policy and statistics logic for perfgate.
+Pure business logic with zero I/O -- statistics, budget evaluation, and verdict
+computation for perfgate.
 
-## Responsibilities
+This crate is intentionally I/O-free. All data arrives via function arguments;
+there is no filesystem access, no network, no process spawning. This makes every
+function deterministic and trivially testable.
 
-- Computes summary statistics from samples (`median`, `min`, `max`).
-- Compares baseline vs current stats against metric budgets.
-- Produces per-metric deltas and verdicts (pass/warn/fail).
-- Derives structured findings/reports from compare receipts.
-- Detects host mismatch signals between baseline and current runs.
-- Provides paired-benchmark math (`compute_paired_stats`, `compare_paired_stats`).
+## Core API
 
-## Boundaries
+### Statistics
 
-- No process spawning.
-- No filesystem or network I/O.
-- No CLI parsing or formatting concerns.
+- `compute_stats(samples, work_units) -> Stats` -- aggregate summary statistics
+  from raw samples (excludes warmup iterations)
+- Re-exports from `perfgate-stats`: `summarize_u64`, `summarize_f64`,
+  `median_u64_sorted`, `median_f64_sorted`
 
-## Why This Layer Exists
+### Budget Evaluation
 
-The crate is intentionally pure so it stays easy to test, deterministic, and reusable from both CLI and higher-level orchestration code.
+- `compare_stats(baseline, current, budgets) -> Comparison` -- evaluate each
+  metric against budget thresholds, producing deltas and a per-metric verdict
+- `compare_runs(baseline, current, budgets, statistics, significance) ->
+  Comparison` -- full run-level comparison with per-metric statistic selection
+  (median or p95) and optional Welch's t-test significance gating
+- Re-exports from `perfgate-budget`: `evaluate_budget`, `evaluate_budgets`,
+  `calculate_regression`, `determine_status`, `aggregate_verdict`
 
-## Workspace Role
+### Report Derivation
 
-`perfgate-domain` sits above `perfgate-types` and below `perfgate-app`:
+- `derive_report(receipt) -> Report` -- extract warn/fail findings from a
+  `CompareReceipt`, sorted by metric name for deterministic output
 
-`perfgate-types` -> `perfgate-domain` -> `perfgate-app`
+### Host Mismatch Detection
+
+- `detect_host_mismatch(baseline, current) -> Option<HostMismatchInfo>` --
+  triggers on OS/arch mismatch, CPU count >2x difference, memory >2x
+  difference, or hostname hash mismatch
+
+### Significance Testing
+
+- `compute_significance(baseline_samples, current_samples, alpha) ->
+  SignificanceResult` -- Welch's t-test with configurable alpha
+- `SignificancePolicy` -- controls alpha, minimum sample count, and whether
+  non-significant regressions are downgraded to pass
+
+### Paired Benchmarking
+
+- `compute_paired_stats(samples) -> PairedStats`
+- `compare_paired_stats(stats, budgets) -> PairedComparison`
+
+### Dependency Blame
+
+- `compare_lockfiles(baseline, current) -> BinaryBlame` -- diff Cargo.lock
+  files to identify added, removed, and updated dependencies
+
+## Key Types
+
+`Comparison` (deltas + verdict), `SignificancePolicy`, `Report`, `Finding`,
+`FindingData`, `DomainError` (`NoSamples`, `Stats`, `InvalidAlpha`).
+
+## Verdict Logic
+
+A metric is **Fail** if regression exceeds the budget threshold, **Warn** if it
+exceeds the warn threshold, **Pass** otherwise. The aggregate verdict is the
+worst status across all evaluated metrics. All output uses `BTreeMap` for
+deterministic ordering.
+
+## Testing
+
+- Unit tests: median, host mismatch boundaries, significance gating
+- Property tests (proptest): host mismatch symmetry, budget boundary conditions
+- Mutation testing target: **100% kill rate**
 
 ## License
 

--- a/crates/perfgate-stats/README.md
+++ b/crates/perfgate-stats/README.md
@@ -1,23 +1,33 @@
 # perfgate-stats
 
-Statistical functions for benchmarking analysis.
+Descriptive statistics for performance data -- the numerical foundation of
+perfgate's budget evaluation pipeline.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+Pure functions with no I/O dependencies. Used by `perfgate-domain` and can be
+independently tested and versioned.
 
-## Overview
+## API
 
-Pure statistical functions with no I/O dependencies. Provides summary
-statistics, percentile calculation, and mean/variance computation for
-benchmark sample data.
+### Summary Statistics
 
-## Key API
+- `summarize_u64(values) -> U64Summary` -- median, min, max, mean, stddev
+- `summarize_f64(values) -> F64Summary` -- same for `f64` samples
 
-- `summarize_u64(values)` — compute median, min, max for `u64` samples → `U64Summary`
-- `summarize_f64(values)` — compute median, min, max for `f64` samples → `F64Summary`
-- `median_u64_sorted(sorted)` — median of pre-sorted `u64` slice (overflow-safe)
-- `median_f64_sorted(sorted)` — median of pre-sorted `f64` slice
-- `percentile(values, q)` — compute the q-th percentile (q ∈ [0, 1])
-- `mean_and_variance(values)` — arithmetic mean and sample variance (Bessel-corrected)
+### Median (pre-sorted)
+
+- `median_u64_sorted(sorted)` -- overflow-safe `u64` median via split-halves
+- `median_f64_sorted(sorted)` -- `f64` median
+
+### Percentile
+
+- `percentile(values, q)` -- q-th percentile (q in [0, 1]) with linear
+  interpolation between adjacent ranks
+
+### Mean and Variance
+
+- `mean_and_variance(values) -> Option<(f64, f64)>` -- arithmetic mean and
+  Bessel-corrected sample variance using Welford's online algorithm for
+  numerical stability; returns `None` for empty or non-finite input
 
 ## Example
 
@@ -32,6 +42,21 @@ assert_eq!(summary.max, 120);
 let p95 = percentile(vec![1.0, 2.0, 3.0, 4.0, 5.0], 0.95).unwrap();
 let (mean, var) = mean_and_variance(&[10.0, 20.0, 30.0]).unwrap();
 ```
+
+## Numerical Stability
+
+`mean_and_variance` uses Welford's one-pass online algorithm, avoiding the
+catastrophic cancellation that affects naive two-pass (sum-of-squares) methods.
+Results are validated as finite before returning.
+
+The `u64` median uses a split-halves technique (`a/2 + b/2 + remainder`) to
+avoid overflow at `u64::MAX` boundaries.
+
+## Testing
+
+- Property-based (proptest): ordering invariants, overflow handling, percentile
+  bounds, mean correctness against naive computation
+- Benchmarks via Criterion (`cargo bench -p perfgate-stats`)
 
 ## License
 

--- a/crates/perfgate-types/README.md
+++ b/crates/perfgate-types/README.md
@@ -1,34 +1,73 @@
 # perfgate-types
 
-Versioned data contracts for perfgate.
+Canonical types and versioned schemas that every perfgate crate depends on.
 
-## Responsibilities
+`perfgate-types` is the innermost crate in the dependency graph. It defines all
+receipt structs, configuration types, enums, and constants shared across the
+workspace. Everything here is a plain data type -- no I/O, no statistics, no
+policy logic.
 
-- Defines receipt and report schemas:
-  - `perfgate.run.v1`
-  - `perfgate.compare.v1`
-  - `perfgate.report.v1`
-  - `sensor.report.v1`
-  - paired benchmarking schema (`perfgate.paired.v1`)
-- Defines config types (`ConfigFile`, `BenchConfigFile`, defaults/budget overrides).
-- Defines shared enums/tokens used across crates (metrics, verdicts, finding codes, reason tokens).
-- Provides JSON Schema derivation support through `schemars`.
+## Schema Versions
 
-## Boundaries
+| Schema                | Struct            | Purpose                           |
+|-----------------------|-------------------|-----------------------------------|
+| `perfgate.run.v1`     | `RunReceipt`      | Single benchmark execution result |
+| `perfgate.compare.v1` | `CompareReceipt`  | Baseline vs current comparison    |
+| `perfgate.report.v1`  | `PerfgateReport`  | Findings and verdict summary      |
+| `perfgate.config.v1`  | `ConfigFile`      | Budget and benchmark definitions  |
+| `perfgate.paired.v1`  | `PairedRunReceipt`| Paired A/B benchmark result       |
+| `sensor.report.v1`    | `SensorReport`    | Cockpit integration envelope      |
 
-- No process execution or host probing.
-- No statistics math or budget decision logic.
-- No CLI parsing or filesystem I/O.
+## Key Types
+
+**Run pipeline:** `RunReceipt`, `RunMeta`, `BenchMeta`, `Sample`, `Stats`,
+`U64Summary`, `F64Summary`
+
+**Comparison:** `CompareReceipt`, `Metric`, `Direction`, `Budget`, `Delta`,
+`MetricStatus`, `Verdict`, `VerdictCounts`
+
+**Reporting:** `PerfgateReport`, `ReportFinding`, `FindingData`, `Severity`
+
+**Configuration:** `ConfigFile`, `DefaultsConfig`, `BenchConfigFile`,
+`BudgetOverride`
+
+**Sensor (cockpit):** `SensorReport`, `SensorVerdict`, `SensorFinding`,
+`SensorCapabilities`, `ToolInfo`, `HostInfo`, `HostMismatchPolicy`
+
+**Paired:** `PairedRunReceipt`, `PairedSample`, `PairedSampleHalf`,
+`PairedStats`, `PairedDiffSummary`
+
+## The `Metric` Enum
+
+Central to budget evaluation. Each variant carries metadata:
+
+- `as_str()` / `parse_key()` -- canonical snake_case key (`wall_ms`, `cpu_ms`, ...)
+- `default_direction()` -- `Lower` or `Higher` (throughput is the only `Higher`)
+- `default_warn_factor()` -- default warning threshold multiplier
 
 ## Feature Flags
 
-- `arbitrary`: enables structure-aware fuzzing derives for core types.
+| Flag        | Effect                                                  |
+|-------------|---------------------------------------------------------|
+| `arbitrary` | Enables `Arbitrary` derive for structure-aware fuzzing  |
 
-## Workspace Role
+JSON Schema generation via `schemars` is always available (not feature-gated).
 
-`perfgate-types` is the innermost crate and the shared contract layer:
+## Design Constraints
 
-`perfgate-types` -> `perfgate-domain` -> `perfgate-adapters` -> `perfgate-app` -> `perfgate` (CLI)
+- **All collections use `BTreeMap`** for deterministic serialization order.
+- **Backward-compatible evolution:** new fields use `#[serde(default)]`;
+  removing or renaming fields is a breaking change.
+- **`SensorReport` uses `serde_json::Value`** for opaque data (ABI hardening),
+  so it cannot derive `JsonSchema` or `Arbitrary`.
+- **No logic:** statistics, policy, and rendering belong in downstream crates.
+
+## Testing
+
+- Property-based (proptest): serialization round-trips for `RunReceipt`,
+  `CompareReceipt`, `ConfigFile`, `Budget`, `BudgetOverride`
+- Snapshot (insta): backward compatibility for `HostInfo` defaults
+- TOML and JSON round-trip tests for all receipt and config types
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrite perfgate-types README with schema versioning focus
- Rewrite perfgate-domain README emphasizing I/O-free design
- Rewrite perfgate-stats README with statistical methods overview

## Test plan
- [ ] Content matches actual crate APIs
- [ ] Markdown renders correctly