### PR TITLE
docs: modernize presentation-layer crate READMEs

### DIFF
--- a/crates/perfgate-export/README.md
+++ b/crates/perfgate-export/README.md
@@ -1,42 +1,55 @@
 # perfgate-export
 
-Export formats for perfgate benchmarks.
+Get performance data out of perfgate and into your existing tools.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
-
-## Overview
-
-Provides functionality for exporting run and compare receipts to various
-formats suitable for trend analysis and time-series ingestion.
+Benchmarks produce structured receipts. This crate converts them into
+formats your dashboards, alerting pipelines, and CI systems already
+understand -- one function call, one format enum.
 
 ## Supported Formats
 
-| Format       | Description                                  |
-|--------------|----------------------------------------------|
-| CSV          | RFC 4180 compliant with header row           |
-| JSONL        | JSON Lines (one JSON object per line)        |
-| HTML         | HTML summary table                           |
-| Prometheus   | Prometheus text exposition format             |
-| JUnit        | JUnit XML for legacy CI reporters             |
+| Format | Extension | Use case |
+|-----------|-----------|-------------------------------------------|
+| CSV | `.csv` | Spreadsheets, pandas, ad-hoc analysis |
+| JSONL | `.jsonl` | Log aggregation (ELK, Loki, Datadog) |
+| HTML | `.html` | Embeddable summary tables for reports |
+| Prometheus | `.prom` | Pushgateway / time-series ingestion |
+| JUnit | `.xml` | Legacy CI reporters (Jenkins, GitLab) |
 
-## Key API
+All formats are available for both **run receipts** (raw samples) and
+**compare receipts** (baseline vs. current deltas).
 
-- `ExportFormat` — enum of supported formats (Csv, Jsonl, Html, Prometheus, JUnit)
-- `ExportFormat::parse(s)` — parse format from string
-- `ExportUseCase::export_run(receipt, format)` — export a run receipt
-- `ExportUseCase::export_compare(receipt, format)` — export a compare receipt
-- `RunExportRow` / `CompareExportRow` — typed row structures
+## API
 
-## Example
+The entire surface is two functions and one enum:
 
-```rust,ignore
+```rust
 use perfgate_export::{ExportFormat, ExportUseCase};
 
-// Export a run receipt to CSV
-let csv = ExportUseCase::export_run(&run_receipt, ExportFormat::Csv)?;
+// Pick a format
+let fmt = ExportFormat::parse("csv").unwrap(); // Csv | Jsonl | Html | Prometheus | JUnit
 
-// Export a compare receipt to Prometheus format
+// Export a run receipt
+let csv = ExportUseCase::export_run(&run_receipt, fmt)?;
+
+// Export a compare receipt
 let prom = ExportUseCase::export_compare(&compare_receipt, ExportFormat::Prometheus)?;
+```
+
+### Types
+
+| Item | Description |
+|---------------------|----------------------------------------------|
+| `ExportFormat` | Enum of supported output formats |
+| `ExportUseCase` | Stateless exporter with `export_run` / `export_compare` |
+| `RunExportRow` | Typed row for run receipt exports |
+| `CompareExportRow` | Typed row for compare receipt exports |
+
+## CLI
+
+```bash
+perfgate export --run out.json --format csv --out data.csv
+perfgate export --run out.json --format prometheus --out metrics.prom
 ```
 
 ## License

--- a/crates/perfgate-render/README.md
+++ b/crates/perfgate-render/README.md
@@ -1,101 +1,54 @@
 # perfgate-render
 
-Rendering utilities for perfgate output (markdown, GitHub annotations).
+Human-readable output from performance comparisons.
 
-## Overview
+Takes a `CompareReceipt` and turns it into something a human can read --
+a Markdown table for a PR comment, GitHub Actions annotations for the
+checks tab, or a fully custom layout via Handlebars templates.
 
-This crate provides functions for rendering performance comparison results as:
-- Markdown tables with metrics, budgets, and status icons
-- GitHub Actions workflow annotations (`::error::` and `::warning::`)
-- Template-based markdown rendering using Handlebars
+## Output Formats
 
-## Features
+| Function | Output | Where it shows up |
+|----------------------------|-------------------------------|----------------------------------|
+| `render_markdown` | Markdown table with verdicts | PR comments, CI summaries |
+| `github_annotations` | `::error::` / `::warning::` | GitHub Actions checks tab |
+| `render_markdown_template` | Custom Handlebars template | Anywhere you need a custom layout |
 
-- **Markdown Tables**: Render `CompareReceipt` as formatted markdown tables with verdict status
-- **GitHub Annotations**: Generate `::error::` and `::warning::` annotations for CI workflows
-- **Template Rendering**: Custom Handlebars templates for flexible output formatting
-- **Helper Functions**: Format metrics, values, percentages, and status indicators
-
-## Usage
+## Quick Start
 
 ```rust
 use perfgate_render::{render_markdown, github_annotations, render_markdown_template};
-use perfgate_types::CompareReceipt;
 
-// Render a markdown table
-let markdown = render_markdown(&compare_receipt);
+// Markdown table for a PR comment
+let md = render_markdown(&compare_receipt);
 
-// Generate GitHub Actions annotations
+// GitHub Actions annotations (only emitted for warn/fail metrics)
 let annotations = github_annotations(&compare_receipt);
 
-// Use a custom template
-let template = "{{header}}\n{{#each rows}}- {{metric}}: {{delta_pct}}\n{{/each}}";
-let custom = render_markdown_template(&compare_receipt, template)?;
+// Custom template
+let tmpl = "{{header}}\n{{#each rows}}- {{metric}}: {{delta_pct}}\n{{/each}}";
+let custom = render_markdown_template(&compare_receipt, tmpl)?;
 ```
 
-## API
+## Helpers
 
-### Main Functions
+Formatting functions used internally, also exported for custom renderers:
 
-| Function | Description |
-|----------|-------------|
-| `render_markdown` | Render a `CompareReceipt` as a markdown table |
-| `render_markdown_template` | Render using a custom Handlebars template |
-| `github_annotations` | Generate GitHub Actions annotations for failed/warned metrics |
-
-### Helper Functions
-
-| Function | Description |
-|----------|-------------|
-| `format_metric` | Get the string representation of a `Metric` |
-| `format_metric_with_statistic` | Format metric name with statistic type |
-| `format_value` | Format a metric value with appropriate precision |
-| `format_pct` | Format a percentage with sign (e.g., `+10.00%`) |
-| `direction_str` | Get the string for a budget direction (`lower`/`higher`) |
-| `metric_status_icon` | Get the emoji for a status (✅/⚠️/❌) |
-| `metric_status_str` | Get the string for a status (`pass`/`warn`/`fail`) |
-| `parse_reason_token` | Parse a reason token like `wall_ms_warn` |
-| `render_reason_line` | Render a reason line with threshold info |
-| `markdown_template_context` | Get the JSON context for template rendering |
+| Function | Example output |
+|-------------------------------|--------------------------|
+| `format_value(metric, v)` | `"42"`, `"1.234"` |
+| `format_pct(pct)` | `"+10.00%"`, `"-3.50%"` |
+| `direction_str(dir)` | `"lower"`, `"higher"` |
+| `metric_status_icon(status)` | pass / warn / fail / skip |
+| `metric_status_str(status)` | `"pass"`, `"warn"` |
+| `parse_reason_token(token)` | `"wall_ms_warn"` -> `(WallMs, Warn)` |
 
 ## Template Context
 
-When using `render_markdown_template`, the following context is available:
+`render_markdown_template` exposes a JSON context with `header`, `bench`,
+`verdict`, `rows` (array of per-metric objects with `metric`, `delta_pct`,
+`status_icon`, `raw`, etc.), `reasons`, and the full `compare` receipt.
 
-```json
-{
-  "header": "✅ perfgate: pass",
-  "bench": { "name": "...", ... },
-  "verdict": { "status": "pass", ... },
-  "rows": [
-    {
-      "metric": "wall_ms",
-      "metric_with_statistic": "wall_ms",
-      "statistic": "median",
-      "baseline": "100",
-      "current": "110",
-      "unit": "ms",
-      "delta_pct": "+10.00%",
-      "budget_threshold_pct": 20.0,
-      "budget_direction": "lower",
-      "status": "warn",
-      "status_icon": "⚠️",
-      "raw": { "baseline": 100.0, "current": 110.0, ... }
-    }
-  ],
-  "reasons": ["wall_ms_warn"],
-  "compare": { ... }
-}
-```
+## License
 
-## Testing
-
-```bash
-cargo test -p perfgate-render
-```
-
-The crate includes:
-- Unit tests for all formatting functions
-- Property-based tests for markdown rendering completeness
-- Property-based tests for GitHub annotation generation
-- Snapshot tests using insta for output verification
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate-sensor/README.md
+++ b/crates/perfgate-sensor/README.md
@@ -1,42 +1,55 @@
 # perfgate-sensor
 
-Sensor report building for cockpit integration.
+Cockpit mode integration via `sensor.report.v1` envelopes.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+CI dashboards and fleet-monitoring tools need a uniform envelope around
+every tool's output. This crate wraps perfgate's typed receipts into a
+generic `SensorReport` that any cockpit system can ingest without
+knowing anything about performance budgets.
 
-## Overview
+## What It Does
 
-Wraps `PerfgateReport` into a `sensor.report.v1` envelope suitable for CI/CD
-cockpit systems. The envelope includes tool metadata, run metadata,
-capabilities, verdicts, findings with fingerprints, and artifact links.
+A `SensorReport` envelope contains:
+
+- **Tool metadata** -- name, version
+- **Run metadata** -- timestamps, duration, capability flags (baseline available, engine features)
+- **Verdict** -- pass/warn/fail with counts
+- **Findings** -- individual check results, each with a stable SHA-256 fingerprint
+- **Artifacts** -- links to detailed run/compare/report receipts
+- **Data** -- opaque summary payload for downstream consumers
 
 ## Key API
 
-- `SensorReportBuilder` — builder for constructing `SensorReport` envelopes
-- `sensor_fingerprint(parts)` — SHA-256 fingerprint from semantic parts (pipe-joined, trimmed)
-- `default_engine_capability()` — platform-aware engine capability detection
-
-## Envelope Contents
-
-- **Tool metadata**: name, version
-- **Run metadata**: timestamps, duration
-- **Capabilities**: baseline availability, engine features
-- **Verdict**: pass/warn/fail with counts
-- **Findings**: individual check results with stable fingerprints
-- **Artifacts**: links to detailed reports
-
-## Example
-
 ```rust
-use perfgate_sensor::{sensor_fingerprint, default_engine_capability};
-use perfgate_types::CapabilityStatus;
+use perfgate_sensor::SensorReportBuilder;
 
-let fp = sensor_fingerprint(&["perfgate", "perf.budget", "metric_fail", "wall_ms"]);
-assert_eq!(fp.len(), 64); // SHA-256 hex
-
-let cap = default_engine_capability();
-// Available on Unix, Unavailable on other platforms
+let report = SensorReportBuilder::new(tool_info, started_at)
+    .ended_at(ended_at, duration_ms)
+    .baseline(true, None)
+    .artifact("extras/perfgate.run.v1.json".into(), "run_receipt".into())
+    .build(&perfgate_report);
 ```
+
+### Builder Methods
+
+| Method | Purpose |
+|--------------------|------------------------------------------------|
+| `new(tool, start)` | Create builder with tool info and start time |
+| `ended_at(t, ms)` | Set end time and duration |
+| `baseline(ok, reason)` | Declare baseline availability |
+| `max_findings(n)` | Cap findings (default 100, adds truncation notice) |
+| `artifact(path, type)` | Attach an artifact link |
+| `build(report)` | Single-bench envelope from a `PerfgateReport` |
+| `build_error(msg, stage, code)` | Error envelope when the tool itself fails |
+| `build_aggregated(outcomes)` | Multi-bench envelope from `Vec<BenchOutcome>` |
+
+### Other Exports
+
+| Item | Purpose |
+|-----------------------------|----------------------------------------------|
+| `sensor_fingerprint(findings)` | SHA-256 fingerprint over a set of findings |
+| `default_engine_capability()` | Platform-aware capability detection |
+| `BenchOutcome` | Success or Error outcome for aggregation |
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrote `perfgate-export` README: leads with getting data into existing tools, adds use-case column to format table, shows single entry-point API (57 lines)
- Rewrote `perfgate-render` README: leads with human-readable output, consolidates output formats into one table, trims helper docs to example-output style (54 lines)
- Rewrote `perfgate-sensor` README: leads with cockpit mode integration, documents full SensorReportBuilder API including aggregation, lists all public exports (56 lines)

## Test plan

- [ ] Verify README rendering on GitHub (tables, code blocks, formatting)
- [ ] Confirm no broken links or references