### PR TITLE
docs: modernize READMEs for adapters, paired, and budget crates

### DIFF
--- a/crates/perfgate-adapters/README.md
+++ b/crates/perfgate-adapters/README.md
@@ -1,34 +1,51 @@
 # perfgate-adapters
 
-Infrastructure adapters for process execution and host probing.
+Platform-specific process execution and metric collection for the
+[perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-## Responsibilities
+Every other crate in the workspace is platform-agnostic. `perfgate-adapters`
+is the single place where OS APIs, `libc`, and `std::process` are used --
+keeping the rest of the codebase testable and portable.
 
-- Runs benchmark commands through `StdProcessRunner` and `ProcessRunner`.
-- Captures wall-clock timing, exit code, timeout status, and capped stdout/stderr.
-- Collects process metrics when available:
-  - Unix: `cpu_ms`, `max_rss_kb`, `page_faults`, `ctx_switches` (via `wait4`/`rusage`)
-  - Windows: best-effort `cpu_ms` and `max_rss_kb`
-- Probes host info via `StdHostProbe` (`os`, `arch`, CPU count, memory, optional hostname hash).
-- Provides `FakeProcessRunner` for deterministic tests.
+## Platform support
 
-## Platform Notes
+| Capability | Unix | Windows | Other |
+|---|---|---|---|
+| Process execution | `wait4` + `WNOHANG` polling | `WaitForSingleObject` | `std::process::Command` |
+| Timeout / kill | SIGKILL after deadline | `WaitForSingleObject` + kill | not supported |
+| CPU time (`cpu_ms`) | `rusage` (user + system) | -- | -- |
+| Peak RSS (`max_rss_kb`) | `rusage.ru_maxrss` | `GetProcessMemoryInfo` | -- |
+| Page faults | `rusage.ru_majflt` | -- | -- |
+| Context switches | `rusage` (vol + invol) | -- | -- |
+| I/O bytes | -- | `GetProcessIoCounters` | -- |
+| Memory detection | `/proc/meminfo`, `sysctl` | `GlobalMemoryStatusEx` | -- |
+| Hostname hash | SHA-256 | SHA-256 | SHA-256 |
 
-- Unix supports command timeouts.
-- Windows currently returns `AdapterError::TimeoutUnsupported` if timeout is requested.
-- Other platforms run without timeout support and with limited metrics.
+> **RSS unit quirk:** Linux reports `ru_maxrss` in KB; macOS reports bytes
+> (divided by 1024 internally).
 
-## Boundaries
+## Key types
 
-- No policy or threshold logic.
-- No markdown/report rendering.
-- No CLI argument parsing.
+| Type | Role |
+|---|---|
+| `CommandSpec` | Describes a command: argv, cwd, env, timeout, output cap |
+| `RunResult` | Execution output: wall_ms, exit_code, cpu_ms, max_rss_kb, stdout/stderr, ... |
+| `AdapterError` | Typed errors: `EmptyArgv`, `Timeout`, `RunCommand`, `Other` |
+| `ProcessRunner` (trait) | Abstracts process execution for dependency injection |
+| `HostProbe` (trait) | Collects OS, arch, CPU count, memory, optional hostname hash |
+| `FakeProcessRunner` | Deterministic test double for `ProcessRunner` |
 
-## Workspace Role
+## Design
 
-`perfgate-adapters` is the "touch the world" layer used by application use-cases:
+- **Traits enable testing** -- `ProcessRunner` and `HostProbe` are trait objects
+  so the app layer can inject fakes without spawning real processes.
+- **Output capping** -- stdout/stderr are truncated to `output_cap_bytes` (default 8 KB).
+- **No policy logic** -- this crate only collects data; thresholds and verdicts
+  live in `perfgate-budget` and `perfgate-domain`.
 
-`perfgate-types` + `perfgate-domain` + `perfgate-adapters` -> `perfgate-app`
+```text
+perfgate-types + perfgate-domain + perfgate-adapters --> perfgate-app
+```
 
 ## License
 

--- a/crates/perfgate-budget/README.md
+++ b/crates/perfgate-budget/README.md
@@ -1,31 +1,47 @@
 # perfgate-budget
 
-Budget evaluation logic for performance thresholds.
+Threshold-based verdict computation -- the decision engine that turns metric
+deltas into pass/warn/fail outcomes.
 
 Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-## Overview
+## How it works
 
-Pure budget evaluation functions with no I/O dependencies. Handles threshold
-checking, regression calculation, and verdict aggregation for performance
-metrics against configurable budgets.
+Given a baseline value, a current value, and a `Budget` (thresholds +
+direction), the crate computes the regression percentage and maps it to a
+status:
 
-## Key API
+| Condition | Status |
+|---|---|
+| `regression > threshold` | **Fail** |
+| `warn_threshold <= regression <= threshold` | **Warn** |
+| `regression < warn_threshold` | **Pass** |
 
-- `evaluate_budget(baseline, current, budget)` — evaluate a single metric → `BudgetResult`
-- `calculate_regression(baseline, current, direction)` — compute regression percentage
-- `determine_status(regression, threshold, warn_threshold)` — map regression to Pass/Warn/Fail
-- `aggregate_verdict(statuses)` — aggregate multiple statuses into a `Verdict`
-- `evaluate_budgets(metrics, budgets)` — batch-evaluate multiple metrics
-- `reason_token(metric, status)` — generate structured reason tokens
+Direction matters: for `Lower`-is-better metrics (e.g., latency), an increase
+is a regression; for `Higher`-is-better (e.g., throughput), a decrease is.
 
-## Status Rules
+When multiple metrics are evaluated, `aggregate_verdict` collapses them:
+Fail dominates Warn dominates Pass.
 
-| Condition                          | Status |
-|------------------------------------|--------|
-| regression > threshold             | Fail   |
-| warn_threshold ≤ regression ≤ threshold | Warn   |
-| regression < warn_threshold        | Pass   |
+## Key types
+
+| Type | Role |
+|---|---|
+| `Budget` | Fail threshold, warn threshold, direction, noise policy |
+| `BudgetResult` | Per-metric outcome: ratio, pct change, regression, status |
+| `Verdict` | Aggregated status + per-status counts + reason tokens |
+| `BudgetError` | `InvalidBaseline` (zero/negative), `NoSamples` |
+
+## API
+
+| Function | Purpose |
+|---|---|
+| `evaluate_budget(baseline, current, budget, cv)` | Single metric evaluation |
+| `evaluate_budgets(metrics, budgets)` | Batch evaluation with verdict aggregation |
+| `calculate_regression(baseline, current, direction)` | Raw regression fraction |
+| `determine_status(regression, threshold, warn)` | Map regression to status |
+| `aggregate_verdict(statuses)` | Collapse multiple statuses into one verdict |
+| `reason_token(metric, status)` | Structured token, e.g. `wall_ms_fail` |
 
 ## Example
 
@@ -33,17 +49,13 @@ metrics against configurable budgets.
 use perfgate_budget::{evaluate_budget, aggregate_verdict};
 use perfgate_types::{Budget, Direction, MetricStatus, VerdictStatus};
 
-let budget = Budget {
-    threshold: 0.20,
-    warn_threshold: 0.10,
-    direction: Direction::Lower,
-};
+let budget = Budget::new(0.20, 0.10, Direction::Lower);
 
-let result = evaluate_budget(100.0, 115.0, &budget).unwrap();
-assert_eq!(result.status, MetricStatus::Warn);
+let result = evaluate_budget(100.0, 115.0, &budget, None).unwrap();
+assert_eq!(result.status, MetricStatus::Warn); // 15% regression
 
 let verdict = aggregate_verdict(&[MetricStatus::Pass, MetricStatus::Warn]);
-assert_eq!(verdict.status, VerdictStatus::Warn);
+assert_eq!(verdict.status, VerdictStatus::Warn); // Warn dominates
 ```
 
 ## License

--- a/crates/perfgate-paired/README.md
+++ b/crates/perfgate-paired/README.md
@@ -1,39 +1,54 @@
 # perfgate-paired
 
-Paired benchmarking statistics for A/B comparison.
+CI runners are noisy. CPU frequency scaling, background daemons, and
+shared-tenancy VMs mean that a single-run comparison can easily produce a
+false-positive regression alert.
+
+`perfgate-paired` solves this with **interleaved A/B benchmarking**: baseline
+and current commands alternate within the same execution window, so
+environmental noise affects both sides equally and cancels out in the paired
+difference.
 
 Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-## Overview
+## How it works
 
-Provides statistical analysis for paired benchmark data where each measurement
-consists of a baseline and current observation from the same experimental unit.
-Uses paired t-test methodology with 95% confidence intervals.
+1. **Alternating execution** -- each "pair" runs baseline then current
+   back-to-back, sharing the same thermal/load conditions.
+2. **Paired t-test** -- the difference distribution (current - baseline) is
+   tested for statistical significance with a 95% confidence interval.
+3. **Significance-based retries** -- if `require_significance` is set and
+   the CI still spans zero, additional pairs are collected automatically
+   (up to `max_retries`).
+4. **Warmup rounds** -- configurable warmup pairs are excluded from
+   statistics so JIT, caches, and page faults stabilize first.
 
 ## Key API
 
-- `compute_paired_stats(samples, budget)` — compute summary stats from paired samples → `PairedStats`
-- `compare_paired_stats(stats)` — compare with confidence intervals → `PairedComparison`
-- `summarize_paired_diffs(samples)` — summarize the distribution of differences
-- `PairedError` — error type (re-exported from `perfgate-error`)
+| Function | Returns | Purpose |
+|---|---|---|
+| `compute_paired_stats(samples, work_units, policy)` | `PairedStats` | Summary statistics for wall time, RSS, and throughput diffs |
+| `compare_paired_stats(stats)` | `PairedComparison` | Confidence interval and significance flag |
+| `summarize_paired_diffs(diffs, policy)` | `PairedDiffSummary` | Mean, median, std dev, min/max, optional significance |
 
-## Statistical Methodology
+## Statistical methodology
 
-- **Paired t-test** with conservative t-values (2.0 for n < 30, 1.96 for n ≥ 30)
-- **95% CI**: `mean ± t × (std_dev / √n)`
-- **Significance**: CI does not span zero
+- **t-value**: 2.0 for n < 30 (conservative), 1.96 for n >= 30
+- **95% CI**: `mean +/- t * (std_dev / sqrt(n))`
+- **Significant**: the CI does not span zero *and* `n >= min_samples`
 
 ## Example
 
 ```rust
 use perfgate_paired::{compute_paired_stats, compare_paired_stats};
-use perfgate_types::{PairedSample, PairedSampleHalf};
 
-// After collecting paired samples...
-// let stats = compute_paired_stats(&samples, None)?;
-// let comparison = compare_paired_stats(&stats);
-// println!("Mean diff: {:.2}ms", comparison.mean_diff_ms);
-// println!("Significant: {}", comparison.is_significant);
+// After collecting interleaved paired samples...
+let stats = compute_paired_stats(&samples, None, None)?;
+let cmp = compare_paired_stats(&stats);
+
+println!("mean diff:   {:.2} ms", cmp.mean_diff_ms);
+println!("95% CI:      [{:.2}, {:.2}]", cmp.ci_95_lower, cmp.ci_95_upper);
+println!("significant: {}", cmp.is_significant);
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- **perfgate-adapters**: Rewritten to lead with platform isolation role and a detailed platform support matrix (Unix vs Windows vs Other). Key types table, design principles, and dependency graph.
- **perfgate-paired**: Rewritten to lead with the CI noise problem, then explain the interleaved A/B benchmarking solution. Covers alternating execution, significance-based retries, warmup rounds, and statistical methodology.
- **perfgate-budget**: Rewritten to lead with threshold-based verdict computation. Covers the status rules table, key types, full API surface, and a working example.

All three READMEs are within their line budgets (52, 56, and 63 lines respectively).

## Test plan

- [ ] Verify README rendering on GitHub for all three crates
- [ ] Confirm no broken links or formatting issues