### PR TITLE
docs(cli): modernize README with problem-first structure

### DIFF
--- a/crates/perfgate-cli/README.md
+++ b/crates/perfgate-cli/README.md
@@ -1,47 +1,121 @@
-# perfgate (CLI crate)
+# perfgate
 
-Command-line entrypoint for perfgate.
+**One tool to run benchmarks, detect regressions, and gate CI.**
 
-This crate wires Clap commands to application use-cases in `perfgate-app`, handles JSON/file I/O, and enforces exit code policy for CI usage.
+You ship code daily. Performance regressions slip through because measuring,
+comparing, and enforcing budgets are three separate problems. perfgate solves
+all three in a single binary that fits into any CI pipeline.
 
-## Commands
-
-- `run`: execute a benchmark command and emit `perfgate.run.v1`.
-- `compare`: compare current vs baseline and emit `perfgate.compare.v1`.
-- `md`: render markdown from a compare receipt.
-- `github-annotations`: emit GitHub Actions annotation lines.
-- `report`: generate `perfgate.report.v1` (optionally markdown too).
-- `promote`: copy/normalize a run receipt into baseline storage.
-- `export`: export run/compare data (`csv`, `jsonl`, `html`, `prometheus`).
-- `check`: config-driven workflow for artifacts and gating.
-- `paired`: interleaved baseline/current benchmarking for noise reduction.
-- `baseline`: manage baselines on a centralized baseline server.
-
-## Quick Usage
+## Install
 
 ```bash
+# Pre-built binary (via cargo-binstall)
+cargo binstall perfgate-cli
+
+# From crates.io
+cargo install perfgate-cli
+
+# From source
+cargo install --path crates/perfgate-cli
+```
+
+## Quick Start
+
+```bash
+# 1. Measure
 perfgate run --name my-bench --out run.json -- ./my-benchmark
-perfgate compare --baseline baseline.json --current run.json --out compare.json
-perfgate md --compare compare.json --out comment.md
+
+# 2. Compare against a baseline
+perfgate compare --baseline baseline.json --current run.json --out cmp.json
+
+# 3. Gate CI (exit 2 on regression)
+perfgate report --compare cmp.json --out report.json
+```
+
+Or use `check` for the full workflow in one command:
+
+```bash
 perfgate check --config perfgate.toml --bench my-bench
 ```
 
+## Commands
+
+Commands are organized by workflow stage.
+
+### Measure
+
+| Command   | Purpose |
+|-----------|---------|
+| `run`     | Execute a command N times, emit a `perfgate.run.v1` receipt |
+| `paired`  | Interleaved A/B benchmarking to cancel out environmental noise |
+
+### Analyze
+
+| Command   | Purpose |
+|-----------|---------|
+| `compare` | Diff current vs baseline, emit a `perfgate.compare.v1` receipt |
+| `blame`   | Identify which Cargo.lock dependency changes caused a regression |
+| `explain` | Generate AI-ready diagnostic prompts for regressions |
+
+### Report
+
+| Command              | Purpose |
+|----------------------|---------|
+| `md`                 | Render Markdown from a compare receipt |
+| `report`             | Generate a `perfgate.report.v1` envelope |
+| `summary`            | Print a terminal table from one or more compare receipts |
+| `github-annotations` | Emit `::error::`/`::warning::` lines for GitHub Actions |
+| `export`             | Export to CSV, JSONL, HTML, Prometheus, or JUnit |
+
+### Manage
+
+| Command     | Purpose |
+|-------------|---------|
+| `promote`   | Copy a run receipt into baseline storage |
+| `baseline`  | Manage baselines on a centralized server (list, upload, download, delete, history, verdicts, migrate) |
+| `aggregate` | Merge multiple run receipts (e.g. from a fleet) into one |
+| `fleet`     | Fleet-wide dependency regression alerts and impact analysis |
+
+### Automate
+
+| Command  | Purpose |
+|----------|---------|
+| `check`  | Config-driven end-to-end workflow: run, compare, report, gate |
+| `bisect` | Binary-search for the commit that introduced a regression |
+
 ## Exit Codes
 
-- `0`: success (or warn without `--fail-on-warn`)
-- `1`: tool/runtime error
-- `2`: policy fail
-- `3`: warn treated as failure (`--fail-on-warn`)
+Every command follows the same contract:
 
-## Scope
+| Code | Meaning |
+|------|---------|
+| `0`  | Success (or warn without `--fail-on-warn`) |
+| `1`  | Runtime error (I/O, parse, spawn failure) |
+| `2`  | Policy fail (budget violated) |
+| `3`  | Warn treated as failure (`--fail-on-warn`) |
 
-- This crate owns CLI UX, argument validation, and artifact file handling.
-- It does not implement core policy math (domain) or process primitives (adapters).
+## Examples
 
-## More Documentation
+```bash
+# Paired A/B benchmarking (interleaved to reduce noise)
+perfgate paired --name my-bench \
+  --baseline-cmd "./old" --current-cmd "./new" --repeat 30 --out cmp.json
 
-- Workspace overview and CI examples: [`README.md`](../../README.md)
-- Testing strategy: [`TESTING.md`](../../TESTING.md)
+# Export metrics for Prometheus
+perfgate export --run run.json --format prometheus --out metrics.prom
+
+# Find the commit that introduced a regression
+perfgate bisect --good v1.0.0 --bad HEAD --executable ./target/release/my-bench
+
+# Cockpit mode: always emit a sensor report, exit 0 for dashboard ingestion
+perfgate check --config perfgate.toml --bench my-bench --mode cockpit
+```
+
+## More
+
+- Workspace overview and CI examples: [README.md](../../README.md)
+- Testing strategy: [TESTING.md](../../TESTING.md)
+- API docs: [docs.rs/perfgate-cli](https://docs.rs/perfgate-cli)
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrites the perfgate-cli README to lead with the problem (single tool for benchmarks, regressions, and CI gating)
- Adds install section with cargo-binstall, crates.io, and source options
- Organizes all 16 commands into five workflow stages: Measure, Analyze, Report, Manage, Automate
- Includes exit code contract table, quick-start guide, and practical examples
- Keeps the file concise at 122 lines (down from verbose but incomplete 48-line original)

## Test plan

- [ ] Verify all listed commands match `perfgate --help` output
- [ ] Confirm Markdown renders correctly on GitHub
- [ ] Check that relative links (../../README.md, ../../TESTING.md) resolve correctly