### PR TITLE
docs: modernize READMEs for support crates

### DIFF
--- a/crates/perfgate-auth/README.md
+++ b/crates/perfgate-auth/README.md
@@ -1,8 +1,60 @@
 # perfgate-auth
 
-Authentication and authorization types for perfgate.
+Authentication and authorization types for the perfgate baseline service.
 
 Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-Defines API key formats (`pg_live_`, `pg_test_`), permission scopes (Read, Write, Promote,
-Delete, Admin), and role-based access control (Viewer, Contributor, Promoter, Admin).
+## Problem
+
+The baseline service controls who can read, write, promote, and delete baselines
+-- scoped to projects and optionally to benchmarks. This crate defines the
+shared type vocabulary used by server, client, and CLI.
+
+## Key Types
+
+| Type | Purpose |
+|------|---------|
+| `ApiKey` | Authenticated key with project scope, role, and optional benchmark regex |
+| `Role` | Viewer, Contributor, Promoter, Admin -- cumulative scopes |
+| `Scope` | Granular permission: Read, Write, Promote, Delete, Admin |
+| `JwtClaims` | JWT payload accepted by the server (subject, project, scopes, expiry) |
+
+## API Key Format
+
+- `pg_live_<32+ alphanumeric>` -- production keys
+- `pg_test_<32+ alphanumeric>` -- test/sandbox keys
+
+`validate_key_format()` enforces prefix and length; `generate_api_key(test)` mints new keys.
+
+## Roles and Scopes
+
+```text
+Viewer       -> [Read]
+Contributor  -> [Read, Write]
+Promoter     -> [Read, Write, Promote]
+Admin        -> [Read, Write, Promote, Delete, Admin]
+```
+
+`Role::from_scopes()` infers the closest built-in role from an arbitrary scope
+set, useful when mapping JWT claims to role-based checks.
+
+## Example
+
+```rust
+use perfgate_auth::{ApiKey, Role, Scope, validate_key_format};
+
+let key = ApiKey::new(
+    "key_1".into(),
+    "CI writer".into(),
+    "my-project".into(),
+    Role::Contributor,
+);
+assert!(key.has_scope(Scope::Write));
+assert!(!key.has_scope(Scope::Delete));
+
+assert!(validate_key_format("pg_live_abcdefghijklmnopqrstuvwxyz123456").is_ok());
+```
+
+## License
+
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate-client/README.md
+++ b/crates/perfgate-client/README.md
@@ -1,36 +1,40 @@
 # perfgate-client
 
-A Rust client library for the perfgate baseline service.
+Rust client library for the perfgate baseline service REST API.
 
-[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](../../LICENSE-MIT)
+Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-## Overview
+## Problem
 
-perfgate-client provides a type-safe, async client for interacting with the perfgate baseline server. It handles:
+CI pipelines and local tools need a reliable way to talk to the centralized
+baseline service -- uploading run receipts, fetching baselines for comparison,
+promoting good builds, and recording verdicts. This crate wraps the REST API
+in a type-safe, async client with retries and local-filesystem fallback.
 
-- API communication with automatic retries
-- Authentication via API keys
-- Fallback to local storage when the server is unavailable
-- Integration with the perfgate CLI
+## Key Operations
 
-**Documentation:** [Getting Started with Baseline Server](../../docs/GETTING_STARTED_BASELINE_SERVER.md)
+| Method | Description |
+|--------|-------------|
+| `upload_baseline` | Push a run receipt to the server |
+| `get_latest_baseline` | Fetch the current baseline for a benchmark |
+| `get_baseline_version` | Fetch a specific historical version |
+| `list_baselines` | Query with filtering and pagination |
+| `promote_baseline` | Promote a version to active baseline |
+| `delete_baseline` | Remove a baseline version |
+| `submit_verdict` | Record a pass/warn/fail verdict |
+| `list_verdicts` | Query verdict history |
+| `health_check` / `is_healthy` | Server liveness probe |
 
-## Features
+## Auth
 
-- **Full API Support**: Upload, download, list, promote, and delete baselines
-- **Automatic Retries**: Configurable retry logic with exponential backoff
-- **Fallback Storage**: Automatic fallback to local storage when server is unavailable
-- **Type-Safe**: Strongly typed request and response models
-- **Async/Await**: Built on Tokio for async operations
+- **API key** -- `config.with_api_key("pg_live_...")` sends `Bearer <key>`
+- **JWT token** -- `config.with_token("ey...")` sends `Token <jwt>`
 
-## Installation
+## Resilience
 
-Add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-perfgate-client = { path = "path/to/perfgate-client" }
-```
+- **Retries** with exponential backoff on 429/5xx (configurable via `RetryConfig`)
+- **Fallback** -- `FallbackClient` reads from local storage when the server is
+  unreachable, so CI never hard-fails on a transient outage
 
 ## Quick Start
 
@@ -39,113 +43,19 @@ use perfgate_client::{BaselineClient, ClientConfig, ListBaselinesQuery};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Create a client
     let config = ClientConfig::new("https://perfgate.example.com/api/v1")
-        .with_api_key("your-api-key");
-    
+        .with_api_key("pg_live_abcdefghijklmnopqrstuvwxyz123456");
     let client = BaselineClient::new(config)?;
-    
-    // Check server health
-    let health = client.health_check().await?;
-    println!("Server status: {}", health.status);
-    
-    // List baselines
+
     let query = ListBaselinesQuery::new().with_limit(10);
     let response = client.list_baselines("my-project", &query).await?;
-    
-    for baseline in &response.baselines {
-        println!("{}: {}", baseline.benchmark, baseline.version);
+    for b in &response.baselines {
+        println!("{}: {}", b.benchmark, b.version);
     }
-    
     Ok(())
 }
 ```
 
-## Fallback Storage
-
-When the server is unavailable, the client can fall back to local file storage:
-
-```rust
-use perfgate_client::{BaselineClient, ClientConfig, FallbackClient, FallbackStorage};
-
-let config = ClientConfig::new("https://perfgate.example.com/api/v1")
-    .with_api_key("your-api-key")
-    .with_fallback(FallbackStorage::local("./baselines"));
-
-let client = BaselineClient::new(config)?;
-let fallback_client = FallbackClient::new(
-    client,
-    Some(FallbackStorage::local("./baselines")),
-);
-
-// This will fall back to local storage if the server is unavailable
-let baseline = fallback_client
-    .get_latest_baseline("my-project", "my-bench")
-    .await?;
-```
-
-## Error Handling
-
-```rust
-use perfgate_client::{BaselineClient, ClientConfig, ClientError};
-
-let config = ClientConfig::new("https://perfgate.example.com/api/v1");
-let client = BaselineClient::new(config).unwrap();
-
-match client.get_latest_baseline("my-project", "my-bench").await {
-    Ok(baseline) => println!("Got baseline: {}", baseline.id),
-    Err(ClientError::NotFoundError(msg)) => {
-        eprintln!("Baseline not found: {}", msg);
-    }
-    Err(ClientError::AuthError(msg)) => {
-        eprintln!("Authentication failed: {}", msg);
-    }
-    Err(ClientError::ConnectionError(msg)) => {
-        eprintln!("Server unavailable: {}", msg);
-    }
-    Err(e) => eprintln!("Error: {}", e),
-}
-```
-
-## API Reference
-
-### `BaselineClient`
-
-The main client for interacting with the baseline service.
-
-| Method | Description |
-|--------|-------------|
-| `new(config)` | Create a new client with configuration |
-| `upload_baseline(project, request)` | Upload a new baseline |
-| `get_latest_baseline(project, benchmark)` | Get the latest baseline for a benchmark |
-| `get_baseline_version(project, benchmark, version)` | Get a specific baseline version |
-| `list_baselines(project, query)` | List baselines with filtering |
-| `delete_baseline(project, benchmark, version)` | Delete a baseline version |
-| `promote_baseline(project, benchmark, request)` | Promote a baseline version |
-| `health_check()` | Check server health |
-| `is_healthy()` | Returns true if server is healthy |
-
-### `FallbackClient`
-
-A client wrapper with automatic fallback to local storage.
-
-| Method | Description |
-|--------|-------------|
-| `new(client, fallback)` | Create a new fallback client |
-| `get_latest_baseline(project, benchmark)` | Get latest with fallback |
-| `get_baseline_version(project, benchmark, version)` | Get version with fallback |
-| `upload_baseline(project, request)` | Upload with fallback |
-| `has_fallback()` | Check if fallback is configured |
-
-### Configuration
-
-| Type | Description |
-|------|-------------|
-| `ClientConfig` | Main client configuration |
-| `RetryConfig` | Retry behavior configuration |
-| `AuthMethod` | Authentication method (None, ApiKey, Token) |
-| `FallbackStorage` | Fallback storage type (Local) |
-
 ## License
 
-MIT OR Apache-2.0
+Licensed under either Apache-2.0 or MIT.

--- a/crates/perfgate-error/README.md
+++ b/crates/perfgate-error/README.md
@@ -1,47 +1,48 @@
 # perfgate-error
 
-Unified error types for the perfgate ecosystem.
+Shared error types and categorization across the perfgate workspace.
 
 Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-## Overview
+## Problem
 
-This crate provides a single, comprehensive error type (`PerfgateError`) that
-unifies all error variants across the perfgate crates, enabling seamless error
-propagation and conversion.
+A workspace with 26 crates needs a single error vocabulary so that errors flow
+cleanly from inner layers (stats, adapters) through orchestration to the CLI
+exit code. This crate defines that vocabulary.
 
 ## Error Categories
 
-| Category     | Type                    | Description                          |
-|--------------|-------------------------|--------------------------------------|
-| Validation   | `ValidationError`       | Bench name and input validation      |
-| Stats        | `StatsError`            | Statistical computation errors       |
-| Adapter      | `AdapterError`          | Process execution, timeout, platform |
-| Config       | `ConfigValidationError` | Configuration parsing/validation     |
-| IO           | `IoError`               | File system and network I/O          |
-| Paired       | `PairedError`           | Paired benchmark errors              |
+| Category | Type | Typical Cause |
+|----------|------|---------------|
+| Validation | `ValidationError` | Invalid bench name, bad characters, path traversal |
+| Stats | `StatsError` | No samples to summarize |
+| Adapter | `AdapterError` | Spawn failure, timeout, unsupported platform |
+| Config | `ConfigValidationError` | Bad config file, invalid bench reference |
+| IO | `IoError` | Missing baseline file, artifact write failure |
+| Paired | `PairedError` | Paired benchmark with no samples |
+| Auth | `AuthError` | Missing/expired key, insufficient permissions |
+
+All variants unify under `PerfgateError` with `From` impls for seamless `?`
+propagation. Every error maps to exit code **1** (vs policy-fail `2` / warn `3`).
 
 ## Key API
 
-- `PerfgateError` — unified error enum with `From` impls for all sub-errors
-- `ValidationError` — bench name validation errors
-- `validate_bench_name(name)` — validate a bench name against naming rules
-- `ErrorCategory` — categorization enum for error routing
-- `Result<T>` — type alias for `std::result::Result<T, PerfgateError>`
+- `PerfgateError` -- unified enum wrapping all category-specific errors
+- `ErrorCategory` -- classification enum for routing and diagnostics
+- `is_recoverable()` -- true for transient failures (I/O, timeouts)
+- `exit_code()` -- always `1` for tool/runtime errors
+- `validate_bench_name(name)` -- bench name validation
+- `Result<T>` -- type alias for `std::result::Result<T, PerfgateError>`
 
 ## Example
 
 ```rust
 use perfgate_error::{PerfgateError, ValidationError, validate_bench_name};
 
-fn check(name: &str) -> Result<(), PerfgateError> {
-    validate_bench_name(name)?;
-    Ok(())
-}
-
-let err = check("").unwrap_err();
-assert!(matches!(err, PerfgateError::Validation(ValidationError::Empty)));
-assert_eq!(err.exit_code(), 1);
+let err = validate_bench_name("../escape").unwrap_err();
+let unified: PerfgateError = err.into();
+assert_eq!(unified.exit_code(), 1);
+assert!(!unified.is_recoverable());
 ```
 
 ## License

--- a/crates/perfgate-validation/README.md
+++ b/crates/perfgate-validation/README.md
@@ -1,40 +1,45 @@
 # perfgate-validation
 
-Validation functions for benchmark names and configuration.
+Schema validation and contract testing for benchmark names in perfgate.
 
 Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
-## Overview
+## Problem
 
-This crate re-exports bench-name validation logic from `perfgate-error` and
-provides a focused entry point for validating benchmark names against strict
-naming rules.
+Benchmark names appear in file paths, JSON keys, and REST URLs. A bad name
+(path traversal, illegal characters, excessive length) can break storage,
+confuse queries, or open security holes. This crate provides a single
+validation entry point that enforces strict naming rules everywhere.
 
 ## Naming Rules
 
-- Lowercase alphanumeric, dots, underscores, hyphens, slashes only
-- Maximum 64 characters
-- No empty path segments (leading/trailing/consecutive slashes)
-- No path traversal (`.` or `..` segments)
+1. Must not be empty.
+2. Maximum 64 characters (`BENCH_NAME_MAX_LEN`).
+3. Lowercase ASCII letters, digits, `_`, `.`, `-`, `/` only (`BENCH_NAME_PATTERN`).
+4. No empty path segments -- leading, trailing, or consecutive `/` forbidden.
+5. No `.` or `..` segments -- path traversal forbidden.
 
 ## Key API
 
-- `validate_bench_name(name)` — validate a bench name, returns `Result<(), ValidationError>`
-- `ValidationError` — error enum (Empty, TooLong, InvalidCharacters, EmptySegment, PathTraversal)
-- `BENCH_NAME_MAX_LEN` — maximum allowed length (64)
-- `BENCH_NAME_PATTERN` — regex pattern for valid names
+- `validate_bench_name(name)` -- returns `Ok(())` or a `ValidationError`
+- `ValidationError` -- enum: `Empty`, `TooLong`, `InvalidCharacters`, `EmptySegment`, `PathTraversal`
+- `BENCH_NAME_MAX_LEN` -- `64`
+- `BENCH_NAME_PATTERN` -- `^[a-z0-9_.\-/]+$`
+
+All types are re-exported from `perfgate-error` for a focused, dependency-light
+entry point.
 
 ## Example
 
 ```rust
 use perfgate_validation::{validate_bench_name, ValidationError};
 
-assert!(validate_bench_name("my-bench").is_ok());
+assert!(validate_bench_name("ci/build-time").is_ok());
 assert!(validate_bench_name("path/to/bench.v2").is_ok());
 
 assert!(matches!(validate_bench_name(""), Err(ValidationError::Empty)));
-assert!(validate_bench_name("MyBench").is_err());   // uppercase
-assert!(validate_bench_name("../bench").is_err());   // path traversal
+assert!(matches!(validate_bench_name("MyBench"), Err(ValidationError::InvalidCharacters { .. })));
+assert!(matches!(validate_bench_name("../escape"), Err(ValidationError::PathTraversal { .. })));
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Rewrote READMEs for `perfgate-auth`, `perfgate-client`, `perfgate-error`, and `perfgate-validation` to a modern, problem-first style
- Each README now leads with the problem the crate solves, followed by key types/API, and a focused example
- Removed verbose API reference tables and duplicative code samples from `perfgate-client` (was 152 lines, now 61)
- Added Auth error category to `perfgate-error` README which was previously missing
- All READMEs are within their target line limits (auth: 60, client: 61, error: 50, validation: 47)

## Test plan

- [ ] Verify READMEs render correctly on GitHub
- [ ] Confirm no Cargo.toml `readme` field changes are needed (paths unchanged)