### PR TITLE
docs: crates.io metadata and lib.rs doc comments

### DIFF
--- a/crates/perfgate-adapters/src/lib.rs
+++ b/crates/perfgate-adapters/src/lib.rs
@@ -1,6 +1,25 @@
-//! Std adapters for perfgate.
+//! Process execution and host probing adapters for perfgate.
 //!
-//! In clean-arch terms: this is where we touch the world.
+//! In clean-arch terms this is where perfgate touches the world: running child
+//! processes, collecting CPU time / RSS via platform APIs, and probing host
+//! environment metadata for mismatch detection.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use perfgate_adapters::{StdProcessRunner, ProcessRunner, CommandSpec};
+//!
+//! let runner = StdProcessRunner;
+//! let spec = CommandSpec {
+//!     name: "echo".into(),
+//!     argv: vec!["hello".into()],
+//!     ..Default::default()
+//! };
+//! let result = runner.run(&spec).unwrap();
+//! println!("wall_ms: {}", result.wall_ms);
+//! ```
 
 mod fake;
 

--- a/crates/perfgate-api/Cargo.toml
+++ b/crates/perfgate-api/Cargo.toml
@@ -8,7 +8,10 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-api"
 authors.workspace = true
+keywords = ["api", "baseline", "performance", "benchmarking"]
+categories = ["web-programming", "development-tools"]
 
 [dependencies]
 serde.workspace = true

--- a/crates/perfgate-api/src/lib.rs
+++ b/crates/perfgate-api/src/lib.rs
@@ -1,4 +1,17 @@
-//! Common API types and models for perfgate baseline service.
+//! Common API types and models for the perfgate baseline service.
+//!
+//! Defines request/response types, baseline records, project models, and verdict
+//! history used by both the server and client crates.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
+//! # Example
+//!
+//! ```
+//! use perfgate_api::BASELINE_SCHEMA_V1;
+//!
+//! assert_eq!(BASELINE_SCHEMA_V1, "perfgate.baseline.v1");
+//! ```
 
 use chrono::{DateTime, Utc};
 use perfgate_types::{RunReceipt, VerdictCounts, VerdictStatus};

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -1,7 +1,10 @@
 //! Application layer for perfgate.
 //!
-//! The app layer coordinates adapters and domain logic.
+//! The app layer coordinates adapters and domain logic into use-case workflows
+//! such as run, compare, report, check, export, paired, and promote.
 //! It does not parse CLI flags and it does not do filesystem I/O.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
 mod aggregate;
 pub mod baseline_resolve;

--- a/crates/perfgate-auth/Cargo.toml
+++ b/crates/perfgate-auth/Cargo.toml
@@ -8,7 +8,10 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-auth"
 authors.workspace = true
+keywords = ["authentication", "authorization", "api-key", "perfgate"]
+categories = ["authentication"]
 
 [dependencies]
 serde.workspace = true

--- a/crates/perfgate-auth/src/lib.rs
+++ b/crates/perfgate-auth/src/lib.rs
@@ -1,4 +1,18 @@
 //! Authentication and authorization types for perfgate.
+//!
+//! Provides API key management, permission scopes, and role-based access control
+//! types used by the perfgate baseline service.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
+//! # Example
+//!
+//! ```
+//! use perfgate_auth::{generate_api_key, API_KEY_PREFIX_LIVE};
+//!
+//! let key = generate_api_key(false);
+//! assert!(key.starts_with(API_KEY_PREFIX_LIVE));
+//! ```
 
 use chrono::{DateTime, Utc};
 use perfgate_error::AuthError;

--- a/crates/perfgate-budget/Cargo.toml
+++ b/crates/perfgate-budget/Cargo.toml
@@ -9,7 +9,8 @@ homepage.workspace = true
 authors.workspace = true
 description = "Budget evaluation logic for performance thresholds"
 readme = "README.md"
-keywords = ["budget", "threshold", "performance"]
+documentation = "https://docs.rs/perfgate-budget"
+keywords = ["budget", "threshold", "performance", "regression"]
 categories = ["development-tools"]
 
 [dependencies]

--- a/crates/perfgate-budget/src/lib.rs
+++ b/crates/perfgate-budget/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides pure budget evaluation functions with no I/O dependencies.
 //! It handles threshold checking, regression calculation, and verdict aggregation.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Overview
 //!
 //! The crate provides:

--- a/crates/perfgate-client/Cargo.toml
+++ b/crates/perfgate-client/Cargo.toml
@@ -9,7 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-client"
 keywords = ["performance", "benchmarking", "baseline", "client"]
+categories = ["web-programming::http-client", "development-tools"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/perfgate-client/src/lib.rs
+++ b/crates/perfgate-client/src/lib.rs
@@ -1,6 +1,4 @@
-//! # perfgate-client
-//!
-//! A Rust client library for the perfgate baseline service.
+//! Client library for the perfgate baseline service.
 //!
 //! This crate provides a client for interacting with the perfgate baseline
 //! service API, including:
@@ -10,6 +8,8 @@
 //! - Promoting and deleting baselines
 //! - Health checking
 //! - Automatic fallback to local storage when the server is unavailable
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 //!
 //! ## Quick Start
 //!

--- a/crates/perfgate-config/Cargo.toml
+++ b/crates/perfgate-config/Cargo.toml
@@ -8,7 +8,10 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-config"
 authors.workspace = true
+keywords = ["configuration", "toml", "benchmarking", "perfgate"]
+categories = ["config", "development-tools"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/perfgate-config/src/lib.rs
+++ b/crates/perfgate-config/src/lib.rs
@@ -1,4 +1,19 @@
 //! Configuration loading and merging logic for perfgate.
+//!
+//! Loads TOML configuration files, merges environment variables and CLI overrides,
+//! and resolves baseline server settings for perfgate workflows.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use perfgate_config::load_config_file;
+//! use std::path::Path;
+//!
+//! let config = load_config_file(Path::new("perfgate.toml")).unwrap();
+//! println!("Benches: {}", config.benches.len());
+//! ```
 
 use anyhow::Context;
 use perfgate_client::{BaselineClient, ClientConfig, FallbackClient, FallbackStorage};

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -1,6 +1,10 @@
 //! Domain logic for perfgate.
 //!
-//! This crate is intentionally I/O-free: it does math and policy.
+//! Pure, I/O-free business logic: statistics computation, budget policy evaluation,
+//! host mismatch detection, and regression analysis. All data comes in via
+//! function arguments; no filesystem, network, or process access.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
 mod blame;
 mod paired;

--- a/crates/perfgate-error/Cargo.toml
+++ b/crates/perfgate-error/Cargo.toml
@@ -9,7 +9,8 @@ homepage.workspace = true
 authors.workspace = true
 description = "Unified error types for perfgate"
 readme = "README.md"
-keywords = ["error", "error-handling"]
+documentation = "https://docs.rs/perfgate-error"
+keywords = ["error", "error-handling", "performance", "benchmarking"]
 categories = ["development-tools"]
 
 [dependencies]

--- a/crates/perfgate-error/src/lib.rs
+++ b/crates/perfgate-error/src/lib.rs
@@ -4,6 +4,8 @@
 //! variants from across the perfgate crates. It enables seamless error propagation
 //! and conversion between different error types.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Error Categories
 //!
 //! The [`PerfgateError`] enum is organized into categories:

--- a/crates/perfgate-export/Cargo.toml
+++ b/crates/perfgate-export/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Export formats for perfgate benchmarks (CSV, JSONL, HTML, Prometheus)"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-export"
 keywords = ["export", "csv", "prometheus", "benchmarking"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-export/src/lib.rs
+++ b/crates/perfgate-export/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides functionality for exporting run and compare receipts
 //! to various formats suitable for trend analysis and time-series ingestion.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Supported Formats
 //!
 //! - **CSV**: RFC 4180 compliant CSV with header row

--- a/crates/perfgate-fake/Cargo.toml
+++ b/crates/perfgate-fake/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Test utilities and fake implementations for perfgate testing"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-fake"
 keywords = ["testing", "fake", "mock", "benchmarking"]
 categories = ["development-tools::testing"]
 

--- a/crates/perfgate-fake/src/lib.rs
+++ b/crates/perfgate-fake/src/lib.rs
@@ -4,6 +4,8 @@
 //! perfgate adapter traits. Use these in unit tests and integration tests
 //! to avoid I/O and ensure reproducible test results.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Available Fakes
 //!
 //! - [`FakeProcessRunner`] - Configurable process runner for testing

--- a/crates/perfgate-host-detect/Cargo.toml
+++ b/crates/perfgate-host-detect/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Host mismatch detection for benchmarking noise reduction"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-host-detect"
 keywords = ["benchmarking", "host", "mismatch", "detection"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-host-detect/src/lib.rs
+++ b/crates/perfgate-host-detect/src/lib.rs
@@ -5,6 +5,8 @@
 //! significant noise into performance measurements, leading to false
 //! positives or negatives in regression detection.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Example
 //!
 //! ```

--- a/crates/perfgate-paired/Cargo.toml
+++ b/crates/perfgate-paired/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Paired benchmarking statistics for A/B comparison"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-paired"
 keywords = ["paired", "benchmarking", "statistics", "ab-testing"]
 categories = ["mathematics", "development-tools"]
 

--- a/crates/perfgate-paired/src/lib.rs
+++ b/crates/perfgate-paired/src/lib.rs
@@ -4,6 +4,8 @@
 //! where each measurement consists of a baseline and current observation from the
 //! same experimental unit (e.g., same input, same machine configuration).
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Overview
 //!
 //! The crate provides:

--- a/crates/perfgate-render/src/lib.rs
+++ b/crates/perfgate-render/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! This crate provides functions for rendering performance comparison results
 //! as markdown tables and GitHub Actions annotations.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
 use anyhow::Context;
 use perfgate_types::{CompareReceipt, Direction, Metric, MetricStatistic, MetricStatus};

--- a/crates/perfgate-sensor/Cargo.toml
+++ b/crates/perfgate-sensor/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Sensor report building for cockpit integration"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-sensor"
 keywords = ["sensor", "report", "cockpit", "integration"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-sensor/src/lib.rs
+++ b/crates/perfgate-sensor/src/lib.rs
@@ -1,7 +1,9 @@
-//! perfgate-sensor: Cockpit mode and sensor report generation.
+//! Cockpit mode and sensor report generation.
 //!
 //! This crate provides functionality for generating `sensor.report.v1` JSON
 //! envelopes compatible with external performance monitoring tools like Cockpit.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 
 use perfgate_sha256::sha256_hex;
 pub use perfgate_types::{

--- a/crates/perfgate-server/Cargo.toml
+++ b/crates/perfgate-server/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-server"
+keywords = ["server", "baseline", "performance", "benchmarking", "api"]
+categories = ["web-programming::http-server", "development-tools"]
 
 [dependencies]
 # Async runtime

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -1,8 +1,10 @@
-//! perfgate-server - REST API server for centralized baseline management.
+//! REST API server for centralized baseline management.
 //!
 //! This crate provides a REST API server for storing and managing performance
 //! baselines. It supports multiple storage backends (in-memory, SQLite, PostgreSQL)
 //! and includes authentication via API keys.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 //!
 //! # Features
 //!

--- a/crates/perfgate-sha256/Cargo.toml
+++ b/crates/perfgate-sha256/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Minimal SHA-256 implementation for perfgate fingerprinting"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-sha256"
 keywords = ["sha256", "hash", "fingerprinting", "no-std"]
 categories = ["cryptography", "no-std"]
 

--- a/crates/perfgate-sha256/src/lib.rs
+++ b/crates/perfgate-sha256/src/lib.rs
@@ -4,6 +4,8 @@
 //! that returns a hexadecimal string. It's designed for fingerprinting
 //! and identification purposes, not for cryptographic security.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Features
 //!
 //! - `std` (default): Enable `std` support

--- a/crates/perfgate-significance/Cargo.toml
+++ b/crates/perfgate-significance/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Statistical significance testing for benchmarking"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-significance"
 keywords = ["statistics", "significance", "t-test", "benchmarking"]
 categories = ["mathematics", "development-tools"]
 

--- a/crates/perfgate-significance/src/lib.rs
+++ b/crates/perfgate-significance/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides Welch's t-test implementation for detecting statistically
 //! significant performance changes between benchmark runs.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Statistical Methodology
 //!
 //! ## Welch's t-test

--- a/crates/perfgate-stats/Cargo.toml
+++ b/crates/perfgate-stats/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Statistical functions for benchmarking analysis"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-stats"
 keywords = ["statistics", "median", "percentile", "benchmarking"]
 categories = ["mathematics", "development-tools"]
 

--- a/crates/perfgate-stats/src/lib.rs
+++ b/crates/perfgate-stats/src/lib.rs
@@ -4,6 +4,8 @@
 //! It is designed to be used by `perfgate-domain` and can be independently
 //! tested and versioned.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Overview
 //!
 //! The crate provides:

--- a/crates/perfgate-summary/Cargo.toml
+++ b/crates/perfgate-summary/Cargo.toml
@@ -8,7 +8,10 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-summary"
 authors.workspace = true
+keywords = ["summary", "benchmarking", "comparison", "performance"]
+categories = ["development-tools"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/perfgate-summary/src/lib.rs
+++ b/crates/perfgate-summary/src/lib.rs
@@ -1,4 +1,23 @@
 //! Summarization logic for perfgate comparison receipts.
+//!
+//! Aggregates multiple comparison receipts into a compact summary table showing
+//! benchmark name, verdict status, wall-clock time, and percentage change.
+//!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use perfgate_summary::{SummaryRequest, SummaryUseCase};
+//!
+//! let uc = SummaryUseCase;
+//! let outcome = uc.execute(SummaryRequest {
+//!     files: vec!["artifacts/perfgate/*.compare.json".to_string()],
+//! }).unwrap();
+//! for row in &outcome.rows {
+//!     println!("{}: {} ({})", row.benchmark, row.status, row.change_pct);
+//! }
+//! ```
 
 use anyhow::Context;
 use glob::glob;

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -3,6 +3,8 @@
 //! Design goal: versioned, explicit, boring.
 //! These structs are used for receipts, PR comments, and (eventually) long-term baselines.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Examples
 //!
 //! Round-trip a [`ToolInfo`] through JSON:

--- a/crates/perfgate-validation/Cargo.toml
+++ b/crates/perfgate-validation/Cargo.toml
@@ -9,6 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 description = "Validation functions for benchmark names and configuration"
 readme = "README.md"
+documentation = "https://docs.rs/perfgate-validation"
 keywords = ["validation", "benchmarking", "names"]
 categories = ["development-tools"]
 

--- a/crates/perfgate-validation/src/lib.rs
+++ b/crates/perfgate-validation/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides validation logic for validating benchmark names
 //! according to a strict set of rules.
 //!
+//! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+//!
 //! # Example
 //!
 //! ```

--- a/crates/perfgate/src/lib.rs
+++ b/crates/perfgate/src/lib.rs
@@ -3,6 +3,21 @@
 //! High-performance, modular Rust library for performance budgeting and baseline diffing.
 //!
 //! This is a facade crate that re-exports functionality from the core perfgate micro-crates.
+//! Use it when you want a single dependency instead of picking individual sub-crates.
+//!
+//! See the [GitHub repository](https://github.com/EffortlessMetrics/perfgate) for full
+//! documentation and usage examples.
+//!
+//! # Example
+//!
+//! ```
+//! use perfgate::types::{ToolInfo, Metric, Direction};
+//!
+//! let tool = ToolInfo { name: "perfgate".into(), version: "1.0.0".into() };
+//! assert_eq!(tool.name, "perfgate");
+//!
+//! assert_eq!(Metric::WallMs.default_direction(), Direction::Lower);
+//! ```
 
 pub use perfgate_adapters as adapters;
 pub use perfgate_app as app;


### PR DESCRIPTION
## Summary

- Add complete `Cargo.toml` metadata (`documentation`, `keywords`, `categories`) to all 23 publishable crates that were missing fields
- Add/expand `//!` doc comments in every publishable crate's `src/lib.rs` with a description, GitHub repo link, and usage example where applicable
- All 74 doctests pass

## Changes

**Cargo.toml** (17 crates updated):
- `documentation = "https://docs.rs/..."` added to: error, auth, config, api, validation, stats, significance, paired, budget, host-detect, sha256, export, sensor, fake, summary, server, client
- `keywords` added to: auth, config, api, summary, server; expanded on: error, budget
- `categories` added to: auth, config, api, summary, server, client

**lib.rs doc comments** (23 crates updated):
- "Part of the [perfgate](...) workspace" link added to every publishable crate
- Thin one-liner docs expanded: auth, config, api, summary, adapters, app, domain, render, sensor, server, client, perfgate facade
- Usage examples added: auth, config, api, summary, adapters, perfgate facade

## Test plan

- [x] `cargo test --doc --all` -- 74 doctests, all pass
- [x] `cargo build --all` -- clean build
- [x] `cargo fmt --all` -- no formatting changes