### PR TITLE
docs: add inline GOTCHA comments for non-obvious pitfalls

### DIFF
--- a/crates/perfgate-ingest/src/criterion.rs
+++ b/crates/perfgate-ingest/src/criterion.rs
@@ -82,7 +82,10 @@ pub fn parse_criterion(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
     let mut stats = compute_u64_summary(&wall_values);
     // Override median with the actual Criterion median
     stats.median = median_ms;
-    // Override mean/stddev with precise floating-point values (ns -> ms)
+    // Override mean/stddev with precise floating-point values (ns -> ms).
+    // IMPORTANT: Use f64 division here, NOT ns_to_ms(). See the GOTCHA on
+    // ns_to_ms — integer truncation would lose the sub-ms precision that
+    // budget evaluation and significance testing rely on.
     stats.mean = Some(mean_ns / 1_000_000.0);
     stats.stddev = Some(std_dev_ns / 1_000_000.0);
 
@@ -105,6 +108,14 @@ pub fn parse_criterion(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
     Ok(make_receipt(&bench_name, samples, full_stats))
 }
 
+/// Integer ns-to-ms conversion for sample `wall_ms` values (u64).
+///
+/// GOTCHA: This intentionally truncates to integer milliseconds -- it is only
+/// appropriate for per-sample u64 fields where sub-ms precision is not needed.
+/// For stats fields (mean, stddev) you MUST use floating-point division
+/// (`ns / 1_000_000.0`) to preserve sub-millisecond precision. Using this
+/// function for stats would silently destroy the fractional component that
+/// downstream budget evaluation and significance testing depend on.
 fn ns_to_ms(ns: f64) -> u64 {
     let ms = ns / 1_000_000.0;
     if ms < 1.0 && ms > 0.0 {

--- a/crates/perfgate-ingest/src/gobench.rs
+++ b/crates/perfgate-ingest/src/gobench.rs
@@ -70,6 +70,9 @@ pub fn parse_gobench(input: &str, name: Option<&str>) -> anyhow::Result<RunRecei
         median: wall_ms,
         min: wall_ms,
         max: wall_ms,
+        // IMPORTANT: Use f64 division here, NOT ns_to_ms(). See the GOTCHA
+        // on ns_to_ms — integer truncation would lose sub-ms precision that
+        // budget evaluation and significance testing rely on.
         mean: Some(first.ns_per_op / 1_000_000.0),
         stddev: None,
     };
@@ -158,6 +161,14 @@ fn parse_gobench_lines(input: &str) -> anyhow::Result<Vec<GoBenchLine>> {
     Ok(lines)
 }
 
+/// Integer ns-to-ms conversion for sample `wall_ms` values (u64).
+///
+/// GOTCHA: This intentionally truncates to integer milliseconds -- it is only
+/// appropriate for per-sample u64 fields where sub-ms precision is not needed.
+/// For stats fields (mean, stddev) you MUST use floating-point division
+/// (`ns / 1_000_000.0`) to preserve sub-millisecond precision. Using this
+/// function for stats would silently destroy the fractional component that
+/// downstream budget evaluation and significance testing depend on.
 fn ns_to_ms(ns: f64) -> u64 {
     let ms = ns / 1_000_000.0;
     if ms < 1.0 && ms > 0.0 {

--- a/crates/perfgate-ingest/src/hyperfine.rs
+++ b/crates/perfgate-ingest/src/hyperfine.rs
@@ -74,10 +74,14 @@ pub fn parse_hyperfine(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
     }
 
     let mut stats = compute_u64_summary(&wall_values);
-    // Override with hyperfine's own statistics (more precise)
+    // Override with hyperfine's own statistics (more precise).
+    // median/min/max are u64 so integer seconds_to_ms() is fine.
     stats.median = seconds_to_ms(result.median);
     stats.min = seconds_to_ms(result.min);
     stats.max = seconds_to_ms(result.max);
+    // IMPORTANT: Use f64 arithmetic here, NOT seconds_to_ms(). See the
+    // GOTCHA on seconds_to_ms — integer truncation would lose sub-ms
+    // precision that budget evaluation and significance testing rely on.
     stats.mean = Some(result.mean * 1000.0);
     stats.stddev = Some(result.stddev * 1000.0);
 
@@ -98,6 +102,14 @@ pub fn parse_hyperfine(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
     Ok(make_receipt(&bench_name, samples, full_stats))
 }
 
+/// Integer seconds-to-ms conversion for sample `wall_ms` values (u64).
+///
+/// GOTCHA: This intentionally truncates to integer milliseconds -- it is only
+/// appropriate for per-sample u64 fields where sub-ms precision is not needed.
+/// For stats fields (mean, stddev) use direct `f64` arithmetic (`value * 1000.0`)
+/// to preserve sub-millisecond precision. Using this function for stats would
+/// silently destroy the fractional component that downstream budget evaluation
+/// and significance testing depend on.
 fn seconds_to_ms(s: f64) -> u64 {
     let ms = s * 1000.0;
     if ms < 1.0 && ms > 0.0 {

--- a/crates/perfgate-ingest/src/pytest.rs
+++ b/crates/perfgate-ingest/src/pytest.rs
@@ -83,10 +83,14 @@ pub fn parse_pytest_benchmark(input: &str, name: Option<&str>) -> anyhow::Result
     }
 
     let mut computed = compute_u64_summary(&wall_values);
-    // Override with the actual pytest-benchmark statistics
+    // Override with the actual pytest-benchmark statistics.
+    // median/min/max are u64 so integer seconds_to_ms() is fine.
     computed.median = seconds_to_ms(stats.median);
     computed.min = seconds_to_ms(stats.min);
     computed.max = seconds_to_ms(stats.max);
+    // IMPORTANT: Use f64 arithmetic here, NOT seconds_to_ms(). See the
+    // GOTCHA on seconds_to_ms — integer truncation would lose sub-ms
+    // precision that budget evaluation and significance testing rely on.
     computed.mean = Some(stats.mean * 1000.0);
     computed.stddev = Some(stats.stddev * 1000.0);
 
@@ -127,6 +131,14 @@ fn make_sample(wall_ms: u64) -> Sample {
     }
 }
 
+/// Integer seconds-to-ms conversion for sample `wall_ms` values (u64).
+///
+/// GOTCHA: This intentionally truncates to integer milliseconds -- it is only
+/// appropriate for per-sample u64 fields where sub-ms precision is not needed.
+/// For stats fields (mean, stddev) use direct `f64` arithmetic (`value * 1000.0`)
+/// to preserve sub-millisecond precision. Using this function for stats would
+/// silently destroy the fractional component that downstream budget evaluation
+/// and significance testing depend on.
 fn seconds_to_ms(s: f64) -> u64 {
     let ms = s * 1000.0;
     if ms < 1.0 && ms > 0.0 {

--- a/crates/perfgate-server/assets/index.html
+++ b/crates/perfgate-server/assets/index.html
@@ -1118,6 +1118,10 @@
                     datasets: [{
                         label: metricLabels[metric] || metric,
                         data: dataPoints,
+                        // GOTCHA: Chart.js renders on a <canvas> 2D context which
+                        // cannot resolve CSS custom properties (var(--color-*)).
+                        // Using var() here silently produces transparent/black
+                        // lines. Always use literal hex/rgba color values.
                         borderColor: '#0366d6',
                         backgroundColor: 'rgba(3, 102, 214, 0.08)',
                         fill: true,

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -78,6 +78,11 @@ impl SqliteStore {
     fn configure_pragmas(conn: &rusqlite::Connection, is_memory: bool) -> Result<(), StoreError> {
         conn.execute_batch("PRAGMA busy_timeout=5000;")?;
 
+        // GOTCHA: In-memory SQLite databases cannot use WAL mode. Executing
+        // `PRAGMA journal_mode=WAL` on an in-memory DB silently succeeds but
+        // returns "memory" instead of "wal". You MUST check the returned
+        // string — a bare `execute_batch("PRAGMA journal_mode=WAL")` will
+        // appear to work but leave you without WAL's concurrency benefits.
         if !is_memory {
             let mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
             if mode.to_lowercase() != "wal" {


### PR DESCRIPTION
## Summary

- **SQLite WAL mode** (`crates/perfgate-server/src/storage/sqlite.rs`): Added comment explaining that in-memory SQLite databases cannot use WAL mode -- `PRAGMA journal_mode=WAL` silently returns `"memory"` instead of `"wal"`, so the return value must be verified, not just executed.
- **Chart.js colors** (`crates/perfgate-server/assets/index.html`): Added comment explaining that Chart.js canvas 2D context cannot resolve CSS custom properties (`var(--color-*)`), so literal hex/rgba values must be used instead.
- **Ingest precision** (`crates/perfgate-ingest/src/{criterion,hyperfine,gobench,pytest}.rs`): Added doc comments on all `ns_to_ms()` / `seconds_to_ms()` helpers and inline comments at each stats override site, explaining that floating-point division must be used for mean/stddev fields to preserve sub-millisecond precision that downstream budget evaluation and significance testing depend on.

No logic changes -- only inline comments added.

## Test plan

- [ ] Verify `cargo fmt --all` passes (no formatting changes needed)
- [ ] Verify `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] Verify `cargo test --all` passes (comment-only change, no behavior affected)