### PR TITLE
feat(cli): add `perfgate serve` local dashboard command

### DIFF
--- a/crates/perfgate-cli/Cargo.toml
+++ b/crates/perfgate-cli/Cargo.toml
@@ -29,6 +29,7 @@ perfgate-app.workspace = true
 perfgate-adapters.workspace = true
 perfgate-domain.workspace = true
 perfgate-sensor.workspace = true
+perfgate-server.workspace = true
 anyhow.workspace = true
 glob.workspace = true
 clap.workspace = true

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -22,7 +22,8 @@ use perfgate_app::{
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::{
-    ListBaselinesQuery, ListVerdictsQuery, SubmitVerdictRequest, UploadBaselineRequest,
+    AuthMethod, BaselineClient, ClientConfig, ListBaselinesQuery, ListVerdictsQuery,
+    SubmitVerdictRequest, UploadBaselineRequest,
 };
 use perfgate_config::{ResolvedServerConfig, load_config_file, resolve_server_config};
 use perfgate_domain::{DependencyChangeType, SignificancePolicy};
@@ -349,6 +350,13 @@ enum Command {
     ///
     /// Exit codes: 0 on clean exit (Ctrl+C), 1 on error.
     Watch(Box<WatchArgs>),
+
+    /// Start a local dashboard server backed by SQLite.
+    ///
+    /// Launches the perfgate server on localhost with no authentication,
+    /// using ~/.perfgate/data.db as the default database. Opens the
+    /// dashboard in the default browser unless --no-open is passed.
+    Serve(Box<ServeArgs>),
 }
 
 #[derive(Debug, Args)]
@@ -478,6 +486,21 @@ pub struct DiffArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct ServeArgs {
+    /// Port to listen on (default: 8484)
+    #[arg(long, default_value_t = 8484)]
+    pub port: u16,
+
+    /// Path to the SQLite database file (default: ~/.perfgate/data.db)
+    #[arg(long)]
+    pub db: Option<PathBuf>,
+
+    /// Do not open the browser automatically
+    #[arg(long, default_value_t = false)]
+    pub no_open: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct BisectArgs {
     /// The known good commit
     #[arg(long)]
@@ -557,6 +580,11 @@ pub struct RunArgs {
     /// Project name for upload (overrides global --project flag).
     #[arg(long)]
     pub upload_project: Option<String>,
+
+    /// Upload the run result to the local perfgate server (started via `perfgate serve`).
+    /// Set the server URL via PERFGATE_LOCAL_DB (default: http://127.0.0.1:8484).
+    #[arg(long, default_value_t = false)]
+    pub local_db: bool,
 
     /// Command to run (argv) after `--`
     #[arg(last = true, required = true)]
@@ -777,6 +805,11 @@ pub struct CheckArgs {
     /// Write GitHub Actions step outputs (verdict/counts) to $GITHUB_OUTPUT.
     #[arg(long, default_value_t = false)]
     pub output_github: bool,
+
+    /// Upload the run result to the local perfgate server (started via `perfgate serve`).
+    /// Set the server URL via PERFGATE_LOCAL_DB (default: http://127.0.0.1:8484).
+    #[arg(long, default_value_t = false)]
+    pub local_db: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1226,6 +1259,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 pretty,
                 upload,
                 upload_project,
+                local_db,
                 command,
             } = *args;
 
@@ -1264,7 +1298,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 let project = server_config.resolve_project(upload_project)?;
 
                 let request = UploadBaselineRequest {
-                    benchmark: name,
+                    benchmark: name.clone(),
                     version: None,
                     git_ref: None,
                     git_sha: None,
@@ -1287,6 +1321,11 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                     );
                     Ok::<(), anyhow::Error>(())
                 })?;
+            }
+
+            // Upload to local server if --local-db is set
+            if local_db {
+                upload_to_local_db(&name, &outcome.receipt)?;
             }
 
             if outcome.failed && !allow_nonzero {
@@ -1584,6 +1623,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 mode,
                 md_template,
                 output_github,
+                local_db,
             } = *args;
 
             let req = CheckConfig {
@@ -1608,6 +1648,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 md_template,
                 output_github,
                 server_flags,
+                local_db,
             };
             match mode {
                 OutputMode::Standard => run_check_standard(req),
@@ -1851,6 +1892,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
         Command::Init(args) => execute_init(*args),
         Command::Watch(args) => run_watch(*args),
+        Command::Serve(args) => execute_serve(*args),
     }
 }
 
@@ -2224,6 +2266,132 @@ fn execute_init(args: InitArgs) -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+const DEFAULT_LOCAL_SERVER_URL: &str = "http://127.0.0.1:8484/api/v1";
+
+/// Resolve the local server URL from the PERFGATE_LOCAL_DB environment variable
+/// or fall back to the default.
+fn resolve_local_db_url() -> String {
+    match std::env::var("PERFGATE_LOCAL_DB") {
+        Ok(val) if !val.is_empty() && val != "true" && val != "1" => val,
+        _ => DEFAULT_LOCAL_SERVER_URL.to_string(),
+    }
+}
+
+/// Upload a run receipt to the local perfgate server (no auth).
+fn upload_to_local_db(name: &str, receipt: &RunReceipt) -> anyhow::Result<()> {
+    let url = resolve_local_db_url();
+    let config = ClientConfig {
+        server_url: url.clone(),
+        auth: AuthMethod::None,
+        ..Default::default()
+    };
+    let client = BaselineClient::new(config)
+        .with_context(|| format!("create client for local server at {url}"))?;
+
+    let request = UploadBaselineRequest {
+        benchmark: name.to_string(),
+        version: None,
+        git_ref: None,
+        git_sha: None,
+        receipt: receipt.clone(),
+        metadata: BTreeMap::new(),
+        tags: Vec::new(),
+        normalize: false,
+    };
+
+    with_tokio_runtime(async {
+        let response: perfgate_client::types::UploadBaselineResponse = client
+            .upload_baseline("default", &request)
+            .await
+            .with_context(|| {
+                format!("upload to local server at {url} -- is `perfgate serve` running?")
+            })?;
+        eprintln!(
+            "Uploaded to local server: {} version {}",
+            response.benchmark, response.version
+        );
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+/// Resolve the default data directory (~/.perfgate/) and ensure it exists.
+fn default_data_dir() -> anyhow::Result<PathBuf> {
+    let home = if cfg!(windows) {
+        std::env::var("USERPROFILE")
+            .or_else(|_| std::env::var("HOME"))
+            .context("could not determine home directory (USERPROFILE / HOME not set)")?
+    } else {
+        std::env::var("HOME").context("could not determine home directory (HOME not set)")?
+    };
+    let dir = PathBuf::from(home).join(".perfgate");
+    fs::create_dir_all(&dir).with_context(|| format!("create data directory {}", dir.display()))?;
+    Ok(dir)
+}
+
+/// Start the local dashboard server.
+fn execute_serve(args: ServeArgs) -> anyhow::Result<()> {
+    let db_path = match args.db {
+        Some(p) => p,
+        None => default_data_dir()?.join("data.db"),
+    };
+
+    // Ensure the parent directory exists for the database file.
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create database directory {}", parent.display()))?;
+    }
+
+    let bind_addr = format!("127.0.0.1:{}", args.port);
+    let url = format!("http://127.0.0.1:{}", args.port);
+
+    eprintln!("perfgate serve");
+    eprintln!("  database : {}", db_path.display());
+    eprintln!("  dashboard: {url}");
+    eprintln!("  auth     : disabled (local mode)");
+    eprintln!();
+    eprintln!("Press Ctrl+C to stop.");
+
+    let config = perfgate_server::ServerConfig::new()
+        .bind(&bind_addr)?
+        .storage_backend(perfgate_server::StorageBackend::Sqlite)
+        .sqlite_path(&db_path)
+        .local_mode(true)
+        .cors(true);
+
+    // Open the browser unless --no-open is passed.
+    if !args.no_open {
+        open_browser(&url);
+    }
+
+    let rt = tokio::runtime::Runtime::new().context("initialize async runtime")?;
+    rt.block_on(async {
+        perfgate_server::run_server(config)
+            .await
+            .map_err(|e| anyhow::anyhow!("{}", e))
+    })?;
+
+    Ok(())
+}
+
+/// Open a URL in the default browser.
+fn open_browser(url: &str) {
+    let result = if cfg!(target_os = "windows") {
+        std::process::Command::new("cmd")
+            .args(["/C", "start", "", url])
+            .spawn()
+    } else if cfg!(target_os = "macos") {
+        std::process::Command::new("open").arg(url).spawn()
+    } else {
+        std::process::Command::new("xdg-open").arg(url).spawn()
+    };
+
+    if let Err(e) = result {
+        eprintln!("warning: could not open browser: {e}");
+    }
 }
 
 /// Execute baseline management actions.
@@ -2663,6 +2831,7 @@ struct CheckConfig {
     md_template: Option<PathBuf>,
     output_github: bool,
     server_flags: ServerFlags,
+    local_db: bool,
 }
 
 fn submit_verdict_if_possible(
@@ -2805,6 +2974,13 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
         // Submit verdict to server if configured
         if let Some(compare) = &outcome.compare_receipt {
             submit_verdict_if_possible(&req.server_flags, &config_file, compare);
+        }
+
+        // Upload to local server if --local-db is set
+        if req.local_db
+            && let Err(e) = upload_to_local_db(bench_name, &outcome.run_receipt)
+        {
+            eprintln!("warning: local-db upload failed: {:#}", e);
         }
 
         // Write artifacts
@@ -3037,6 +3213,13 @@ fn run_check_cockpit_inner(
             // Submit verdict to server if configured
             if let Some(compare) = &check_outcome.compare_receipt {
                 submit_verdict_if_possible(&req.server_flags, &config_file, compare);
+            }
+
+            // Upload to local server if --local-db is set
+            if req.local_db
+                && let Err(e) = upload_to_local_db(bench_name, &check_outcome.run_receipt)
+            {
+                eprintln!("warning: local-db upload failed: {:#}", e);
             }
 
             // Write native artifacts to extras/

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_check.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_check.snap
@@ -56,6 +56,8 @@ Options:
 
       --output-github Write GitHub Actions step outputs (verdict/counts) to $GITHUB_OUTPUT
 
+      --local-db Upload the run result to the local perfgate server (started via `perfgate serve`). Set the server URL via PERFGATE_LOCAL_DB (default: http://127.0.0.1:8484)
+
   -h, --help Print help (see a summary with '-h')
 
 Global Options:

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -29,6 +29,7 @@ Commands:
   diff Quick "did I make it slower?" comparison against baselines
   init Scan a repository and generate a perfgate.toml config file
   watch Watch for file changes and re-run benchmarks with live terminal output
+  serve Start a local dashboard server backed by SQLite
   help Print this message or the help of the given subcommand(s)
 
 Options:

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_run.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_run.snap
@@ -24,6 +24,7 @@ Options:
       --pretty Pretty-print JSON
       --upload Upload the run result to the baseline server
       --upload-project <UPLOAD_PROJECT> Project name for upload (overrides global --project flag)
+      --local-db Upload the run result to the local perfgate server (started via `perfgate serve`). Set the server URL via PERFGATE_LOCAL_DB (default: http://127.0.0.1:8484)
   -h, --help Print help
 
 Global Options:

--- a/crates/perfgate-server/assets/index.html
+++ b/crates/perfgate-server/assets/index.html
@@ -582,6 +582,7 @@
         <div class="header-left">
             <h1 onclick="showDashboard()">perfgate</h1>
             <span class="version-badge">Dashboard</span>
+            <span id="localModeBadge" style="display:none;background:#28a745;color:white;padding:3px 10px;border-radius:10px;font-size:12px;font-weight:600;">Local Mode</span>
             <span class="health-dot unknown" id="healthDot" title="Checking..."></span>
         </div>
         <div class="project-bar">
@@ -1089,6 +1090,15 @@
 
             updateChart(history);
         }
+
+        // Detect local mode and show badge
+        async function checkLocalMode() {
+            const info = await fetchApi('/api/v1/info');
+            if (info && info.local_mode) {
+                document.getElementById('localModeBadge').style.display = 'inline-block';
+            }
+        }
+        checkLocalMode();
 
         /* ======= Chart ======= */
         function updateChart(history) {

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -156,6 +156,9 @@ pub struct ServerConfig {
 
     /// Request timeout in seconds
     pub timeout_seconds: u64,
+
+    /// Local mode: disable authentication for single-user local use.
+    pub local_mode: bool,
 }
 
 impl Default for ServerConfig {
@@ -172,6 +175,7 @@ impl Default for ServerConfig {
             oidc: None,
             cors: true,
             timeout_seconds: 30,
+            local_mode: false,
         }
     }
 }
@@ -258,6 +262,12 @@ impl ServerConfig {
     /// Enables or disables CORS.
     pub fn cors(mut self, enabled: bool) -> Self {
         self.cors = enabled;
+        self
+    }
+
+    /// Enables or disables local mode (no authentication).
+    pub fn local_mode(mut self, enabled: bool) -> Self {
+        self.local_mode = enabled;
         self
     }
 }
@@ -347,8 +357,16 @@ pub(crate) fn create_router(
     config: &ServerConfig,
     prometheus_handle: Option<PrometheusHandle>,
 ) -> Router {
+    let local_mode = config.local_mode;
+
     // Health check (no auth required)
     let health_routes = Router::new().route("/health", get(health_check));
+
+    // Info endpoint: exposes local_mode flag for the dashboard.
+    let info_routes = Router::new().route(
+        "/info",
+        get(move || async move { axum::Json(serde_json::json!({ "local_mode": local_mode })) }),
+    );
 
     // Dashboard routes (no auth required for read-only view)
     let dashboard_routes = Router::new()
@@ -356,8 +374,8 @@ pub(crate) fn create_router(
         .route("/index.html", get(dashboard_index))
         .route("/assets/{*path}", get(static_asset));
 
-    // API routes that require authentication
-    let api_routes = Router::new()
+    // API routes — auth middleware is skipped in local mode.
+    let api_routes_inner = Router::new()
         // Baseline CRUD
         .route("/projects/{project}/baselines", post(upload_baseline))
         .route(
@@ -378,14 +396,22 @@ pub(crate) fn create_router(
         .route(
             "/projects/{project}/baselines/{benchmark}/promote",
             post(promote_baseline),
-        )
-        .layer(middleware::from_fn_with_state(auth_state, auth_middleware));
+        );
+
+    let api_routes = if config.local_mode {
+        api_routes_inner
+    } else {
+        api_routes_inner.layer(middleware::from_fn_with_state(auth_state, auth_middleware))
+    };
 
     // Combine routes under /api/v1, plus root /health and dashboard
     let mut app = Router::new()
         .merge(dashboard_routes)
         .merge(health_routes.clone())
-        .nest("/api/v1", health_routes.merge(api_routes));
+        .nest(
+            "/api/v1",
+            health_routes.merge(info_routes).merge(api_routes),
+        );
 
     // Add /metrics endpoint if Prometheus handle is available
     if let Some(handle) = prometheus_handle {


### PR DESCRIPTION
## Summary

- Add `perfgate serve` subcommand that starts the existing server on localhost with SQLite storage and no authentication, then opens the dashboard in the default browser
- Default database location: `~/.perfgate/data.db` (created automatically)
- Add `--local-db` flag to `run` and `check` commands for uploading results to the local server
- Add `local_mode` to `ServerConfig` to disable auth middleware for single-user local use
- Dashboard shows a "Local Mode" badge when connected to a local server

### Usage

```bash
# Start local dashboard (opens browser)
perfgate serve

# Custom port and database
perfgate serve --port 9090 --db ./my.db

# Run a benchmark and upload to local server
perfgate serve &
perfgate run --name my-bench --local-db -- ./my-benchmark

# Or use the env var
export PERFGATE_LOCAL_DB=http://127.0.0.1:8484/api/v1
perfgate run --name my-bench --local-db -- ./my-benchmark
perfgate check --config perfgate.toml --bench my-bench --local-db
```

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all` passes
- [x] All 15 help snapshot tests pass (updated for new subcommand and flags)
- [x] All 24 CLI unit tests pass
- [x] All server unit/integration tests pass (20 passed, 2 ignored)
- [x] `perfgate serve --help` shows correct usage
- [x] `perfgate run --help` shows `--local-db` flag
- [x] `perfgate check --help` shows `--local-db` flag