### PR TITLE
fix: refresh generated schemas and align docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ schemas/*.tmp
 .DS_Store
 .idea/
 .vscode/
+.claude/patches/
+.claude/worktrees/
 mutants.out/
 mutants.out.old/
 test_output/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ command = ["./target/release/my-bench"]
 perfgate check --config perfgate.toml --bench my-service
 ```
 
+Optional diagnostics for regressing benches:
+
+```bash
+perfgate check --config perfgate.toml --bench my-service --profile-on-regression
+```
+
 **3. Gate** -- wire into GitHub Actions:
 
 ```yaml
@@ -116,11 +122,28 @@ sample sizes are too small to be conclusive.
 - Paired benchmarking for noisy CI environments with significance-based retries
 - Noise detection (CV-based) with configurable escalation policy
 - Per-metric statistic selection (median, p95, etc.)
+- Scaling validation with best-fit complexity classification via `perfgate scale`
 
 **Diagnostics**
 - `bisect` -- find the exact commit that introduced a regression
 - `blame` -- map regressions to `Cargo.lock` dependency changes
 - `explain` -- generate AI-ready regression diagnostics for PR comments
+- Optional flamegraph capture on warn/fail regressions via `--profile-on-regression`
+- Trend analysis and predictive budget alerts for drifting benchmarks
+
+## Advanced Workflows
+
+Validate computational complexity for a benchmark command:
+
+```bash
+perfgate scale --name parser --command "./target/release/parser-bench --size {n}" --sizes 100,1000,10000 --expected "O(n)"
+```
+
+Post or update a PR comment from a compare receipt:
+
+```bash
+perfgate comment --compare artifacts/perfgate/compare.json --repo owner/repo --pr 123
+```
 
 **CI Integration**
 - GitHub Actions, GitLab CI support with native annotations
@@ -140,12 +163,24 @@ sample sizes are too small to be conclusive.
 | **`check`** | **Config-driven workflow (start here)** |
 | `run` | Execute a benchmark, emit a run receipt |
 | `compare` | Compare a run against a baseline |
+| `diff` | Run a quick local regression check against discovered config/baselines |
 | `paired` | Interleaved A/B benchmarking for noisy environments |
 | `promote` | Promote a run to become the new baseline |
 | `md` | Render a comparison as Markdown |
 | `report` | Generate a cockpit-compatible report |
 | `export` | Export to CSV, JSONL, HTML, Prometheus, or JUnit |
+| `cargo-bench` | Wrap `cargo bench` and emit perfgate receipts |
+| `ingest` | Import external benchmark results into perfgate format |
+| `badge` | Generate SVG status, metric, or trend badges |
+| `discover` | Scan a repo for benchmarks and print detected targets |
+| `init` | Generate `perfgate.toml` and optional CI scaffolding |
+| `watch` | Re-run a benchmark on file changes with live deltas |
+| `serve` | Start the local dashboard/baseline server |
+| `scale` | Validate complexity scaling across input sizes |
+| `comment` | Post or update a GitHub PR performance comment |
+| `trend` | Analyze metric drift and predict threshold breaches |
 | `baseline` | Manage baselines on the server |
+| `fleet` | Analyze dependency regressions across projects |
 | `summary` | Summarize multiple comparisons in a table |
 | `aggregate` | Merge run receipts from multiple runners |
 | `bisect` | Find the commit that introduced a regression |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ perfgate intentionally avoids these responsibilities:
 
 1. **Mandatory baseline service**: perfgate core does NOT require a centralized server. Users MAY use the optional baseline server for centralized management, but file-based and cloud storage baselines remain fully supported
 
-2. **Profiler**: perfgate does NOT profile code or identify hot paths. It measures whole-command execution only
+2. **General-purpose profiler**: perfgate is not a profiler-first system and does NOT instrument every run or automatically identify hot paths. It measures whole-command execution first, and may optionally capture a flamegraph after a warn/fail regression for follow-up diagnosis
 
 3. **Test runner/director**: perfgate does NOT orchestrate test suites or manage parallelism. It runs a single command specification
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -24,6 +24,7 @@ budgets = { wall_ms = { threshold = 0.20, warn_factor = 0.90, statistic = "p95" 
 name = "api_latency"
 command = ["./target/release/api-bench"]
 repeat = 10                                   # override defaults per bench
+scaling = { sizes = [100, 1000, 10000], expected = "O(n)", repeat = 5, r_squared_threshold = 0.90 }
 ```
 
 ## Budget Configuration
@@ -38,6 +39,25 @@ statistic = "p95"       # gate on p95 instead of median
 ```
 
 Available statistics: `median` (default), `p95`.
+
+## Scaling Configuration
+
+Each benchmark can optionally declare a scaling policy for `perfgate scale`
+and JSON/TOML schema validation:
+
+```toml
+[[bench]]
+name = "parser"
+command = ["./target/release/parser-bench", "--size", "{n}"]
+scaling = { sizes = [100, 1000, 10000], expected = "O(n)", repeat = 7, r_squared_threshold = 0.95 }
+```
+
+| Field | Description |
+|-------|-------------|
+| `sizes` | Required input sizes used for complexity fitting |
+| `expected` | Optional expected complexity class such as `O(n)` or `O(n^2)` |
+| `repeat` | Optional repetitions per input size |
+| `r_squared_threshold` | Optional minimum fit quality threshold |
 
 ## Presets
 
@@ -66,6 +86,7 @@ perfgate check --config perfgate.toml --bench my-bench \
   --baseline gs://my-baselines/bench.json \
   --output-github \
   --mode cockpit \
+  --profile-on-regression \
   --md-template .github/perfgate-comment.hbs \
   --bench-regex "^service/"
 ```

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -8,8 +8,17 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 |--------|-------------|-------------|
 | `perfgate.run.v1` | `run`, `check` | Raw measurement data from a benchmark execution |
 | `perfgate.compare.v1` | `compare`, `check`, `paired` | Comparison of current run against baseline |
-| `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope |
+| `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
 | `sensor.report.v1` | `check --mode cockpit` | Sensor integration envelope for dashboards |
+
+## Additional Generated Schemas
+
+perfgate also commits generated schemas for tooling and editor integration:
+
+| File | Purpose |
+|------|---------|
+| `schemas/perfgate.config.v1.schema.json` | Validates `perfgate.toml` / JSON config shape, including optional per-benchmark scaling configuration |
+| `schemas/perfgate.report.v1.schema.json` | Validates report receipts, including additive diagnostics such as `profile_path` |
 
 ## JSON Schema Generation
 

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -135,6 +135,17 @@
           "format": "uint32",
           "minimum": 0
         },
+        "scaling": {
+          "description": "Optional scaling validation configuration.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ScalingConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "timeout": {
           "description": "Duration string parseable by humantime, e.g. \"2s\".",
           "type": [
@@ -347,6 +358,48 @@
           "type": "string",
           "const": "skip"
         }
+      ]
+    },
+    "ScalingConfig": {
+      "description": "Configuration for computational complexity validation.",
+      "type": "object",
+      "properties": {
+        "expected": {
+          "description": "Expected complexity class (e.g., \"O(n)\", \"O(n^2)\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "r_squared_threshold": {
+          "description": "Minimum R-squared for a valid fit (default: 0.90).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "repeat": {
+          "description": "Number of repetitions per input size (default: 5).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "sizes": {
+          "description": "Input sizes to test.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        }
+      },
+      "required": [
+        "sizes"
       ]
     }
   }

--- a/schemas/perfgate.report.v1.schema.json
+++ b/schemas/perfgate.report.v1.schema.json
@@ -22,6 +22,13 @@
         "$ref": "#/$defs/ReportFinding"
       }
     },
+    "profile_path": {
+      "description": "Path to a flamegraph SVG captured when regression was detected.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "report_type": {
       "description": "Schema identifier, always \"perfgate.report.v1\".",
       "type": "string"


### PR DESCRIPTION
## Summary
- refresh the committed generated schemas so `xtask ci` no longer fails on schema drift
- document the shipped CLI/schema surface for scaling, regression profiling, and newer commands
- ignore only transient `.claude/patches/` and `.claude/worktrees/` paths instead of the whole `.claude` tree

## Verification
- `cargo run -p xtask -- ci`
- `cargo run -p xtask -- docs-check`