### PR TITLE
chore(release): prepare 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-03-28
+
+### Fixed
+- Restored local `perfgate serve` baseline workflows by injecting a synthetic auth context for local-mode API routes.
+- Tightened baseline-service docs so `README`, getting-started guides, and service notes match the current shipped surface instead of historical or aspirational behavior.
+
+### Changed
+- Bumped the workspace and internal crate versions to `0.15.1`.
+- Updated GitHub Action examples to pin `EffortlessMetrics/perfgate@v0.15.1`.
+
 ## [0.15.0] - 2026-03-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -133,30 +133,30 @@ wiremock = "0.6"
 libc = "0.2.182"
 
 # Internal crates
-perfgate-error = { path = "crates/perfgate-error", version = "0.15.0" }
-perfgate-auth = { path = "crates/perfgate-auth", version = "0.15.0" }
-perfgate-api = { path = "crates/perfgate-api", version = "0.15.0" }
-perfgate-config = { path = "crates/perfgate-config", version = "0.15.0" }
-perfgate-types = { path = "crates/perfgate-types", version = "0.15.0" }
-perfgate-validation = { path = "crates/perfgate-validation", version = "0.15.0" }
-perfgate-stats = { path = "crates/perfgate-stats", version = "0.15.0" }
-perfgate-significance = { path = "crates/perfgate-significance", version = "0.15.0" }
-perfgate-paired = { path = "crates/perfgate-paired", version = "0.15.0" }
-perfgate-budget = { path = "crates/perfgate-budget", version = "0.15.0" }
-perfgate-domain = { path = "crates/perfgate-domain", version = "0.15.0" }
-perfgate-host-detect = { path = "crates/perfgate-host-detect", version = "0.15.0" }
-perfgate-sha256 = { path = "crates/perfgate-sha256", version = "0.15.0" }
-perfgate-render = { path = "crates/perfgate-render", version = "0.15.0" }
-perfgate-export = { path = "crates/perfgate-export", version = "0.15.0" }
-perfgate-sensor = { path = "crates/perfgate-sensor", version = "0.15.0" }
-perfgate-fake = { path = "crates/perfgate-fake", version = "0.15.0" }
-perfgate-summary = { path = "crates/perfgate-summary", version = "0.15.0" }
-perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.15.0" }
-perfgate-ingest = { path = "crates/perfgate-ingest", version = "0.15.0" }
-perfgate-profile = { path = "crates/perfgate-profile", version = "0.15.0" }
-perfgate-app = { path = "crates/perfgate-app", version = "0.15.0" }
-perfgate-server = { path = "crates/perfgate-server", version = "0.15.0" }
-perfgate-client = { path = "crates/perfgate-client", version = "0.15.0" }
-perfgate-scaling = { path = "crates/perfgate-scaling", version = "0.15.0" }
-perfgate-github = { path = "crates/perfgate-github", version = "0.15.0" }
-perfgate = { path = "crates/perfgate", version = "0.15.0" }
+perfgate-error = { path = "crates/perfgate-error", version = "0.15.1" }
+perfgate-auth = { path = "crates/perfgate-auth", version = "0.15.1" }
+perfgate-api = { path = "crates/perfgate-api", version = "0.15.1" }
+perfgate-config = { path = "crates/perfgate-config", version = "0.15.1" }
+perfgate-types = { path = "crates/perfgate-types", version = "0.15.1" }
+perfgate-validation = { path = "crates/perfgate-validation", version = "0.15.1" }
+perfgate-stats = { path = "crates/perfgate-stats", version = "0.15.1" }
+perfgate-significance = { path = "crates/perfgate-significance", version = "0.15.1" }
+perfgate-paired = { path = "crates/perfgate-paired", version = "0.15.1" }
+perfgate-budget = { path = "crates/perfgate-budget", version = "0.15.1" }
+perfgate-domain = { path = "crates/perfgate-domain", version = "0.15.1" }
+perfgate-host-detect = { path = "crates/perfgate-host-detect", version = "0.15.1" }
+perfgate-sha256 = { path = "crates/perfgate-sha256", version = "0.15.1" }
+perfgate-render = { path = "crates/perfgate-render", version = "0.15.1" }
+perfgate-export = { path = "crates/perfgate-export", version = "0.15.1" }
+perfgate-sensor = { path = "crates/perfgate-sensor", version = "0.15.1" }
+perfgate-fake = { path = "crates/perfgate-fake", version = "0.15.1" }
+perfgate-summary = { path = "crates/perfgate-summary", version = "0.15.1" }
+perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.15.1" }
+perfgate-ingest = { path = "crates/perfgate-ingest", version = "0.15.1" }
+perfgate-profile = { path = "crates/perfgate-profile", version = "0.15.1" }
+perfgate-app = { path = "crates/perfgate-app", version = "0.15.1" }
+perfgate-server = { path = "crates/perfgate-server", version = "0.15.1" }
+perfgate-client = { path = "crates/perfgate-client", version = "0.15.1" }
+perfgate-scaling = { path = "crates/perfgate-scaling", version = "0.15.1" }
+perfgate-github = { path = "crates/perfgate-github", version = "0.15.1" }
+perfgate = { path = "crates/perfgate", version = "0.15.1" }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ perfgate check --config perfgate.toml --bench my-service --profile-on-regression
 
 ```yaml
 # .github/workflows/perf.yml
-- uses: EffortlessMetrics/perfgate@v0.15.0
+- uses: EffortlessMetrics/perfgate@v0.15.1
   with:
     config: perfgate.toml
     all: "true"

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -46,7 +46,7 @@ jobs:
 
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.15.0
+        uses: EffortlessMetrics/perfgate@v0.15.1
         with:
           config: perfgate.toml
           all: "true"

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,15 @@
-# Release Readiness: v0.15.0
+# Release Readiness: v0.15.1
 
-Last verified: 2026-03-27 against commit on main.
+Last verified: 2026-03-28 against the 0.15.1 release-prep branch.
+
+## Patch Scope
+
+This patch release is intentionally narrow:
+- restore local `perfgate serve` baseline workflows (`promote --to-server`,
+  `baseline list`, `baseline history`, `compare --baseline @server:<bench>`)
+- align baseline-service docs with the actual `0.15.x` command and server
+  surface
+- roll examples and release docs forward to `v0.15.1`
 
 ## Tested and Working
 
@@ -26,10 +35,12 @@ These commands were tested end-to-end on Windows (x86_64, Rust 1.92):
 | `explain` | **Works** | Generates diagnostic text |
 | `blame` | **Works** | Diff two Cargo.lock files |
 | `bisect` | **Not tested** | Wraps git bisect, requires repo with history |
+| `serve` | **Works** | Local SQLite dashboard/server; local baseline workflows re-verified |
 | `baseline upload` | **Works** | Requires `pg_live_` key with 32+ char suffix |
 | `baseline list` | **Works** | Lists uploaded baselines correctly |
 | `baseline download` | **Works** | Note: uses `--output` not `--out` |
-| `baseline delete/history/verdicts` | **Not tested** | Server is functional, these likely work |
+| `baseline history` | **Works** | Local-mode smoke flow re-verified in 0.15.1 prep |
+| `baseline delete/verdicts` | **Not tested** | Server is functional, but these were not re-run for this patch |
 | `check --mode cockpit` | **Works** | Produces sensor.report.v1 envelope + extras |
 
 ## Known Bugs
@@ -73,7 +84,7 @@ The **core local gating pipeline** is production-quality:
 
 ## What's Functional But Needs Hardening
 
-- **Baseline server** — works for dev/small-team. Storage backends (SQLite, PostgreSQL, S3) are implemented. Not load-tested. OIDC is partially implemented (GitHub Actions only). No audit trail.
+- **Baseline server** — works for dev/small-team. Storage backends (SQLite, PostgreSQL, S3) are implemented. Not load-tested. GitHub Actions OIDC is exercised; GitLab and custom OIDC exist but remain lightly exercised.
 - **`bisect`** — wraps git bisect. Works in concept but depends on repo structure and build system. Edge cases likely.
 - **`explain`** — generates prompts, doesn't call an LLM. Useful but the name oversells it.
 - **`aggregate`** — simple merge, no weighting or outlier detection.
@@ -90,7 +101,7 @@ The **core local gating pipeline** is production-quality:
 
 ## Recommended Release Approach
 
-1. **Merge cleanup** (this branch) — version alignment, README, debug prints, stale refs
-2. **Fix doc flag mismatches** (#56) — `paired`, `blame`, `bisect` examples
-3. **Tag v0.15.0** — first published release
-4. **Follow up**: crates.io publish, versioned action tag, server hardening
+1. **Merge local-mode/doc cleanup** — already complete on `main`
+2. **Merge 0.15.1 prep** — version bump, changelog, action example updates
+3. **Tag `v0.15.1`** — trigger the binary release workflow
+4. **Follow up** — crates.io publish, versioned action tag, workflow action runtime upgrades


### PR DESCRIPTION
## Summary
- bump the workspace and internal crate versions from `0.15.0` to `0.15.1`
- add the `0.15.1` changelog entry and refresh release-readiness notes for the patch scope
- update GitHub Action examples to pin `EffortlessMetrics/perfgate@v0.15.1`

## Verification
- `cargo run -p xtask -- ci`
