### PR TITLE
Add explicit promote-time budget ratcheting workflow

### DIFF
--- a/crates/perfgate-app/Cargo.toml
+++ b/crates/perfgate-app/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["development-tools"]
 
 [dependencies]
 perfgate-types.workspace = true
+perfgate-budget.workspace = true
 perfgate-error.workspace = true
 perfgate-domain.workspace = true
 perfgate-adapters.workspace = true

--- a/crates/perfgate-app/src/baseline_resolve.rs
+++ b/crates/perfgate-app/src/baseline_resolve.rs
@@ -48,7 +48,7 @@ pub fn is_remote_storage_uri(path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perfgate_types::{BaselineServerConfig, ConfigFile, DefaultsConfig};
+    use perfgate_types::{BaselineServerConfig, ConfigFile, DefaultsConfig, RatchetConfig};
 
     #[test]
     fn test_resolve_baseline_path_uses_cli_over_config() {
@@ -60,6 +60,7 @@ mod tests {
                 ..Default::default()
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: RatchetConfig::default(),
             benches: Vec::new(),
         };
 

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -994,6 +994,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench.clone()],
         };
 
@@ -1124,6 +1125,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench.clone()],
         };
 
@@ -1201,6 +1203,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench],
         };
 
@@ -1255,6 +1258,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench],
         };
 
@@ -1326,6 +1330,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench],
         };
 
@@ -1383,6 +1388,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench],
         };
 
@@ -1413,6 +1419,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![],
         };
 
@@ -1465,6 +1472,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: perfgate_types::RatchetConfig::default(),
             benches: vec![bench],
         };
 

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -20,6 +20,7 @@ mod explain;
 pub mod init;
 mod paired;
 mod promote;
+mod ratchet;
 mod report;
 mod sensor_report;
 mod trend;
@@ -39,6 +40,9 @@ pub use diff::{
 pub use explain::{ExplainOutcome, ExplainRequest, ExplainUseCase};
 pub use paired::{PairedRunOutcome, PairedRunRequest, PairedRunUseCase};
 pub use promote::{PromoteRequest, PromoteResult, PromoteUseCase};
+pub use ratchet::{
+    RatchetOutcome, RatchetRequest, RatchetUseCase, render_preview as render_ratchet_preview,
+};
 pub use report::{ReportRequest, ReportResult, ReportUseCase};
 pub use sensor_report::{
     BenchOutcome, SensorCheckOptions, SensorReportBuilder, classify_error,

--- a/crates/perfgate-app/src/ratchet.rs
+++ b/crates/perfgate-app/src/ratchet.rs
@@ -1,0 +1,195 @@
+use perfgate_budget::evaluate_ratchet_threshold;
+use perfgate_types::{
+    CompareReceipt, ConfigFile, MetricStatus, RATCHET_SCHEMA_V1, RatchetChange, RatchetConfig,
+    RatchetEvidence, RatchetReceipt, VerdictStatus,
+};
+
+#[derive(Debug, Clone)]
+pub struct RatchetRequest {
+    pub compare: CompareReceipt,
+    pub config: ConfigFile,
+}
+
+#[derive(Debug, Clone)]
+pub struct RatchetOutcome {
+    pub bench_name: String,
+    pub changes: Vec<RatchetChange>,
+    pub skipped: Vec<String>,
+}
+
+pub struct RatchetUseCase;
+
+impl RatchetUseCase {
+    pub fn preview(req: RatchetRequest) -> RatchetOutcome {
+        let mut changes = Vec::new();
+        let mut skipped = Vec::new();
+        let compare = req.compare;
+        let policy: RatchetConfig = req.config.ratchet;
+
+        if compare.verdict.status != VerdictStatus::Pass {
+            skipped.push("verdict is not pass".to_string());
+            return RatchetOutcome {
+                bench_name: compare.bench.name,
+                changes,
+                skipped,
+            };
+        }
+
+        let host_mismatch = compare
+            .verdict
+            .reasons
+            .iter()
+            .any(|r| r == perfgate_types::VERDICT_REASON_HOST_MISMATCH);
+        if host_mismatch {
+            skipped.push("host mismatch present".to_string());
+            return RatchetOutcome {
+                bench_name: compare.bench.name,
+                changes,
+                skipped,
+            };
+        }
+
+        let Some(bench_cfg) = req
+            .config
+            .benches
+            .iter()
+            .find(|b| b.name == compare.bench.name)
+        else {
+            skipped.push(format!(
+                "bench '{}' not found in config",
+                compare.bench.name
+            ));
+            return RatchetOutcome {
+                bench_name: compare.bench.name,
+                changes,
+                skipped,
+            };
+        };
+
+        let Some(budget_overrides) = &bench_cfg.budgets else {
+            skipped.push("bench has no explicit budgets to ratchet".to_string());
+            return RatchetOutcome {
+                bench_name: compare.bench.name,
+                changes,
+                skipped,
+            };
+        };
+
+        for metric in &policy.allow_metrics {
+            let Some(delta) = compare.deltas.get(metric) else {
+                skipped.push(format!("{}: missing delta", metric.as_str()));
+                continue;
+            };
+            if delta.status != MetricStatus::Pass {
+                skipped.push(format!("{}: status is not pass", metric.as_str()));
+                continue;
+            }
+            let Some(override_budget) = budget_overrides.get(metric) else {
+                skipped.push(format!("{}: no config budget override", metric.as_str()));
+                continue;
+            };
+            let Some(current_threshold) = override_budget.threshold else {
+                skipped.push(format!("{}: threshold missing in config", metric.as_str()));
+                continue;
+            };
+            let Some(compare_budget) = compare.budgets.get(metric) else {
+                skipped.push(format!("{}: compare budget missing", metric.as_str()));
+                continue;
+            };
+
+            let noisy =
+                matches!(delta.cv.zip(delta.noise_threshold), Some((cv, limit)) if cv > limit);
+            if noisy {
+                skipped.push(format!("{}: noisy sample detected", metric.as_str()));
+                continue;
+            }
+
+            let significance_met = delta
+                .significance
+                .as_ref()
+                .map(|s| s.significant)
+                .unwrap_or(false);
+            if policy.require_significance && !significance_met {
+                skipped.push(format!("{}: significance not met", metric.as_str()));
+                continue;
+            }
+
+            let decision = evaluate_ratchet_threshold(
+                delta.baseline,
+                delta.current,
+                current_threshold,
+                compare_budget.direction,
+                &policy,
+            );
+            if !decision.eligible {
+                skipped.push(format!("{}: {}", metric.as_str(), decision.reason));
+                continue;
+            }
+
+            let new_threshold = decision.proposed_threshold.unwrap_or(current_threshold);
+            if new_threshold >= current_threshold {
+                continue;
+            }
+
+            changes.push(RatchetChange {
+                metric: *metric,
+                old_threshold: current_threshold,
+                new_threshold,
+                improvement: decision.improvement,
+                reason: decision.reason,
+                confidence: RatchetEvidence {
+                    verdict_pass: true,
+                    host_mismatch,
+                    noisy,
+                    significance_met: !policy.require_significance || significance_met,
+                },
+            });
+        }
+
+        RatchetOutcome {
+            bench_name: compare.bench.name,
+            changes,
+            skipped,
+        }
+    }
+
+    pub fn build_receipt(
+        outcome: &RatchetOutcome,
+        policy: RatchetConfig,
+        applied: bool,
+    ) -> RatchetReceipt {
+        RatchetReceipt {
+            schema: RATCHET_SCHEMA_V1.to_string(),
+            bench_name: outcome.bench_name.clone(),
+            mode: policy.mode,
+            applied,
+            changes: outcome.changes.clone(),
+            skipped: outcome.skipped.clone(),
+        }
+    }
+}
+
+pub fn render_preview(outcome: &RatchetOutcome) -> String {
+    let mut out = String::new();
+    if outcome.changes.is_empty() {
+        out.push_str("No ratchet changes proposed.\n");
+    } else {
+        out.push_str("Proposed ratchet changes:\n");
+        for change in &outcome.changes {
+            out.push_str(&format!(
+                "- {}: {:.6} -> {:.6} (improvement {:.2}%)\n",
+                change.metric.as_str(),
+                change.old_threshold,
+                change.new_threshold,
+                change.improvement * 100.0
+            ));
+        }
+    }
+    if !outcome.skipped.is_empty() {
+        out.push_str("Skipped:\n");
+        for reason in &outcome.skipped {
+            out.push_str(&format!("- {reason}\n"));
+        }
+    }
+    out
+}

--- a/crates/perfgate-budget/src/lib.rs
+++ b/crates/perfgate-budget/src/lib.rs
@@ -40,7 +40,8 @@
 //! ```
 
 use perfgate_types::{
-    Budget, Direction, Metric, MetricStatus, Verdict, VerdictCounts, VerdictStatus,
+    Budget, Direction, Metric, MetricStatus, RatchetConfig, RatchetMode, Verdict, VerdictCounts,
+    VerdictStatus,
 };
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -118,6 +119,14 @@ pub struct BudgetResult {
     pub status: MetricStatus,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct RatchetDecision {
+    pub eligible: bool,
+    pub improvement: f64,
+    pub proposed_threshold: Option<f64>,
+    pub reason: String,
+}
+
 /// Evaluates a metric against a budget threshold.
 ///
 /// This is the core budget evaluation function that:
@@ -185,6 +194,62 @@ pub fn evaluate_budget(
         noise_threshold: budget.noise_threshold,
         status,
     })
+}
+
+pub fn evaluate_ratchet_threshold(
+    baseline: f64,
+    current: f64,
+    current_threshold: f64,
+    direction: Direction,
+    policy: &RatchetConfig,
+) -> RatchetDecision {
+    if !matches!(policy.mode, RatchetMode::Threshold) {
+        return RatchetDecision {
+            eligible: false,
+            improvement: 0.0,
+            proposed_threshold: None,
+            reason: "ratchet mode baseline_value not supported for thresholds".to_string(),
+        };
+    }
+    if baseline <= 0.0 {
+        return RatchetDecision {
+            eligible: false,
+            improvement: 0.0,
+            proposed_threshold: None,
+            reason: "baseline must be > 0".to_string(),
+        };
+    }
+    let improvement = match direction {
+        Direction::Lower => ((baseline - current) / baseline).max(0.0),
+        Direction::Higher => ((current - baseline) / baseline).max(0.0),
+    };
+    if improvement < policy.min_improvement {
+        return RatchetDecision {
+            eligible: false,
+            improvement,
+            proposed_threshold: None,
+            reason: format!(
+                "improvement {:.4} below min_improvement {:.4}",
+                improvement, policy.min_improvement
+            ),
+        };
+    }
+    let tightening = improvement.min(policy.max_tightening);
+    let candidate = current_threshold * (1.0 - tightening);
+    if candidate >= current_threshold {
+        return RatchetDecision {
+            eligible: false,
+            improvement,
+            proposed_threshold: None,
+            reason: "candidate is not tighter than current threshold".to_string(),
+        };
+    }
+    RatchetDecision {
+        eligible: true,
+        improvement,
+        proposed_threshold: Some(candidate),
+        reason: format!("tightened by {:.4} (capped)", tightening),
+    }
 }
 
 /// Calculates the regression percentage between baseline and current values.

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -16,16 +16,18 @@ use perfgate_app::{
     BlameRequest, BlameUseCase, CheckOutcome, CheckRequest, CheckUseCase, Clock, CompareRequest,
     CompareUseCase, DiffRequest, DiffUseCase, ExplainRequest, ExplainUseCase, ExportFormat,
     ExportUseCase, PairedRunRequest, PairedRunUseCase, PromoteRequest, PromoteUseCase,
-    ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase, SensorReportBuilder,
-    SystemClock, classify_error, github_annotations, render_json_diff, render_markdown,
-    render_markdown_template, render_terminal_diff,
+    RatchetRequest, RatchetUseCase, ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase,
+    SensorReportBuilder, SystemClock, classify_error, github_annotations, render_json_diff,
+    render_markdown, render_markdown_template, render_ratchet_preview, render_terminal_diff,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::{
     AuthMethod, BaselineClient, ClientConfig, ListBaselinesQuery, ListVerdictsQuery,
     SubmitVerdictRequest, UploadBaselineRequest,
 };
-use perfgate_config::{ResolvedServerConfig, load_config_file, resolve_server_config};
+use perfgate_config::{
+    ResolvedServerConfig, apply_ratchet_changes, load_config_file, resolve_server_config,
+};
 use perfgate_domain::{DependencyChangeType, SignificancePolicy};
 use perfgate_error::{ConfigValidationError, IoError, PerfgateError};
 use perfgate_github::{CommentOptions, GitHubClient};
@@ -857,6 +859,26 @@ pub struct PromoteArgs {
     /// Pretty-print JSON
     #[arg(long, default_value_t = false)]
     pub pretty: bool,
+
+    /// Ratchet budgets using a compare receipt (explicit promote path only).
+    #[arg(long, default_value_t = false)]
+    pub ratchet: bool,
+
+    /// Compare receipt used as ratchet evidence.
+    #[arg(long, requires = "ratchet")]
+    pub compare: Option<PathBuf>,
+
+    /// Config path to preview/apply ratchet changes.
+    #[arg(long, requires = "ratchet", default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Preview ratchet config changes without writing.
+    #[arg(long, requires = "ratchet", default_value_t = false)]
+    pub ratchet_preview: bool,
+
+    /// Path to write ratchet artifact receipt.
+    #[arg(long, requires = "ratchet", default_value = "perfgate-ratchet.json")]
+    pub ratchet_artifact: PathBuf,
 }
 
 #[derive(Debug, Args)]
@@ -1740,6 +1762,11 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 version,
                 normalize,
                 pretty,
+                ratchet,
+                compare,
+                config,
+                ratchet_preview,
+                ratchet_artifact,
             } = *args;
 
             let receipt: RunReceipt = read_json_from_location(&current)?;
@@ -1792,6 +1819,42 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
                 let result = PromoteUseCase::execute(PromoteRequest { receipt, normalize });
                 write_json_to_location(&to_path, &result.receipt, pretty)?;
+            }
+
+            if ratchet {
+                if to_server {
+                    anyhow::bail!(
+                        "--ratchet currently supports local promote only (without --to-server)"
+                    );
+                }
+                let compare_path = compare.ok_or_else(|| {
+                    anyhow::anyhow!("--ratchet requires --compare <perfgate.compare.v1.json>")
+                })?;
+                let compare_receipt: CompareReceipt = read_json(&compare_path)?;
+                let cfg = load_config_file(&config)?;
+                if !cfg.ratchet.enabled {
+                    anyhow::bail!(
+                        "ratchet is disabled in config ([ratchet].enabled=false); refusing to apply"
+                    );
+                }
+
+                let ratchet_outcome = RatchetUseCase::preview(RatchetRequest {
+                    compare: compare_receipt,
+                    config: cfg.clone(),
+                });
+                eprintln!("{}", render_ratchet_preview(&ratchet_outcome));
+
+                if !ratchet_preview {
+                    apply_ratchet_changes(
+                        &config,
+                        &ratchet_outcome.bench_name,
+                        &ratchet_outcome.changes,
+                    )?;
+                }
+
+                let ratchet_receipt =
+                    RatchetUseCase::build_receipt(&ratchet_outcome, cfg.ratchet, !ratchet_preview);
+                write_json(&ratchet_artifact, &ratchet_receipt, true)?;
             }
 
             Ok(())

--- a/crates/perfgate-cli/tests/cli_promote_tests.rs
+++ b/crates/perfgate-cli/tests/cli_promote_tests.rs
@@ -363,3 +363,63 @@ fn test_promote_creates_parent_directories() {
         "baseline file should exist in nested directory"
     );
 }
+
+#[test]
+fn test_promote_ratchet_preview_does_not_write_config() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let compare_path = temp_dir.path().join("compare.json");
+    let baseline = fixtures_dir().join("baseline.json");
+    let current = fixtures_dir().join("current_pass.json");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let out_baseline = temp_dir.path().join("baseline-out.json");
+
+    fs::write(
+        &config_path,
+        r#"[ratchet]
+enabled = true
+mode = "threshold"
+min_improvement = 0.01
+max_tightening = 0.10
+require_significance = false
+allow_metrics = ["wall_ms"]
+
+[[bench]]
+name = "my-bench"
+command = ["echo", "hello"]
+
+[bench.budgets.wall_ms]
+threshold = 0.20
+"#,
+    )
+    .expect("write config");
+    let before = fs::read_to_string(&config_path).expect("read config before");
+
+    let mut compare_cmd = perfgate_cmd();
+    compare_cmd
+        .arg("compare")
+        .arg("--baseline")
+        .arg(&baseline)
+        .arg("--current")
+        .arg(&current)
+        .arg("--out")
+        .arg(&compare_path);
+    compare_cmd.assert().success();
+
+    let mut promote_cmd = perfgate_cmd();
+    promote_cmd
+        .arg("promote")
+        .arg("--current")
+        .arg(&baseline)
+        .arg("--to")
+        .arg(&out_baseline)
+        .arg("--ratchet")
+        .arg("--compare")
+        .arg(&compare_path)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--ratchet-preview");
+    promote_cmd.assert().success();
+
+    let after = fs::read_to_string(&config_path).expect("read config after");
+    assert_eq!(before, after, "preview should not modify config");
+}

--- a/crates/perfgate-config/src/lib.rs
+++ b/crates/perfgate-config/src/lib.rs
@@ -17,7 +17,7 @@
 
 use anyhow::Context;
 use perfgate_client::{BaselineClient, ClientConfig, FallbackClient, FallbackStorage};
-use perfgate_types::{BaselineServerConfig, ConfigFile};
+use perfgate_types::{BaselineServerConfig, ConfigFile, RatchetChange};
 use std::fs;
 use std::path::Path;
 
@@ -127,4 +127,37 @@ pub fn resolve_server_config(
         project: flag_project.or_else(|| file_config.resolved_project()),
         fallback_to_local: file_config.fallback_to_local,
     }
+}
+
+/// Apply ratchet threshold changes to a TOML config.
+pub fn apply_ratchet_changes(
+    path: &Path,
+    bench_name: &str,
+    changes: &[RatchetChange],
+) -> anyhow::Result<()> {
+    if changes.is_empty() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let mut updated = content.clone();
+    for change in changes {
+        let section = format!("[bench.budgets.{}]", change.metric.as_str());
+        if let Some(section_idx) = updated.find(&section) {
+            let tail = &updated[section_idx..];
+            if let Some(line_rel) = tail.find("threshold =") {
+                let start = section_idx + line_rel;
+                let line_end = updated[start..]
+                    .find('\n')
+                    .map(|i| start + i)
+                    .unwrap_or(updated.len());
+                updated.replace_range(
+                    start..line_end,
+                    &format!("threshold = {:.6}", change.new_threshold),
+                );
+            }
+        }
+    }
+    let _ = bench_name;
+    fs::write(path, updated).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
 }

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -48,6 +48,7 @@ pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
+pub const RATCHET_SCHEMA_V1: &str = "perfgate.ratchet.v1";
 
 // Stable contract identifiers and tokens.
 pub const CHECK_ID_BUDGET: &str = "perf.budget";
@@ -1154,8 +1155,97 @@ pub struct ConfigFile {
     #[serde(default)]
     pub baseline_server: BaselineServerConfig,
 
+    #[serde(default)]
+    pub ratchet: RatchetConfig,
+
     #[serde(default, rename = "bench")]
     pub benches: Vec<BenchConfigFile>,
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum RatchetMode {
+    #[default]
+    Threshold,
+    BaselineValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub mode: RatchetMode,
+    #[serde(default = "default_min_improvement")]
+    pub min_improvement: f64,
+    #[serde(default = "default_max_tightening")]
+    pub max_tightening: f64,
+    #[serde(default = "default_require_significance")]
+    pub require_significance: bool,
+    #[serde(default = "default_ratchet_allow_metrics")]
+    pub allow_metrics: Vec<Metric>,
+}
+
+impl Default for RatchetConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: RatchetMode::Threshold,
+            min_improvement: default_min_improvement(),
+            max_tightening: default_max_tightening(),
+            require_significance: default_require_significance(),
+            allow_metrics: default_ratchet_allow_metrics(),
+        }
+    }
+}
+
+fn default_min_improvement() -> f64 {
+    0.05
+}
+
+fn default_max_tightening() -> f64 {
+    0.10
+}
+
+fn default_require_significance() -> bool {
+    true
+}
+
+fn default_ratchet_allow_metrics() -> Vec<Metric> {
+    vec![Metric::WallMs, Metric::CpuMs]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetChange {
+    pub metric: Metric,
+    pub old_threshold: f64,
+    pub new_threshold: f64,
+    pub improvement: f64,
+    pub reason: String,
+    pub confidence: RatchetEvidence,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetEvidence {
+    pub verdict_pass: bool,
+    pub host_mismatch: bool,
+    pub noisy: bool,
+    pub significance_met: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetReceipt {
+    pub schema: String,
+    pub bench_name: String,
+    pub mode: RatchetMode,
+    pub applied: bool,
+    pub changes: Vec<RatchetChange>,
+    pub skipped: Vec<String>,
 }
 
 impl ConfigFile {
@@ -1540,6 +1630,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: RatchetConfig::default(),
             benches: vec![BenchConfigFile {
                 name: "bad|name".to_string(),
                 cwd: None,
@@ -1629,6 +1720,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: RatchetConfig::default(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
                 cwd: None,
@@ -2027,6 +2119,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: RatchetConfig::default(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".into(),
                 cwd: Some("/home/user/project".into()),
@@ -2064,6 +2157,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: RatchetConfig::default(),
             benches: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
@@ -3031,13 +3125,20 @@ mod property_tests {
         (
             defaults_config_strategy(),
             baseline_server_config_strategy(),
+            proptest::bool::ANY,
             proptest::collection::vec(bench_config_file_strategy(), 0..5),
         )
-            .prop_map(|(defaults, baseline_server, benches)| ConfigFile {
-                defaults,
-                baseline_server,
-                benches,
-            })
+            .prop_map(
+                |(defaults, baseline_server, ratchet_enabled, benches)| ConfigFile {
+                    defaults,
+                    baseline_server,
+                    ratchet: RatchetConfig {
+                        enabled: ratchet_enabled,
+                        ..RatchetConfig::default()
+                    },
+                    benches,
+                },
+            )
     }
 
     // **Feature: comprehensive-test-coverage, Property 1: JSON Serialization Round-Trip**

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -21,6 +21,20 @@
     "defaults": {
       "$ref": "#/$defs/DefaultsConfig",
       "default": {}
+    },
+    "ratchet": {
+      "$ref": "#/$defs/RatchetConfig",
+      "default": {
+        "allow_metrics": [
+          "wall_ms",
+          "cpu_ms"
+        ],
+        "enabled": false,
+        "max_tightening": 0.1,
+        "min_improvement": 0.05,
+        "mode": "threshold",
+        "require_significance": true
+      }
     }
   },
   "$defs": {
@@ -358,6 +372,50 @@
           "type": "string",
           "const": "skip"
         }
+      ]
+    },
+    "RatchetConfig": {
+      "type": "object",
+      "properties": {
+        "allow_metrics": {
+          "type": "array",
+          "default": [
+            "wall_ms",
+            "cpu_ms"
+          ],
+          "items": {
+            "$ref": "#/$defs/Metric"
+          }
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "max_tightening": {
+          "type": "number",
+          "format": "double",
+          "default": 0.1
+        },
+        "min_improvement": {
+          "type": "number",
+          "format": "double",
+          "default": 0.05
+        },
+        "mode": {
+          "$ref": "#/$defs/RatchetMode",
+          "default": "threshold"
+        },
+        "require_significance": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "RatchetMode": {
+      "type": "string",
+      "enum": [
+        "threshold",
+        "baseline_value"
       ]
     },
     "ScalingConfig": {


### PR DESCRIPTION
### Motivation

- Provide an explicit, conservative ratcheting flow so promoted improvements can be recorded into `perfgate.toml` without any silent edits during normal compare/check runs.
- Ratcheting must be gated to trusted promote paths and only tighten budgets when evidence is trustworthy (pass verdict, no host mismatch, no high-noise, optionally significant). 

### Description

- Add typed ratchet policy and artifact types in `perfgate-types` including `RatchetConfig`, `RatchetMode`, `RatchetChange`, `RatchetEvidence`, `RatchetReceipt`, and `RATCHET_SCHEMA_V1` and include them in the generated config schema. 
- Add budget decision helper `evaluate_ratchet_threshold` in `perfgate-budget` which computes observed improvement, enforces `min_improvement` and `max_tightening`, and only proposes tighter thresholds. 
- Add `RatchetUseCase` in `perfgate-app` which gates ratcheting on pass/no-host-mismatch/no-noise/significance, produces a preview, and builds a ratchet receipt; also export preview rendering. 
- Extend `perfgate promote` CLI with explicit flags (`--ratchet`, `--compare`, `--config`, `--ratchet-preview`, `--ratchet-artifact`) to preview or apply ratchet changes only on promote path, and emit a machine-readable ratchet artifact. 
- Add `apply_ratchet_changes` in `perfgate-config` to update `[bench.budgets.<metric>].threshold` in the TOML file (text-aware replace to preserve formatting/comments where possible). 
- Add an integration test validating that `--ratchet-preview` does not modify the config, and regenerate the config JSON schema to include the `[ratchet]` section. 

### Testing

- Ran unit/property tests offline for core crates: `perfgate-types` (all tests passed), `perfgate-budget` (all tests passed), `perfgate-config` (ok), and `perfgate-app` (ok). 
- Ran the promote CLI integration tests `cargo test -p perfgate-cli --test cli_promote_tests --offline` which passed (including the new preview test). 
- Attempted an online combined `cargo test` which failed early due to network/crates.io access in this environment, but subsequent offline test runs completed successfully. 
- Ran `cargo run -p xtask -- schema` to regenerate schemas and `cargo fmt --all`; both completed (schema regenerated to include ratchet defaults).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a536cad88333b47177073df31c37)