### PR TITLE
Add OpenTelemetry JSON ingest and span custom metric support

### DIFF
--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -693,6 +693,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }
@@ -810,6 +811,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }

--- a/crates/perfgate-app/src/diff.rs
+++ b/crates/perfgate-app/src/diff.rs
@@ -740,6 +740,7 @@ mod tests {
                 max_rss_kb: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
                 io_read_bytes: None,
                 io_write_bytes: None,
                 energy_uj: None,

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -434,6 +434,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }

--- a/crates/perfgate-app/src/promote.rs
+++ b/crates/perfgate-app/src/promote.rs
@@ -123,6 +123,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }

--- a/crates/perfgate-app/src/trend.rs
+++ b/crates/perfgate-app/src/trend.rs
@@ -244,6 +244,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1074,7 +1074,7 @@ pub struct PairedArgs {
 
 #[derive(Debug, Args)]
 pub struct IngestArgs {
-    /// Input format: criterion, hyperfine, gobench, pytest
+    /// Input format: criterion, hyperfine, gobench, pytest, otel
     #[arg(long)]
     pub format: String,
 
@@ -1085,6 +1085,14 @@ pub struct IngestArgs {
     /// Benchmark name (default: derived from input data)
     #[arg(long)]
     pub name: Option<String>,
+
+    /// Span name to include (exact match). Repeatable. Only used by --format otel.
+    #[arg(long = "include-span")]
+    pub include_spans: Vec<String>,
+
+    /// Span name to exclude (exact match). Repeatable. Only used by --format otel.
+    #[arg(long = "exclude-span")]
+    pub exclude_spans: Vec<String>,
 
     /// Output file path
     #[arg(long, default_value = "perfgate-ingest.json")]
@@ -2039,13 +2047,15 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 format,
                 input,
                 name,
+                include_spans,
+                exclude_spans,
                 out,
                 pretty,
             } = *args;
 
             let format = IngestFormat::parse(&format).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "unknown ingest format '{}'; supported: criterion, hyperfine, gobench, pytest",
+                    "unknown ingest format '{}'; supported: criterion, hyperfine, gobench, pytest, otel",
                     format
                 )
             })?;
@@ -2057,6 +2067,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 format,
                 input: content,
                 name,
+                include_spans,
+                exclude_spans,
             };
 
             let receipt = perfgate_ingest::ingest(&request)?;
@@ -4915,6 +4927,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/perfgate-client/src/fallback.rs
+++ b/crates/perfgate-client/src/fallback.rs
@@ -403,6 +403,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }

--- a/crates/perfgate-client/tests/client_server_integration.rs
+++ b/crates/perfgate-client/tests/client_server_integration.rs
@@ -53,6 +53,7 @@ fn create_test_receipt() -> RunReceipt {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         },
     }
 }

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -327,6 +327,7 @@ pub fn compute_stats(
         energy_uj,
         binary_bytes,
         throughput_per_s,
+        custom_metrics: std::collections::BTreeMap::new(),
     })
 }
 
@@ -396,6 +397,7 @@ fn aggregate_verdict_from_counts(counts: VerdictCounts, reasons: Vec<String>) ->
 ///     io_read_bytes: None, io_write_bytes: None, network_packets: None,
 ///     energy_uj: None,
 ///     binary_bytes: None, throughput_per_s: None,
+///     custom_metrics: std::collections::BTreeMap::new(),
 /// };
 /// let current = Stats {
 ///     wall_ms: U64Summary::new(105, 95, 115 ),
@@ -404,6 +406,7 @@ fn aggregate_verdict_from_counts(counts: VerdictCounts, reasons: Vec<String>) ->
 ///     io_read_bytes: None, io_write_bytes: None, network_packets: None,
 ///     energy_uj: None,
 ///     binary_bytes: None, throughput_per_s: None,
+///     custom_metrics: std::collections::BTreeMap::new(),
 /// };
 ///
 /// let mut budgets = BTreeMap::new();
@@ -1722,6 +1725,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
 
                 let current_stats = Stats {
@@ -1736,6 +1740,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
 
                 // Create budget with the generated thresholds
@@ -1802,6 +1807,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: Some(F64Summary::new(baseline, baseline, baseline)),                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 let current_stats = Stats {
                     wall_ms: U64Summary::new(1000, 1000, 1000),
@@ -1815,6 +1821,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: Some(F64Summary::new(current, current, current)),                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 // Create budget with the generated thresholds
                 let mut budgets = BTreeMap::new();
@@ -1877,6 +1884,7 @@ mod tests {
                         energy_uj: None,
                         binary_bytes: None,
                         throughput_per_s: None,
+                        custom_metrics: std::collections::BTreeMap::new(),
                         };                    let cs = Stats {
                         wall_ms: U64Summary::new(current as u64, current as u64, current as u64),
                         cpu_ms: None,
@@ -1889,6 +1897,7 @@ mod tests {
                         energy_uj: None,
                         binary_bytes: None,
                         throughput_per_s: None,
+                        custom_metrics: std::collections::BTreeMap::new(),
                         };                    let mut b = BTreeMap::new();
                     b.insert(Metric::WallMs, Budget {
                         noise_threshold: None,
@@ -1907,6 +1916,7 @@ mod tests {
                         energy_uj: None,
                         binary_bytes: None,
                         throughput_per_s: Some(F64Summary::new(baseline, baseline, baseline)),                    };
+                        custom_metrics: std::collections::BTreeMap::new(),
                     let cs = Stats {
                         wall_ms: U64Summary::new(1000, 1000, 1000),
                         cpu_ms: None,
@@ -1919,6 +1929,7 @@ mod tests {
                         energy_uj: None,
                         binary_bytes: None,
                         throughput_per_s: Some(F64Summary::new(current, current, current)),                    };
+                        custom_metrics: std::collections::BTreeMap::new(),
                     let mut b = BTreeMap::new();
                     b.insert(Metric::ThroughputPerS, Budget {
                         noise_threshold: None,
@@ -1966,6 +1977,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: Some(F64Summary::new(baseline, baseline, baseline)),                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 // For Direction::Higher, regression = max(0, (baseline - current) / baseline)
                 // To get regression = threshold, we need: (baseline - current) / baseline = threshold
@@ -1986,6 +1998,7 @@ mod tests {
                         energy_uj: None,
                         binary_bytes: None,
                         throughput_per_s: Some(F64Summary::new(current_at_threshold_higher, current_at_threshold_higher, current_at_threshold_higher)),
+                        custom_metrics: std::collections::BTreeMap::new(),
                     };
 
                     let mut budgets = BTreeMap::new();
@@ -2082,6 +2095,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: Some(F64Summary {
+                    custom_metrics: std::collections::BTreeMap::new(),
                     median: median as f64,
                     min: median as f64,
                     max: median as f64,
@@ -2211,6 +2225,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 // Compute current values to achieve desired statuses
                 let wall_ms_current = current_for_status(baseline, threshold, warn_threshold, wall_ms_status);
@@ -2243,6 +2258,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
 
                 let mut wall_budget = Budget {
@@ -2315,6 +2331,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: Some(F64Summary::new(baseline_throughput, baseline_throughput, baseline_throughput)),                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 // Compute current values to achieve desired statuses
                 let wall_ms_current = current_for_status(baseline, threshold, warn_threshold, wall_ms_status);
@@ -2365,6 +2382,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: Some(F64Summary {
+                    custom_metrics: std::collections::BTreeMap::new(),
                         median: throughput_current,
                         min: throughput_current,
                         max: throughput_current,
@@ -2454,6 +2472,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 // wall_ms will be Fail, max_rss will be the random status
                 let wall_ms_current = current_for_status(baseline, threshold, warn_threshold, MetricStatus::Fail);
@@ -2471,6 +2490,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
 
                 let mut budgets = BTreeMap::new();
@@ -2535,6 +2555,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,                };
+                    custom_metrics: std::collections::BTreeMap::new(),
 
                 // wall_ms will be Warn, max_rss will be Pass or Warn
                 let wall_ms_current = current_for_status(baseline, threshold, warn_threshold, MetricStatus::Warn);
@@ -2552,6 +2573,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
 
                 let mut budgets = BTreeMap::new();
@@ -2620,6 +2642,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: if num_metrics >= 3 {
+                    custom_metrics: std::collections::BTreeMap::new(),
                         Some(F64Summary::new(baseline_throughput, baseline_throughput, baseline_throughput))
                     } else {
                         None
@@ -2713,6 +2736,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             };
             let current = Stats {
                 wall_ms: U64Summary::new(current_wall, current_wall, current_wall),
@@ -2726,6 +2750,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             };
                 let mut budgets = BTreeMap::new();
                 budgets.insert(Metric::WallMs, Budget {
@@ -3032,6 +3057,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
 
                 let mut budgets = BTreeMap::new();
@@ -3084,6 +3110,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
                 let mut budgets = BTreeMap::new();
                 budgets.insert(Metric::WallMs, budget);
@@ -3120,6 +3147,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 };
                 let mut budgets = BTreeMap::new();
                 budgets.insert(Metric::WallMs, budget);
@@ -3396,6 +3424,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         // Current has 100% increase in cpu_ms (50 -> 100)
         let current = Stats {
@@ -3410,6 +3439,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(Metric::CpuMs, Budget::new(0.20, 0.10, Direction::Lower));
@@ -3451,6 +3481,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         // Current has 50% decrease in cpu_ms (100 -> 50) - improvement!
         let current = Stats {
@@ -3465,6 +3496,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(Metric::CpuMs, Budget::new(0.20, 0.10, Direction::Lower));
@@ -3503,6 +3535,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let current = Stats {
             wall_ms: U64Summary::new(100, 100, 100),
@@ -3516,6 +3549,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(Metric::CpuMs, Budget::new(0.20, 0.10, Direction::Lower));
@@ -3544,6 +3578,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let current = Stats {
             wall_ms: U64Summary::new(100, 100, 100),
@@ -3557,6 +3592,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(Metric::CpuMs, Budget::new(0.20, 0.10, Direction::Lower));
@@ -3585,6 +3621,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         // Current has 15% increase in cpu_ms (100 -> 115)
         let current = Stats {
@@ -3599,6 +3636,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(Metric::CpuMs, Budget::new(0.20, 0.10, Direction::Lower));
@@ -3632,6 +3670,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let current = Stats {
             wall_ms: U64Summary::new(1100, 1100, 1100),
@@ -3645,6 +3684,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(Metric::WallMs, Budget::new(0.20, 0.18, Direction::Lower));
@@ -3669,6 +3709,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: Some(F64Summary::new(110.0, 110.0, 110.0)),
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let current = Stats {
             wall_ms: U64Summary::new(1000, 1000, 1000),
@@ -3682,6 +3723,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: Some(F64Summary::new(100.0, 100.0, 100.0)),
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let mut budgets = BTreeMap::new();
         budgets.insert(
@@ -3886,6 +3928,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let current = Stats {
@@ -3900,6 +3943,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let mut budgets = BTreeMap::new();
@@ -3930,6 +3974,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: Some(F64Summary::new(0.0, 0.0, 0.0)),
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let current = Stats {
@@ -3944,6 +3989,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: Some(F64Summary::new(100.0, 100.0, 100.0)),
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let mut budgets = BTreeMap::new();
@@ -3977,6 +4023,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let current = Stats {
@@ -3991,6 +4038,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let mut budgets = BTreeMap::new();
@@ -4022,6 +4070,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: Some(F64Summary::new(-10.0, -10.0, -10.0)),
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let current = Stats {
@@ -4036,6 +4085,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: Some(F64Summary::new(100.0, 100.0, 100.0)),
+                custom_metrics: std::collections::BTreeMap::new(),
             };
 
             let mut budgets = BTreeMap::new();

--- a/crates/perfgate-export/examples/export_example.rs
+++ b/crates/perfgate-export/examples/export_example.rs
@@ -86,6 +86,7 @@ fn create_run_receipt() -> RunReceipt {
             ctx_switches: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         },
     }
 }

--- a/crates/perfgate-export/src/lib.rs
+++ b/crates/perfgate-export/src/lib.rs
@@ -46,6 +46,7 @@
 //!         cpu_ms: None, page_faults: None, ctx_switches: None,
 //!         max_rss_kb: None, io_read_bytes: None, io_write_bytes: None,
 //!         network_packets: None, energy_uj: None, binary_bytes: None, throughput_per_s: None,
+//!         custom_metrics: std::collections::BTreeMap::new(),
 //!     },
 //! };
 //!
@@ -245,6 +246,7 @@ impl ExportUseCase {
     ///         cpu_ms: None, page_faults: None, ctx_switches: None,
     ///         max_rss_kb: None, io_read_bytes: None, io_write_bytes: None,
     ///         network_packets: None, energy_uj: None, binary_bytes: None, throughput_per_s: None,
+    ///         custom_metrics: std::collections::BTreeMap::new(),
     ///     },
     /// };
     /// let csv = ExportUseCase::export_run(&receipt, ExportFormat::Csv).unwrap();
@@ -877,6 +879,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }
@@ -1176,6 +1179,7 @@ mod tests {
                     energy_uj: None,
                     binary_bytes: None,
                     throughput_per_s: None,
+                    custom_metrics: std::collections::BTreeMap::new(),
                 },
             }
         }

--- a/crates/perfgate-ingest/src/criterion.rs
+++ b/crates/perfgate-ingest/src/criterion.rs
@@ -103,6 +103,7 @@ pub fn parse_criterion(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
         energy_uj: None,
         binary_bytes: None,
         throughput_per_s: None,
+        custom_metrics: std::collections::BTreeMap::new(),
     };
 
     Ok(make_receipt(&bench_name, samples, full_stats))

--- a/crates/perfgate-ingest/src/gobench.rs
+++ b/crates/perfgate-ingest/src/gobench.rs
@@ -101,6 +101,7 @@ pub fn parse_gobench(input: &str, name: Option<&str>) -> anyhow::Result<RunRecei
         energy_uj: None,
         binary_bytes: None,
         throughput_per_s: None,
+        custom_metrics: std::collections::BTreeMap::new(),
     };
 
     let mut receipt = make_receipt(&bench_name, vec![sample], stats);

--- a/crates/perfgate-ingest/src/hyperfine.rs
+++ b/crates/perfgate-ingest/src/hyperfine.rs
@@ -97,6 +97,7 @@ pub fn parse_hyperfine(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
         energy_uj: None,
         binary_bytes: None,
         throughput_per_s: None,
+        custom_metrics: std::collections::BTreeMap::new(),
     };
 
     Ok(make_receipt(&bench_name, samples, full_stats))

--- a/crates/perfgate-ingest/src/lib.rs
+++ b/crates/perfgate-ingest/src/lib.rs
@@ -9,6 +9,7 @@
 mod criterion;
 mod gobench;
 mod hyperfine;
+mod otel;
 mod pytest;
 
 use perfgate_types::{
@@ -20,6 +21,7 @@ use uuid::Uuid;
 pub use criterion::parse_criterion;
 pub use gobench::parse_gobench;
 pub use hyperfine::parse_hyperfine;
+pub use otel::parse_otel_json;
 pub use pytest::parse_pytest_benchmark;
 
 /// Supported ingest formats.
@@ -29,6 +31,7 @@ pub enum IngestFormat {
     Hyperfine,
     GoBench,
     PytestBenchmark,
+    OTelJson,
 }
 
 impl IngestFormat {
@@ -39,6 +42,7 @@ impl IngestFormat {
             "hyperfine" => Some(Self::Hyperfine),
             "gobench" | "go" => Some(Self::GoBench),
             "pytest" | "pytest-benchmark" | "pytest_benchmark" => Some(Self::PytestBenchmark),
+            "otel" | "otlp-json" | "opentelemetry" => Some(Self::OTelJson),
             _ => None,
         }
     }
@@ -52,6 +56,10 @@ pub struct IngestRequest {
     pub input: String,
     /// Benchmark name override. If None, derived from the input data.
     pub name: Option<String>,
+    /// Optional list of span names to include (exact match).
+    pub include_spans: Vec<String>,
+    /// Optional list of span names to exclude (exact match).
+    pub exclude_spans: Vec<String>,
 }
 
 /// Perform an ingest operation, returning a `RunReceipt`.
@@ -63,6 +71,12 @@ pub fn ingest(request: &IngestRequest) -> anyhow::Result<RunReceipt> {
         IngestFormat::PytestBenchmark => {
             parse_pytest_benchmark(&request.input, request.name.as_deref())
         }
+        IngestFormat::OTelJson => parse_otel_json(
+            &request.input,
+            request.name.as_deref(),
+            &request.include_spans,
+            &request.exclude_spans,
+        ),
     }
 }
 
@@ -179,6 +193,11 @@ mod tests {
             IngestFormat::parse("pytest_benchmark"),
             Some(IngestFormat::PytestBenchmark)
         );
+        assert_eq!(IngestFormat::parse("otel"), Some(IngestFormat::OTelJson));
+        assert_eq!(
+            IngestFormat::parse("opentelemetry"),
+            Some(IngestFormat::OTelJson)
+        );
         assert_eq!(IngestFormat::parse("unknown"), None);
     }
 
@@ -253,6 +272,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let receipt = make_receipt("test-bench", samples, stats);
         assert_eq!(receipt.schema, RUN_SCHEMA_V1);

--- a/crates/perfgate-ingest/src/otel.rs
+++ b/crates/perfgate-ingest/src/otel.rs
@@ -1,0 +1,265 @@
+//! Parser for OpenTelemetry JSON trace exports.
+
+use anyhow::Context;
+use perfgate_types::{F64Summary, RunReceipt, Sample, Stats};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::{compute_u64_summary, make_receipt};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OTelExport {
+    #[serde(default)]
+    resource_spans: Vec<ResourceSpans>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceSpans {
+    #[serde(default)]
+    scope_spans: Vec<ScopeSpans>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScopeSpans {
+    #[serde(default)]
+    spans: Vec<OTelSpan>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OTelSpan {
+    name: String,
+    start_time_unix_nano: String,
+    end_time_unix_nano: String,
+}
+
+pub fn parse_otel_json(
+    input: &str,
+    name: Option<&str>,
+    include_spans: &[String],
+    exclude_spans: &[String],
+) -> anyhow::Result<RunReceipt> {
+    let export: OTelExport = serde_json::from_str(input).context("failed to parse OTel JSON")?;
+
+    let include: BTreeSet<&str> = include_spans.iter().map(String::as_str).collect();
+    let exclude: BTreeSet<&str> = exclude_spans.iter().map(String::as_str).collect();
+
+    let mut durations_by_span: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    let mut all_wall_ms: Vec<u64> = Vec::new();
+
+    for resource in export.resource_spans {
+        for scope in resource.scope_spans {
+            for span in scope.spans {
+                if !include.is_empty() && !include.contains(span.name.as_str()) {
+                    continue;
+                }
+                if exclude.contains(span.name.as_str()) {
+                    continue;
+                }
+
+                let start = parse_nanos(&span.start_time_unix_nano).with_context(|| {
+                    format!("invalid startTimeUnixNano for span '{}'", span.name)
+                })?;
+                let end = parse_nanos(&span.end_time_unix_nano)
+                    .with_context(|| format!("invalid endTimeUnixNano for span '{}'", span.name))?;
+
+                if end < start {
+                    continue;
+                }
+
+                let duration_ms = (end - start) as f64 / 1_000_000.0;
+                durations_by_span
+                    .entry(span.name)
+                    .or_default()
+                    .push(duration_ms);
+                all_wall_ms.push(duration_ms.max(0.0).round() as u64);
+            }
+        }
+    }
+
+    if !include.is_empty() {
+        let missing: Vec<_> = include
+            .iter()
+            .copied()
+            .filter(|name| !durations_by_span.contains_key(*name))
+            .collect();
+        if !missing.is_empty() {
+            anyhow::bail!(
+                "requested span(s) not found in trace: {}",
+                missing.join(", ")
+            );
+        }
+    }
+
+    if all_wall_ms.is_empty() {
+        anyhow::bail!("no spans matched filters in OTel JSON export");
+    }
+
+    let bench_name = name.unwrap_or("otel-trace");
+
+    let samples = all_wall_ms
+        .iter()
+        .map(|&wall_ms| Sample {
+            wall_ms,
+            exit_code: 0,
+            warmup: false,
+            timed_out: false,
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            stdout: None,
+            stderr: None,
+        })
+        .collect::<Vec<_>>();
+
+    let mut custom_metrics = BTreeMap::new();
+    for (span_name, durations) in durations_by_span {
+        let key = format!("span.{}.wall_ms", sanitize_metric_key(&span_name));
+        custom_metrics.insert(key, compute_f64_summary(&durations));
+    }
+
+    let stats = Stats {
+        wall_ms: compute_u64_summary(&all_wall_ms),
+        cpu_ms: None,
+        page_faults: None,
+        ctx_switches: None,
+        max_rss_kb: None,
+        io_read_bytes: None,
+        io_write_bytes: None,
+        network_packets: None,
+        energy_uj: None,
+        binary_bytes: None,
+        throughput_per_s: None,
+        custom_metrics,
+    };
+
+    Ok(make_receipt(bench_name, samples, stats))
+}
+
+fn parse_nanos(v: &str) -> anyhow::Result<u64> {
+    v.parse::<u64>()
+        .with_context(|| format!("failed to parse '{}' as u64 nanoseconds", v))
+}
+
+fn compute_f64_summary(values: &[f64]) -> F64Summary {
+    if values.is_empty() {
+        return F64Summary::new(0.0, 0.0, 0.0);
+    }
+
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    let median = if sorted.len().is_multiple_of(2) {
+        (sorted[sorted.len() / 2 - 1] + sorted[sorted.len() / 2]) / 2.0
+    } else {
+        sorted[sorted.len() / 2]
+    };
+
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / values.len() as f64;
+
+    F64Summary {
+        median,
+        min,
+        max,
+        mean: Some(mean),
+        stddev: Some(variance.sqrt()),
+    }
+}
+
+fn sanitize_metric_key(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push('_');
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OTEL_JSON: &str = r#"{
+      "resourceSpans": [{
+        "scopeSpans": [{
+          "spans": [
+            {
+              "name": "ast_parsing",
+              "startTimeUnixNano": "1000000000",
+              "endTimeUnixNano": "1040000000"
+            },
+            {
+              "name": "ast_parsing",
+              "startTimeUnixNano": "1100000000",
+              "endTimeUnixNano": "1165000000"
+            },
+            {
+              "name": "resolve_imports",
+              "startTimeUnixNano": "2000000000",
+              "endTimeUnixNano": "2070000000"
+            }
+          ]
+        }]
+      }]
+    }"#;
+
+    #[test]
+    fn parse_otel_builds_custom_metrics() {
+        let receipt = parse_otel_json(OTEL_JSON, Some("lsp"), &[], &[]).unwrap();
+        assert_eq!(receipt.bench.name, "lsp");
+        assert!(
+            receipt
+                .stats
+                .custom_metrics
+                .contains_key("span.ast_parsing.wall_ms")
+        );
+        assert!(
+            receipt
+                .stats
+                .custom_metrics
+                .contains_key("span.resolve_imports.wall_ms")
+        );
+    }
+
+    #[test]
+    fn parse_otel_include_span_missing_errors() {
+        let err = parse_otel_json(OTEL_JSON, None, &["missing_span".to_string()], &[]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("requested span(s) not found in trace")
+        );
+    }
+
+    #[test]
+    fn parse_otel_include_and_exclude_filters() {
+        let receipt = parse_otel_json(
+            OTEL_JSON,
+            None,
+            &["ast_parsing".to_string()],
+            &["resolve_imports".to_string()],
+        )
+        .unwrap();
+        assert_eq!(receipt.stats.custom_metrics.len(), 1);
+        assert!(
+            receipt
+                .stats
+                .custom_metrics
+                .contains_key("span.ast_parsing.wall_ms")
+        );
+    }
+}

--- a/crates/perfgate-ingest/src/pytest.rs
+++ b/crates/perfgate-ingest/src/pytest.rs
@@ -106,6 +106,7 @@ pub fn parse_pytest_benchmark(input: &str, name: Option<&str>) -> anyhow::Result
         energy_uj: None,
         binary_bytes: None,
         throughput_per_s: None,
+        custom_metrics: std::collections::BTreeMap::new(),
     };
 
     Ok(make_receipt(&bench_name, samples, full_stats))

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -871,6 +871,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         }
     }

--- a/crates/perfgate-server/tests/common/mod.rs
+++ b/crates/perfgate-server/tests/common/mod.rs
@@ -124,6 +124,7 @@ pub fn create_test_receipt(benchmark: &str) -> perfgate_types::RunReceipt {
             ctx_switches: None,
             binary_bytes: None,
             throughput_per_s: None,
+            custom_metrics: std::collections::BTreeMap::new(),
         },
     }
 }

--- a/crates/perfgate-types/examples/types_example.rs
+++ b/crates/perfgate-types/examples/types_example.rs
@@ -40,6 +40,7 @@ fn main() {
         energy_uj: None,
         binary_bytes: None,
         throughput_per_s: None,
+        custom_metrics: std::collections::BTreeMap::new(),
     };
 
     // Assemble the receipt

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -459,6 +459,7 @@ impl F64Summary {
 ///     energy_uj: None,
 ///     binary_bytes: None,
 ///     throughput_per_s: None,
+///     custom_metrics: std::collections::BTreeMap::new(),
 /// };
 /// assert_eq!(stats.wall_ms.median, 100);
 /// assert_eq!(stats.max_rss_kb.unwrap().median, 4096);
@@ -505,6 +506,12 @@ pub struct Stats {
 
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub throughput_per_s: Option<F64Summary>,
+
+    /// Extensible custom metrics (e.g. ingested OpenTelemetry span durations).
+    ///
+    /// Keys are metric identifiers such as `span.ast_parsing.wall_ms`.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub custom_metrics: BTreeMap<String, F64Summary>,
 }
 
 /// A versioned receipt from a single benchmark run (`perfgate.run.v1`).
@@ -537,6 +544,7 @@ pub struct Stats {
 ///         cpu_ms: None, page_faults: None, ctx_switches: None,
 ///         max_rss_kb: None, io_read_bytes: None, io_write_bytes: None,
 ///         network_packets: None, energy_uj: None, binary_bytes: None, throughput_per_s: None,
+///         custom_metrics: std::collections::BTreeMap::new(),
 ///     },
 /// };
 ///
@@ -1725,6 +1733,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: Some(U64Summary::new(4096, 4096, 4096)),
                 throughput_per_s: Some(F64Summary::new(10.526, 10.0, 11.111)),
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         };
         let json = serde_json::to_string(&receipt).unwrap();
@@ -1774,6 +1783,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         };
         let json = serde_json::to_string(&receipt).unwrap();
@@ -1839,6 +1849,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: Some(F64Summary::new(f64::MAX, 0.0, f64::MAX)),
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         };
         let json = serde_json::to_string(&receipt).unwrap();
@@ -2085,6 +2096,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: Some(U64Summary::new(1024, 1024, 1024)),
             throughput_per_s: Some(F64Summary::new(2.0, 1.111, 10.0)),
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let json = serde_json::to_string(&stats).unwrap();
         let back: Stats = serde_json::from_str(&json).unwrap();
@@ -2105,6 +2117,7 @@ mod tests {
             energy_uj: None,
             binary_bytes: None,
             throughput_per_s: Some(F64Summary::new(0.0, 0.0, 0.0)),
+            custom_metrics: std::collections::BTreeMap::new(),
         };
         let json = serde_json::to_string(&stats).unwrap();
         let back: Stats = serde_json::from_str(&json).unwrap();
@@ -2280,6 +2293,7 @@ mod tests {
                 energy_uj: None,
                 binary_bytes: None,
                 throughput_per_s: None,
+                custom_metrics: std::collections::BTreeMap::new(),
             },
         };
 


### PR DESCRIPTION
### Motivation
- Enable ingesting OpenTelemetry trace exports so span durations can be represented and budgeted like existing metrics.
- Keep run receipts backward-compatible by adding an extensible custom metric surface rather than changing core metric fields.
- Provide a simple, import-first UX (`ingest otel`) with exact-name include/exclude filters for v1 scope.

### Description
- Add `custom_metrics: BTreeMap<String, F64Summary>` to `Stats` in `perfgate-types` to hold namespaced span metrics (e.g. `span.ast_parsing.wall_ms`).
- Implement a new `perfgate-ingest` parser `parse_otel_json` that reads OTel JSON (`resourceSpans/scopeSpans/spans`), computes per-span duration summaries, sanitizes span names into keys, and populates `Stats::custom_metrics`.
- Extend ingest plumbing with an `OTelJson` format, add `include_spans` / `exclude_spans` to `IngestRequest`, and wire new CLI flags `--format otel`, `--include-span`, and `--exclude-span` through the `ingest` command.
- Propagate `Stats::custom_metrics` defaults to existing stats initializers across the codebase to preserve compilation and maintain existing behavior.

### Testing
- Ran `cargo fmt --all` successfully to normalize formatting.
- Ran `cargo check -p perfgate-types -p perfgate-ingest -p perfgate-cli` and it completed without errors.
- Ran `cargo test -p perfgate-ingest` and all unit tests passed (34 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a568dc5c83338783ce9f06e6a0d9)