### PR TITLE
Add OTel JSON span ingestion path for `perfgate ingest`

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1074,7 +1074,7 @@ pub struct PairedArgs {
 
 #[derive(Debug, Args)]
 pub struct IngestArgs {
-    /// Input format: criterion, hyperfine, gobench, pytest
+    /// Input format: criterion, hyperfine, gobench, pytest, otel
     #[arg(long)]
     pub format: String,
 
@@ -1085,6 +1085,14 @@ pub struct IngestArgs {
     /// Benchmark name (default: derived from input data)
     #[arg(long)]
     pub name: Option<String>,
+
+    /// Include span names when ingesting OTel JSON (exact match, repeatable).
+    #[arg(long = "include-span")]
+    pub include_span: Vec<String>,
+
+    /// Exclude span names when ingesting OTel JSON (exact match, repeatable).
+    #[arg(long = "exclude-span")]
+    pub exclude_span: Vec<String>,
 
     /// Output file path
     #[arg(long, default_value = "perfgate-ingest.json")]
@@ -2039,13 +2047,15 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 format,
                 input,
                 name,
+                include_span,
+                exclude_span,
                 out,
                 pretty,
             } = *args;
 
             let format = IngestFormat::parse(&format).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "unknown ingest format '{}'; supported: criterion, hyperfine, gobench, pytest",
+                    "unknown ingest format '{}'; supported: criterion, hyperfine, gobench, pytest, otel",
                     format
                 )
             })?;
@@ -2057,6 +2067,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 format,
                 input: content,
                 name,
+                include_spans: include_span,
+                exclude_spans: exclude_span,
             };
 
             let receipt = perfgate_ingest::ingest(&request)?;

--- a/crates/perfgate-ingest/src/lib.rs
+++ b/crates/perfgate-ingest/src/lib.rs
@@ -9,6 +9,7 @@
 mod criterion;
 mod gobench;
 mod hyperfine;
+mod otel;
 mod pytest;
 
 use perfgate_types::{
@@ -20,6 +21,7 @@ use uuid::Uuid;
 pub use criterion::parse_criterion;
 pub use gobench::parse_gobench;
 pub use hyperfine::parse_hyperfine;
+pub use otel::parse_otel_json;
 pub use pytest::parse_pytest_benchmark;
 
 /// Supported ingest formats.
@@ -29,6 +31,7 @@ pub enum IngestFormat {
     Hyperfine,
     GoBench,
     PytestBenchmark,
+    Otel,
 }
 
 impl IngestFormat {
@@ -39,6 +42,7 @@ impl IngestFormat {
             "hyperfine" => Some(Self::Hyperfine),
             "gobench" | "go" => Some(Self::GoBench),
             "pytest" | "pytest-benchmark" | "pytest_benchmark" => Some(Self::PytestBenchmark),
+            "otel" | "opentelemetry" => Some(Self::Otel),
             _ => None,
         }
     }
@@ -52,6 +56,10 @@ pub struct IngestRequest {
     pub input: String,
     /// Benchmark name override. If None, derived from the input data.
     pub name: Option<String>,
+    /// Optional include filter for span names (exact match).
+    pub include_spans: Vec<String>,
+    /// Optional exclude filter for span names (exact match).
+    pub exclude_spans: Vec<String>,
 }
 
 /// Perform an ingest operation, returning a `RunReceipt`.
@@ -63,6 +71,12 @@ pub fn ingest(request: &IngestRequest) -> anyhow::Result<RunReceipt> {
         IngestFormat::PytestBenchmark => {
             parse_pytest_benchmark(&request.input, request.name.as_deref())
         }
+        IngestFormat::Otel => parse_otel_json(
+            &request.input,
+            request.name.as_deref(),
+            &request.include_spans,
+            &request.exclude_spans,
+        ),
     }
 }
 
@@ -178,6 +192,11 @@ mod tests {
         assert_eq!(
             IngestFormat::parse("pytest_benchmark"),
             Some(IngestFormat::PytestBenchmark)
+        );
+        assert_eq!(IngestFormat::parse("otel"), Some(IngestFormat::Otel));
+        assert_eq!(
+            IngestFormat::parse("opentelemetry"),
+            Some(IngestFormat::Otel)
         );
         assert_eq!(IngestFormat::parse("unknown"), None);
     }

--- a/crates/perfgate-ingest/src/otel.rs
+++ b/crates/perfgate-ingest/src/otel.rs
@@ -1,0 +1,181 @@
+use anyhow::{Context, anyhow};
+use serde::Deserialize;
+
+use crate::{compute_u64_summary, make_receipt};
+use perfgate_types::{Sample, Stats};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OTelTrace {
+    #[serde(default)]
+    resource_spans: Vec<ResourceSpans>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceSpans {
+    #[serde(default)]
+    scope_spans: Vec<ScopeSpans>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ScopeSpans {
+    #[serde(default)]
+    spans: Vec<Span>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Span {
+    name: String,
+    start_time_unix_nano: String,
+    end_time_unix_nano: String,
+}
+
+pub fn parse_otel_json(
+    input: &str,
+    name: Option<&str>,
+    include_spans: &[String],
+    exclude_spans: &[String],
+) -> anyhow::Result<perfgate_types::RunReceipt> {
+    let trace: OTelTrace =
+        serde_json::from_str(input).context("failed to parse OTel JSON trace export")?;
+
+    let mut durations_ms = Vec::new();
+
+    for resource in trace.resource_spans {
+        for scope in resource.scope_spans {
+            for span in scope.spans {
+                if !include_spans.is_empty() && !include_spans.iter().any(|s| s == &span.name) {
+                    continue;
+                }
+                if exclude_spans.iter().any(|s| s == &span.name) {
+                    continue;
+                }
+
+                let start_ns: u128 = span.start_time_unix_nano.parse().with_context(|| {
+                    format!("invalid start_time_unix_nano for span '{}'", span.name)
+                })?;
+                let end_ns: u128 = span.end_time_unix_nano.parse().with_context(|| {
+                    format!("invalid end_time_unix_nano for span '{}'", span.name)
+                })?;
+
+                if end_ns < start_ns {
+                    return Err(anyhow!(
+                        "span '{}' has end_time_unix_nano earlier than start_time_unix_nano",
+                        span.name
+                    ));
+                }
+
+                let duration_ns = end_ns - start_ns;
+                let duration_ms = (duration_ns / 1_000_000) as u64;
+                durations_ms.push(duration_ms);
+            }
+        }
+    }
+
+    if durations_ms.is_empty() {
+        let include_hint = if include_spans.is_empty() {
+            "no spans found in the OTel export".to_string()
+        } else {
+            format!(
+                "no spans matched include filter [{}]",
+                include_spans.join(", ")
+            )
+        };
+        return Err(anyhow!(
+            "no span durations available for ingest: {}",
+            include_hint
+        ));
+    }
+
+    let samples: Vec<Sample> = durations_ms
+        .iter()
+        .map(|wall_ms| Sample {
+            wall_ms: *wall_ms,
+            exit_code: 0,
+            warmup: false,
+            timed_out: false,
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            stdout: None,
+            stderr: None,
+        })
+        .collect();
+
+    let stats = Stats {
+        wall_ms: compute_u64_summary(&durations_ms),
+        cpu_ms: None,
+        page_faults: None,
+        ctx_switches: None,
+        max_rss_kb: None,
+        io_read_bytes: None,
+        io_write_bytes: None,
+        network_packets: None,
+        energy_uj: None,
+        binary_bytes: None,
+        throughput_per_s: None,
+    };
+
+    let bench_name = name
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "otel-spans".to_string());
+
+    Ok(make_receipt(&bench_name, samples, stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRACE_JSON: &str = r#"{
+      "resourceSpans": [
+        {
+          "scopeSpans": [
+            {
+              "spans": [
+                {"name": "ast_parsing", "startTimeUnixNano": "1000000000", "endTimeUnixNano": "1050000000"},
+                {"name": "ast_parsing", "startTimeUnixNano": "2000000000", "endTimeUnixNano": "2070000000"},
+                {"name": "resolve_imports", "startTimeUnixNano": "3000000000", "endTimeUnixNano": "3060000000"}
+              ]
+            }
+          ]
+        }
+      ]
+    }"#;
+
+    #[test]
+    fn ingest_otel_with_include_filter() {
+        let receipt = parse_otel_json(
+            TRACE_JSON,
+            Some("otel-ast"),
+            &["ast_parsing".to_string()],
+            &[],
+        )
+        .expect("ingest OTel");
+
+        assert_eq!(receipt.bench.name, "otel-ast");
+        assert_eq!(receipt.samples.len(), 2);
+        assert_eq!(receipt.stats.wall_ms.min, 50);
+        assert_eq!(receipt.stats.wall_ms.max, 70);
+    }
+
+    #[test]
+    fn ingest_otel_missing_span_returns_error() {
+        let err = parse_otel_json(TRACE_JSON, None, &["does_not_exist".to_string()], &[])
+            .expect_err("expected missing span error");
+
+        assert!(
+            err.to_string().contains("no spans matched include filter"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- Allow ingesting OpenTelemetry trace exports so span durations can be gated like other metrics. 
- Keep the change focused on import/ingest and reuse existing `perfgate.run.v1` receipts and budget machinery. 
- Provide simple, explicit include/exclude filtering for v1 to enable per-span gating without introducing a tracing backend.

### Description

- Add a new `otel` ingest format and enum variant in `perfgate-ingest::IngestFormat` and expose `parse_otel_json` from the ingest crate. 
- Implement `crates/perfgate-ingest/src/otel.rs` to parse `resourceSpans -> scopeSpans -> spans`, compute span duration from `startTimeUnixNano`/`endTimeUnixNano`, apply exact-name `include`/`exclude` filters, and emit a standard `RunReceipt` with span durations as `wall_ms` samples/stats. 
- Extend the `IngestRequest` to carry `include_spans` and `exclude_spans`, wire those fields into the ingest dispatcher, and add CLI flags `--include-span` / `--exclude-span` and advertise `otel` in the `perfgate ingest` help. 
- Add unit tests for successful filtered ingest and for the missing-span error path in the new parser.

### Testing

- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perfgate-ingest` and all tests passed (`33 passed; 0 failed`). 
- Ran `cargo test -p perfgate-cli --no-run` which compiled the CLI tests successfully (test binaries built without running them).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a568dc5c83338783ce9f06e6a0d9)