### PR TITLE
Add OpenTelemetry JSON ingest with span metrics in run receipts

### DIFF
--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -74,6 +74,7 @@ impl AggregateUseCase {
             bench,
             samples: combined_samples,
             stats,
+            span_metrics: Default::default(),
         };
 
         Ok(AggregateOutcome { receipt })

--- a/crates/perfgate-app/src/cargo_bench.rs
+++ b/crates/perfgate-app/src/cargo_bench.rs
@@ -337,6 +337,7 @@ pub fn benchmarks_to_receipt(
         },
         samples,
         stats,
+        span_metrics: Default::default(),
     })
 }
 
@@ -395,6 +396,7 @@ pub fn benchmarks_to_individual_receipts(
             },
             samples: vec![sample],
             stats,
+            span_metrics: Default::default(),
         });
     }
 

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -207,6 +207,7 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> RunBenchUseCase<R, H, C> {
             bench,
             samples,
             stats,
+            span_metrics: Default::default(),
         };
 
         let failed = !reasons.is_empty();

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1074,12 +1074,12 @@ pub struct PairedArgs {
 
 #[derive(Debug, Args)]
 pub struct IngestArgs {
-    /// Input format: criterion, hyperfine, gobench, pytest
+    /// Input format: criterion, hyperfine, gobench, pytest, otel
     #[arg(long)]
     pub format: String,
 
     /// Path to the input file (or directory for criterion)
-    #[arg(long)]
+    #[arg(long, visible_alias = "file")]
     pub input: PathBuf,
 
     /// Benchmark name (default: derived from input data)
@@ -2045,7 +2045,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
             let format = IngestFormat::parse(&format).ok_or_else(|| {
                 anyhow::anyhow!(
-                    "unknown ingest format '{}'; supported: criterion, hyperfine, gobench, pytest",
+                    "unknown ingest format '{}'; supported: criterion, hyperfine, gobench, pytest, otel",
                     format
                 )
             })?;
@@ -4899,6 +4899,7 @@ mod tests {
             },
             samples: Vec::new(),
             stats,
+            span_metrics: Default::default(),
         }
     }
 

--- a/crates/perfgate-ingest/src/lib.rs
+++ b/crates/perfgate-ingest/src/lib.rs
@@ -9,6 +9,7 @@
 mod criterion;
 mod gobench;
 mod hyperfine;
+mod otel;
 mod pytest;
 
 use perfgate_types::{
@@ -20,6 +21,7 @@ use uuid::Uuid;
 pub use criterion::parse_criterion;
 pub use gobench::parse_gobench;
 pub use hyperfine::parse_hyperfine;
+pub use otel::parse_otel;
 pub use pytest::parse_pytest_benchmark;
 
 /// Supported ingest formats.
@@ -28,6 +30,7 @@ pub enum IngestFormat {
     Criterion,
     Hyperfine,
     GoBench,
+    OTel,
     PytestBenchmark,
 }
 
@@ -38,6 +41,7 @@ impl IngestFormat {
             "criterion" => Some(Self::Criterion),
             "hyperfine" => Some(Self::Hyperfine),
             "gobench" | "go" => Some(Self::GoBench),
+            "otel" | "opentelemetry" => Some(Self::OTel),
             "pytest" | "pytest-benchmark" | "pytest_benchmark" => Some(Self::PytestBenchmark),
             _ => None,
         }
@@ -60,6 +64,7 @@ pub fn ingest(request: &IngestRequest) -> anyhow::Result<RunReceipt> {
         IngestFormat::Criterion => parse_criterion(&request.input, request.name.as_deref()),
         IngestFormat::Hyperfine => parse_hyperfine(&request.input, request.name.as_deref()),
         IngestFormat::GoBench => parse_gobench(&request.input, request.name.as_deref()),
+        IngestFormat::OTel => parse_otel(&request.input, request.name.as_deref()),
         IngestFormat::PytestBenchmark => {
             parse_pytest_benchmark(&request.input, request.name.as_deref())
         }
@@ -102,6 +107,7 @@ fn make_receipt(name: &str, samples: Vec<Sample>, stats: Stats) -> RunReceipt {
         },
         samples,
         stats,
+        span_metrics: Default::default(),
     }
 }
 
@@ -167,6 +173,11 @@ mod tests {
         );
         assert_eq!(IngestFormat::parse("gobench"), Some(IngestFormat::GoBench));
         assert_eq!(IngestFormat::parse("go"), Some(IngestFormat::GoBench));
+        assert_eq!(IngestFormat::parse("otel"), Some(IngestFormat::OTel));
+        assert_eq!(
+            IngestFormat::parse("opentelemetry"),
+            Some(IngestFormat::OTel)
+        );
         assert_eq!(
             IngestFormat::parse("pytest"),
             Some(IngestFormat::PytestBenchmark)

--- a/crates/perfgate-ingest/src/otel.rs
+++ b/crates/perfgate-ingest/src/otel.rs
@@ -1,0 +1,231 @@
+use std::collections::BTreeMap;
+
+use anyhow::{Context, anyhow};
+use perfgate_types::{F64Summary, RunReceipt, Sample, Stats};
+use serde_json::Value;
+
+use crate::{compute_u64_summary, make_receipt};
+
+pub fn parse_otel(input: &str, name_override: Option<&str>) -> anyhow::Result<RunReceipt> {
+    let parsed: Value = serde_json::from_str(input).context("parse OTel JSON")?;
+    let spans = collect_spans(&parsed)?;
+    if spans.is_empty() {
+        return Err(anyhow!(
+            "no OTel spans with start/end timestamps found in JSON"
+        ));
+    }
+
+    let mut durations_by_name: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    let mut all_wall_ms: Vec<u64> = Vec::with_capacity(spans.len());
+
+    for (name, duration_ms) in spans {
+        durations_by_name.entry(name).or_default().push(duration_ms);
+        all_wall_ms.push(duration_ms.round().max(0.0) as u64);
+    }
+
+    let wall_summary = compute_u64_summary(&all_wall_ms);
+    let mut receipt = make_receipt(
+        name_override.unwrap_or("otel-trace"),
+        build_samples(&all_wall_ms),
+        Stats {
+            wall_ms: wall_summary,
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            throughput_per_s: None,
+        },
+    );
+
+    receipt.span_metrics = durations_by_name
+        .into_iter()
+        .map(|(span_name, values)| {
+            let key = format!("span.{span_name}.wall_ms");
+            (key, summarize_f64(&values))
+        })
+        .collect();
+
+    Ok(receipt)
+}
+
+fn collect_spans(v: &Value) -> anyhow::Result<Vec<(String, f64)>> {
+    let resource_spans = v
+        .get("resourceSpans")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("missing resourceSpans array in OTel JSON"))?;
+
+    let mut spans = Vec::new();
+
+    for resource in resource_spans {
+        let Some(scope_spans) = resource
+            .get("scopeSpans")
+            .or_else(|| resource.get("instrumentationLibrarySpans"))
+            .and_then(Value::as_array)
+        else {
+            continue;
+        };
+
+        for scope in scope_spans {
+            if let Some(span_array) = scope.get("spans").and_then(Value::as_array) {
+                for span in span_array {
+                    let Some(name) = span.get("name").and_then(Value::as_str) else {
+                        continue;
+                    };
+
+                    let start_ns = match extract_u128(span.get("startTimeUnixNano")) {
+                        Some(v) => v,
+                        None => continue,
+                    };
+                    let end_ns = match extract_u128(span.get("endTimeUnixNano")) {
+                        Some(v) => v,
+                        None => continue,
+                    };
+                    if end_ns < start_ns {
+                        continue;
+                    }
+                    let duration_ms = (end_ns - start_ns) as f64 / 1_000_000.0;
+                    spans.push((sanitize_span_name(name), duration_ms));
+                }
+            }
+        }
+    }
+
+    Ok(spans)
+}
+
+fn extract_u128(v: Option<&Value>) -> Option<u128> {
+    let value = v?;
+    if let Some(s) = value.as_str() {
+        return s.parse::<u128>().ok();
+    }
+    if let Some(n) = value.as_u64() {
+        return Some(n as u128);
+    }
+    None
+}
+
+fn summarize_f64(values: &[f64]) -> F64Summary {
+    if values.is_empty() {
+        return F64Summary {
+            median: 0.0,
+            min: 0.0,
+            max: 0.0,
+            mean: None,
+            stddev: None,
+        };
+    }
+
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+
+    let min = sorted[0];
+    let max = sorted[sorted.len() - 1];
+    let median = if sorted.len().is_multiple_of(2) {
+        (sorted[sorted.len() / 2 - 1] + sorted[sorted.len() / 2]) / 2.0
+    } else {
+        sorted[sorted.len() / 2]
+    };
+
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / values.len() as f64;
+
+    F64Summary {
+        median,
+        min,
+        max,
+        mean: Some(mean),
+        stddev: Some(variance.sqrt()),
+    }
+}
+
+fn build_samples(values: &[u64]) -> Vec<Sample> {
+    values
+        .iter()
+        .map(|value| Sample {
+            wall_ms: *value,
+            exit_code: 0,
+            warmup: false,
+            timed_out: false,
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            stdout: None,
+            stderr: None,
+        })
+        .collect()
+}
+
+fn sanitize_span_name(input: &str) -> String {
+    input
+        .chars()
+        .map(|c| match c {
+            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-' => c,
+            _ => '_',
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_otel_trace_into_span_metrics() {
+        let json = r#"{
+  "resourceSpans": [
+    {
+      "scopeSpans": [
+        {
+          "spans": [
+            {"name": "ast_parsing", "startTimeUnixNano": "1000000000", "endTimeUnixNano": "1120000000"},
+            {"name": "ast_parsing", "startTimeUnixNano": "2000000000", "endTimeUnixNano": "2140000000"},
+            {"name": "resolve/imports", "startTimeUnixNano": "3000000000", "endTimeUnixNano": "3060000000"}
+          ]
+        }
+      ]
+    }
+  ]
+}"#;
+
+        let receipt = parse_otel(json, Some("otel-test")).expect("parse otel");
+
+        assert_eq!(receipt.bench.name, "otel-test");
+        assert_eq!(receipt.samples.len(), 3);
+        assert!(
+            receipt
+                .span_metrics
+                .contains_key("span.ast_parsing.wall_ms")
+        );
+        assert!(
+            receipt
+                .span_metrics
+                .contains_key("span.resolve_imports.wall_ms")
+        );
+        let parsing = receipt
+            .span_metrics
+            .get("span.ast_parsing.wall_ms")
+            .expect("span summary");
+        assert!((parsing.median - 130.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn errors_when_no_spans_found() {
+        let json = r#"{"resourceSpans": []}"#;
+        let err = parse_otel(json, None).expect_err("should fail");
+        assert!(
+            err.to_string()
+                .contains("no OTel spans with start/end timestamps")
+        );
+    }
+}

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -553,6 +553,9 @@ pub struct RunReceipt {
     pub bench: BenchMeta,
     pub samples: Vec<Sample>,
     pub stats: Stats,
+    /// Extensible metrics keyed by namespaced identifier (e.g. `span.ast_parsing.wall_ms`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub span_metrics: BTreeMap<String, F64Summary>,
 }
 
 #[derive(

--- a/schemas/perfgate.run.v1.schema.json
+++ b/schemas/perfgate.run.v1.schema.json
@@ -19,6 +19,13 @@
     "schema": {
       "type": "string"
     },
+    "span_metrics": {
+      "description": "Extensible metrics keyed by namespaced identifier (e.g. `span.ast_parsing.wall_ms`).",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/F64Summary"
+      }
+    },
     "stats": {
       "$ref": "#/$defs/Stats"
     },


### PR DESCRIPTION
### Motivation
- Enable gating on fine-grained OpenTelemetry span durations by ingesting spans as metrics inside the existing run receipt model so existing compare/report/verdict logic can be reused.
- Provide a simple v1 UX for importing OTel JSON exports (no live OTLP receiver) and keep per-run receipts backward-compatible.

### Description
- Add an optional `span_metrics: BTreeMap<String, F64Summary>` to `RunReceipt` to carry namespaced span metrics (e.g. `span.ast_parsing.wall_ms`) and serialize only when non-empty.
- Implement OTel JSON ingestion with a new `parse_otel` parser and register the `OTel` format in `perfgate-ingest::IngestFormat`, which extracts spans from `resourceSpans[].scopeSpans[].spans[]`, computes per-span `F64Summary`, and populates `span_metrics` while still producing `samples`/`stats.wall_ms`.
- Update CLI ingest UX to recognize `otel` / `opentelemetry`, add `--file` as an alias for `--input`, and include `otel` in the supported-format error message.
- Initialize `span_metrics` as empty in all `RunReceipt` constructors and regenerate the `perfgate.run.v1` JSON schema to include the new `span_metrics` object.

### Testing
- Ran `cargo check --all` and it completed successfully.
- Ran unit tests for the ingest crate with `cargo test -p perfgate-ingest` and all tests passed.
- Ran CLI ingest tests with `cargo test -p perfgate-cli ingest -- --nocapture` and they passed (no failures reported).
- Ran formatter and schema generation with `cargo fmt --all` and `cargo run -p xtask -- schema` and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a568dc5c83338783ce9f06e6a0d9)