### PR TITLE
Add promote-time budget ratcheting: types, logic, CLI, and TOML apply

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ uuid = { version = "1.21.0", features = ["v4"] }
 schemars = { version = "1.2.1", features = ["uuid1", "chrono04"] }
 shell-words = "1.1.1"
 toml = "0.9.8"
+toml_edit = "0.22.27"
 statrs = "0.18.0"
 glob = "0.3.2"
 notify = { version = "7.0", default-features = false, features = ["macos_kqueue"] }

--- a/crates/perfgate-app/Cargo.toml
+++ b/crates/perfgate-app/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["development-tools"]
 perfgate-types.workspace = true
 perfgate-error.workspace = true
 perfgate-domain.workspace = true
+perfgate-budget.workspace = true
 perfgate-adapters.workspace = true
 perfgate-config.workspace = true
 perfgate-sha256.workspace = true

--- a/crates/perfgate-app/src/baseline_resolve.rs
+++ b/crates/perfgate-app/src/baseline_resolve.rs
@@ -60,6 +60,7 @@ mod tests {
                 ..Default::default()
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: Vec::new(),
         };
 

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -994,6 +994,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench.clone()],
         };
 
@@ -1124,6 +1125,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench.clone()],
         };
 
@@ -1201,6 +1203,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench],
         };
 
@@ -1255,6 +1258,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench],
         };
 
@@ -1326,6 +1330,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench],
         };
 
@@ -1383,6 +1388,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench],
         };
 
@@ -1413,6 +1419,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![],
         };
 
@@ -1465,6 +1472,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![bench],
         };
 

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -20,6 +20,7 @@ mod explain;
 pub mod init;
 mod paired;
 mod promote;
+mod ratchet;
 mod report;
 mod sensor_report;
 mod trend;
@@ -39,6 +40,7 @@ pub use diff::{
 pub use explain::{ExplainOutcome, ExplainRequest, ExplainUseCase};
 pub use paired::{PairedRunOutcome, PairedRunRequest, PairedRunUseCase};
 pub use promote::{PromoteRequest, PromoteResult, PromoteUseCase};
+pub use ratchet::{RatchetOutcome, RatchetRequest, RatchetUseCase};
 pub use report::{ReportRequest, ReportResult, ReportUseCase};
 pub use sensor_report::{
     BenchOutcome, SensorCheckOptions, SensorReportBuilder, classify_error,

--- a/crates/perfgate-app/src/ratchet.rs
+++ b/crates/perfgate-app/src/ratchet.rs
@@ -1,0 +1,81 @@
+use perfgate_budget::{build_ratchet_receipt, ratchet_threshold_for_metric};
+use perfgate_types::{
+    CompareReceipt, RatchetChange, RatchetConfig, RatchetEvidence, RatchetMode, RatchetReceipt,
+    VerdictStatus,
+};
+
+#[derive(Debug, Clone)]
+pub struct RatchetRequest {
+    pub compare: CompareReceipt,
+    pub policy: RatchetConfig,
+    pub tool: perfgate_types::ToolInfo,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RatchetOutcome {
+    pub changes: Vec<RatchetChange>,
+}
+
+pub struct RatchetUseCase;
+
+impl RatchetUseCase {
+    pub fn execute(req: RatchetRequest) -> RatchetOutcome {
+        if !req.policy.enabled || req.compare.verdict.status != VerdictStatus::Pass {
+            return RatchetOutcome::default();
+        }
+
+        if req
+            .compare
+            .verdict
+            .reasons
+            .iter()
+            .any(|r| r.contains("host_mismatch"))
+        {
+            return RatchetOutcome::default();
+        }
+
+        let mut changes = Vec::new();
+        for (metric, delta) in &req.compare.deltas {
+            let Some(budget) = req.compare.budgets.get(metric) else {
+                continue;
+            };
+
+            let Some((improvement, new_value)) =
+                ratchet_threshold_for_metric(*metric, budget, delta, &req.policy)
+            else {
+                continue;
+            };
+
+            let (old_value, mode) = match req.policy.mode {
+                RatchetMode::Threshold => (budget.threshold, RatchetMode::Threshold),
+                RatchetMode::BaselineValue => (budget.threshold, RatchetMode::BaselineValue),
+            };
+
+            changes.push(RatchetChange {
+                metric: *metric,
+                mode,
+                old_value,
+                new_value,
+                reason: "trusted_improvement".to_string(),
+                evidence: RatchetEvidence {
+                    improvement,
+                    cv: delta.cv,
+                    noise_threshold: delta.noise_threshold,
+                    p_value: delta.significance.as_ref().and_then(|s| s.p_value),
+                    significant: delta.significance.as_ref().map(|s| s.significant),
+                },
+            });
+        }
+
+        RatchetOutcome { changes }
+    }
+
+    pub fn build_receipt(req: &RatchetRequest, outcome: RatchetOutcome) -> RatchetReceipt {
+        build_ratchet_receipt(
+            req.compare.bench.name.clone(),
+            req.compare.current_ref.clone(),
+            req.tool.clone(),
+            outcome.changes,
+        )
+    }
+}

--- a/crates/perfgate-budget/src/lib.rs
+++ b/crates/perfgate-budget/src/lib.rs
@@ -40,7 +40,8 @@
 //! ```
 
 use perfgate_types::{
-    Budget, Direction, Metric, MetricStatus, Verdict, VerdictCounts, VerdictStatus,
+    Budget, Delta, Direction, Metric, MetricStatus, RatchetConfig, RatchetMode, RatchetReceipt,
+    ToolInfo, Verdict, VerdictCounts, VerdictStatus,
 };
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -396,6 +397,70 @@ where
     verdict.reasons = reasons;
 
     Ok((deltas, verdict))
+}
+
+/// Evaluates whether a metric qualifies for ratcheting and returns `(improvement, tighter_value)`.
+pub fn ratchet_threshold_for_metric(
+    metric: Metric,
+    budget: &Budget,
+    delta: &Delta,
+    policy: &RatchetConfig,
+) -> Option<(f64, f64)> {
+    if !policy.allow_metrics.is_empty() && !policy.allow_metrics.contains(&metric) {
+        return None;
+    }
+    if delta.status != MetricStatus::Pass {
+        return None;
+    }
+    if let (Some(cv), Some(limit)) = (delta.cv, delta.noise_threshold)
+        && cv > limit
+    {
+        return None;
+    }
+    if policy.require_significance {
+        let Some(sig) = &delta.significance else {
+            return None;
+        };
+        if !sig.significant {
+            return None;
+        }
+    }
+
+    let improvement = match budget.direction {
+        Direction::Lower => ((delta.baseline - delta.current) / delta.baseline).max(0.0),
+        Direction::Higher => ((delta.current - delta.baseline) / delta.baseline).max(0.0),
+    };
+    if improvement < policy.min_improvement {
+        return None;
+    }
+
+    let tightening = improvement.min(policy.max_tightening);
+    let new_value = match policy.mode {
+        RatchetMode::Threshold => budget.threshold * (1.0 - tightening),
+        RatchetMode::BaselineValue => delta.current,
+    };
+
+    if new_value >= budget.threshold {
+        return None;
+    }
+
+    Some((improvement, new_value))
+}
+
+/// Build a machine-readable ratchet artifact.
+pub fn build_ratchet_receipt(
+    bench_name: String,
+    compare_ref: perfgate_types::CompareRef,
+    tool: ToolInfo,
+    changes: Vec<perfgate_types::RatchetChange>,
+) -> RatchetReceipt {
+    RatchetReceipt {
+        schema: perfgate_types::RATCHET_SCHEMA_V1.to_string(),
+        tool,
+        bench_name,
+        compare_ref,
+        changes,
+    }
 }
 
 #[cfg(test)]

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -16,16 +16,18 @@ use perfgate_app::{
     BlameRequest, BlameUseCase, CheckOutcome, CheckRequest, CheckUseCase, Clock, CompareRequest,
     CompareUseCase, DiffRequest, DiffUseCase, ExplainRequest, ExplainUseCase, ExportFormat,
     ExportUseCase, PairedRunRequest, PairedRunUseCase, PromoteRequest, PromoteUseCase,
-    ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase, SensorReportBuilder,
-    SystemClock, classify_error, github_annotations, render_json_diff, render_markdown,
-    render_markdown_template, render_terminal_diff,
+    RatchetRequest, RatchetUseCase, ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase,
+    SensorReportBuilder, SystemClock, classify_error, github_annotations, render_json_diff,
+    render_markdown, render_markdown_template, render_terminal_diff,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::{
     AuthMethod, BaselineClient, ClientConfig, ListBaselinesQuery, ListVerdictsQuery,
     SubmitVerdictRequest, UploadBaselineRequest,
 };
-use perfgate_config::{ResolvedServerConfig, load_config_file, resolve_server_config};
+use perfgate_config::{
+    ResolvedServerConfig, apply_ratchet_changes_to_toml, load_config_file, resolve_server_config,
+};
 use perfgate_domain::{DependencyChangeType, SignificancePolicy};
 use perfgate_error::{ConfigValidationError, IoError, PerfgateError};
 use perfgate_github::{CommentOptions, GitHubClient};
@@ -202,6 +204,9 @@ enum Command {
     ///
     /// Exit codes: 0 for success, 1 for errors.
     Promote(Box<PromoteArgs>),
+
+    /// Preview budget ratchet changes from a compare receipt.
+    Ratchet(Box<RatchetArgs>),
 
     /// Generate a cockpit-compatible report from a compare receipt.
     ///
@@ -857,6 +862,33 @@ pub struct PromoteArgs {
     /// Pretty-print JSON
     #[arg(long, default_value_t = false)]
     pub pretty: bool,
+
+    /// Apply automatic budget ratcheting after a successful promote.
+    #[arg(long, default_value_t = false)]
+    pub ratchet: bool,
+
+    /// Path to config used for ratcheting.
+    #[arg(long, default_value = "perfgate.toml", requires = "ratchet")]
+    pub config: PathBuf,
+
+    /// Compare receipt used as ratcheting evidence.
+    #[arg(long, requires = "ratchet")]
+    pub compare: Option<PathBuf>,
+
+    /// Ratchet artifact output path.
+    #[arg(long, requires = "ratchet")]
+    pub ratchet_out: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct RatchetArgs {
+    /// Path to config file (TOML).
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Path to compare receipt with ratchet evidence.
+    #[arg(long)]
+    pub compare: PathBuf,
 }
 
 #[derive(Debug, Args)]
@@ -1740,6 +1772,10 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 version,
                 normalize,
                 pretty,
+                ratchet,
+                config,
+                compare,
+                ratchet_out,
             } = *args;
 
             let receipt: RunReceipt = read_json_from_location(&current)?;
@@ -1794,6 +1830,77 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 write_json_to_location(&to_path, &result.receipt, pretty)?;
             }
 
+            if ratchet {
+                let compare_path = compare.ok_or_else(|| {
+                    anyhow::anyhow!("--compare is required when --ratchet is set")
+                })?;
+                let config_file = load_config_file(&config)?;
+                let compare_receipt: CompareReceipt = read_json(&compare_path)?;
+                let req = RatchetRequest {
+                    compare: compare_receipt.clone(),
+                    policy: config_file.ratchet.clone(),
+                    tool: ToolInfo {
+                        name: env!("CARGO_PKG_NAME").to_string(),
+                        version: env!("CARGO_PKG_VERSION").to_string(),
+                    },
+                };
+                let outcome = RatchetUseCase::execute(req.clone());
+
+                if outcome.changes.is_empty() {
+                    eprintln!("ratchet: no eligible changes");
+                } else {
+                    eprintln!("ratchet: {} change(s)", outcome.changes.len());
+                    for change in &outcome.changes {
+                        eprintln!(
+                            "  {}: {:.4} -> {:.4} ({:.2}% improvement)",
+                            change.metric.as_str(),
+                            change.old_value,
+                            change.new_value,
+                            change.evidence.improvement * 100.0
+                        );
+                    }
+                    apply_ratchet_changes_to_toml(
+                        &config,
+                        &compare_receipt.bench.name,
+                        &outcome.changes,
+                    )?;
+                }
+
+                if let Some(out_path) = ratchet_out {
+                    let artifact = RatchetUseCase::build_receipt(&req, outcome);
+                    write_json(&out_path, &artifact, pretty)?;
+                }
+            }
+
+            Ok(())
+        }
+
+        Command::Ratchet(args) => {
+            let RatchetArgs { config, compare } = *args;
+            let config_file = load_config_file(&config)?;
+            let compare_receipt: CompareReceipt = read_json(&compare)?;
+            let req = RatchetRequest {
+                compare: compare_receipt,
+                policy: config_file.ratchet,
+                tool: ToolInfo {
+                    name: env!("CARGO_PKG_NAME").to_string(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                },
+            };
+            let outcome = RatchetUseCase::execute(req);
+            if outcome.changes.is_empty() {
+                println!("No ratchet changes.");
+            } else {
+                for change in outcome.changes {
+                    println!(
+                        "{}: {:.4} -> {:.4} ({:.2}% improvement)",
+                        change.metric.as_str(),
+                        change.old_value,
+                        change.new_value,
+                        change.evidence.improvement * 100.0
+                    );
+                }
+            }
             Ok(())
         }
 

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 229
+assertion_line: 241
 expression: "help_output(&[\"--help\"])"
 ---
 Perf budgets and baseline diffs for CI / PR bots
@@ -14,6 +14,7 @@ Commands:
   github-annotations Emit GitHub Actions annotations from a compare receipt
   export Export a run or compare receipt to CSV, JSONL, HTML, Prometheus, or JUnit format
   promote Promote a run receipt to become the new baseline
+  ratchet Preview budget ratchet changes from a compare receipt
   report Generate a cockpit-compatible report from a compare receipt
   check Config-driven one-command workflow
   paired Run paired benchmark: interleave baseline and current commands for reduced noise

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_promote.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_promote.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 261
 expression: "help_output(&[\"promote\", \"--help\"])"
 ---
 Promote a run receipt to become the new baseline.
@@ -26,6 +27,14 @@ Options:
       --normalize Strip run-specific fields (run_id, timestamps) for stable baselines
 
       --pretty Pretty-print JSON
+
+      --ratchet Apply automatic budget ratcheting after a successful promote
+
+      --config <CONFIG> Path to config used for ratcheting [default: perfgate.toml]
+
+      --compare <COMPARE> Compare receipt used as ratcheting evidence
+
+      --ratchet-out <RATCHET_OUT> Ratchet artifact output path
 
   -h, --help Print help (see a summary with '-h')
 

--- a/crates/perfgate-config/Cargo.toml
+++ b/crates/perfgate-config/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 perfgate-types.workspace = true
 perfgate-client.workspace = true
 url.workspace = true

--- a/crates/perfgate-config/src/lib.rs
+++ b/crates/perfgate-config/src/lib.rs
@@ -17,9 +17,10 @@
 
 use anyhow::Context;
 use perfgate_client::{BaselineClient, ClientConfig, FallbackClient, FallbackStorage};
-use perfgate_types::{BaselineServerConfig, ConfigFile};
+use perfgate_types::{BaselineServerConfig, ConfigFile, RatchetChange};
 use std::fs;
 use std::path::Path;
+use toml_edit::{DocumentMut, Item, Table, Value, value};
 
 /// Resolved server configuration with all sources merged.
 #[derive(Debug, Clone, Default)]
@@ -127,4 +128,53 @@ pub fn resolve_server_config(
         project: flag_project.or_else(|| file_config.resolved_project()),
         fallback_to_local: file_config.fallback_to_local,
     }
+}
+
+/// Apply ratchet changes to a TOML config while preserving comments/ordering.
+pub fn apply_ratchet_changes_to_toml(
+    config_path: &Path,
+    bench_name: &str,
+    changes: &[RatchetChange],
+) -> anyhow::Result<()> {
+    let content = fs::read_to_string(config_path)
+        .with_context(|| format!("read {}", config_path.display()))?;
+    let mut doc = content
+        .parse::<DocumentMut>()
+        .with_context(|| format!("parse {}", config_path.display()))?;
+
+    let benches = doc["bench"]
+        .as_array_of_tables_mut()
+        .ok_or_else(|| anyhow::anyhow!("config has no [[bench]] entries"))?;
+
+    let bench = benches
+        .iter_mut()
+        .find(|b| b["name"].as_str() == Some(bench_name))
+        .ok_or_else(|| anyhow::anyhow!("bench '{}' not found in config", bench_name))?;
+
+    for change in changes {
+        let metric_key = change.metric.as_str();
+        if !bench["budgets"].is_table() {
+            bench["budgets"] = Item::Table(Table::new());
+        }
+        let metric_item = &mut bench["budgets"][metric_key];
+        match metric_item {
+            Item::Table(metric_table) => {
+                metric_table["threshold"] = value(change.new_value);
+            }
+            Item::Value(v) if v.is_inline_table() => {
+                if let Some(inline) = v.as_inline_table_mut() {
+                    inline.insert("threshold", Value::from(change.new_value));
+                }
+            }
+            _ => {
+                let mut metric_table = Table::new();
+                metric_table["threshold"] = value(change.new_value);
+                *metric_item = Item::Table(metric_table);
+            }
+        }
+    }
+
+    fs::write(config_path, doc.to_string())
+        .with_context(|| format!("write {}", config_path.display()))?;
+    Ok(())
 }

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -48,6 +48,7 @@ pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
+pub const RATCHET_SCHEMA_V1: &str = "perfgate.ratchet.v1";
 
 // Stable contract identifiers and tokens.
 pub const CHECK_ID_BUDGET: &str = "perf.budget";
@@ -1003,6 +1004,44 @@ pub struct CompareReceipt {
     pub verdict: Verdict,
 }
 
+/// Evidence captured for a ratchet decision.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetEvidence {
+    pub improvement: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cv: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub noise_threshold: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub p_value: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub significant: Option<bool>,
+}
+
+/// A single metric ratchet change.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetChange {
+    pub metric: Metric,
+    pub mode: RatchetMode,
+    pub old_value: f64,
+    pub new_value: f64,
+    pub reason: String,
+    pub evidence: RatchetEvidence,
+}
+
+/// Machine-readable ratchet artifact.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub bench_name: String,
+    pub compare_ref: CompareRef,
+    pub changes: Vec<RatchetChange>,
+}
+
 // ----------------------------
 // Report types (perfgate.report.v1)
 // ----------------------------
@@ -1154,6 +1193,10 @@ pub struct ConfigFile {
     #[serde(default)]
     pub baseline_server: BaselineServerConfig,
 
+    /// Optional budget ratcheting policy (explicit promote path only).
+    #[serde(default)]
+    pub ratchet: RatchetConfig,
+
     #[serde(default, rename = "bench")]
     pub benches: Vec<BenchConfigFile>,
 }
@@ -1220,6 +1263,72 @@ pub struct BaselineServerConfig {
     /// Fall back to local storage when server is unavailable.
     #[serde(default = "default_fallback_to_local")]
     pub fallback_to_local: bool,
+}
+
+/// Ratcheting mode used when tightening budgets.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum RatchetMode {
+    /// Tighten budget threshold values.
+    #[default]
+    Threshold,
+    /// Track improved baseline values in ratchet artifacts.
+    BaselineValue,
+}
+
+/// Ratchet policy configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetConfig {
+    /// Opt-in gate; ratcheting is disabled by default.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Ratcheting mode.
+    #[serde(default)]
+    pub mode: RatchetMode,
+
+    /// Minimum improvement required before tightening (fraction).
+    #[serde(default = "default_ratchet_min_improvement")]
+    pub min_improvement: f64,
+
+    /// Maximum tightening applied in one step (fraction).
+    #[serde(default = "default_ratchet_max_tightening")]
+    pub max_tightening: f64,
+
+    /// Require statistical significance evidence for each ratcheted metric.
+    #[serde(default = "default_ratchet_require_significance")]
+    pub require_significance: bool,
+
+    /// Optional allow-list of metrics eligible for ratcheting.
+    #[serde(default)]
+    pub allow_metrics: Vec<Metric>,
+}
+
+impl Default for RatchetConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: RatchetMode::Threshold,
+            min_improvement: default_ratchet_min_improvement(),
+            max_tightening: default_ratchet_max_tightening(),
+            require_significance: default_ratchet_require_significance(),
+            allow_metrics: vec![Metric::WallMs, Metric::CpuMs],
+        }
+    }
+}
+
+fn default_ratchet_min_improvement() -> f64 {
+    0.05
+}
+
+fn default_ratchet_max_tightening() -> f64 {
+    0.10
+}
+
+fn default_ratchet_require_significance() -> bool {
+    true
 }
 
 fn default_fallback_to_local() -> bool {
@@ -1540,6 +1649,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![BenchConfigFile {
                 name: "bad|name".to_string(),
                 cwd: None,
@@ -1629,6 +1739,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
                 cwd: None,
@@ -2027,6 +2138,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".into(),
                 cwd: Some("/home/user/project".into()),
@@ -2064,6 +2176,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Default::default(),
             benches: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
@@ -3036,6 +3149,7 @@ mod property_tests {
             .prop_map(|(defaults, baseline_server, benches)| ConfigFile {
                 defaults,
                 baseline_server,
+                ratchet: RatchetConfig::default(),
                 benches,
             })
     }

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -21,6 +21,21 @@
     "defaults": {
       "$ref": "#/$defs/DefaultsConfig",
       "default": {}
+    },
+    "ratchet": {
+      "description": "Optional budget ratcheting policy (explicit promote path only).",
+      "$ref": "#/$defs/RatchetConfig",
+      "default": {
+        "allow_metrics": [
+          "wall_ms",
+          "cpu_ms"
+        ],
+        "enabled": false,
+        "max_tightening": 0.1,
+        "min_improvement": 0.05,
+        "mode": "threshold",
+        "require_significance": true
+      }
     }
   },
   "$defs": {
@@ -357,6 +372,62 @@
           "description": "Demote Pass and Fail to Skip.",
           "type": "string",
           "const": "skip"
+        }
+      ]
+    },
+    "RatchetConfig": {
+      "description": "Ratchet policy configuration.",
+      "type": "object",
+      "properties": {
+        "allow_metrics": {
+          "description": "Optional allow-list of metrics eligible for ratcheting.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Metric"
+          }
+        },
+        "enabled": {
+          "description": "Opt-in gate; ratcheting is disabled by default.",
+          "type": "boolean",
+          "default": false
+        },
+        "max_tightening": {
+          "description": "Maximum tightening applied in one step (fraction).",
+          "type": "number",
+          "format": "double",
+          "default": 0.1
+        },
+        "min_improvement": {
+          "description": "Minimum improvement required before tightening (fraction).",
+          "type": "number",
+          "format": "double",
+          "default": 0.05
+        },
+        "mode": {
+          "description": "Ratcheting mode.",
+          "$ref": "#/$defs/RatchetMode",
+          "default": "threshold"
+        },
+        "require_significance": {
+          "description": "Require statistical significance evidence for each ratcheted metric.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "RatchetMode": {
+      "description": "Ratcheting mode used when tightening budgets.",
+      "oneOf": [
+        {
+          "description": "Tighten budget threshold values.",
+          "type": "string",
+          "const": "threshold"
+        },
+        {
+          "description": "Track improved baseline values in ratchet artifacts.",
+          "type": "string",
+          "const": "baseline_value"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- Enable conservative, explicit budget ratcheting on a trusted promote path so genuine improvements can be made persistent without relaxing budgets accidentally.
- Keep ratcheting opt-in, tighten-only, and gated by trust signals (pass verdict, no host mismatch, noise/significance checks) and preserve human TOML formatting/comments when applying changes.

### Description
- Add typed ratchet policy and artifact contracts in `perfgate-types` including `RatchetConfig`, `RatchetMode`, `RatchetReceipt`, `RatchetChange`, and `RatchetEvidence` and a new `RATCHET_SCHEMA_V1` constant, and wire `ConfigFile.ratchet` for `[ratchet]` config.
- Implement conservative ratchet decision logic in `perfgate-budget` (`ratchet_threshold_for_metric`) that only tightens, enforces `min_improvement` and `max_tightening`, filters noisy metrics, and optionally requires significance; also build ratchet artifacts (`build_ratchet_receipt`).
- Add an app-layer `RatchetUseCase` in `perfgate-app` to evaluate a `CompareReceipt` into ratchet `changes` and to render a `RatchetReceipt` for artifact output.
- Implement TOML-preserving mutation in `perfgate-config` using `toml_edit` to update only targeted bench budget thresholds while keeping comments/ordering intact.
- Extend CLI (`perfgate`) with a preview command `perfgate ratchet --config ... --compare ...` and an apply option on promote `perfgate promote --ratchet --config perfgate.toml --compare compare.json [--ratchet-out out.json]`, and update help snapshots and generated config schema accordingly.
- Add workspace dependency on `toml_edit` and wire `perfgate-budget` into `perfgate-app` for orchestration.

### Testing
- Ran formatting: `cargo fmt --all` (succeeded).
- Ran unit/test suites: `cargo test -p perfgate-config -p perfgate-types -p perfgate-budget -p perfgate-app` (all tests passed).
- Ran CLI snapshot test: `cargo test -p perfgate-cli --test cli_help_snapshot_tests` after regenerating snapshots (passed after snapshots were updated to include new ratchet flags).
- Regenerated JSON schema: `cargo run -p xtask -- schema` and verified `schemas/perfgate.config.v1.schema.json` includes the new `[ratchet]` section (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a56fa048833381f42576b21cef23)