### PR TITLE
Add ratchet policy config types and schema support

### DIFF
--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1154,6 +1154,10 @@ pub struct ConfigFile {
     #[serde(default)]
     pub baseline_server: BaselineServerConfig,
 
+    /// Optional ratchet policy used to tighten budgets during explicit promote flows.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ratchet: Option<RatchetConfig>,
+
     #[serde(default, rename = "bench")]
     pub benches: Vec<BenchConfigFile>,
 }
@@ -1252,6 +1256,72 @@ impl BaselineServerConfig {
             .ok()
             .or_else(|| self.project.clone())
     }
+}
+
+/// Strategy used when applying ratchet updates.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum RatchetMode {
+    /// Tighten the budget threshold by a bounded percentage.
+    #[default]
+    Threshold,
+    /// Update baseline-value references to an improved observed value.
+    BaselineValue,
+}
+
+/// Policy for conservative, opt-in budget ratcheting.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetConfig {
+    /// Enables ratcheting when explicitly requested by a command.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Ratcheting strategy.
+    #[serde(default)]
+    pub mode: RatchetMode,
+
+    /// Minimum required improvement ratio (e.g. 0.05 = 5%).
+    #[serde(default = "default_ratchet_min_improvement")]
+    pub min_improvement: f64,
+
+    /// Maximum one-step tightening ratio.
+    #[serde(default = "default_ratchet_max_tightening")]
+    pub max_tightening: f64,
+
+    /// Require significance evidence before tightening.
+    #[serde(default = "default_ratchet_require_significance")]
+    pub require_significance: bool,
+
+    /// Optional allow-list of metrics eligible for ratcheting.
+    #[serde(default)]
+    pub allow_metrics: Vec<Metric>,
+}
+
+impl Default for RatchetConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: RatchetMode::Threshold,
+            min_improvement: default_ratchet_min_improvement(),
+            max_tightening: default_ratchet_max_tightening(),
+            require_significance: default_ratchet_require_significance(),
+            allow_metrics: vec![],
+        }
+    }
+}
+
+fn default_ratchet_min_improvement() -> f64 {
+    0.05
+}
+
+fn default_ratchet_max_tightening() -> f64 {
+    0.10
+}
+
+fn default_ratchet_require_significance() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
@@ -1540,6 +1610,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![BenchConfigFile {
                 name: "bad|name".to_string(),
                 cwd: None,
@@ -1629,6 +1700,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
                 cwd: None,
@@ -2027,6 +2099,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: Some(RatchetConfig::default()),
             benches: vec![BenchConfigFile {
                 name: "my-bench".into(),
                 cwd: Some("/home/user/project".into()),
@@ -2064,11 +2137,30 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let back: ConfigFile = serde_json::from_str(&json).unwrap();
         assert_eq!(config, back);
+    }
+
+    #[test]
+    fn config_file_toml_deserializes_ratchet_defaults() {
+        let config: ConfigFile = toml::from_str(
+            r#"
+            [ratchet]
+            enabled = true
+            "#,
+        )
+        .unwrap();
+        let ratchet = config.ratchet.unwrap();
+        assert!(ratchet.enabled);
+        assert_eq!(ratchet.mode, RatchetMode::Threshold);
+        assert_eq!(ratchet.min_improvement, 0.05);
+        assert_eq!(ratchet.max_tightening, 0.10);
+        assert!(ratchet.require_significance);
+        assert!(ratchet.allow_metrics.is_empty());
     }
 
     #[test]
@@ -3036,6 +3128,7 @@ mod property_tests {
             .prop_map(|(defaults, baseline_server, benches)| ConfigFile {
                 defaults,
                 baseline_server,
+                ratchet: None,
                 benches,
             })
     }

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -21,6 +21,17 @@
     "defaults": {
       "$ref": "#/$defs/DefaultsConfig",
       "default": {}
+    },
+    "ratchet": {
+      "description": "Optional ratchet policy used to tighten budgets during explicit promote flows.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RatchetConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "$defs": {
@@ -357,6 +368,62 @@
           "description": "Demote Pass and Fail to Skip.",
           "type": "string",
           "const": "skip"
+        }
+      ]
+    },
+    "RatchetConfig": {
+      "description": "Policy for conservative, opt-in budget ratcheting.",
+      "type": "object",
+      "properties": {
+        "allow_metrics": {
+          "description": "Optional allow-list of metrics eligible for ratcheting.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Metric"
+          }
+        },
+        "enabled": {
+          "description": "Enables ratcheting when explicitly requested by a command.",
+          "type": "boolean",
+          "default": false
+        },
+        "max_tightening": {
+          "description": "Maximum one-step tightening ratio.",
+          "type": "number",
+          "format": "double",
+          "default": 0.1
+        },
+        "min_improvement": {
+          "description": "Minimum required improvement ratio (e.g. 0.05 = 5%).",
+          "type": "number",
+          "format": "double",
+          "default": 0.05
+        },
+        "mode": {
+          "description": "Ratcheting strategy.",
+          "$ref": "#/$defs/RatchetMode",
+          "default": "threshold"
+        },
+        "require_significance": {
+          "description": "Require significance evidence before tightening.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "RatchetMode": {
+      "description": "Strategy used when applying ratchet updates.",
+      "oneOf": [
+        {
+          "description": "Tighten the budget threshold by a bounded percentage.",
+          "type": "string",
+          "const": "threshold"
+        },
+        {
+          "description": "Update baseline-value references to an improved observed value.",
+          "type": "string",
+          "const": "baseline_value"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- Provide typed, schema-backed configuration for conservative, opt-in budget ratcheting so future commands can implement preview/apply flows without changing core types.
- Keep ratcheting opt-in and conservative by default to avoid accidental budget relaxation.

### Description
- Add an optional top-level `ratchet` field to `ConfigFile` and introduce `RatchetConfig` and `RatchetMode` in `crates/perfgate-types/src/lib.rs` with conservative defaults (`enabled=false`, `mode=threshold`, `min_improvement=0.05`, `max_tightening=0.10`, `require_significance=true`, `allow_metrics=[]`).
- Update unit tests and property-test fixtures to account for the new `ratchet` field and add a TOML deserialization test that validates defaulting behavior for `[ratchet]`.
- Regenerate the JSON schema (`schemas/perfgate.config.v1.schema.json`) so the new `ratchet` section and its `$defs` appear in generated schema output.
- This change is scaffolding only and does not implement preview/apply logic, TOML-preserving writes, or CLI flags yet.

### Testing
- Ran `cargo fmt --all` to format changes and it completed successfully.
- Ran unit tests for the updated crate with `cargo test -p perfgate-types` and all tests passed (68 passed, 0 failed).
- Regenerated schemas with `cargo run -p xtask -- schema` and the `perfgate.config.v1` schema was updated to include `RatchetConfig` and `RatchetMode`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a56fa048833381f42576b21cef23)