### PR TITLE
Add ratchet config types and schema support

### DIFF
--- a/crates/perfgate-app/src/baseline_resolve.rs
+++ b/crates/perfgate-app/src/baseline_resolve.rs
@@ -60,6 +60,7 @@ mod tests {
                 ..Default::default()
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: Vec::new(),
         };
 

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -994,6 +994,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench.clone()],
         };
 
@@ -1124,6 +1125,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench.clone()],
         };
 
@@ -1201,6 +1203,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench],
         };
 
@@ -1255,6 +1258,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench],
         };
 
@@ -1326,6 +1330,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench],
         };
 
@@ -1383,6 +1388,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench],
         };
 
@@ -1413,6 +1419,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![],
         };
 
@@ -1465,6 +1472,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![bench],
         };
 

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1154,6 +1154,10 @@ pub struct ConfigFile {
     #[serde(default)]
     pub baseline_server: BaselineServerConfig,
 
+    /// Optional automated budget ratcheting policy.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ratchet: Option<RatchetConfig>,
+
     #[serde(default, rename = "bench")]
     pub benches: Vec<BenchConfigFile>,
 }
@@ -1220,6 +1224,79 @@ pub struct BaselineServerConfig {
     /// Fall back to local storage when server is unavailable.
     #[serde(default = "default_fallback_to_local")]
     pub fallback_to_local: bool,
+}
+
+/// Configuration for automated budget ratcheting.
+///
+/// Ratcheting is conservative by default and only applies on explicit
+/// promotion/ratchet flows.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RatchetConfig {
+    /// Enable ratcheting behavior for explicit ratchet workflows.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Ratcheting mode.
+    #[serde(default)]
+    pub mode: RatchetMode,
+
+    /// Minimum required improvement (fraction) before tightening is considered.
+    #[serde(default = "default_ratchet_min_improvement")]
+    pub min_improvement: f64,
+
+    /// Maximum one-step tightening cap (fraction).
+    #[serde(default = "default_ratchet_max_tightening")]
+    pub max_tightening: f64,
+
+    /// Require statistical significance evidence before ratcheting.
+    #[serde(default = "default_ratchet_require_significance")]
+    pub require_significance: bool,
+
+    /// Metrics eligible for ratcheting.
+    #[serde(default = "default_ratchet_allow_metrics")]
+    pub allow_metrics: Vec<Metric>,
+}
+
+impl Default for RatchetConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mode: RatchetMode::Threshold,
+            min_improvement: default_ratchet_min_improvement(),
+            max_tightening: default_ratchet_max_tightening(),
+            require_significance: default_ratchet_require_significance(),
+            allow_metrics: default_ratchet_allow_metrics(),
+        }
+    }
+}
+
+fn default_ratchet_min_improvement() -> f64 {
+    0.05
+}
+
+fn default_ratchet_max_tightening() -> f64 {
+    0.10
+}
+
+fn default_ratchet_require_significance() -> bool {
+    true
+}
+
+fn default_ratchet_allow_metrics() -> Vec<Metric> {
+    vec![Metric::WallMs, Metric::CpuMs]
+}
+
+/// Ratcheting policy mode.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum RatchetMode {
+    /// Tighten explicit threshold values.
+    #[default]
+    Threshold,
+    /// Tighten by updating baseline reference values.
+    BaselineValue,
 }
 
 fn default_fallback_to_local() -> bool {
@@ -1540,6 +1617,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![BenchConfigFile {
                 name: "bad|name".to_string(),
                 cwd: None,
@@ -1629,6 +1707,7 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
                 cwd: None,
@@ -2027,6 +2106,7 @@ mod tests {
                 markdown_template: None,
             },
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![BenchConfigFile {
                 name: "my-bench".into(),
                 cwd: Some("/home/user/project".into()),
@@ -2064,11 +2144,36 @@ mod tests {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
+            ratchet: None,
             benches: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let back: ConfigFile = serde_json::from_str(&json).unwrap();
         assert_eq!(config, back);
+    }
+
+    #[test]
+    fn config_file_parses_ratchet_block() {
+        let config: ConfigFile = toml::from_str(
+            r#"
+            [ratchet]
+            enabled = true
+            mode = "threshold"
+            min_improvement = 0.05
+            max_tightening = 0.10
+            require_significance = true
+            allow_metrics = ["wall_ms", "cpu_ms"]
+            "#,
+        )
+        .expect("valid ratchet config");
+
+        let ratchet = config.ratchet.expect("ratchet should be parsed");
+        assert!(ratchet.enabled);
+        assert_eq!(ratchet.mode, RatchetMode::Threshold);
+        assert_eq!(ratchet.min_improvement, 0.05);
+        assert_eq!(ratchet.max_tightening, 0.10);
+        assert!(ratchet.require_significance);
+        assert_eq!(ratchet.allow_metrics, vec![Metric::WallMs, Metric::CpuMs]);
     }
 
     #[test]
@@ -3036,6 +3141,7 @@ mod property_tests {
             .prop_map(|(defaults, baseline_server, benches)| ConfigFile {
                 defaults,
                 baseline_server,
+                ratchet: None,
                 benches,
             })
     }

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -21,6 +21,17 @@
     "defaults": {
       "$ref": "#/$defs/DefaultsConfig",
       "default": {}
+    },
+    "ratchet": {
+      "description": "Optional automated budget ratcheting policy.",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RatchetConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   },
   "$defs": {
@@ -357,6 +368,65 @@
           "description": "Demote Pass and Fail to Skip.",
           "type": "string",
           "const": "skip"
+        }
+      ]
+    },
+    "RatchetConfig": {
+      "description": "Configuration for automated budget ratcheting.\n\nRatcheting is conservative by default and only applies on explicit\npromotion/ratchet flows.",
+      "type": "object",
+      "properties": {
+        "allow_metrics": {
+          "description": "Metrics eligible for ratcheting.",
+          "type": "array",
+          "default": [
+            "wall_ms",
+            "cpu_ms"
+          ],
+          "items": {
+            "$ref": "#/$defs/Metric"
+          }
+        },
+        "enabled": {
+          "description": "Enable ratcheting behavior for explicit ratchet workflows.",
+          "type": "boolean",
+          "default": false
+        },
+        "max_tightening": {
+          "description": "Maximum one-step tightening cap (fraction).",
+          "type": "number",
+          "format": "double",
+          "default": 0.1
+        },
+        "min_improvement": {
+          "description": "Minimum required improvement (fraction) before tightening is considered.",
+          "type": "number",
+          "format": "double",
+          "default": 0.05
+        },
+        "mode": {
+          "description": "Ratcheting mode.",
+          "$ref": "#/$defs/RatchetMode",
+          "default": "threshold"
+        },
+        "require_significance": {
+          "description": "Require statistical significance evidence before ratcheting.",
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "RatchetMode": {
+      "description": "Ratcheting policy mode.",
+      "oneOf": [
+        {
+          "description": "Tighten explicit threshold values.",
+          "type": "string",
+          "const": "threshold"
+        },
+        {
+          "description": "Tighten by updating baseline reference values.",
+          "type": "string",
+          "const": "baseline_value"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- Introduce a typed, conservative configuration surface for automated budget ratcheting so future work can implement preview/apply flows without breaking existing config shape.  
- Keep defaults conservative (disabled) and ensure the config is expressible in TOML/JSON and validated by existing schema generation.  

### Description
- Added an optional `ratchet: Option<RatchetConfig>` field to `ConfigFile` in `perfgate-types` and implemented `RatchetConfig` with fields `enabled`, `mode`, `min_improvement`, `max_tightening`, `require_significance`, and `allow_metrics`.  
- Introduced `RatchetMode` enum (`threshold` | `baseline_value`) and conservative default helpers (e.g. `min_improvement = 0.05`, `max_tightening = 0.10`, `require_significance = true`, `allow_metrics = [wall_ms, cpu_ms]`).  
- Updated serialization/property-test strategies and unit tests in `crates/perfgate-types` to cover the new field and added a focused TOML parsing unit test for `[ratchet]`.  
- Regenerated JSON schema (`schemas/perfgate.config.v1.schema.json`) and updated a few `perfgate-app` test call sites that construct `ConfigFile` directly to set `ratchet: None` so tests compile.  

### Testing
- Ran `cargo check` which succeeded.  
- Ran `cargo test -p perfgate-types` and all tests passed.  
- Ran `cargo test -p perfgate-app` and all tests passed.  
- Regenerated schemas via `cargo run -p xtask -- schema` which completed successfully and updated `schemas/perfgate.config.v1.schema.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a56fa048833381f42576b21cef23)