### PR TITLE
Add repair context schema and emit repair_context.json on check failures

### DIFF
--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -20,6 +20,7 @@ mod explain;
 pub mod init;
 mod paired;
 mod promote;
+mod repair_context;
 mod report;
 mod sensor_report;
 mod trend;
@@ -39,6 +40,9 @@ pub use diff::{
 pub use explain::{ExplainOutcome, ExplainRequest, ExplainUseCase};
 pub use paired::{PairedRunOutcome, PairedRunRequest, PairedRunUseCase};
 pub use promote::{PromoteRequest, PromoteResult, PromoteUseCase};
+pub use repair_context::{
+    RepairContextOptions, build_repair_context, redact_sensitive, summarize_changed_files,
+};
 pub use report::{ReportRequest, ReportResult, ReportUseCase};
 pub use sensor_report::{
     BenchOutcome, SensorCheckOptions, SensorReportBuilder, classify_error,

--- a/crates/perfgate-app/src/repair_context.rs
+++ b/crates/perfgate-app/src/repair_context.rs
@@ -1,0 +1,140 @@
+use crate::CheckOutcome;
+use perfgate_types::{
+    MetricStatus, REPAIR_CONTEXT_SCHEMA_V1, RepairBreachedMetric, RepairChangedFilesSummary,
+    RepairContext, RepairGitContext, RepairSpanIdentifiers,
+};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Default)]
+pub struct RepairContextOptions {
+    pub compare_receipt_path: Option<String>,
+    pub report_path: Option<String>,
+    pub profile_path: Option<String>,
+    pub changed_files: RepairChangedFilesSummary,
+    pub git: RepairGitContext,
+    pub spans: Option<RepairSpanIdentifiers>,
+    pub next_commands: Vec<String>,
+}
+
+pub fn build_repair_context(
+    outcome: &CheckOutcome,
+    options: RepairContextOptions,
+) -> RepairContext {
+    let breached_metrics = outcome
+        .compare_receipt
+        .as_ref()
+        .map(|compare| {
+            compare
+                .deltas
+                .iter()
+                .filter_map(|(metric, delta)| {
+                    if matches!(delta.status, MetricStatus::Warn | MetricStatus::Fail) {
+                        let budget = compare.budgets.get(metric)?;
+                        Some(RepairBreachedMetric {
+                            metric: *metric,
+                            status: delta.status,
+                            threshold: budget.threshold,
+                            warn_threshold: budget.warn_threshold,
+                            baseline: delta.baseline,
+                            current: delta.current,
+                            regression_pct: delta.pct * 100.0,
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    RepairContext {
+        schema: REPAIR_CONTEXT_SCHEMA_V1.to_string(),
+        benchmark: outcome.run_receipt.bench.name.clone(),
+        verdict: outcome.report.verdict.clone(),
+        breached_metrics,
+        compare_receipt_path: options.compare_receipt_path,
+        report_path: options.report_path,
+        profile_path: options.profile_path,
+        changed_files: options.changed_files,
+        git: options.git,
+        spans: options.spans,
+        next_commands: options
+            .next_commands
+            .into_iter()
+            .map(|cmd| redact_sensitive(&cmd))
+            .collect(),
+    }
+}
+
+pub fn summarize_changed_files(files: &[String]) -> RepairChangedFilesSummary {
+    let mut count_by_area: BTreeMap<String, u32> = BTreeMap::new();
+    for file in files {
+        let area = classify_area(file);
+        *count_by_area.entry(area).or_insert(0) += 1;
+    }
+
+    RepairChangedFilesSummary {
+        files: files.iter().map(|f| redact_sensitive(f)).collect(),
+        total_count: files.len() as u32,
+        count_by_area,
+    }
+}
+
+fn classify_area(path: &str) -> String {
+    let p = Path::new(path);
+    let mut parts = p.components();
+
+    let Some(first) = parts.next() else {
+        return "root".to_string();
+    };
+    let first = first.as_os_str().to_string_lossy();
+    if first == "crates"
+        && let Some(second) = parts.next()
+    {
+        return format!("crates/{}", second.as_os_str().to_string_lossy());
+    }
+    first.to_string()
+}
+
+pub fn redact_sensitive(input: &str) -> String {
+    const SENSITIVE_KEYS: &[&str] = &["token", "secret", "password", "apikey", "api_key", "key"];
+    let mut out = input.to_string();
+    for key in SENSITIVE_KEYS {
+        let needle = format!("{key}=");
+        if let Some(pos) = out.to_ascii_lowercase().find(&needle) {
+            let start = pos + needle.len();
+            let end = out[start..]
+                .find([' ', '&', ';'])
+                .map(|idx| start + idx)
+                .unwrap_or(out.len());
+            out.replace_range(start..end, "***");
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{redact_sensitive, summarize_changed_files};
+
+    #[test]
+    fn redacts_sensitive_key_value_pairs() {
+        let redacted = redact_sensitive("curl https://x?token=abc123&mode=fast");
+        assert!(redacted.contains("token=***"));
+        assert!(!redacted.contains("abc123"));
+    }
+
+    #[test]
+    fn summarize_groups_by_crate() {
+        let summary = summarize_changed_files(&[
+            "crates/perfgate-cli/src/main.rs".to_string(),
+            "crates/perfgate-app/src/check.rs".to_string(),
+            "README.md".to_string(),
+        ]);
+        assert_eq!(summary.total_count, 3);
+        assert_eq!(summary.count_by_area.get("crates/perfgate-cli"), Some(&1));
+        assert_eq!(summary.count_by_area.get("crates/perfgate-app"), Some(&1));
+        assert_eq!(summary.count_by_area.get("README.md"), Some(&1));
+    }
+}

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -16,9 +16,10 @@ use perfgate_app::{
     BlameRequest, BlameUseCase, CheckOutcome, CheckRequest, CheckUseCase, Clock, CompareRequest,
     CompareUseCase, DiffRequest, DiffUseCase, ExplainRequest, ExplainUseCase, ExportFormat,
     ExportUseCase, PairedRunRequest, PairedRunUseCase, PromoteRequest, PromoteUseCase,
-    ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase, SensorReportBuilder,
-    SystemClock, classify_error, github_annotations, render_json_diff, render_markdown,
-    render_markdown_template, render_terminal_diff,
+    RepairContextOptions, ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase,
+    SensorReportBuilder, SystemClock, build_repair_context, classify_error, github_annotations,
+    render_json_diff, render_markdown, render_markdown_template, render_terminal_diff,
+    summarize_changed_files,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::{
@@ -37,7 +38,8 @@ use perfgate_scaling::{
 use perfgate_summary::{SummaryRequest, SummaryUseCase};
 use perfgate_types::{
     BASELINE_REASON_NO_BASELINE, BaselineServerConfig, CompareReceipt, CompareRef, ConfigFile,
-    HostMismatchPolicy, PerfgateReport, RunReceipt, SensorVerdictStatus, ToolInfo, VerdictStatus,
+    HostMismatchPolicy, PerfgateReport, RepairGitContext, RunReceipt, SensorVerdictStatus,
+    ToolInfo, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::BTreeMap;
@@ -977,6 +979,12 @@ pub struct CheckArgs {
     /// Requires a profiler: perf (Linux), dtrace (macOS), or cargo-flamegraph.
     #[arg(long, default_value_t = false)]
     pub profile_on_regression: bool,
+
+    /// Emit repair_context.json even on PASS verdicts.
+    ///
+    /// By default, repair context is emitted only for WARN/FAIL.
+    #[arg(long, default_value_t = false)]
+    pub emit_repair_context: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1858,6 +1866,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 output_github,
                 local_db,
                 profile_on_regression,
+                emit_repair_context,
             } = *args;
 
             let req = CheckConfig {
@@ -1882,6 +1891,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 md_template,
                 output_github,
                 profile_on_regression,
+                emit_repair_context,
                 server_flags,
                 local_db,
             };
@@ -3585,6 +3595,7 @@ struct CheckConfig {
     md_template: Option<PathBuf>,
     output_github: bool,
     profile_on_regression: bool,
+    emit_repair_context: bool,
     server_flags: ServerFlags,
     local_db: bool,
 }
@@ -3664,6 +3675,76 @@ fn submit_verdict_if_possible(
             Ok::<(), anyhow::Error>(())
         });
     }
+}
+
+fn should_emit_repair_context(status: VerdictStatus, force_emit: bool) -> bool {
+    force_emit || matches!(status, VerdictStatus::Warn | VerdictStatus::Fail)
+}
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let out = std::process::Command::new("git").args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+fn collect_git_context() -> RepairGitContext {
+    RepairGitContext {
+        branch: git_output(&["rev-parse", "--abbrev-ref", "HEAD"]),
+        sha: git_output(&["rev-parse", "HEAD"]),
+    }
+}
+
+fn collect_changed_files() -> Vec<String> {
+    let Some(raw) = git_output(&["status", "--porcelain"]) else {
+        return Vec::new();
+    };
+    raw.lines()
+        .filter_map(|line| {
+            if line.len() > 3 {
+                Some(line[3..].trim().to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn emit_repair_context_artifact(
+    outcome: &CheckOutcome,
+    out_dir: &Path,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    let changed_files = collect_changed_files();
+    let git = collect_git_context();
+    let sha_for_cmd = git.sha.clone().unwrap_or_else(|| "HEAD".to_string());
+    let repair_context = build_repair_context(
+        outcome,
+        RepairContextOptions {
+            compare_receipt_path: outcome
+                .compare_path
+                .as_ref()
+                .map(|p| p.display().to_string()),
+            report_path: Some(outcome.report_path.display().to_string()),
+            profile_path: outcome.report.profile_path.clone(),
+            changed_files: summarize_changed_files(&changed_files),
+            git,
+            spans: None,
+            next_commands: vec![
+                format!("perfgate bisect --good <GOOD_SHA> --bad {}", sha_for_cmd),
+                "perfgate blame --baseline old-Cargo.lock --current Cargo.lock".to_string(),
+                format!(
+                    "perfgate paired --name {} --baseline-cmd \"<baseline-cmd>\" --current-cmd \"<current-cmd>\" --repeat 10 --out artifacts/perfgate/paired.json",
+                    outcome.run_receipt.bench.name
+                ),
+            ],
+        },
+    );
+
+    let repair_path = out_dir.join("repair_context.json");
+    write_json(&repair_path, &repair_context, pretty)
 }
 
 /// Run check in standard mode (exit codes reflect verdict).
@@ -3778,6 +3859,11 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
         // Write artifacts
         write_check_artifacts(&outcome, req.pretty)
             .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
+
+        if should_emit_repair_context(outcome.report.verdict.status, req.emit_repair_context) {
+            emit_repair_context_artifact(&outcome, &bench_out_dir, req.pretty)
+                .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
+        }
 
         // Profile on regression if requested
         if req.profile_on_regression
@@ -4030,6 +4116,14 @@ fn run_check_cockpit_inner(
             // Write native artifacts to extras/
             write_check_artifacts(&check_outcome, req.pretty)
                 .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
+
+            if should_emit_repair_context(
+                check_outcome.report.verdict.status,
+                req.emit_repair_context,
+            ) {
+                emit_repair_context_artifact(&check_outcome, &extras_dir, req.pretty)
+                    .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
+            }
 
             // Profile on regression if requested
             if req.profile_on_regression
@@ -5308,6 +5402,70 @@ mod tests {
         assert!(run_path.exists());
         assert!(report_path.exists());
         assert!(markdown_path.exists());
+    }
+
+    #[test]
+    fn should_emit_repair_context_on_warn_or_fail_by_default() {
+        assert!(should_emit_repair_context(VerdictStatus::Warn, false));
+        assert!(should_emit_repair_context(VerdictStatus::Fail, false));
+        assert!(!should_emit_repair_context(VerdictStatus::Pass, false));
+    }
+
+    #[test]
+    fn should_emit_repair_context_on_pass_when_forced() {
+        assert!(should_emit_repair_context(VerdictStatus::Pass, true));
+    }
+
+    #[test]
+    fn emit_repair_context_writes_artifact() {
+        let dir = tempdir().unwrap();
+        let out_dir = dir.path().join("out");
+        fs::create_dir_all(&out_dir).unwrap();
+
+        let run_path = out_dir.join("run.json");
+        let report_path = out_dir.join("report.json");
+        let markdown_path = out_dir.join("comment.md");
+        let compare_path = out_dir.join("compare.json");
+
+        let compare_receipt: CompareReceipt =
+            serde_json::from_str(&create_compare_receipt_json("warn", "warn")).unwrap();
+        let report = PerfgateReport {
+            report_type: "perfgate.report.v1".to_string(),
+            verdict: compare_receipt.verdict.clone(),
+            compare: Some(compare_receipt.clone()),
+            findings: Vec::new(),
+            summary: ReportSummary {
+                pass_count: 0,
+                warn_count: 1,
+                fail_count: 0,
+                skip_count: 0,
+                total_count: 1,
+            },
+            profile_path: Some("profiles/bench.svg".to_string()),
+        };
+        let outcome = CheckOutcome {
+            run_receipt: make_receipt(make_stats_with_wall(100)),
+            run_path,
+            compare_receipt: Some(compare_receipt),
+            compare_path: Some(compare_path),
+            report,
+            report_path,
+            markdown: "hello".to_string(),
+            markdown_path,
+            warnings: Vec::new(),
+            failed: false,
+            exit_code: 0,
+            suggest_paired: false,
+        };
+
+        emit_repair_context_artifact(&outcome, &out_dir, false).unwrap();
+        let path = out_dir.join("repair_context.json");
+        assert!(path.exists());
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(value["schema"], "perfgate.repair_context.v1");
+        assert_eq!(value["benchmark"], "bench");
+        assert_eq!(value["profile_path"], "profiles/bench.svg");
     }
 
     #[test]

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -47,6 +47,7 @@ pub const RUN_SCHEMA_V1: &str = "perfgate.run.v1";
 pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
+pub const REPAIR_CONTEXT_SCHEMA_V1: &str = "perfgate.repair_context.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
 
 // Stable contract identifiers and tokens.
@@ -1116,6 +1117,76 @@ pub struct PerfgateReport {
     /// Path to a flamegraph SVG captured when regression was detected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub profile_path: Option<String>,
+}
+
+/// Git metadata associated with a repair context artifact.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairGitContext {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sha: Option<String>,
+}
+
+/// Summary of repository file changes useful for triage automation.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairChangedFilesSummary {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+    #[serde(default)]
+    pub total_count: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub count_by_area: BTreeMap<String, u32>,
+}
+
+/// Optional span identifiers when OTel ingestion is present.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairSpanIdentifiers {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub span_id: Option<String>,
+}
+
+/// Breached metric details included in repair context.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairBreachedMetric {
+    pub metric: Metric,
+    pub status: MetricStatus,
+    pub threshold: f64,
+    pub warn_threshold: f64,
+    pub baseline: f64,
+    pub current: f64,
+    pub regression_pct: f64,
+}
+
+/// Machine-readable triage package emitted for warn/fail checks.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairContext {
+    pub schema: String,
+    pub benchmark: String,
+    pub verdict: Verdict,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub breached_metrics: Vec<RepairBreachedMetric>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub compare_receipt_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub report_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub profile_path: Option<String>,
+    #[serde(default)]
+    pub changed_files: RepairChangedFilesSummary,
+    #[serde(default)]
+    pub git: RepairGitContext,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub spans: Option<RepairSpanIdentifiers>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_commands: Vec<String>,
 }
 
 // ----------------------------

--- a/schemas/perfgate.repair_context.v1.schema.json
+++ b/schemas/perfgate.repair_context.v1.schema.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RepairContext",
+  "description": "Machine-readable triage package emitted for warn/fail checks.",
+  "type": "object",
+  "properties": {
+    "benchmark": {
+      "type": "string"
+    },
+    "breached_metrics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RepairBreachedMetric"
+      }
+    },
+    "changed_files": {
+      "$ref": "#/$defs/RepairChangedFilesSummary",
+      "default": {
+        "total_count": 0
+      }
+    },
+    "compare_receipt_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "git": {
+      "$ref": "#/$defs/RepairGitContext",
+      "default": {}
+    },
+    "next_commands": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "profile_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "report_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "schema": {
+      "type": "string"
+    },
+    "spans": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/RepairSpanIdentifiers"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "verdict": {
+      "$ref": "#/$defs/Verdict"
+    }
+  },
+  "required": [
+    "schema",
+    "benchmark",
+    "verdict"
+  ],
+  "$defs": {
+    "Metric": {
+      "type": "string",
+      "enum": [
+        "binary_bytes",
+        "cpu_ms",
+        "ctx_switches",
+        "energy_uj",
+        "io_read_bytes",
+        "io_write_bytes",
+        "max_rss_kb",
+        "network_packets",
+        "page_faults",
+        "throughput_per_s",
+        "wall_ms"
+      ]
+    },
+    "MetricStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "RepairBreachedMetric": {
+      "description": "Breached metric details included in repair context.",
+      "type": "object",
+      "properties": {
+        "baseline": {
+          "type": "number",
+          "format": "double"
+        },
+        "current": {
+          "type": "number",
+          "format": "double"
+        },
+        "metric": {
+          "$ref": "#/$defs/Metric"
+        },
+        "regression_pct": {
+          "type": "number",
+          "format": "double"
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        },
+        "threshold": {
+          "type": "number",
+          "format": "double"
+        },
+        "warn_threshold": {
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "metric",
+        "status",
+        "threshold",
+        "warn_threshold",
+        "baseline",
+        "current",
+        "regression_pct"
+      ]
+    },
+    "RepairChangedFilesSummary": {
+      "description": "Summary of repository file changes useful for triage automation.",
+      "type": "object",
+      "properties": {
+        "count_by_area": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "total_count": {
+          "type": "integer",
+          "format": "uint32",
+          "default": 0,
+          "minimum": 0
+        }
+      }
+    },
+    "RepairGitContext": {
+      "description": "Git metadata associated with a repair context artifact.",
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "RepairSpanIdentifiers": {
+      "description": "Optional span identifiers when OTel ingestion is present.",
+      "type": "object",
+      "properties": {
+        "span_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trace_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Verdict": {
+      "description": "Overall verdict for a comparison, with pass/warn/fail counts.\n\n# Examples\n\n```\nuse perfgate_types::{Verdict, VerdictStatus, VerdictCounts};\n\nlet verdict = Verdict {\n    status: VerdictStatus::Pass,\n    counts: VerdictCounts { pass: 2, warn: 0, fail: 0, skip: 0 },\n    reasons: vec![],\n};\nassert_eq!(verdict.status, VerdictStatus::Pass);\n\nlet failing = Verdict {\n    status: VerdictStatus::Fail,\n    counts: VerdictCounts { pass: 1, warn: 0, fail: 1, skip: 0 },\n    reasons: vec![\"wall_ms.fail\".into()],\n};\nassert_eq!(failing.status, VerdictStatus::Fail);\nassert!(!failing.reasons.is_empty());\n```",
+      "type": "object",
+      "properties": {
+        "counts": {
+          "$ref": "#/$defs/VerdictCounts"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/VerdictStatus"
+        }
+      },
+      "required": [
+        "status",
+        "counts",
+        "reasons"
+      ]
+    },
+    "VerdictCounts": {
+      "type": "object",
+      "properties": {
+        "fail": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "pass": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "skip": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "warn": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "VerdictStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    }
+  }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,11 +7,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const SCHEMA_FILES: [&str; 5] = [
+const SCHEMA_FILES: [&str; 6] = [
     "perfgate.run.v1.schema.json",
     "perfgate.compare.v1.schema.json",
     "perfgate.config.v1.schema.json",
     "perfgate.report.v1.schema.json",
+    "perfgate.repair_context.v1.schema.json",
     "sensor.report.v1.schema.json",
 ];
 
@@ -720,9 +721,15 @@ fn cmd_schema(out_dir: &PathBuf) -> anyhow::Result<()> {
         schema_for!(perfgate_types::PerfgateReport),
     )?;
 
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[4],
+        schema_for!(perfgate_types::RepairContext),
+    )?;
+
     // Sensor report schema is vendored from contracts/, not generated.
     let vendored_schema = PathBuf::from("contracts/schemas/sensor.report.v1.schema.json");
-    let dest = out_dir.join(SCHEMA_FILES[4]);
+    let dest = out_dir.join(SCHEMA_FILES[5]);
     fs::copy(&vendored_schema, &dest).with_context(|| {
         format!(
             "copy vendored schema {} -> {}",


### PR DESCRIPTION
### Motivation

- Provide a small, structured, machine-readable artifact emitted when a budget violation occurs so humans or automated agents can triage immediately. 
- Make the artifact predictable, redactable, and lightweight (no env dumps or full patches) and include pertinent context like breached metrics, compare/report paths, changed-file summaries, and git metadata.
- Enable optional always-on emission for CI/workflow automation with a CLI switch so systems can opt into repair packages even on `Pass`.

### Description

- Introduce a new stable schema identifier `perfgate.repair_context.v1` and related types (`RepairContext`, `RepairBreachedMetric`, `RepairChangedFilesSummary`, `RepairGitContext`, `RepairSpanIdentifiers`) in `crates/perfgate-types/src/lib.rs`.
- Add an app-layer assembler `crates/perfgate-app/src/repair_context.rs` that builds `RepairContext` from a `CheckOutcome`, summarizes changed files by area (e.g., `crates/<name>`), and redacts sensitive key-value fragments in strings.
- Wire emission into the CLI: add `--emit-repair-context` to `perfgate check`, add best-effort git-changed-file and git-ref collectors, and write `repair_context.json` to the check output directory when verdict is `Warn`/`Fail` (or always when forced) in both standard and cockpit flows (`crates/perfgate-cli/src/main.rs`).
- Update `xtask` schema generation to include `perfgate.repair_context.v1` and add the generated schema file `schemas/perfgate.repair_context.v1.schema.json`.

### Testing

- Ran formatting: `cargo fmt --all` (succeeded).
- Unit tests for the app repair module: `cargo test -p perfgate-app repair_context -- --nocapture` (2 tests passed).
- CLI unit tests covering gating and artifact emission: `cargo test -p perfgate-cli should_emit_repair_context -- --nocapture` and `cargo test -p perfgate-cli emit_repair_context_writes_artifact -- --nocapture` (tests passed).
- Generated schemas using `cargo run -p xtask -- schema --out-dir schemas` to produce `perfgate.repair_context.v1.schema.json` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5797bb08333b60bd0835c797f6e)