### PR TITLE
Add perfgate.repair_context.v1 and emit repair_context.json for check regressions

### DIFF
--- a/crates/perfgate-app/src/baseline_resolve.rs
+++ b/crates/perfgate-app/src/baseline_resolve.rs
@@ -59,6 +59,7 @@ mod tests {
                 baseline_dir: Some("bases".to_string()),
                 ..Default::default()
             },
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: Vec::new(),
         };

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -993,6 +993,7 @@ mod tests {
                 baseline_pattern: None,
                 markdown_template: None,
             },
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench.clone()],
         };
@@ -1123,6 +1124,7 @@ mod tests {
                 baseline_pattern: None,
                 markdown_template: None,
             },
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench.clone()],
         };
@@ -1200,6 +1202,7 @@ mod tests {
         };
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
         };
@@ -1254,6 +1257,7 @@ mod tests {
         };
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
         };
@@ -1325,6 +1329,7 @@ mod tests {
                 baseline_pattern: None,
                 markdown_template: None,
             },
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
         };
@@ -1382,6 +1387,7 @@ mod tests {
         };
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
         };
@@ -1412,6 +1418,7 @@ mod tests {
     fn execute_bench_not_found_returns_error() {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![],
         };
@@ -1464,6 +1471,7 @@ mod tests {
                 baseline_pattern: None,
                 markdown_template: None,
             },
+            diagnostics: perfgate_types::DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
         };

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -20,6 +20,7 @@ mod explain;
 pub mod init;
 mod paired;
 mod promote;
+mod repair_context;
 mod report;
 mod sensor_report;
 mod trend;
@@ -39,6 +40,7 @@ pub use diff::{
 pub use explain::{ExplainOutcome, ExplainRequest, ExplainUseCase};
 pub use paired::{PairedRunOutcome, PairedRunRequest, PairedRunUseCase};
 pub use promote::{PromoteRequest, PromoteResult, PromoteUseCase};
+pub use repair_context::{RepairContextOptions, build_repair_context};
 pub use report::{ReportRequest, ReportResult, ReportUseCase};
 pub use sensor_report::{
     BenchOutcome, SensorCheckOptions, SensorReportBuilder, classify_error,

--- a/crates/perfgate-app/src/repair_context.rs
+++ b/crates/perfgate-app/src/repair_context.rs
@@ -1,0 +1,243 @@
+use crate::CheckOutcome;
+use perfgate_types::{
+    ChangedFilesSummary, GitContext, MetricStatus, REPAIR_CONTEXT_SCHEMA_V1, RepairArtifacts,
+    RepairContextReceipt, RepairMetricBreach, SpanIdentifiers, VerdictStatus,
+    redact_sensitive_tokens,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct RepairContextOptions {
+    pub changed_files: Option<ChangedFilesSummary>,
+    pub git: Option<GitContext>,
+    pub spans: Option<SpanIdentifiers>,
+}
+
+pub fn build_repair_context(
+    outcome: &CheckOutcome,
+    options: RepairContextOptions,
+) -> Option<RepairContextReceipt> {
+    let compare = outcome.compare_receipt.as_ref()?;
+
+    let breached_metrics = compare
+        .deltas
+        .iter()
+        .filter_map(|(metric, delta)| {
+            if !matches!(delta.status, MetricStatus::Warn | MetricStatus::Fail) {
+                return None;
+            }
+            let budget = compare.budgets.get(metric)?;
+            Some(RepairMetricBreach {
+                metric: metric.as_str().to_string(),
+                status: delta.status.as_str().to_string(),
+                baseline: delta.baseline,
+                current: delta.current,
+                threshold: budget.threshold,
+                warn_threshold: budget.warn_threshold,
+                direction: budget.direction,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let mut recommended_next_commands = vec![
+        format!(
+            "perfgate blame --baseline {} --current {}",
+            compare
+                .baseline_ref
+                .path
+                .clone()
+                .unwrap_or_else(|| "baseline.json".to_string()),
+            compare
+                .current_ref
+                .path
+                .clone()
+                .unwrap_or_else(|| "artifacts/perfgate/run.json".to_string())
+        ),
+        format!(
+            "perfgate paired --name {} --baseline-cmd \"<baseline command>\" --current-cmd \"<current command>\" --repeat 10 --out artifacts/perfgate/paired.json",
+            compare.bench.name
+        ),
+        "perfgate bisect --good <good_sha> --bad HEAD --executable <bench_binary>".to_string(),
+    ];
+    if compare.verdict.status == VerdictStatus::Warn {
+        recommended_next_commands.push(format!(
+            "perfgate check --config perfgate.toml --bench {} --fail-on-warn",
+            compare.bench.name
+        ));
+    }
+    recommended_next_commands = recommended_next_commands
+        .into_iter()
+        .map(|cmd| redact_sensitive_tokens(&cmd))
+        .collect();
+
+    Some(RepairContextReceipt {
+        schema: REPAIR_CONTEXT_SCHEMA_V1.to_string(),
+        benchmark: compare.bench.name.clone(),
+        verdict: compare.verdict.clone(),
+        breached_metrics,
+        artifacts: RepairArtifacts {
+            compare_receipt_path: outcome
+                .compare_path
+                .as_ref()
+                .map(|p| p.display().to_string()),
+            report_path: outcome.report_path.display().to_string(),
+        },
+        profile_path: outcome.report.profile_path.clone(),
+        changed_files: options.changed_files,
+        git: options.git,
+        spans: options.spans,
+        recommended_next_commands,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perfgate_types::{
+        BenchMeta, Budget, CompareReceipt, CompareRef, Delta, Direction, PerfgateReport,
+        ReportSummary, ToolInfo, Verdict, VerdictCounts,
+    };
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn build_repair_context_collects_warn_and_fail_metrics() {
+        let mut budgets = BTreeMap::new();
+        budgets.insert(
+            perfgate_types::Metric::WallMs,
+            Budget {
+                threshold: 0.2,
+                warn_threshold: 0.18,
+                noise_threshold: None,
+                noise_policy: perfgate_types::NoisePolicy::Warn,
+                direction: Direction::Lower,
+            },
+        );
+
+        let mut deltas = BTreeMap::new();
+        deltas.insert(
+            perfgate_types::Metric::WallMs,
+            Delta {
+                baseline: 100.0,
+                current: 130.0,
+                ratio: 1.3,
+                pct: 0.3,
+                regression: 0.3,
+                cv: None,
+                noise_threshold: None,
+                statistic: perfgate_types::MetricStatistic::Median,
+                status: MetricStatus::Fail,
+                significance: None,
+            },
+        );
+
+        let compare = CompareReceipt {
+            schema: perfgate_types::COMPARE_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".into(),
+                version: "1.0.0".into(),
+            },
+            bench: BenchMeta {
+                name: "bench-a".into(),
+                cwd: None,
+                command: vec!["echo".into()],
+                repeat: 1,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            baseline_ref: CompareRef {
+                path: Some("base.json".into()),
+                run_id: None,
+            },
+            current_ref: CompareRef {
+                path: Some("run.json".into()),
+                run_id: None,
+            },
+            budgets,
+            deltas,
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    pass: 0,
+                    warn: 0,
+                    fail: 1,
+                    skip: 0,
+                },
+                reasons: vec!["wall_ms_fail".into()],
+            },
+        };
+
+        let outcome = CheckOutcome {
+            run_receipt: perfgate_types::RunReceipt {
+                schema: perfgate_types::RUN_SCHEMA_V1.to_string(),
+                tool: compare.tool.clone(),
+                run: perfgate_types::RunMeta {
+                    id: "id".into(),
+                    started_at: "s".into(),
+                    ended_at: "e".into(),
+                    host: perfgate_types::HostInfo {
+                        os: "linux".into(),
+                        arch: "x86_64".into(),
+                        cpu_count: None,
+                        memory_bytes: None,
+                        hostname_hash: None,
+                    },
+                },
+                bench: compare.bench.clone(),
+                samples: vec![],
+                stats: perfgate_types::Stats {
+                    wall_ms: perfgate_types::U64Summary::new(100, 100, 100),
+                    cpu_ms: None,
+                    page_faults: None,
+                    ctx_switches: None,
+                    max_rss_kb: None,
+                    io_read_bytes: None,
+                    io_write_bytes: None,
+                    network_packets: None,
+                    energy_uj: None,
+                    binary_bytes: None,
+                    throughput_per_s: None,
+                },
+            },
+            run_path: PathBuf::from("artifacts/perfgate/run.json"),
+            compare_receipt: Some(compare),
+            compare_path: Some(PathBuf::from("artifacts/perfgate/compare.json")),
+            report: PerfgateReport {
+                report_type: perfgate_types::REPORT_SCHEMA_V1.to_string(),
+                verdict: Verdict {
+                    status: VerdictStatus::Fail,
+                    counts: VerdictCounts {
+                        pass: 0,
+                        warn: 0,
+                        fail: 1,
+                        skip: 0,
+                    },
+                    reasons: vec![],
+                },
+                compare: None,
+                findings: vec![],
+                summary: ReportSummary {
+                    pass_count: 0,
+                    warn_count: 0,
+                    fail_count: 1,
+                    skip_count: 0,
+                    total_count: 1,
+                },
+                profile_path: Some("profiles/bench.svg".into()),
+            },
+            report_path: PathBuf::from("artifacts/perfgate/report.json"),
+            markdown: String::new(),
+            markdown_path: PathBuf::from("artifacts/perfgate/comment.md"),
+            warnings: vec![],
+            failed: true,
+            exit_code: 2,
+            suggest_paired: false,
+        };
+
+        let ctx = build_repair_context(&outcome, RepairContextOptions::default())
+            .expect("repair context should exist");
+        assert_eq!(ctx.schema, REPAIR_CONTEXT_SCHEMA_V1);
+        assert_eq!(ctx.breached_metrics.len(), 1);
+        assert_eq!(ctx.profile_path.as_deref(), Some("profiles/bench.svg"));
+    }
+}

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -16,9 +16,9 @@ use perfgate_app::{
     BlameRequest, BlameUseCase, CheckOutcome, CheckRequest, CheckUseCase, Clock, CompareRequest,
     CompareUseCase, DiffRequest, DiffUseCase, ExplainRequest, ExplainUseCase, ExportFormat,
     ExportUseCase, PairedRunRequest, PairedRunUseCase, PromoteRequest, PromoteUseCase,
-    ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase, SensorReportBuilder,
-    SystemClock, classify_error, github_annotations, render_json_diff, render_markdown,
-    render_markdown_template, render_terminal_diff,
+    RepairContextOptions, ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase,
+    SensorReportBuilder, SystemClock, build_repair_context, classify_error, github_annotations,
+    render_json_diff, render_markdown, render_markdown_template, render_terminal_diff,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::{
@@ -36,8 +36,10 @@ use perfgate_scaling::{
 };
 use perfgate_summary::{SummaryRequest, SummaryUseCase};
 use perfgate_types::{
-    BASELINE_REASON_NO_BASELINE, BaselineServerConfig, CompareReceipt, CompareRef, ConfigFile,
-    HostMismatchPolicy, PerfgateReport, RunReceipt, SensorVerdictStatus, ToolInfo, VerdictStatus,
+    BASELINE_REASON_NO_BASELINE, BaselineServerConfig, ChangedFilesSummary, CompareReceipt,
+    CompareRef, ConfigFile, GitContext, HostMismatchPolicy, PerfgateReport,
+    REPAIR_CONTEXT_SCHEMA_V1, RepairContextReceipt, RunReceipt, SensorVerdictStatus, ToolInfo,
+    VerdictStatus,
 };
 use regex::Regex;
 use std::collections::BTreeMap;
@@ -977,6 +979,10 @@ pub struct CheckArgs {
     /// Requires a profiler: perf (Linux), dtrace (macOS), or cargo-flamegraph.
     #[arg(long, default_value_t = false)]
     pub profile_on_regression: bool,
+
+    /// Emit a machine-readable repair artifact at `repair_context.json`.
+    #[arg(long, default_value_t = false)]
+    pub emit_repair_context: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1858,6 +1864,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 output_github,
                 local_db,
                 profile_on_regression,
+                emit_repair_context,
             } = *args;
 
             let req = CheckConfig {
@@ -1882,6 +1889,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 md_template,
                 output_github,
                 profile_on_regression,
+                emit_repair_context,
                 server_flags,
                 local_db,
             };
@@ -3585,6 +3593,7 @@ struct CheckConfig {
     md_template: Option<PathBuf>,
     output_github: bool,
     profile_on_regression: bool,
+    emit_repair_context: bool,
     server_flags: ServerFlags,
     local_db: bool,
 }
@@ -3698,7 +3707,7 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
     )?;
     let bench_count = bench_names.len() as u32;
 
-    let markdown_template_path = req.md_template.or_else(|| {
+    let markdown_template_path = req.md_template.clone().or_else(|| {
         config_file
             .defaults
             .markdown_template
@@ -3775,8 +3784,22 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
             eprintln!("warning: local-db upload failed: {:#}", e);
         }
 
+        let verdict = outcome.compare_receipt.as_ref().map(|c| c.verdict.status);
+        let repair_context = if should_emit_repair_context(&req, &config_file, verdict) {
+            build_repair_context(
+                &outcome,
+                RepairContextOptions {
+                    changed_files: collect_changed_files_summary(),
+                    git: collect_git_context(),
+                    spans: None,
+                },
+            )
+        } else {
+            None
+        };
+
         // Write artifacts
-        write_check_artifacts(&outcome, req.pretty)
+        write_check_artifacts(&outcome, repair_context.as_ref(), req.pretty)
             .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
 
         // Profile on regression if requested
@@ -3804,6 +3827,13 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
             } else {
                 all_warnings.push(msg);
             }
+        }
+        if repair_context.is_some() {
+            let mut markdown = fs::read_to_string(&outcome.markdown_path).unwrap_or_default();
+            markdown.push_str("\n\n### Repair Context\n\n");
+            markdown.push_str("- `artifacts/perfgate/repair_context.json`\n");
+            atomic_write(&outcome.markdown_path, markdown.as_bytes())
+                .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
         }
         for warning in &outcome.warnings {
             if req.all {
@@ -4027,8 +4057,25 @@ fn run_check_cockpit_inner(
                 eprintln!("warning: local-db upload failed: {:#}", e);
             }
 
+            let verdict = check_outcome
+                .compare_receipt
+                .as_ref()
+                .map(|c| c.verdict.status);
+            let repair_context = if should_emit_repair_context(req, &config_file, verdict) {
+                build_repair_context(
+                    &check_outcome,
+                    RepairContextOptions {
+                        changed_files: collect_changed_files_summary(),
+                        git: collect_git_context(),
+                        spans: None,
+                    },
+                )
+            } else {
+                None
+            };
+
             // Write native artifacts to extras/
-            write_check_artifacts(&check_outcome, req.pretty)
+            write_check_artifacts(&check_outcome, repair_context.as_ref(), req.pretty)
                 .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
 
             // Profile on regression if requested
@@ -4059,6 +4106,15 @@ fn run_check_cockpit_inner(
                 );
                 check_outcome.markdown.clone()
             };
+
+            if repair_context.is_some() {
+                let mut markdown =
+                    fs::read_to_string(&check_outcome.markdown_path).unwrap_or_default();
+                markdown.push_str("\n\n### Repair Context\n\n");
+                markdown.push_str("- `artifacts/perfgate/repair_context.json`\n");
+                atomic_write(&check_outcome.markdown_path, markdown.as_bytes())
+                    .map_err(|e| PerfgateError::Io(IoError::ArtifactWrite(e.to_string())))?;
+            }
 
             // Rename extras files to versioned names
             rename_extras_to_versioned(&extras_dir)
@@ -4147,6 +4203,98 @@ fn run_check_cockpit_inner(
 
     // Cockpit mode: always exit 0 if we got here
     Ok(())
+}
+
+fn should_emit_repair_context(
+    req: &CheckConfig,
+    config_file: &ConfigFile,
+    verdict: Option<VerdictStatus>,
+) -> bool {
+    if req.emit_repair_context {
+        return true;
+    }
+
+    let diagnostics = &config_file.diagnostics;
+    if diagnostics.emit_repair_context != Some(true) {
+        return false;
+    }
+
+    match verdict {
+        Some(VerdictStatus::Fail) => true,
+        Some(VerdictStatus::Warn) => diagnostics.emit_repair_context_on_warn.unwrap_or(true),
+        _ => false,
+    }
+}
+
+fn collect_git_context() -> Option<GitContext> {
+    fn run_git(args: &[&str]) -> Option<String> {
+        let output = std::process::Command::new("git").args(args).output().ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let text = String::from_utf8(output.stdout).ok()?;
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    let branch = run_git(&["rev-parse", "--abbrev-ref", "HEAD"]);
+    let sha = run_git(&["rev-parse", "HEAD"]);
+    let reference = run_git(&["describe", "--always", "--dirty"]);
+
+    if branch.is_none() && sha.is_none() && reference.is_none() {
+        None
+    } else {
+        Some(GitContext {
+            branch,
+            sha,
+            reference,
+        })
+    }
+}
+
+fn collect_changed_files_summary() -> Option<ChangedFilesSummary> {
+    fn git_lines(args: &[&str]) -> Vec<String> {
+        let output = match std::process::Command::new("git").args(args).output() {
+            Ok(o) if o.status.success() => o,
+            _ => return Vec::new(),
+        };
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    let mut files = git_lines(&["diff", "--name-only", "HEAD"]);
+    files.extend(git_lines(&["ls-files", "--others", "--exclude-standard"]));
+    files.sort();
+    files.dedup();
+
+    if files.is_empty() {
+        return None;
+    }
+
+    let mut count_by_root: BTreeMap<String, u32> = BTreeMap::new();
+    for file in &files {
+        let root = file
+            .split('/')
+            .next()
+            .filter(|seg| !seg.is_empty())
+            .unwrap_or(".")
+            .to_string();
+        *count_by_root.entry(root).or_default() += 1;
+    }
+
+    Some(ChangedFilesSummary {
+        total_files: files.len() as u32,
+        files,
+        count_by_root,
+    })
 }
 
 fn update_max_exit_code(max_exit_code: &mut i32, outcome_exit_code: i32) {
@@ -4547,7 +4695,11 @@ fn run_watch_iteration(ctx: &WatchIterationCtx<'_>, state: &mut WatchState) {
 }
 
 /// Write all artifacts from a check outcome.
-fn write_check_artifacts(outcome: &CheckOutcome, pretty: bool) -> anyhow::Result<()> {
+fn write_check_artifacts(
+    outcome: &CheckOutcome,
+    repair_context: Option<&RepairContextReceipt>,
+    pretty: bool,
+) -> anyhow::Result<()> {
     // Write run receipt
     write_json(&outcome.run_path, &outcome.run_receipt, pretty)?;
 
@@ -4567,6 +4719,17 @@ fn write_check_artifacts(outcome: &CheckOutcome, pretty: bool) -> anyhow::Result
     // Write markdown
     fs::write(&outcome.markdown_path, &outcome.markdown)
         .with_context(|| format!("write {}", outcome.markdown_path.display()))?;
+
+    let parent = outcome.run_path.parent().unwrap_or_else(|| Path::new(""));
+    let repair_path = parent.join("repair_context.json");
+    if let Some(ctx) = repair_context {
+        if ctx.schema != REPAIR_CONTEXT_SCHEMA_V1 {
+            anyhow::bail!("unexpected repair context schema: {}", ctx.schema);
+        }
+        write_json(&repair_path, ctx, pretty)?;
+    } else {
+        remove_stale_file(&repair_path)?;
+    }
 
     Ok(())
 }
@@ -5243,7 +5406,7 @@ mod tests {
             suggest_paired: false,
         };
 
-        write_check_artifacts(&outcome, false).unwrap();
+        write_check_artifacts(&outcome, None, false).unwrap();
 
         assert!(!stale_compare.exists());
         assert!(run_path.exists());
@@ -5303,7 +5466,7 @@ mod tests {
             suggest_paired: false,
         };
 
-        write_check_artifacts(&outcome, false).unwrap();
+        write_check_artifacts(&outcome, None, false).unwrap();
 
         assert!(run_path.exists());
         assert!(report_path.exists());

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -24,6 +24,7 @@
 
 mod defaults_config;
 mod paired;
+mod repair_context;
 
 pub use paired::{
     NoiseDiagnostics, NoiseLevel, PAIRED_SCHEMA_V1, PairedBenchMeta, PairedDiffSummary,
@@ -31,6 +32,7 @@ pub use paired::{
 };
 
 pub use defaults_config::*;
+pub use repair_context::*;
 
 pub use perfgate_validation::{
     BENCH_NAME_MAX_LEN, BENCH_NAME_PATTERN, ValidationError as BenchNameValidationError,
@@ -48,6 +50,7 @@ pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
+pub const REPAIR_CONTEXT_SCHEMA_V1: &str = "perfgate.repair_context.v1";
 
 // Stable contract identifiers and tokens.
 pub const CHECK_ID_BUDGET: &str = "perf.budget";
@@ -1150,6 +1153,10 @@ pub struct ConfigFile {
     #[serde(default)]
     pub defaults: DefaultsConfig,
 
+    /// Optional diagnostics configuration for additional machine-readable artifacts.
+    #[serde(default)]
+    pub diagnostics: DiagnosticsConfig,
+
     /// Optional baseline server configuration for centralized baseline management.
     #[serde(default)]
     pub baseline_server: BaselineServerConfig,
@@ -1539,6 +1546,7 @@ mod tests {
     fn config_file_validate_catches_bad_bench_name() {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![BenchConfigFile {
                 name: "bad|name".to_string(),
@@ -1628,6 +1636,7 @@ mod tests {
     fn config_file_validate_passes_good_bench_names() {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
@@ -2026,6 +2035,7 @@ mod tests {
                 baseline_pattern: Some("baselines/{bench}.json".into()),
                 markdown_template: None,
             },
+            diagnostics: DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".into(),
@@ -2063,6 +2073,7 @@ mod tests {
     fn config_file_serde_roundtrip_edge_empty() {
         let config = ConfigFile {
             defaults: DefaultsConfig::default(),
+            diagnostics: DiagnosticsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![],
         };
@@ -3035,6 +3046,7 @@ mod property_tests {
         )
             .prop_map(|(defaults, baseline_server, benches)| ConfigFile {
                 defaults,
+                diagnostics: DiagnosticsConfig::default(),
                 baseline_server,
                 benches,
             })

--- a/crates/perfgate-types/src/repair_context.rs
+++ b/crates/perfgate-types/src/repair_context.rs
@@ -1,0 +1,123 @@
+use crate::{Direction, Verdict};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct DiagnosticsConfig {
+    /// Emit `repair_context.json` artifacts for non-pass verdicts.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub emit_repair_context: Option<bool>,
+
+    /// Emit `repair_context.json` for warn verdicts when diagnostics are enabled.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub emit_repair_context_on_warn: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairContextReceipt {
+    pub schema: String,
+    pub benchmark: String,
+    pub verdict: Verdict,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub breached_metrics: Vec<RepairMetricBreach>,
+    pub artifacts: RepairArtifacts,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub profile_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub changed_files: Option<ChangedFilesSummary>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub git: Option<GitContext>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub spans: Option<SpanIdentifiers>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recommended_next_commands: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairArtifacts {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub compare_receipt_path: Option<String>,
+    pub report_path: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RepairMetricBreach {
+    pub metric: String,
+    pub status: String,
+    pub baseline: f64,
+    pub current: f64,
+    pub threshold: f64,
+    pub warn_threshold: f64,
+    pub direction: Direction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ChangedFilesSummary {
+    pub total_files: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub count_by_root: BTreeMap<String, u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct GitContext {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reference: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct SpanIdentifiers {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub span_id: Option<String>,
+}
+
+/// Redacts likely secrets from diagnostic command strings.
+pub fn redact_sensitive_tokens(input: &str) -> String {
+    const NEEDLES: [&str; 4] = ["token", "secret", "password", "apikey"];
+    input
+        .split_whitespace()
+        .map(|segment| {
+            if let Some((k, _)) = segment.split_once('=') {
+                if NEEDLES
+                    .iter()
+                    .any(|needle| k.to_ascii_lowercase().contains(needle))
+                {
+                    return format!("{}=<redacted>", k);
+                }
+            }
+            segment.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_sensitive_tokens_masks_common_secret_keys() {
+        let cmd = "perfgate check API_TOKEN=abc PASSWORD=xyz SAFE=value";
+        let redacted = redact_sensitive_tokens(cmd);
+        assert!(redacted.contains("API_TOKEN=<redacted>"));
+        assert!(redacted.contains("PASSWORD=<redacted>"));
+        assert!(redacted.contains("SAFE=value"));
+        assert!(!redacted.contains("abc"));
+        assert!(!redacted.contains("xyz"));
+    }
+}

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -21,6 +21,11 @@
     "defaults": {
       "$ref": "#/$defs/DefaultsConfig",
       "default": {}
+    },
+    "diagnostics": {
+      "description": "Optional diagnostics configuration for additional machine-readable artifacts.",
+      "$ref": "#/$defs/DiagnosticsConfig",
+      "default": {}
     }
   },
   "$defs": {
@@ -308,6 +313,25 @@
             "null"
           ],
           "format": "double"
+        }
+      }
+    },
+    "DiagnosticsConfig": {
+      "type": "object",
+      "properties": {
+        "emit_repair_context": {
+          "description": "Emit `repair_context.json` artifacts for non-pass verdicts.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "emit_repair_context_on_warn": {
+          "description": "Emit `repair_context.json` for warn verdicts when diagnostics are enabled.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       }
     },

--- a/schemas/perfgate.repair_context.v1.schema.json
+++ b/schemas/perfgate.repair_context.v1.schema.json
@@ -1,0 +1,268 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RepairContextReceipt",
+  "type": "object",
+  "properties": {
+    "artifacts": {
+      "$ref": "#/$defs/RepairArtifacts"
+    },
+    "benchmark": {
+      "type": "string"
+    },
+    "breached_metrics": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/RepairMetricBreach"
+      }
+    },
+    "changed_files": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ChangedFilesSummary"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "git": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GitContext"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "profile_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "recommended_next_commands": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "schema": {
+      "type": "string"
+    },
+    "spans": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SpanIdentifiers"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "verdict": {
+      "$ref": "#/$defs/Verdict"
+    }
+  },
+  "required": [
+    "schema",
+    "benchmark",
+    "verdict",
+    "artifacts"
+  ],
+  "$defs": {
+    "ChangedFilesSummary": {
+      "type": "object",
+      "properties": {
+        "count_by_root": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "total_files": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "total_files"
+      ]
+    },
+    "Direction": {
+      "type": "string",
+      "enum": [
+        "lower",
+        "higher"
+      ]
+    },
+    "GitContext": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reference": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "RepairArtifacts": {
+      "type": "object",
+      "properties": {
+        "compare_receipt_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "report_path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "report_path"
+      ]
+    },
+    "RepairMetricBreach": {
+      "type": "object",
+      "properties": {
+        "baseline": {
+          "type": "number",
+          "format": "double"
+        },
+        "current": {
+          "type": "number",
+          "format": "double"
+        },
+        "direction": {
+          "$ref": "#/$defs/Direction"
+        },
+        "metric": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "threshold": {
+          "type": "number",
+          "format": "double"
+        },
+        "warn_threshold": {
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "metric",
+        "status",
+        "baseline",
+        "current",
+        "threshold",
+        "warn_threshold",
+        "direction"
+      ]
+    },
+    "SpanIdentifiers": {
+      "type": "object",
+      "properties": {
+        "span_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "trace_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Verdict": {
+      "description": "Overall verdict for a comparison, with pass/warn/fail counts.\n\n# Examples\n\n```\nuse perfgate_types::{Verdict, VerdictStatus, VerdictCounts};\n\nlet verdict = Verdict {\n    status: VerdictStatus::Pass,\n    counts: VerdictCounts { pass: 2, warn: 0, fail: 0, skip: 0 },\n    reasons: vec![],\n};\nassert_eq!(verdict.status, VerdictStatus::Pass);\n\nlet failing = Verdict {\n    status: VerdictStatus::Fail,\n    counts: VerdictCounts { pass: 1, warn: 0, fail: 1, skip: 0 },\n    reasons: vec![\"wall_ms.fail\".into()],\n};\nassert_eq!(failing.status, VerdictStatus::Fail);\nassert!(!failing.reasons.is_empty());\n```",
+      "type": "object",
+      "properties": {
+        "counts": {
+          "$ref": "#/$defs/VerdictCounts"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/VerdictStatus"
+        }
+      },
+      "required": [
+        "status",
+        "counts",
+        "reasons"
+      ]
+    },
+    "VerdictCounts": {
+      "type": "object",
+      "properties": {
+        "fail": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "pass": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "skip": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "warn": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "VerdictStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    }
+  }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,11 +7,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-const SCHEMA_FILES: [&str; 5] = [
+const SCHEMA_FILES: [&str; 6] = [
     "perfgate.run.v1.schema.json",
     "perfgate.compare.v1.schema.json",
     "perfgate.config.v1.schema.json",
     "perfgate.report.v1.schema.json",
+    "perfgate.repair_context.v1.schema.json",
     "sensor.report.v1.schema.json",
 ];
 
@@ -720,9 +721,15 @@ fn cmd_schema(out_dir: &PathBuf) -> anyhow::Result<()> {
         schema_for!(perfgate_types::PerfgateReport),
     )?;
 
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[4],
+        schema_for!(perfgate_types::RepairContextReceipt),
+    )?;
+
     // Sensor report schema is vendored from contracts/, not generated.
     let vendored_schema = PathBuf::from("contracts/schemas/sensor.report.v1.schema.json");
-    let dest = out_dir.join(SCHEMA_FILES[4]);
+    let dest = out_dir.join(SCHEMA_FILES[5]);
     fs::copy(&vendored_schema, &dest).with_context(|| {
         format!(
             "copy vendored schema {} -> {}",


### PR DESCRIPTION
### Motivation

- Provide a small, structured, machine-readable failure package to aid triage automation when a budget violation or warn/fail verdict occurs. 
- Allow config-driven diagnostics and a CLI flag to emit the artifact as a stable artifact (`artifacts/perfgate/repair_context.json`) rather than ad-hoc logs. 
- Keep emitted context redactable and privacy-friendly by excluding environment secrets and offering a redaction helper for common token patterns.

### Description

- Introduce a new stable schema `perfgate.repair_context.v1` and types in `crates/perfgate-types/src/repair_context.rs` including `RepairContextReceipt`, `RepairMetricBreach`, `RepairArtifacts`, `GitContext`, `ChangedFilesSummary`, `SpanIdentifiers`, and `DiagnosticsConfig`. 
- Add `DiagnosticsConfig` to `ConfigFile` so `[diagnostics]` can control emission and warn-behavior, and add the `REPAIR_CONTEXT_SCHEMA_V1` constant. 
- Implement `perfgate-app::build_repair_context` in `crates/perfgate-app/src/repair_context.rs` to assemble the repair context from a `CheckOutcome` and optional git/changed-file/span inputs, and re-export the builder from `perfgate-app`. 
- Wire CLI plumbing in `crates/perfgate-cli/src/main.rs`: new `--emit-repair-context` flag, `should_emit_repair_context` config/flag logic, helpers `collect_git_context` and `collect_changed_files_summary`, append a markdown link when emitted, and update `write_check_artifacts` to write/remove `repair_context.json` next to other artifacts. 
- Add `redact_sensitive_tokens` helper with unit test to mask common secret-like key/value tokens in recommended commands. 
- Update `xtask` schema generation to emit `perfgate.repair_context.v1.schema.json` and commit the generated schema under `schemas/`.

### Testing

- Ran `cargo check -p perfgate-types -p perfgate-app -p perfgate-cli -p xtask` and compilation succeeded. 
- Ran `cargo run -p xtask -- schema` to generate JSON schemas and the new `perfgate.repair_context.v1` schema was produced and committed. 
- Unit tests executed: `cargo test -p perfgate-types redact_sensitive_tokens_masks_common_secret_keys` passed, `cargo test -p perfgate-app build_repair_context_collects_warn_and_fail_metrics` passed, and `cargo test -p perfgate-cli write_check_artifacts_removes_stale_compare_when_missing_baseline` and `cargo test -p perfgate-cli write_check_artifacts_skips_compare_when_path_missing` both passed. 
- Ran `cargo fmt --all` successfully as part of validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5797bb08333b60bd0835c797f6e)