### PR TITLE
Add explicit tradeoff rules for composite budget downgrades

### DIFF
--- a/crates/perfgate-app/src/baseline_resolve.rs
+++ b/crates/perfgate-app/src/baseline_resolve.rs
@@ -61,6 +61,7 @@ mod tests {
             },
             baseline_server: BaselineServerConfig::default(),
             benches: Vec::new(),
+            tradeoffs: Vec::new(),
         };
 
         let cli = Some(PathBuf::from("cli.json"));

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -199,6 +199,7 @@ impl<R: ProcessRunner + Clone, H: HostProbe + Clone, C: Clock + Clone> CheckUseC
                         )
                     })
                     .transpose()?,
+                tradeoff_rules: req.config.tradeoffs.clone(),
                 baseline_ref: CompareRef {
                     path: req.baseline_path.as_ref().map(|p| p.display().to_string()),
                     run_id: Some(baseline.run.id.clone()),
@@ -995,6 +996,7 @@ mod tests {
             },
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench.clone()],
+            tradeoffs: vec![],
         };
 
         let req = CheckRequest {
@@ -1125,6 +1127,7 @@ mod tests {
             },
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench.clone()],
+            tradeoffs: vec![],
         };
 
         let baseline = make_baseline_receipt(
@@ -1202,6 +1205,7 @@ mod tests {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
+            tradeoffs: vec![],
         };
 
         let runner = TestRunner::new(vec![run_result(100, 0, false)]);
@@ -1256,6 +1260,7 @@ mod tests {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
+            tradeoffs: vec![],
         };
 
         let baseline = make_baseline_receipt(
@@ -1327,6 +1332,7 @@ mod tests {
             },
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
+            tradeoffs: vec![],
         };
 
         let baseline = make_baseline_receipt(
@@ -1384,6 +1390,7 @@ mod tests {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
+            tradeoffs: vec![],
         };
 
         let runner = TestRunner::new(vec![run_result(100, 0, false)]);
@@ -1414,6 +1421,7 @@ mod tests {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![],
+            tradeoffs: vec![],
         };
 
         let runner = TestRunner::new(vec![]);
@@ -1466,6 +1474,7 @@ mod tests {
             },
             baseline_server: BaselineServerConfig::default(),
             benches: vec![bench],
+            tradeoffs: vec![],
         };
 
         let baseline = make_baseline_receipt(

--- a/crates/perfgate-app/src/diff.rs
+++ b/crates/perfgate-app/src/diff.rs
@@ -282,6 +282,7 @@ impl<R: ProcessRunner + Clone, H: HostProbe + Clone, C: Clock + Clone> DiffUseCa
                 budgets,
                 metric_statistics,
                 significance: None,
+                tradeoff_rules: config.tradeoffs.clone(),
                 baseline_ref: CompareRef {
                     path: Some(baseline_path.display().to_string()),
                     run_id: Some(baseline.run.id.clone()),

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -60,11 +60,12 @@ pub use perfgate_export::{CompareExportRow, ExportFormat, ExportUseCase, RunExpo
 
 use perfgate_adapters::{CommandSpec, HostProbe, HostProbeOptions, ProcessRunner, RunResult};
 use perfgate_domain::{
-    Comparison, SignificancePolicy, compare_runs, compute_stats, detect_host_mismatch,
+    Comparison, SignificancePolicy, compare_runs_with_tradeoffs, compute_stats,
+    detect_host_mismatch,
 };
 use perfgate_types::{
     BenchMeta, Budget, CompareReceipt, CompareRef, HostMismatchInfo, HostMismatchPolicy, Metric,
-    MetricStatistic, RunMeta, RunReceipt, Sample, ToolInfo,
+    MetricStatistic, RunMeta, RunReceipt, Sample, ToolInfo, TradeoffRule,
 };
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -259,6 +260,7 @@ pub struct CompareRequest {
     pub budgets: BTreeMap<Metric, Budget>,
     pub metric_statistics: BTreeMap<Metric, MetricStatistic>,
     pub significance: Option<SignificancePolicy>,
+    pub tradeoff_rules: Vec<TradeoffRule>,
     pub baseline_ref: CompareRef,
     pub current_ref: CompareRef,
     pub tool: ToolInfo,
@@ -296,12 +298,13 @@ impl CompareUseCase {
             );
         }
 
-        let Comparison { deltas, verdict } = compare_runs(
+        let Comparison { deltas, verdict } = compare_runs_with_tradeoffs(
             &req.baseline,
             &req.current,
             &req.budgets,
             &req.metric_statistics,
             req.significance,
+            &req.tradeoff_rules,
         )?;
 
         let receipt = CompareReceipt {
@@ -677,6 +680,7 @@ mod tests {
             budgets: budgets.clone(),
             metric_statistics: BTreeMap::new(),
             significance: None,
+            tradeoff_rules: Vec::new(),
             baseline_ref: CompareRef {
                 path: None,
                 run_id: None,
@@ -700,6 +704,7 @@ mod tests {
             budgets: budgets.clone(),
             metric_statistics: BTreeMap::new(),
             significance: None,
+            tradeoff_rules: Vec::new(),
             baseline_ref: CompareRef {
                 path: None,
                 run_id: None,
@@ -723,6 +728,7 @@ mod tests {
             budgets,
             metric_statistics: BTreeMap::new(),
             significance: None,
+            tradeoff_rules: Vec::new(),
             baseline_ref: CompareRef {
                 path: None,
                 run_id: None,

--- a/crates/perfgate-budget/src/lib.rs
+++ b/crates/perfgate-budget/src/lib.rs
@@ -355,6 +355,11 @@ pub fn reason_token(metric: Metric, status: MetricStatus) -> String {
     format!("{}_{}", metric.as_str(), status.as_str())
 }
 
+/// Generates a reason token when a tradeoff rule is applied.
+pub fn tradeoff_applied_reason_token(rule_name: &str) -> String {
+    format!("tradeoff_{}_applied", rule_name)
+}
+
 /// Evaluates multiple metrics against their budgets.
 ///
 /// This function combines individual budget evaluations and aggregates

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1648,6 +1648,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 budgets,
                 metric_statistics,
                 significance,
+                tradeoff_rules: config_file.tradeoffs.clone(),
                 baseline_ref,
                 current_ref: CompareRef {
                     path: Some(current.display().to_string()),
@@ -2475,6 +2476,7 @@ fn execute_cargo_bench(args: CargoBenchArgs) -> anyhow::Result<()> {
             budgets,
             metric_statistics,
             significance: None,
+            tradeoff_rules: Vec::new(),
             baseline_ref: CompareRef {
                 path: Some(baseline_path.to_string_lossy().to_string()),
                 run_id: None,

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -18,7 +18,7 @@ pub use perfgate_host_detect::detect_host_mismatch;
 
 pub use perfgate_budget::{
     BudgetError, BudgetResult, aggregate_verdict, calculate_regression, determine_status,
-    evaluate_budget, evaluate_budgets, reason_token,
+    evaluate_budget, evaluate_budgets, reason_token, tradeoff_applied_reason_token,
 };
 
 pub use perfgate_significance::{compute_significance, mean_and_variance};
@@ -30,8 +30,8 @@ pub use perfgate_stats::{median_f64_sorted, median_u64_sorted, summarize_f64, su
 
 use perfgate_types::{
     Budget, CHECK_ID_BUDGET, CompareReceipt, Delta, FINDING_CODE_METRIC_FAIL,
-    FINDING_CODE_METRIC_WARN, Metric, MetricStatistic, MetricStatus, RunReceipt, Stats, Verdict,
-    VerdictCounts, VerdictStatus,
+    FINDING_CODE_METRIC_WARN, Metric, MetricStatistic, MetricStatus, RunReceipt, Stats,
+    TradeoffRule, Verdict, VerdictCounts, VerdictStatus,
 };
 use std::collections::BTreeMap;
 
@@ -421,6 +421,16 @@ pub fn compare_stats(
     current: &Stats,
     budgets: &BTreeMap<Metric, Budget>,
 ) -> Result<Comparison, DomainError> {
+    compare_stats_with_tradeoffs(baseline, current, budgets, &[])
+}
+
+/// Compare stats under the provided budgets and optional tradeoff rules.
+pub fn compare_stats_with_tradeoffs(
+    baseline: &Stats,
+    current: &Stats,
+    budgets: &BTreeMap<Metric, Budget>,
+    tradeoff_rules: &[TradeoffRule],
+) -> Result<Comparison, DomainError> {
     let mut deltas: BTreeMap<Metric, Delta> = BTreeMap::new();
     let mut reasons: Vec<String> = Vec::new();
 
@@ -496,6 +506,7 @@ pub fn compare_stats(
         );
     }
 
+    apply_tradeoff_rules(&mut deltas, &mut counts, &mut reasons, tradeoff_rules);
     let verdict = aggregate_verdict_from_counts(counts, reasons);
 
     Ok(Comparison { deltas, verdict })
@@ -512,6 +523,25 @@ pub fn compare_runs(
     budgets: &BTreeMap<Metric, Budget>,
     metric_statistics: &BTreeMap<Metric, MetricStatistic>,
     significance_policy: Option<SignificancePolicy>,
+) -> Result<Comparison, DomainError> {
+    compare_runs_with_tradeoffs(
+        baseline,
+        current,
+        budgets,
+        metric_statistics,
+        significance_policy,
+        &[],
+    )
+}
+
+/// Compare full run receipts under budgets and optional tradeoff rules.
+pub fn compare_runs_with_tradeoffs(
+    baseline: &RunReceipt,
+    current: &RunReceipt,
+    budgets: &BTreeMap<Metric, Budget>,
+    metric_statistics: &BTreeMap<Metric, MetricStatistic>,
+    significance_policy: Option<SignificancePolicy>,
+    tradeoff_rules: &[TradeoffRule],
 ) -> Result<Comparison, DomainError> {
     let mut deltas: BTreeMap<Metric, Delta> = BTreeMap::new();
     let mut reasons: Vec<String> = Vec::new();
@@ -619,9 +649,69 @@ pub fn compare_runs(
         );
     }
 
+    apply_tradeoff_rules(&mut deltas, &mut counts, &mut reasons, tradeoff_rules);
     let verdict = aggregate_verdict_from_counts(counts, reasons);
 
     Ok(Comparison { deltas, verdict })
+}
+
+fn apply_tradeoff_rules(
+    deltas: &mut BTreeMap<Metric, Delta>,
+    counts: &mut VerdictCounts,
+    reasons: &mut Vec<String>,
+    tradeoff_rules: &[TradeoffRule],
+) {
+    for rule in tradeoff_rules {
+        let Some(if_failed_delta) = deltas.get(&rule.if_failed) else {
+            continue;
+        };
+        if if_failed_delta.status != MetricStatus::Fail {
+            continue;
+        }
+
+        let mut all_requirements_satisfied = true;
+        for requirement in &rule.require {
+            let Some(required_delta) = deltas.get(&requirement.metric) else {
+                reasons.push("tradeoff_missing_required_metric".to_string());
+                all_requirements_satisfied = false;
+                break;
+            };
+
+            let improvement_ratio = match requirement.metric.default_direction() {
+                perfgate_types::Direction::Higher => {
+                    required_delta.current / required_delta.baseline
+                }
+                perfgate_types::Direction::Lower => {
+                    required_delta.baseline / required_delta.current
+                }
+            };
+
+            if !improvement_ratio.is_finite()
+                || improvement_ratio < requirement.min_improvement_ratio
+            {
+                all_requirements_satisfied = false;
+                reasons.push("tradeoff_rule_not_satisfied".to_string());
+                break;
+            }
+        }
+
+        if !all_requirements_satisfied {
+            continue;
+        }
+
+        let downgrade_to = rule.downgrade_to.to_metric_status();
+        if let Some(delta) = deltas.get_mut(&rule.if_failed) {
+            // counts: fail -> warn/pass
+            counts.fail = counts.fail.saturating_sub(1);
+            match downgrade_to {
+                MetricStatus::Warn => counts.warn += 1,
+                MetricStatus::Pass => counts.pass += 1,
+                _ => {}
+            }
+            delta.status = downgrade_to;
+        }
+        reasons.push(tradeoff_applied_reason_token(&rule.name));
+    }
 }
 
 // ============================================================================
@@ -4483,6 +4573,126 @@ mod tests {
             assert_eq!(metric_to_string(Metric::WallMs), "wall_ms");
             assert_eq!(metric_to_string(Metric::MaxRssKb), "max_rss_kb");
             assert_eq!(metric_to_string(Metric::ThroughputPerS), "throughput_per_s");
+        }
+    }
+
+    mod tradeoff_engine_tests {
+        use super::*;
+        use perfgate_types::{Direction, TradeoffDowngradeTo, TradeoffRequirement, TradeoffRule};
+
+        fn stats(wall_ms: u64, max_rss_kb: u64, throughput_per_s: f64) -> Stats {
+            Stats {
+                wall_ms: U64Summary::new(wall_ms, wall_ms, wall_ms),
+                cpu_ms: None,
+                page_faults: None,
+                ctx_switches: None,
+                max_rss_kb: Some(U64Summary::new(max_rss_kb, max_rss_kb, max_rss_kb)),
+                io_read_bytes: None,
+                io_write_bytes: None,
+                network_packets: None,
+                energy_uj: None,
+                binary_bytes: None,
+                throughput_per_s: Some(F64Summary::new(
+                    throughput_per_s,
+                    throughput_per_s,
+                    throughput_per_s,
+                )),
+            }
+        }
+
+        fn budgets() -> BTreeMap<Metric, Budget> {
+            let mut budgets = BTreeMap::new();
+            budgets.insert(Metric::MaxRssKb, Budget::new(0.20, 0.10, Direction::Lower));
+            budgets.insert(
+                Metric::ThroughputPerS,
+                Budget::new(0.20, 0.10, Direction::Higher),
+            );
+            budgets
+        }
+
+        fn memory_for_speed_rule() -> TradeoffRule {
+            TradeoffRule {
+                name: "memory_for_speed".to_string(),
+                if_failed: Metric::MaxRssKb,
+                require: vec![TradeoffRequirement {
+                    metric: Metric::ThroughputPerS,
+                    min_improvement_ratio: 1.5,
+                }],
+                downgrade_to: TradeoffDowngradeTo::Warn,
+            }
+        }
+
+        #[test]
+        fn tradeoff_downgrades_fail_when_rule_satisfied() {
+            let baseline = stats(100, 1000, 100.0);
+            let current = stats(100, 1300, 170.0);
+            let comparison = compare_stats_with_tradeoffs(
+                &baseline,
+                &current,
+                &budgets(),
+                &[memory_for_speed_rule()],
+            )
+            .expect("compare with tradeoff");
+
+            assert_eq!(
+                comparison.deltas[&Metric::MaxRssKb].status,
+                MetricStatus::Warn
+            );
+            assert!(
+                comparison
+                    .verdict
+                    .reasons
+                    .contains(&"tradeoff_memory_for_speed_applied".to_string())
+            );
+        }
+
+        #[test]
+        fn tradeoff_stays_fail_when_rule_not_satisfied() {
+            let baseline = stats(100, 1000, 100.0);
+            let current = stats(100, 1300, 140.0);
+            let comparison = compare_stats_with_tradeoffs(
+                &baseline,
+                &current,
+                &budgets(),
+                &[memory_for_speed_rule()],
+            )
+            .expect("compare with tradeoff");
+
+            assert_eq!(
+                comparison.deltas[&Metric::MaxRssKb].status,
+                MetricStatus::Fail
+            );
+            assert!(
+                comparison
+                    .verdict
+                    .reasons
+                    .contains(&"tradeoff_rule_not_satisfied".to_string())
+            );
+        }
+
+        #[test]
+        fn tradeoff_missing_metric_emits_reason() {
+            let baseline = stats(100, 1000, 100.0);
+            let current = stats(100, 1300, 170.0);
+            let mut rule = memory_for_speed_rule();
+            rule.require = vec![TradeoffRequirement {
+                metric: Metric::CpuMs,
+                min_improvement_ratio: 1.1,
+            }];
+
+            let comparison = compare_stats_with_tradeoffs(&baseline, &current, &budgets(), &[rule])
+                .expect("compare with tradeoff");
+
+            assert!(
+                comparison
+                    .verdict
+                    .reasons
+                    .contains(&"tradeoff_missing_required_metric".to_string())
+            );
+            assert_eq!(
+                comparison.deltas[&Metric::MaxRssKb].status,
+                MetricStatus::Fail
+            );
         }
     }
 }

--- a/crates/perfgate-render/src/lib.rs
+++ b/crates/perfgate-render/src/lib.rs
@@ -199,6 +199,19 @@ pub fn parse_reason_token(token: &str) -> Option<(Metric, MetricStatus)> {
 
 /// Render a single verdict reason token as a human-readable bullet line.
 pub fn render_reason_line(compare: &CompareReceipt, token: &str) -> String {
+    if let Some(rule_name) = token
+        .strip_prefix("tradeoff_")
+        .and_then(|t| t.strip_suffix("_applied"))
+    {
+        return format!("- {token}: tradeoff rule `{rule_name}` applied\n");
+    }
+    if token == "tradeoff_rule_not_satisfied" {
+        return "- tradeoff_rule_not_satisfied: required improvement not met\n".to_string();
+    }
+    if token == "tradeoff_missing_required_metric" {
+        return "- tradeoff_missing_required_metric: required metric missing\n".to_string();
+    }
+
     let context = parse_reason_token(token).and_then(|(metric, status)| {
         compare
             .deltas
@@ -424,5 +437,22 @@ mod tests {
         assert_eq!(lines.len(), 2);
         assert!(lines.iter().any(|l| l.starts_with("::warning::")));
         assert!(lines.iter().any(|l| l.starts_with("::error::")));
+    }
+
+    #[test]
+    fn render_reason_line_handles_tradeoff_tokens() {
+        let compare = make_compare_receipt(MetricStatus::Warn);
+        assert!(
+            render_reason_line(&compare, "tradeoff_memory_for_speed_applied")
+                .contains("tradeoff rule `memory_for_speed` applied")
+        );
+        assert!(
+            render_reason_line(&compare, "tradeoff_rule_not_satisfied")
+                .contains("required improvement not met")
+        );
+        assert!(
+            render_reason_line(&compare, "tradeoff_missing_required_metric")
+                .contains("required metric missing")
+        );
     }
 }

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1156,6 +1156,11 @@ pub struct ConfigFile {
 
     #[serde(default, rename = "bench")]
     pub benches: Vec<BenchConfigFile>,
+
+    /// Explicit tradeoff rules that can downgrade metric failures when
+    /// required compensating improvements are present.
+    #[serde(default, rename = "tradeoff")]
+    pub tradeoffs: Vec<TradeoffRule>,
 }
 
 impl ConfigFile {
@@ -1332,6 +1337,42 @@ pub struct BudgetOverride {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub statistic: Option<MetricStatistic>,
+}
+
+/// Tradeoff downgrade target when a rule is satisfied.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum TradeoffDowngradeTo {
+    Warn,
+    Pass,
+}
+
+impl TradeoffDowngradeTo {
+    pub fn to_metric_status(self) -> MetricStatus {
+        match self {
+            TradeoffDowngradeTo::Warn => MetricStatus::Warn,
+            TradeoffDowngradeTo::Pass => MetricStatus::Pass,
+        }
+    }
+}
+
+/// A required compensating improvement for a tradeoff rule.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffRequirement {
+    pub metric: Metric,
+    pub min_improvement_ratio: f64,
+}
+
+/// Explicit, typed tradeoff rule for governed budget downgrades.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffRule {
+    pub name: String,
+    pub if_failed: Metric,
+    pub require: Vec<TradeoffRequirement>,
+    pub downgrade_to: TradeoffDowngradeTo,
 }
 
 #[cfg(test)]
@@ -1553,6 +1594,7 @@ mod tests {
 
                 scaling: None,
             }],
+            tradeoffs: vec![],
         };
         assert!(config.validate().is_err());
     }
@@ -1642,6 +1684,7 @@ mod tests {
 
                 scaling: None,
             }],
+            tradeoffs: vec![],
         };
         assert!(config.validate().is_ok());
     }
@@ -2053,6 +2096,7 @@ mod tests {
                 }),
                 scaling: None,
             }],
+            tradeoffs: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let back: ConfigFile = serde_json::from_str(&json).unwrap();
@@ -2065,6 +2109,7 @@ mod tests {
             defaults: DefaultsConfig::default(),
             baseline_server: BaselineServerConfig::default(),
             benches: vec![],
+            tradeoffs: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
         let back: ConfigFile = serde_json::from_str(&json).unwrap();
@@ -3037,6 +3082,7 @@ mod property_tests {
                 defaults,
                 baseline_server,
                 benches,
+                tradeoffs: vec![],
             })
     }
 


### PR DESCRIPTION
### Motivation
- Provide a simple, typed, auditable mechanism to allow governed tradeoffs like “more memory is acceptable if throughput improved enough” without a general-purpose expression language. 
- Avoid punishing desirable architecture changes by enabling explicit opt-in downgrade rules that preserve per-metric budgets as the primary signal.

### Description
- Add typed tradeoff config to `ConfigFile` (`tradeoffs` / `[[tradeoff]]`) and new types `TradeoffRule`, `TradeoffRequirement`, and `TradeoffDowngradeTo` in `perfgate-types` so rules are schema- and review-friendly. 
- Add a helper `tradeoff_applied_reason_token` in `perfgate-budget` and keep existing `reason_token` for consistency. 
- Implement tradeoff evaluation in `perfgate-domain` by adding `compare_stats_with_tradeoffs` / `compare_runs_with_tradeoffs`, introducing `apply_tradeoff_rules` which downgrades matching failed metrics when all typed requirements are satisfied and emits explicit reason tokens (`tradeoff_<name>_applied`, `tradeoff_rule_not_satisfied`, `tradeoff_missing_required_metric`). 
- Wire rules through the app and CLI (`CompareRequest.tradeoff_rules`) so config-defined tradeoffs flow end-to-end, and update `perfgate-render` to render tradeoff reason tokens clearly in markdown notes. 

### Testing
- Ran formatting: `cargo fmt --all` successfully. 
- Ran selected test suites: `cargo test -p perfgate-types -p perfgate-domain -p perfgate-render -p perfgate-app`, and all tests passed including new tradeoff unit tests. 
- Added unit tests covering: satisfied-rule downgrade, unsatisfied-rule remains fail, and missing-required-metric handling, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5831eb88333acac61a016cff322)