### PR TITLE
docs(release): record crates.io publish completion

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,6 @@
 # Release Readiness: v0.15.1
 
-Last verified: 2026-03-28 after publishing `v0.15.1` and merging the release workflow recovery.
+Last verified: 2026-03-28 after publishing `v0.15.1`, publishing crates.io packages, and merging the release workflow and publish-preflight fixes.
 
 ## Patch Scope
 
@@ -16,7 +16,9 @@ This patch release is intentionally narrow:
 - Workspace and internal crate versions are set to `0.15.1` on `main`.
 - The local-mode baseline fix and doc cleanup are merged on `main`.
 - `cargo run -p xtask -- ci` passed locally on 2026-03-28 against `main`.
+- `cargo run -p xtask -- publish-check` passed locally on 2026-03-28 against `main`.
 - GitHub release `v0.15.1` is published with platform binaries and `sha256sums.txt`.
+- Publishable workspace crates are now published to crates.io at `0.15.1`.
 - GitHub Action tags now include the exact release tag `v0.15.1` plus moving aliases `v0.15` and `v0`.
 
 ## Tested and Working
@@ -109,6 +111,6 @@ The **core local gating pipeline** is production-quality:
 
 ## Post-Release Follow-Up
 
-1. **Publish to crates.io** — requires registry credentials, so this remains a manual operator step
-2. **Keep action runtimes current** — first-party actions are on current majors, but future runner/runtime upgrades still need periodic review
-3. **Carry the release workflow repair forward** — future tags should continue using the recovered workflow now merged on `main`
+1. **Keep action runtimes current** — first-party actions are on current majors, but future runner/runtime upgrades still need periodic review
+2. **Carry the release workflow repair forward** — future tags should continue using the recovered workflow now merged on `main`
+3. **Keep crates publish preflight in CI** — `cargo run -p xtask -- publish-check` now guards missing crate readmes and `publish = false` workspace dependencies before release


### PR DESCRIPTION
## Summary
- update release readiness to reflect completed crates.io publication
- record the new xtask publish-check preflight in the release state
- replace the stale post-release crates.io TODO with the ongoing publish-preflight follow-up

## Verification
- crates.io API check confirmed all publishable workspace crates expose 