### PR TITLE
Add matrix/fleet aggregation policies and aggregate receipt model

### DIFF
--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -1,15 +1,23 @@
 use anyhow::Context;
-use perfgate_domain::compute_stats;
-use perfgate_types::{HostInfo, RunMeta, RunReceipt};
+use perfgate_domain::detect_host_mismatch;
+use perfgate_types::{
+    AGGREGATE_SCHEMA_V1, AggregatePolicyConfig, AggregateReceipt, AggregateRunEvidence,
+    AggregateStatus, AggregateVerdict, AggregationPolicy, RunMeta, RunReceipt,
+};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::PathBuf;
 
 pub struct AggregateRequest {
     pub files: Vec<PathBuf>,
+    pub policy: AggregationPolicy,
+    pub quorum: Option<u32>,
+    pub fail_threshold: Option<u32>,
+    pub weights: BTreeMap<String, f64>,
 }
 
 pub struct AggregateOutcome {
-    pub receipt: RunReceipt,
+    pub receipt: AggregateReceipt,
 }
 
 pub struct AggregateUseCase;
@@ -29,7 +37,6 @@ impl AggregateUseCase {
             receipts.push(receipt);
         }
 
-        // Verify all receipts are for the same bench name
         let first_bench_name = &receipts[0].bench.name;
         for r in &receipts {
             if &r.bench.name != first_bench_name {
@@ -41,41 +48,315 @@ impl AggregateUseCase {
             }
         }
 
-        let mut combined_samples = Vec::new();
+        let mut seen_ids = BTreeSet::new();
         for r in &receipts {
-            combined_samples.extend(r.samples.clone());
+            if !seen_ids.insert(r.run.id.clone()) {
+                anyhow::bail!("duplicate run id in aggregation inputs: {}", r.run.id);
+            }
         }
 
-        // We assume work_units is consistent across the receipts.
-        // If they differ, we take the first one.
-        let work_units = receipts[0].bench.work_units;
+        let mut host_mismatch_warnings = Vec::new();
+        let baseline_host = &receipts[0].run.host;
+        for r in receipts.iter().skip(1) {
+            if let Some(mismatch) = detect_host_mismatch(baseline_host, &r.run.host) {
+                for reason in mismatch.reasons {
+                    host_mismatch_warnings.push(format!(
+                        "run {} host mismatch vs {}: {}",
+                        r.run.id, receipts[0].run.id, reason
+                    ));
+                }
+            }
+        }
 
-        let stats = compute_stats(&combined_samples, work_units)?;
+        let runs: Vec<AggregateRunEvidence> = receipts.iter().map(run_evidence).collect();
+        let verdict = compute_verdict(&runs, &req)?;
 
-        // Update bench metadata.
-        let mut bench = receipts[0].bench.clone();
-        bench.repeat = combined_samples.len() as u32;
-
-        let receipt = RunReceipt {
-            schema: perfgate_types::RUN_SCHEMA_V1.to_string(),
+        let receipt = AggregateReceipt {
+            schema: AGGREGATE_SCHEMA_V1.to_string(),
             tool: receipts[0].tool.clone(),
             run: RunMeta {
                 id: uuid::Uuid::new_v4().to_string(),
                 started_at: receipts[0].run.started_at.clone(),
                 ended_at: receipts.last().unwrap().run.ended_at.clone(),
-                host: HostInfo {
-                    os: "fleet".to_string(),
-                    arch: "mixed".to_string(),
-                    cpu_count: None,
-                    memory_bytes: None,
-                    hostname_hash: None,
-                },
+                host: receipts[0].run.host.clone(),
+                runner: None,
             },
-            bench,
-            samples: combined_samples,
-            stats,
+            bench_name: first_bench_name.clone(),
+            policy: AggregatePolicyConfig {
+                policy: req.policy,
+                quorum: req.quorum,
+                fail_threshold: req.fail_threshold,
+                weights: req.weights,
+            },
+            verdict,
+            host_mismatch_warnings,
+            runs,
         };
 
         Ok(AggregateOutcome { receipt })
+    }
+}
+
+fn run_evidence(receipt: &RunReceipt) -> AggregateRunEvidence {
+    let mut reasons = Vec::new();
+    for (idx, sample) in receipt.samples.iter().enumerate() {
+        if sample.timed_out {
+            reasons.push(format!("sample {} timed out", idx));
+        }
+        if sample.exit_code != 0 {
+            reasons.push(format!("sample {} exit_code={}", idx, sample.exit_code));
+        }
+    }
+    AggregateRunEvidence {
+        run_id: receipt.run.id.clone(),
+        bench_name: receipt.bench.name.clone(),
+        host: receipt.run.host.clone(),
+        runner: receipt.run.runner.clone(),
+        pass: reasons.is_empty(),
+        reasons,
+    }
+}
+
+fn compute_verdict(
+    runs: &[AggregateRunEvidence],
+    req: &AggregateRequest,
+) -> anyhow::Result<AggregateVerdict> {
+    let pass_count = runs.iter().filter(|r| r.pass).count() as u32;
+    let total_count = runs.len() as u32;
+    let fail_count = total_count.saturating_sub(pass_count);
+
+    let verdict = match req.policy {
+        AggregationPolicy::All => AggregateVerdict {
+            status: if pass_count == total_count {
+                AggregateStatus::Pass
+            } else {
+                AggregateStatus::Fail
+            },
+            reason: format!("all policy: {}/{} runs passed", pass_count, total_count),
+            pass_count,
+            fail_count,
+            total_count,
+            pass_weight: None,
+            fail_weight: None,
+            total_weight: None,
+        },
+        AggregationPolicy::Majority => AggregateVerdict {
+            status: if pass_count > total_count / 2 {
+                AggregateStatus::Pass
+            } else {
+                AggregateStatus::Fail
+            },
+            reason: format!(
+                "majority policy: {}/{} runs passed",
+                pass_count, total_count
+            ),
+            pass_count,
+            fail_count,
+            total_count,
+            pass_weight: None,
+            fail_weight: None,
+            total_weight: None,
+        },
+        AggregationPolicy::Weighted => {
+            let mut pass_weight = 0.0f64;
+            let mut fail_weight = 0.0f64;
+            for run in runs {
+                let label = run
+                    .runner
+                    .as_ref()
+                    .and_then(|r| r.label.as_deref().map(ToString::to_string))
+                    .unwrap_or_else(|| format!("{}-{}", run.host.os, run.host.arch));
+                let weight = req
+                    .weights
+                    .get(&label)
+                    .copied()
+                    .or_else(|| run.runner.as_ref().and_then(|r| r.weight))
+                    .unwrap_or(1.0);
+                if run.pass {
+                    pass_weight += weight;
+                } else {
+                    fail_weight += weight;
+                }
+            }
+            let total_weight = pass_weight + fail_weight;
+            if total_weight <= 0.0 {
+                anyhow::bail!("weighted policy requires a positive total weight");
+            }
+            AggregateVerdict {
+                status: if pass_weight > total_weight / 2.0 {
+                    AggregateStatus::Pass
+                } else {
+                    AggregateStatus::Fail
+                },
+                reason: format!(
+                    "weighted policy: pass_weight={:.3}, total_weight={:.3}",
+                    pass_weight, total_weight
+                ),
+                pass_count,
+                fail_count,
+                total_count,
+                pass_weight: Some(pass_weight),
+                fail_weight: Some(fail_weight),
+                total_weight: Some(total_weight),
+            }
+        }
+        AggregationPolicy::Quorum => {
+            let quorum = req
+                .quorum
+                .ok_or_else(|| anyhow::anyhow!("quorum policy requires --quorum"))?;
+            AggregateVerdict {
+                status: if pass_count >= quorum {
+                    AggregateStatus::Pass
+                } else {
+                    AggregateStatus::Fail
+                },
+                reason: format!(
+                    "quorum policy: pass_count={} required_quorum={}",
+                    pass_count, quorum
+                ),
+                pass_count,
+                fail_count,
+                total_count,
+                pass_weight: None,
+                fail_weight: None,
+                total_weight: None,
+            }
+        }
+        AggregationPolicy::FailIfNOfM => {
+            let threshold = req.fail_threshold.ok_or_else(|| {
+                anyhow::anyhow!("fail_if_n_of_m policy requires --fail-threshold")
+            })?;
+            AggregateVerdict {
+                status: if fail_count >= threshold {
+                    AggregateStatus::Fail
+                } else {
+                    AggregateStatus::Pass
+                },
+                reason: format!(
+                    "fail_if_n_of_m policy: fail_count={} fail_threshold={}",
+                    fail_count, threshold
+                ),
+                pass_count,
+                fail_count,
+                total_count,
+                pass_weight: None,
+                fail_weight: None,
+                total_weight: None,
+            }
+        }
+    };
+    Ok(verdict)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perfgate_types::{BenchMeta, HostInfo, Sample, Stats, ToolInfo, U64Summary};
+
+    fn run(id: &str, label: Option<&str>, pass: bool) -> RunReceipt {
+        RunReceipt {
+            schema: perfgate_types::RUN_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "test".to_string(),
+            },
+            run: RunMeta {
+                id: id.to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                ended_at: "2026-01-01T00:00:01Z".to_string(),
+                host: HostInfo {
+                    os: "linux".to_string(),
+                    arch: "x86_64".to_string(),
+                    cpu_count: Some(8),
+                    memory_bytes: Some(16 * 1024 * 1024 * 1024),
+                    hostname_hash: Some(format!("host-{id}")),
+                },
+                runner: Some(perfgate_types::RunnerMeta {
+                    label: label.map(ToString::to_string),
+                    class: None,
+                    weight: None,
+                    lane: Some("default".to_string()),
+                }),
+            },
+            bench: BenchMeta {
+                name: "bench".to_string(),
+                cwd: None,
+                command: vec!["echo".to_string(), "x".to_string()],
+                repeat: 1,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            samples: vec![Sample {
+                wall_ms: 100,
+                exit_code: if pass { 0 } else { 1 },
+                warmup: false,
+                timed_out: !pass,
+                cpu_ms: None,
+                page_faults: None,
+                ctx_switches: None,
+                max_rss_kb: None,
+                io_read_bytes: None,
+                io_write_bytes: None,
+                network_packets: None,
+                energy_uj: None,
+                binary_bytes: None,
+                stdout: None,
+                stderr: None,
+            }],
+            stats: Stats {
+                wall_ms: U64Summary::new(100, 100, 100),
+                cpu_ms: None,
+                page_faults: None,
+                ctx_switches: None,
+                max_rss_kb: None,
+                io_read_bytes: None,
+                io_write_bytes: None,
+                network_packets: None,
+                energy_uj: None,
+                binary_bytes: None,
+                throughput_per_s: None,
+            },
+        }
+    }
+
+    #[test]
+    fn majority_policy_passes_when_strict_majority_pass() {
+        let runs = vec![
+            run_evidence(&run("r1", Some("ubuntu-x86_64"), true)),
+            run_evidence(&run("r2", Some("windows-x86_64"), true)),
+            run_evidence(&run("r3", Some("macos-arm64"), false)),
+        ];
+        let req = AggregateRequest {
+            files: vec![],
+            policy: AggregationPolicy::Majority,
+            quorum: None,
+            fail_threshold: None,
+            weights: BTreeMap::new(),
+        };
+        let verdict = compute_verdict(&runs, &req).expect("verdict");
+        assert_eq!(verdict.status, AggregateStatus::Pass);
+    }
+
+    #[test]
+    fn weighted_policy_uses_configured_weights() {
+        let runs = vec![
+            run_evidence(&run("r1", Some("ubuntu-x86_64"), true)),
+            run_evidence(&run("r2", Some("windows-x86_64"), false)),
+            run_evidence(&run("r3", Some("macos-arm64"), false)),
+        ];
+        let mut weights = BTreeMap::new();
+        weights.insert("ubuntu-x86_64".to_string(), 0.7);
+        weights.insert("windows-x86_64".to_string(), 0.2);
+        weights.insert("macos-arm64".to_string(), 0.1);
+        let req = AggregateRequest {
+            files: vec![],
+            policy: AggregationPolicy::Weighted,
+            quorum: None,
+            fail_threshold: None,
+            weights,
+        };
+        let verdict = compute_verdict(&runs, &req).expect("verdict");
+        assert_eq!(verdict.status, AggregateStatus::Pass);
     }
 }

--- a/crates/perfgate-app/src/cargo_bench.rs
+++ b/crates/perfgate-app/src/cargo_bench.rs
@@ -325,6 +325,7 @@ pub fn benchmarks_to_receipt(
             started_at,
             ended_at,
             host: host.clone(),
+            runner: None,
         },
         bench: BenchMeta {
             name: name.to_string(),
@@ -383,6 +384,7 @@ pub fn benchmarks_to_individual_receipts(
                 started_at: ts.clone(),
                 ended_at: ts,
                 host: host.clone(),
+                runner: None,
             },
             bench: BenchMeta {
                 name: bench.name.clone(),

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -650,6 +650,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "test-bench".to_string(),
@@ -787,6 +788,7 @@ mod tests {
                 started_at: "2024-01-01T00:00:00Z".to_string(),
                 ended_at: "2024-01-01T00:00:01Z".to_string(),
                 host,
+                runner: None,
             },
             bench: BenchMeta {
                 name: "bench".to_string(),

--- a/crates/perfgate-app/src/diff.rs
+++ b/crates/perfgate-app/src/diff.rs
@@ -730,6 +730,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             samples: vec![],
             stats: Stats {

--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -203,6 +203,7 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> RunBenchUseCase<R, H, C> {
                 started_at,
                 ended_at,
                 host,
+                runner: None,
             },
             bench,
             samples,
@@ -411,6 +412,7 @@ mod tests {
                 started_at: "2024-01-01T00:00:00Z".to_string(),
                 ended_at: "2024-01-01T00:00:01Z".to_string(),
                 host,
+                runner: None,
             },
             bench: BenchMeta {
                 name: "bench".to_string(),

--- a/crates/perfgate-app/src/paired.rs
+++ b/crates/perfgate-app/src/paired.rs
@@ -178,6 +178,7 @@ impl<R: ProcessRunner, H: HostProbe, C: Clock> PairedRunUseCase<R, H, C> {
                 started_at,
                 ended_at,
                 host,
+                runner: None,
             },
             bench,
             samples,

--- a/crates/perfgate-app/src/promote.rs
+++ b/crates/perfgate-app/src/promote.rs
@@ -56,6 +56,7 @@ impl PromoteUseCase {
                 memory_bytes: receipt.run.host.memory_bytes,
                 hostname_hash: receipt.run.host.hostname_hash,
             },
+            runner: None,
         };
         receipt
     }
@@ -84,6 +85,7 @@ mod tests {
                     memory_bytes: Some(8_000_000_000),
                     hostname_hash: Some("testhash123".to_string()),
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "test-benchmark".to_string(),

--- a/crates/perfgate-app/src/trend.rs
+++ b/crates/perfgate-app/src/trend.rs
@@ -199,6 +199,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: name.to_string(),

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -36,8 +36,9 @@ use perfgate_scaling::{
 };
 use perfgate_summary::{SummaryRequest, SummaryUseCase};
 use perfgate_types::{
-    BASELINE_REASON_NO_BASELINE, BaselineServerConfig, CompareReceipt, CompareRef, ConfigFile,
-    HostMismatchPolicy, PerfgateReport, RunReceipt, SensorVerdictStatus, ToolInfo, VerdictStatus,
+    AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig, CompareReceipt,
+    CompareRef, ConfigFile, HostMismatchPolicy, PerfgateReport, RunReceipt, SensorVerdictStatus,
+    ToolInfo, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::BTreeMap;
@@ -255,6 +256,22 @@ enum Command {
         /// Paths to run receipts (glob patterns supported)
         #[arg(required = true, num_args = 1..)]
         files: Vec<String>,
+
+        /// Aggregation policy: all, majority, weighted, quorum, fail-if-n-of-m
+        #[arg(long, default_value = "all")]
+        policy: String,
+
+        /// Quorum threshold (required with --policy quorum)
+        #[arg(long)]
+        quorum: Option<u32>,
+
+        /// Failure threshold (required with --policy fail-if-n-of-m)
+        #[arg(long)]
+        fail_threshold: Option<u32>,
+
+        /// Policy weights as label=value (repeatable, for --policy weighted)
+        #[arg(long = "weight", value_name = "LABEL=VALUE")]
+        weights: Vec<String>,
 
         /// Output file path
         #[arg(long, default_value = "perfgate-aggregated.json")]
@@ -1988,7 +2005,15 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
             Ok(())
         }
 
-        Command::Aggregate { files, out, pretty } => {
+        Command::Aggregate {
+            files,
+            policy,
+            quorum,
+            fail_threshold,
+            weights,
+            out,
+            pretty,
+        } => {
             let usecase = perfgate_app::AggregateUseCase;
             let mut resolved_files = Vec::new();
             for pattern in files {
@@ -1996,8 +2021,13 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                     resolved_files.push(entry?);
                 }
             }
+            let weights = parse_aggregate_weights(&weights)?;
             let outcome = usecase.execute(perfgate_app::AggregateRequest {
                 files: resolved_files,
+                policy: parse_aggregation_policy(&policy)?,
+                quorum,
+                fail_threshold,
+                weights,
             })?;
             write_json(&out, &outcome.receipt, pretty)?;
             Ok(())
@@ -4636,6 +4666,31 @@ fn parse_key_val_f64(s: &str) -> Result<(String, f64), String> {
     Ok((k.to_string(), f))
 }
 
+fn parse_aggregation_policy(s: &str) -> Result<AggregationPolicy, String> {
+    match s.to_lowercase().as_str() {
+        "all" => Ok(AggregationPolicy::All),
+        "majority" => Ok(AggregationPolicy::Majority),
+        "weighted" => Ok(AggregationPolicy::Weighted),
+        "quorum" => Ok(AggregationPolicy::Quorum),
+        "fail-if-n-of-m" | "fail_if_n_of_m" => Ok(AggregationPolicy::FailIfNOfM),
+        _ => Err(format!(
+            "invalid aggregation policy: {s} (expected all|majority|weighted|quorum|fail-if-n-of-m)"
+        )),
+    }
+}
+
+fn parse_aggregate_weights(weights: &[String]) -> anyhow::Result<BTreeMap<String, f64>> {
+    let mut parsed = BTreeMap::new();
+    for weight in weights {
+        let (label, value) = parse_key_val_f64(weight)?;
+        if value < 0.0 {
+            anyhow::bail!("weight for '{label}' must be >= 0, got {value}");
+        }
+        parsed.insert(label, value);
+    }
+    Ok(parsed)
+}
+
 fn parse_noise_policy(s: &str) -> Result<perfgate_types::NoisePolicy, String> {
     match s.to_lowercase().as_str() {
         "warn" => Ok(perfgate_types::NoisePolicy::Warn),
@@ -4887,6 +4942,7 @@ mod tests {
                     memory_bytes: Some(8 * 1024 * 1024 * 1024),
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "bench".to_string(),

--- a/crates/perfgate-client/src/fallback.rs
+++ b/crates/perfgate-client/src/fallback.rs
@@ -380,6 +380,7 @@ mod tests {
                     memory_bytes: Some(16000000000),
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: benchmark.to_string(),

--- a/crates/perfgate-client/tests/client_server_integration.rs
+++ b/crates/perfgate-client/tests/client_server_integration.rs
@@ -30,6 +30,7 @@ fn create_test_receipt() -> RunReceipt {
                 memory_bytes: None,
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: "my-bench".into(),

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -95,6 +95,7 @@ mod advanced_analytics_tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: name.to_string(),
@@ -2765,6 +2766,7 @@ mod tests {
                         memory_bytes: None,
                         hostname_hash: None,
                     },
+                    runner: None,
                 },
                 bench: BenchMeta {
                     name: name.into(),

--- a/crates/perfgate-export/examples/export_example.rs
+++ b/crates/perfgate-export/examples/export_example.rs
@@ -28,6 +28,7 @@ fn create_run_receipt() -> RunReceipt {
                 memory_bytes: Some(16 * 1024 * 1024 * 1024),
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: "example-bench".to_string(),

--- a/crates/perfgate-export/src/lib.rs
+++ b/crates/perfgate-export/src/lib.rs
@@ -29,6 +29,7 @@
 //!         ended_at: "2024-01-01T00:00:01Z".into(),
 //!         host: HostInfo { os: "linux".into(), arch: "x86_64".into(),
 //!             cpu_count: None, memory_bytes: None, hostname_hash: None },
+//!         runner: None,
 //!     },
 //!     bench: BenchMeta {
 //!         name: "bench".into(), cwd: None,
@@ -228,6 +229,7 @@ impl ExportUseCase {
     ///         ended_at: "2024-01-01T00:00:01Z".into(),
     ///         host: HostInfo { os: "linux".into(), arch: "x86_64".into(),
     ///             cpu_count: None, memory_bytes: None, hostname_hash: None },
+    ///         runner: None,
     ///     },
     ///     bench: BenchMeta {
     ///         name: "bench".into(), cwd: None,
@@ -819,6 +821,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "test-benchmark".to_string(),
@@ -1153,6 +1156,7 @@ mod tests {
                         memory_bytes: None,
                         hostname_hash: None,
                     },
+                    runner: None,
                 },
                 bench: BenchMeta {
                     name: "empty-bench".to_string(),
@@ -1986,6 +1990,7 @@ mod property_tests {
                 started_at,
                 ended_at,
                 host,
+                runner: None,
             })
     }
 

--- a/crates/perfgate-ingest/src/lib.rs
+++ b/crates/perfgate-ingest/src/lib.rs
@@ -90,6 +90,7 @@ fn make_receipt(name: &str, samples: Vec<Sample>, stats: Stats) -> RunReceipt {
                 memory_bytes: None,
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: name.to_string(),

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -848,6 +848,7 @@ mod tests {
                     memory_bytes: Some(16 * 1024 * 1024 * 1024),
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: name.to_string(),

--- a/crates/perfgate-server/tests/common/mod.rs
+++ b/crates/perfgate-server/tests/common/mod.rs
@@ -49,6 +49,7 @@ pub fn create_test_receipt(benchmark: &str) -> perfgate_types::RunReceipt {
                 cpu_count: Some(8),
                 memory_bytes: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: benchmark.to_string(),

--- a/crates/perfgate-types/examples/types_example.rs
+++ b/crates/perfgate-types/examples/types_example.rs
@@ -60,6 +60,7 @@ fn main() {
                 memory_bytes: Some(16_000_000_000),
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: "my-benchmark".to_string(),

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -44,6 +44,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 pub const RUN_SCHEMA_V1: &str = "perfgate.run.v1";
+pub const AGGREGATE_SCHEMA_V1: &str = "perfgate.aggregate.v1";
 pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
@@ -287,13 +288,116 @@ pub struct HostMismatchInfo {
     pub reasons: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+/// Optional runner metadata for matrix/fleet execution contexts.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RunnerMeta {
+    /// Stable runner label used for weighting and grouping (e.g. "ubuntu-x86_64").
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub label: Option<String>,
+
+    /// Optional runner class (e.g. "self-hosted", "gha-standard", "metal").
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub class: Option<String>,
+
+    /// Optional runner weight used by weighted aggregation.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub weight: Option<f64>,
+
+    /// Optional benchmark lane/group for matrix dimensions (e.g. "smoke", "full", "nightly").
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub lane: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct RunMeta {
     pub id: String,
     pub started_at: String,
     pub ended_at: String,
     pub host: HostInfo,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub runner: Option<RunnerMeta>,
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum AggregationPolicy {
+    All,
+    Majority,
+    Weighted,
+    Quorum,
+    FailIfNOfM,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregatePolicyConfig {
+    pub policy: AggregationPolicy,
+
+    /// Required pass count for `quorum`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub quorum: Option<u32>,
+
+    /// Fail threshold for `fail_if_n_of_m`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub fail_threshold: Option<u32>,
+
+    /// Optional explicit runner-label weights for `weighted`.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub weights: BTreeMap<String, f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum AggregateStatus {
+    Pass,
+    Fail,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregateVerdict {
+    pub status: AggregateStatus,
+    pub reason: String,
+    pub pass_count: u32,
+    pub fail_count: u32,
+    pub total_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pass_weight: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub fail_weight: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub total_weight: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregateRunEvidence {
+    pub run_id: String,
+    pub bench_name: String,
+    pub host: HostInfo,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub runner: Option<RunnerMeta>,
+    pub pass: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregateReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub run: RunMeta,
+    pub bench_name: String,
+    pub policy: AggregatePolicyConfig,
+    pub verdict: AggregateVerdict,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub host_mismatch_warnings: Vec<String>,
+    pub runs: Vec<AggregateRunEvidence>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -525,6 +629,7 @@ pub struct Stats {
 ///             os: "linux".into(), arch: "x86_64".into(),
 ///             cpu_count: None, memory_bytes: None, hostname_hash: None,
 ///         },
+///         runner: None,
 ///     },
 ///     bench: BenchMeta {
 ///         name: "my-bench".into(), cwd: None,
@@ -1667,6 +1772,7 @@ mod tests {
                     memory_bytes: Some(16_000_000_000),
                     hostname_hash: Some("cafebabe".into()),
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "my-bench".into(),
@@ -1751,6 +1857,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "b".into(),
@@ -1800,6 +1907,7 @@ mod tests {
                     memory_bytes: Some(u64::MAX),
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "big".into(),
@@ -2241,6 +2349,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "minimal".into(),
@@ -2439,6 +2548,7 @@ mod property_tests {
                 started_at,
                 ended_at,
                 host,
+                runner: None,
             })
     }
 

--- a/crates/perfgate-types/src/paired.rs
+++ b/crates/perfgate-types/src/paired.rs
@@ -170,6 +170,7 @@ mod tests {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: PairedBenchMeta {
                 name: "bench".to_string(),

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -191,6 +191,7 @@ impl PerfgateWorld {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "test-bench".to_string(),
@@ -284,6 +285,7 @@ impl PerfgateWorld {
                     memory_bytes: None,
                     hostname_hash: None,
                 },
+                runner: None,
             },
             bench: BenchMeta {
                 name: "test-bench".to_string(),
@@ -4324,6 +4326,7 @@ async fn given_run_receipt_for_export(world: &mut PerfgateWorld, bench_name: Str
                 memory_bytes: None,
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: bench_name,

--- a/tests/integration/budget_significance_flow.rs
+++ b/tests/integration/budget_significance_flow.rs
@@ -58,6 +58,7 @@ fn make_run_receipt(samples: Vec<u64>) -> RunReceipt {
                 memory_bytes: None,
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: "test-bench".to_string(),

--- a/tests/integration/cross_crate_pipeline.rs
+++ b/tests/integration/cross_crate_pipeline.rs
@@ -60,6 +60,7 @@ fn run_receipt(name: &str, samples: Vec<Sample>) -> RunReceipt {
                 memory_bytes: Some(16 * 1024 * 1024 * 1024),
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: name.to_string(),
@@ -426,6 +427,7 @@ fn paired_receipt_json_roundtrip() {
                 memory_bytes: Some(16 * 1024 * 1024 * 1024),
                 hostname_hash: Some("abc123".to_string()),
             },
+            runner: None,
         },
         bench: PairedBenchMeta {
             name: "paired-bench".to_string(),

--- a/tests/integration/export_render_flow.rs
+++ b/tests/integration/export_render_flow.rs
@@ -30,6 +30,7 @@ fn make_run_receipt() -> RunReceipt {
                 memory_bytes: None,
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: "test-bench".to_string(),

--- a/tests/integration/full_pipeline_flow.rs
+++ b/tests/integration/full_pipeline_flow.rs
@@ -55,6 +55,7 @@ fn make_run_receipt_from_samples(samples: Vec<Sample>) -> RunReceipt {
                 memory_bytes: None,
                 hostname_hash: None,
             },
+            runner: None,
         },
         bench: BenchMeta {
             name: "pipeline-bench".to_string(),

--- a/tests/integration/host_detect_to_app.rs
+++ b/tests/integration/host_detect_to_app.rs
@@ -24,6 +24,7 @@ fn make_run_receipt(host: HostInfo) -> RunReceipt {
             started_at: "2024-01-01T00:00:00Z".to_string(),
             ended_at: "2024-01-01T00:00:01Z".to_string(),
             host,
+            runner: None,
         },
         bench: BenchMeta {
             name: "test-bench".to_string(),


### PR DESCRIPTION
### Motivation
- Enable robust CI gating across OS/arch/runner matrices by shifting truth to an explicit aggregation policy applied to per-run receipts.
- Preserve raw per-run evidence and host-mismatch signals so fleet-level decisions remain auditable and do not hide individual runner failures.
- Make aggregation policy explicit and configurable (e.g. `all`, `majority`, `weighted`, `quorum`, `fail-if-n-of-m`) so CI owners can reason about tradeoffs.

### Description
- Introduce `perfgate.aggregate.v1` and new types in `perfgate-types`: `RunnerMeta`, `AggregationPolicy`, `AggregatePolicyConfig`, `AggregateRunEvidence`, `AggregateVerdict`, and `AggregateReceipt`, and add optional `runner` to `RunMeta`.
- Implement a file-based aggregation use case in `perfgate-app` that ingests multiple `RunReceipt`s, rejects duplicate run IDs, retains per-run evidence and reasons, surfaces host mismatch warnings, and evaluates the explicit policies listed above.
- Extend the CLI `aggregate` command with `--policy`, `--quorum`, `--fail-threshold`, and repeatable `--weight LABEL=VALUE` flags plus parsing helpers and validation for weights and policies.
- Update workspace code/tests/examples to initialize the new optional `runner` field (`runner: None` when not populated) and add unit tests for majority and weighted policies in `perfgate-app`.

### Testing
- Ran `cargo check --all-targets` which completed successfully.
- Ran the new `perfgate-app` tests with `cargo test -p perfgate-app aggregate -- --nocapture` and the coverage tests for the new policies passed (2 tests OK).
- The workspace compiles and unit tests added for aggregation policies succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a58d565c8333b6b0f87219d1fc93)