### PR TITLE
Add matrix/fleet aggregation policies and formal aggregate receipt output

### DIFF
--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -1,15 +1,22 @@
 use anyhow::Context;
-use perfgate_domain::compute_stats;
-use perfgate_types::{HostInfo, RunMeta, RunReceipt};
+use perfgate_types::{
+    AGGREGATE_SCHEMA_V1, AggregateMember, AggregatePolicy, AggregateReceipt, AggregateSummary,
+    RunReceipt, Verdict, VerdictCounts, VerdictStatus,
+};
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::PathBuf;
 
 pub struct AggregateRequest {
     pub files: Vec<PathBuf>,
+    pub policy: AggregatePolicy,
+    pub quorum: Option<f64>,
+    pub fail_threshold: Option<u32>,
+    pub weights: BTreeMap<String, f64>,
 }
 
 pub struct AggregateOutcome {
-    pub receipt: RunReceipt,
+    pub receipt: AggregateReceipt,
 }
 
 pub struct AggregateUseCase;
@@ -26,12 +33,11 @@ impl AggregateUseCase {
                 fs::read_to_string(file).with_context(|| format!("failed to read {:?}", file))?;
             let receipt: RunReceipt = serde_json::from_str(&content)
                 .with_context(|| format!("failed to parse {:?}", file))?;
-            receipts.push(receipt);
+            receipts.push((file, receipt));
         }
 
-        // Verify all receipts are for the same bench name
-        let first_bench_name = &receipts[0].bench.name;
-        for r in &receipts {
+        let first_bench_name = &receipts[0].1.bench.name;
+        for (_, r) in &receipts {
             if &r.bench.name != first_bench_name {
                 anyhow::bail!(
                     "Cannot aggregate receipts for different benchmarks: {} vs {}",
@@ -41,41 +47,239 @@ impl AggregateUseCase {
             }
         }
 
-        let mut combined_samples = Vec::new();
-        for r in &receipts {
-            combined_samples.extend(r.samples.clone());
+        let mut warnings = Vec::new();
+        let mut seen_ids = BTreeSet::new();
+        let mut members = Vec::with_capacity(receipts.len());
+
+        for (path, receipt) in receipts {
+            if !seen_ids.insert(receipt.run.id.clone()) {
+                warnings.push(format!(
+                    "duplicate run id detected: {} ({})",
+                    receipt.run.id,
+                    path.display()
+                ));
+            }
+
+            let has_failures = receipt
+                .samples
+                .iter()
+                .filter(|s| !s.warmup)
+                .any(|s| s.timed_out || s.exit_code != 0);
+
+            let status = if has_failures {
+                VerdictStatus::Fail
+            } else {
+                VerdictStatus::Pass
+            };
+
+            let runner_label = format!("{}-{}", receipt.run.host.os, receipt.run.host.arch);
+            let weight = req.weights.get(&runner_label).copied().unwrap_or(1.0);
+            members.push(AggregateMember {
+                path: path.display().to_string(),
+                run_id: receipt.run.id,
+                bench_name: receipt.bench.name,
+                runner: runner_label,
+                os: receipt.run.host.os,
+                arch: receipt.run.host.arch,
+                host_fingerprint: receipt.run.host.hostname_hash,
+                status,
+                weight,
+                reasons: if has_failures {
+                    vec!["nonzero_or_timeout_sample".to_string()]
+                } else {
+                    Vec::new()
+                },
+            });
         }
 
-        // We assume work_units is consistent across the receipts.
-        // If they differ, we take the first one.
-        let work_units = receipts[0].bench.work_units;
+        let summary = summarize(&members);
 
-        let stats = compute_stats(&combined_samples, work_units)?;
+        // Preserve host mismatch signal at fleet-level: mixed host tuples are surfaced as warnings.
+        let host_variants: BTreeSet<(String, String)> = members
+            .iter()
+            .map(|m| (m.os.clone(), m.arch.clone()))
+            .collect();
+        if host_variants.len() > 1 {
+            let labels: Vec<String> = host_variants
+                .iter()
+                .map(|(os, arch)| format!("{os}/{arch}"))
+                .collect();
+            warnings.push(format!(
+                "host mismatch across fleet inputs: {}",
+                labels.join(", ")
+            ));
+        }
 
-        // Update bench metadata.
-        let mut bench = receipts[0].bench.clone();
-        bench.repeat = combined_samples.len() as u32;
+        let status = evaluate_policy(req.policy, &summary, req.quorum, req.fail_threshold)?;
+        let counts = VerdictCounts {
+            pass: summary.pass,
+            warn: summary.warn,
+            fail: summary.fail,
+            skip: summary.skip,
+        };
+        let mut reasons = vec![format!("policy.{}", req.policy.as_str())];
+        if status == VerdictStatus::Fail {
+            reasons.push("fleet_gate_failed".to_string());
+        }
 
-        let receipt = RunReceipt {
-            schema: perfgate_types::RUN_SCHEMA_V1.to_string(),
-            tool: receipts[0].tool.clone(),
-            run: RunMeta {
-                id: uuid::Uuid::new_v4().to_string(),
-                started_at: receipts[0].run.started_at.clone(),
-                ended_at: receipts.last().unwrap().run.ended_at.clone(),
-                host: HostInfo {
-                    os: "fleet".to_string(),
-                    arch: "mixed".to_string(),
-                    cpu_count: None,
-                    memory_bytes: None,
-                    hostname_hash: None,
-                },
+        let receipt = AggregateReceipt {
+            schema: AGGREGATE_SCHEMA_V1.to_string(),
+            tool: perfgate_types::ToolInfo {
+                name: "perfgate".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
             },
-            bench,
-            samples: combined_samples,
-            stats,
+            policy: req.policy,
+            verdict: Verdict {
+                status,
+                counts,
+                reasons,
+            },
+            summary,
+            warnings,
+            members,
         };
 
         Ok(AggregateOutcome { receipt })
+    }
+}
+
+fn summarize(members: &[AggregateMember]) -> AggregateSummary {
+    let mut summary = AggregateSummary {
+        total: members.len() as u32,
+        pass: 0,
+        fail: 0,
+        warn: 0,
+        skip: 0,
+        pass_weight: 0.0,
+        fail_weight: 0.0,
+    };
+
+    for m in members {
+        match m.status {
+            VerdictStatus::Pass => {
+                summary.pass += 1;
+                summary.pass_weight += m.weight;
+            }
+            VerdictStatus::Fail => {
+                summary.fail += 1;
+                summary.fail_weight += m.weight;
+            }
+            VerdictStatus::Warn => summary.warn += 1,
+            VerdictStatus::Skip => summary.skip += 1,
+        }
+    }
+
+    summary
+}
+
+fn evaluate_policy(
+    policy: AggregatePolicy,
+    summary: &AggregateSummary,
+    quorum: Option<f64>,
+    fail_threshold: Option<u32>,
+) -> anyhow::Result<VerdictStatus> {
+    if summary.total == 0 {
+        return Ok(VerdictStatus::Skip);
+    }
+
+    let pass = summary.pass;
+    let fail = summary.fail;
+    let total = summary.total;
+
+    let status = match policy {
+        AggregatePolicy::All => {
+            if fail == 0 {
+                VerdictStatus::Pass
+            } else {
+                VerdictStatus::Fail
+            }
+        }
+        AggregatePolicy::Majority => {
+            if pass > fail {
+                VerdictStatus::Pass
+            } else {
+                VerdictStatus::Fail
+            }
+        }
+        AggregatePolicy::Weighted => {
+            if summary.pass_weight > summary.fail_weight {
+                VerdictStatus::Pass
+            } else {
+                VerdictStatus::Fail
+            }
+        }
+        AggregatePolicy::Quorum => {
+            let required = quorum.unwrap_or(0.67);
+            if !(0.0..=1.0).contains(&required) {
+                anyhow::bail!("quorum must be in [0.0, 1.0]");
+            }
+            let ratio = (pass as f64) / (total as f64);
+            if ratio >= required {
+                VerdictStatus::Pass
+            } else {
+                VerdictStatus::Fail
+            }
+        }
+        AggregatePolicy::FailIfNOfM => {
+            let threshold = fail_threshold.unwrap_or(1);
+            if fail >= threshold {
+                VerdictStatus::Fail
+            } else {
+                VerdictStatus::Pass
+            }
+        }
+    };
+
+    Ok(status)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn member(status: VerdictStatus, weight: f64) -> AggregateMember {
+        AggregateMember {
+            path: "x.json".into(),
+            run_id: "run-1".into(),
+            bench_name: "bench".into(),
+            runner: "linux-x86_64".into(),
+            os: "linux".into(),
+            arch: "x86_64".into(),
+            host_fingerprint: None,
+            status,
+            weight,
+            reasons: vec![],
+        }
+    }
+
+    #[test]
+    fn majority_policy_passes_when_more_pass_than_fail() {
+        let s = summarize(&[
+            member(VerdictStatus::Pass, 1.0),
+            member(VerdictStatus::Pass, 1.0),
+            member(VerdictStatus::Fail, 1.0),
+        ]);
+        let out = evaluate_policy(AggregatePolicy::Majority, &s, None, None).unwrap();
+        assert_eq!(out, VerdictStatus::Pass);
+    }
+
+    #[test]
+    fn weighted_policy_uses_weights() {
+        let s = summarize(&[
+            member(VerdictStatus::Pass, 0.2),
+            member(VerdictStatus::Fail, 0.8),
+        ]);
+        let out = evaluate_policy(AggregatePolicy::Weighted, &s, None, None).unwrap();
+        assert_eq!(out, VerdictStatus::Fail);
+    }
+
+    #[test]
+    fn fail_if_n_of_m_respects_threshold() {
+        let s = summarize(&[
+            member(VerdictStatus::Fail, 1.0),
+            member(VerdictStatus::Pass, 1.0),
+        ]);
+        let out = evaluate_policy(AggregatePolicy::FailIfNOfM, &s, None, Some(2)).unwrap();
+        assert_eq!(out, VerdictStatus::Pass);
     }
 }

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -256,6 +256,22 @@ enum Command {
         #[arg(required = true, num_args = 1..)]
         files: Vec<String>,
 
+        /// Aggregation policy (all|majority|weighted|quorum|fail-if-n-of-m)
+        #[arg(long, default_value = "all", value_parser = parse_aggregate_policy)]
+        policy: perfgate_types::AggregatePolicy,
+
+        /// Pass quorum ratio for --policy quorum (0.0..=1.0)
+        #[arg(long)]
+        quorum: Option<f64>,
+
+        /// Failure threshold for --policy fail-if-n-of-m
+        #[arg(long)]
+        fail_threshold: Option<u32>,
+
+        /// Runner weight override (repeatable): --weight ubuntu-x86_64=0.5
+        #[arg(long = "weight", value_parser = parse_weight_kv)]
+        weights: Vec<(String, f64)>,
+
         /// Output file path
         #[arg(long, default_value = "perfgate-aggregated.json")]
         out: PathBuf,
@@ -1988,7 +2004,15 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
             Ok(())
         }
 
-        Command::Aggregate { files, out, pretty } => {
+        Command::Aggregate {
+            files,
+            policy,
+            quorum,
+            fail_threshold,
+            weights,
+            out,
+            pretty,
+        } => {
             let usecase = perfgate_app::AggregateUseCase;
             let mut resolved_files = Vec::new();
             for pattern in files {
@@ -1996,8 +2020,13 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                     resolved_files.push(entry?);
                 }
             }
+            let weights_map = weights.into_iter().collect();
             let outcome = usecase.execute(perfgate_app::AggregateRequest {
                 files: resolved_files,
+                policy,
+                quorum,
+                fail_threshold,
+                weights: weights_map,
             })?;
             write_json(&out, &outcome.receipt, pretty)?;
             Ok(())
@@ -4671,6 +4700,33 @@ fn parse_host_mismatch_policy(s: &str) -> Result<HostMismatchPolicy, String> {
     }
 }
 
+fn parse_aggregate_policy(s: &str) -> Result<perfgate_types::AggregatePolicy, String> {
+    match s {
+        "all" => Ok(perfgate_types::AggregatePolicy::All),
+        "majority" => Ok(perfgate_types::AggregatePolicy::Majority),
+        "weighted" => Ok(perfgate_types::AggregatePolicy::Weighted),
+        "quorum" => Ok(perfgate_types::AggregatePolicy::Quorum),
+        "fail-if-n-of-m" => Ok(perfgate_types::AggregatePolicy::FailIfNOfM),
+        _ => Err(format!(
+            "invalid aggregate policy: {} (expected all|majority|weighted|quorum|fail-if-n-of-m)",
+            s
+        )),
+    }
+}
+
+fn parse_weight_kv(s: &str) -> Result<(String, f64), String> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| format!("invalid weight '{s}', expected runner=weight"))?;
+    let weight: f64 = v
+        .parse()
+        .map_err(|_| format!("invalid weight value '{v}', expected number"))?;
+    if weight < 0.0 {
+        return Err("weight must be >= 0".to_string());
+    }
+    Ok((k.to_string(), weight))
+}
+
 fn parse_significance_alpha(s: &str) -> Result<f64, String> {
     let alpha: f64 = s.parse().map_err(|_| format!("invalid float value: {s}"))?;
     if !(0.0..=1.0).contains(&alpha) {
@@ -5000,6 +5056,40 @@ mod tests {
             "unexpected error: {}",
             err
         );
+    }
+
+    #[test]
+    fn parse_aggregate_policy_accepts_and_errors() {
+        assert_eq!(
+            parse_aggregate_policy("all").unwrap(),
+            perfgate_types::AggregatePolicy::All
+        );
+        assert_eq!(
+            parse_aggregate_policy("majority").unwrap(),
+            perfgate_types::AggregatePolicy::Majority
+        );
+        assert_eq!(
+            parse_aggregate_policy("weighted").unwrap(),
+            perfgate_types::AggregatePolicy::Weighted
+        );
+        assert_eq!(
+            parse_aggregate_policy("quorum").unwrap(),
+            perfgate_types::AggregatePolicy::Quorum
+        );
+        assert_eq!(
+            parse_aggregate_policy("fail-if-n-of-m").unwrap(),
+            perfgate_types::AggregatePolicy::FailIfNOfM
+        );
+        assert!(parse_aggregate_policy("sometimes").is_err());
+    }
+
+    #[test]
+    fn parse_weight_kv_parses_and_validates() {
+        let parsed = parse_weight_kv("ubuntu-x86_64=0.5").unwrap();
+        assert_eq!(parsed.0, "ubuntu-x86_64");
+        assert!((parsed.1 - 0.5).abs() < f64::EPSILON);
+        assert!(parse_weight_kv("bad").is_err());
+        assert!(parse_weight_kv("runner=-0.1").is_err());
     }
 
     #[test]

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -47,6 +47,7 @@ pub const RUN_SCHEMA_V1: &str = "perfgate.run.v1";
 pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
+pub const AGGREGATE_SCHEMA_V1: &str = "perfgate.aggregate.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
 
 // Stable contract identifiers and tokens.
@@ -1001,6 +1002,75 @@ pub struct CompareReceipt {
     pub deltas: BTreeMap<Metric, Delta>,
 
     pub verdict: Verdict,
+}
+
+/// Policy used for fleet/matrix aggregation.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum AggregatePolicy {
+    All,
+    Majority,
+    Weighted,
+    Quorum,
+    FailIfNOfM,
+}
+
+impl AggregatePolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AggregatePolicy::All => "all",
+            AggregatePolicy::Majority => "majority",
+            AggregatePolicy::Weighted => "weighted",
+            AggregatePolicy::Quorum => "quorum",
+            AggregatePolicy::FailIfNOfM => "fail_if_n_of_m",
+        }
+    }
+}
+
+/// One member run included in an aggregate decision.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregateMember {
+    pub path: String,
+    pub run_id: String,
+    pub bench_name: String,
+    pub runner: String,
+    pub os: String,
+    pub arch: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub host_fingerprint: Option<String>,
+    pub status: VerdictStatus,
+    pub weight: f64,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub reasons: Vec<String>,
+}
+
+/// Summary counts for an aggregate decision.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregateSummary {
+    pub total: u32,
+    pub pass: u32,
+    pub fail: u32,
+    pub warn: u32,
+    pub skip: u32,
+    pub pass_weight: f64,
+    pub fail_weight: f64,
+}
+
+/// Aggregate receipt for matrix/fleet CI gating (`perfgate.aggregate.v1`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct AggregateReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub policy: AggregatePolicy,
+    pub verdict: Verdict,
+    pub summary: AggregateSummary,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub warnings: Vec<String>,
+    pub members: Vec<AggregateMember>,
 }
 
 // ----------------------------


### PR DESCRIPTION
### Motivation

- Provide an explicit, auditable way to gate CI across OS/arch/runner matrices by aggregating individual `perfgate.run.v1` receipts with a policy-driven decision. 
- Preserve per-run evidence and host fingerprint signals while shifting truth to a controlled aggregation policy instead of a single noisy runner. 
- Support common v1 policies (`all`, `majority`, `weighted`, `quorum`, `fail-if-n-of-m`) and make weights/quorums configurable from the CLI.

### Description

- Add a formal aggregate contract and types in `perfgate-types`: `AGGREGATE_SCHEMA_V1`, `AggregatePolicy`, `AggregateMember`, `AggregateSummary`, and `AggregateReceipt` to represent fleet/matrix decisions and metadata. 
- Implement policy-driven fleet aggregation in `perfgate-app` via a new `AggregateUseCase` that reads `RunReceipt` files, classifies per-member pass/fail from non-warmup samples, detects duplicate `run.id`, preserves host-variation as warnings, computes summary counts and weights, evaluates configured policies (`all`, `majority`, `weighted`, `quorum`, `fail-if-n-of-m`), and emits a structured `AggregateReceipt`. 
- Extend `perfgate-cli` `aggregate` UX with new flags `--policy`, `--quorum`, `--fail-threshold`, and repeatable `--weight runner=weight`, add parsers/validation helpers `parse_aggregate_policy` and `parse_weight_kv`, and wire CLI options into the `AggregateRequest` to the app layer. 
- Add unit tests covering policy evaluation (`majority`, `weighted`, `fail-if-n-of-m`) and CLI parsing for aggregate policy and weight key-values, and add handling for weight overrides when computing weighted decisions.

### Testing

- Ran formatting with `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p perfgate-app aggregate -- --nocapture` and all aggregate unit tests passed. 
- Ran `cargo test -p perfgate-cli parse_aggregate_policy -- --nocapture` and `cargo test -p perfgate-cli parse_weight_kv -- --nocapture` and both CLI parsing unit tests passed. 
- The changes were validated locally by the unit test suite invoked above and produced the expected results for the new aggregation behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a58d565c8333b6b0f87219d1fc93)