### PR TITLE
Add env/file/command API key policy sources for perfgate-server

### DIFF
--- a/crates/perfgate-auth/Cargo.toml
+++ b/crates/perfgate-auth/Cargo.toml
@@ -15,10 +15,11 @@ categories = ["authentication"]
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
+toml.workspace = true
 chrono = { version = "0.4.39", features = ["serde"] }
 perfgate-error.workspace = true
 uuid = { workspace = true }
 schemars.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true

--- a/crates/perfgate-auth/src/lib.rs
+++ b/crates/perfgate-auth/src/lib.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Utc};
 use perfgate_error::AuthError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// API key prefix for live keys.
 pub const API_KEY_PREFIX_LIVE: &str = "pg_live_";
@@ -239,6 +240,95 @@ pub fn generate_api_key(test: bool) -> String {
     format!("{}{}", prefix, random)
 }
 
+/// External credential source descriptor for server auth material.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CredentialMaterialSource {
+    /// Read policy document from an environment variable value.
+    Env { var: String },
+    /// Read policy document from a file path.
+    File { path: String },
+    /// Read policy document from shell command stdout.
+    Command { command: String },
+}
+
+/// Policy document format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyDocFormat {
+    /// JSON format.
+    #[default]
+    Json,
+    /// TOML format.
+    Toml,
+}
+
+/// API key authorization policy entry.
+///
+/// This keeps authorization metadata (role/scope/project/regex) in perfgate while letting
+/// secret origin stay external.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct ApiKeyPolicy {
+    /// Stable credential identifier for audit and revocation.
+    pub id: String,
+    /// Role granted to this credential.
+    pub role: Role,
+    /// Project scope ("*" means all projects).
+    pub project: String,
+    /// Optional benchmark restriction regex.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub benchmark_regex: Option<String>,
+    /// Optional expiration metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Raw shared secret (material loaded externally by env/file/command).
+    pub secret: String,
+}
+
+/// Parses API key policies from JSON or TOML bytes.
+pub fn parse_api_key_policies(
+    content: &str,
+    format: PolicyDocFormat,
+) -> Result<Vec<ApiKeyPolicy>, String> {
+    let policies: Vec<ApiKeyPolicy> = match format {
+        PolicyDocFormat::Json => serde_json::from_str(content)
+            .map_err(|e| format!("failed to parse API key policy JSON: {e}"))?,
+        PolicyDocFormat::Toml => {
+            #[derive(Deserialize)]
+            struct TomlPolicies {
+                policies: Vec<ApiKeyPolicy>,
+            }
+            toml::from_str::<TomlPolicies>(content)
+                .map(|v| v.policies)
+                .map_err(|e| format!("failed to parse API key policy TOML: {e}"))?
+        }
+    };
+    validate_api_key_policies(&policies)?;
+    Ok(policies)
+}
+
+/// Infers policy format from file extension.
+pub fn infer_policy_doc_format(path: &Path) -> PolicyDocFormat {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("toml") => PolicyDocFormat::Toml,
+        _ => PolicyDocFormat::Json,
+    }
+}
+
+fn validate_api_key_policies(policies: &[ApiKeyPolicy]) -> Result<(), String> {
+    for policy in policies {
+        if policy.id.trim().is_empty() {
+            return Err("policy id must not be empty".to_string());
+        }
+        if policy.project.trim().is_empty() {
+            return Err(format!("policy '{}' project must not be empty", policy.id));
+        }
+        validate_key_format(&policy.secret)
+            .map_err(|e| format!("policy '{}' has invalid secret: {e}", policy.id))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,5 +371,49 @@ mod tests {
         let test_key = generate_api_key(true);
         assert!(test_key.starts_with(API_KEY_PREFIX_TEST));
         assert!(test_key.len() >= 40);
+    }
+
+    #[test]
+    fn parse_policy_json() {
+        let doc = r#"
+[
+  {
+    "id": "ci-promoter",
+    "role": "promoter",
+    "project": "my-project",
+    "benchmark_regex": ".*",
+    "secret": "pg_live_abcdefghijklmnopqrstuvwxyz123456"
+  }
+]
+"#;
+        let parsed = parse_api_key_policies(doc, PolicyDocFormat::Json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "ci-promoter");
+    }
+
+    #[test]
+    fn parse_policy_toml() {
+        let doc = r#"
+[[policies]]
+id = "ci-viewer"
+role = "viewer"
+project = "my-project"
+secret = "pg_test_abcdefghijklmnopqrstuvwxyz123456"
+"#;
+        #[derive(Deserialize)]
+        struct Wrap {
+            policies: Vec<ApiKeyPolicy>,
+        }
+        let wrap: Wrap = toml::from_str(doc).unwrap();
+        assert_eq!(wrap.policies.len(), 1);
+        assert_eq!(wrap.policies[0].id, "ci-viewer");
+    }
+
+    #[test]
+    fn parse_policy_rejects_invalid_key() {
+        let doc = r#"
+[{"id":"bad","role":"viewer","project":"p","secret":"nope"}]
+"#;
+        assert!(parse_api_key_policies(doc, PolicyDocFormat::Json).is_err());
     }
 }

--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -65,6 +65,33 @@ Keys are scoped to a project and optionally restricted by benchmark regex:
 --api-keys contributor:pg_live_abc123:my-project:^bench-.*$
 ```
 
+For integration with existing secret tooling, you can load key policy documents from env, file,
+or command output:
+
+```bash
+perfgate-server \
+  --api-keys-file /etc/perfgate/keys.json \
+  --api-keys-command "op read op://perfgate/api-keys/json" \
+  --api-keys-env PERFGATE_API_KEYS_JSON
+```
+
+Source precedence is additive and deterministic: static `--api-keys` entries are loaded first,
+then `--api-keys-env`, then `--api-keys-file`, then `--api-keys-command`.
+
+Policy document shape (JSON):
+
+```json
+[
+  {
+    "id": "ci-promoter",
+    "role": "promoter",
+    "project": "my-project",
+    "benchmark_regex": ".*",
+    "secret": "pg_live_abcdefghijklmnopqrstuvwxyz123456"
+  }
+]
+```
+
 For GitHub Actions CI, use OIDC (`--github-oidc org/repo:project-id:contributor`).
 GitLab OIDC and custom OIDC providers are also supported. JWT tokens (HS256)
 are supported via `--jwt-secret`.
@@ -78,6 +105,10 @@ are supported via `--jwt-secret`.
 | `--storage-type` | `memory` | `memory`, `sqlite`, or `postgres` |
 | `--database-url` | -- | DB path (SQLite) or connection string (Postgres) |
 | `--api-keys` | -- | `role:key[:project[:benchmark_regex]]` (repeatable) |
+| `--api-keys-file` | -- | path to external API key policy document (JSON/TOML) |
+| `--api-keys-env` | -- | env var containing external API key policy document |
+| `--api-keys-command` | -- | shell command returning policy document on stdout |
+| `--api-keys-format` | `json` | format for env/command policy docs (`json`, `toml`) |
 | `--github-oidc` | -- | `org/repo:project_id:role` (repeatable) |
 | `--gitlab-oidc` | -- | `group/project:project_id:role` (repeatable) |
 | `--oidc-provider` | -- | custom OIDC issuer/JWKS/audience mapping |

--- a/crates/perfgate-server/src/bin/perfgate-server.rs
+++ b/crates/perfgate-server/src/bin/perfgate-server.rs
@@ -30,7 +30,10 @@
 //! ```
 
 use clap::Parser;
+use perfgate_auth::{PolicyDocFormat, infer_policy_doc_format, parse_api_key_policies};
 use std::net::SocketAddr;
+use std::path::Path;
+use std::process::Command;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -91,6 +94,22 @@ struct Args {
     /// Example: --api-keys admin:pg_live_abc123,contributor:pg_live_def456:my-project:^bench-.*$
     #[arg(long = "api-keys", value_parser = parse_api_key)]
     api_keys: Vec<ApiKeyConfigArg>,
+
+    /// API key policy document file (JSON by default, TOML if .toml extension).
+    #[arg(long = "api-keys-file")]
+    api_keys_file: Option<String>,
+
+    /// API key policy document environment variable name.
+    #[arg(long = "api-keys-env")]
+    api_keys_env: Option<String>,
+
+    /// API key policy document command (stdout must be policy JSON/TOML).
+    #[arg(long = "api-keys-command")]
+    api_keys_command: Option<String>,
+
+    /// Policy format override for env/command sources: json|toml (default: json).
+    #[arg(long = "api-keys-format", default_value = "json", value_parser = parse_policy_doc_format)]
+    api_keys_format: PolicyDocFormat,
 
     /// HS256 secret used to validate `Authorization: Token <jwt>` requests.
     #[arg(long)]
@@ -212,6 +231,16 @@ fn parse_role(s: &str) -> Result<Role, String> {
     }
 }
 
+fn parse_policy_doc_format(s: &str) -> Result<PolicyDocFormat, String> {
+    match s.to_ascii_lowercase().as_str() {
+        "json" => Ok(PolicyDocFormat::Json),
+        "toml" => Ok(PolicyDocFormat::Toml),
+        _ => Err(format!(
+            "Unknown api key policy format '{s}'. Expected: json, toml"
+        )),
+    }
+}
+
 /// Parses an OIDC identity mapping "identity:project_id:role".
 fn parse_oidc_mapping(mapping: &str, flag_name: &str) -> Result<(String, String, Role), String> {
     let parts: Vec<&str> = mapping.split(':').collect();
@@ -247,6 +276,47 @@ fn init_logging(level: &str, format: &str) {
                 .init();
         }
     }
+}
+
+fn load_external_api_keys(
+    env_var: Option<&str>,
+    file_path: Option<&str>,
+    command: Option<&str>,
+    default_format: PolicyDocFormat,
+) -> Result<Vec<perfgate_auth::ApiKeyPolicy>, String> {
+    let mut out = Vec::new();
+
+    if let Some(var) = env_var {
+        let value = std::env::var(var)
+            .map_err(|_| format!("Environment variable '{var}' is not set or unreadable"))?;
+        out.extend(parse_api_key_policies(&value, default_format)?);
+    }
+
+    if let Some(path) = file_path {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("Unable to read API keys file '{path}': {e}"))?;
+        let format = infer_policy_doc_format(Path::new(path));
+        out.extend(parse_api_key_policies(&content, format)?);
+    }
+
+    if let Some(cmd) = command {
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .output()
+            .map_err(|e| format!("Failed to execute api-keys command '{cmd}': {e}"))?;
+        if !output.status.success() {
+            return Err(format!(
+                "api-keys command '{cmd}' failed with status {}",
+                output.status
+            ));
+        }
+        let stdout = String::from_utf8(output.stdout)
+            .map_err(|e| format!("api-keys command '{cmd}' emitted invalid UTF-8: {e}"))?;
+        out.extend(parse_api_key_policies(&stdout, default_format)?);
+    }
+
+    Ok(out)
 }
 
 #[tokio::main]
@@ -299,9 +369,26 @@ async fn main() {
         statement_timeout: Duration::from_secs(args.pg_statement_timeout),
     });
 
-    // Add API keys
+    // Add static API keys
     for cfg in args.api_keys {
         config = config.scoped_api_key(cfg.key, cfg.role, cfg.project, cfg.benchmark_regex);
+    }
+
+    // Add external API key policies loaded via env/file/command.
+    let external_keys = load_external_api_keys(
+        args.api_keys_env.as_deref(),
+        args.api_keys_file.as_deref(),
+        args.api_keys_command.as_deref(),
+        args.api_keys_format,
+    )
+    .unwrap_or_else(|e| panic!("Failed to load external API key policies: {e}"));
+    for policy in external_keys {
+        config = config.scoped_api_key(
+            policy.secret,
+            policy.role,
+            policy.project,
+            policy.benchmark_regex,
+        );
     }
 
     // ----- GitHub OIDC -----
@@ -484,6 +571,7 @@ mod tests {
         assert_eq!(args.pg_max_lifetime, 1800);
         assert_eq!(args.pg_acquire_timeout, 5);
         assert_eq!(args.pg_statement_timeout, 30);
+        assert_eq!(args.api_keys_format, PolicyDocFormat::Json);
     }
 
     #[test]
@@ -516,6 +604,39 @@ mod tests {
         assert_eq!(args.pg_max_lifetime, 3600);
         assert_eq!(args.pg_acquire_timeout, 10);
         assert_eq!(args.pg_statement_timeout, 60);
+    }
+
+    #[test]
+    fn test_policy_doc_format_parser() {
+        assert_eq!(
+            parse_policy_doc_format("json").unwrap(),
+            PolicyDocFormat::Json
+        );
+        assert_eq!(
+            parse_policy_doc_format("toml").unwrap(),
+            PolicyDocFormat::Toml
+        );
+        assert!(parse_policy_doc_format("yaml").is_err());
+    }
+
+    #[test]
+    fn test_load_external_api_keys_from_env() {
+        let env_name = "PERFGATE_TEST_API_KEYS_JSON";
+        // SAFETY: test process controls this env var for the duration of the test.
+        unsafe {
+            std::env::set_var(
+                env_name,
+                r#"[{"id":"env-key","role":"viewer","project":"p","secret":"pg_test_abcdefghijklmnopqrstuvwxyz123456"}]"#,
+            );
+        }
+        let policies =
+            load_external_api_keys(Some(env_name), None, None, PolicyDocFormat::Json).unwrap();
+        assert_eq!(policies.len(), 1);
+        assert_eq!(policies[0].id, "env-key");
+        // SAFETY: cleanup of test-owned env var.
+        unsafe {
+            std::env::remove_var(env_name);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Allow the server to consume credential material managed externally (env/file/command) so perfgate can integrate with existing secret tooling without becoming a KMS.
- Keep authorization metadata inside perfgate while leaving secret origin, rotation and lifecycle to external systems.

### Description
- Add policy primitives to `perfgate-auth`: `CredentialMaterialSource`, `PolicyDocFormat`, `ApiKeyPolicy`, `parse_api_key_policies(...)`, `infer_policy_doc_format(...)` and validation helpers to parse JSON/TOML policy docs and validate secret format.
- Add `serde_json` and `toml` dependencies to `crates/perfgate-auth` to support policy parsing.
- Extend `perfgate-server` CLI with `--api-keys-file`, `--api-keys-env`, `--api-keys-command`, and `--api-keys-format` and implement `load_external_api_keys(...)` which reads from env, file, or runs `sh -c` for command output, infers format (or honors `--api-keys-format`) and merges policies into startup `ServerConfig` via `scoped_api_key`.
- Document the UX and precedence in `crates/perfgate-server/README.md` and add unit tests validating parsing and CLI behavior.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p perfgate-auth` and all tests passed.
- Ran `cargo test -p perfgate-server --lib --bin` and unit/bin tests passed.
- Ran `cargo test -p perfgate-auth -p perfgate-server` which showed the new unit tests passing but the workspace run included an existing integration test `real_server_integration::test_server_end_to_end_workflow` that failed in this environment (unit and bin tests remain green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5a0743c8333bbff68042fbdd9dc)