### PR TITLE
Support external key policy sources (env/file/command) and parsing

### DIFF
--- a/crates/perfgate-auth/Cargo.toml
+++ b/crates/perfgate-auth/Cargo.toml
@@ -15,10 +15,11 @@ categories = ["authentication"]
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
 chrono = { version = "0.4.39", features = ["serde"] }
 perfgate-error.workspace = true
 uuid = { workspace = true }
 schemars.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true

--- a/crates/perfgate-auth/src/lib.rs
+++ b/crates/perfgate-auth/src/lib.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Utc};
 use perfgate_error::AuthError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 /// API key prefix for live keys.
 pub const API_KEY_PREFIX_LIVE: &str = "pg_live_";
@@ -239,6 +240,116 @@ pub fn generate_api_key(test: bool) -> String {
     format!("{}{}", prefix, random)
 }
 
+/// Policy entry with metadata and secret material.
+///
+/// Designed for external secret-manager integration where perfgate consumes
+/// credentials from env/file/command.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ApiCredentialPolicy {
+    /// Stable identifier used for audit and revocation.
+    pub id: String,
+    /// Authorization role.
+    pub role: Role,
+    /// Project scope.
+    pub project: String,
+    /// Optional benchmark regex restriction.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub benchmark_regex: Option<String>,
+    /// Optional expiration metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Secret material consumed by perfgate.
+    pub secret: String,
+    /// Optional display name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+impl ApiCredentialPolicy {
+    /// Converts this policy entry into an [`ApiKey`] metadata record.
+    pub fn to_api_key(&self) -> ApiKey {
+        let mut key = ApiKey::new(
+            self.id.clone(),
+            self.name
+                .clone()
+                .unwrap_or_else(|| format!("{} key", self.role)),
+            self.project.clone(),
+            self.role,
+        );
+        key.benchmark_regex = self.benchmark_regex.clone();
+        key.expires_at = self.expires_at;
+        key
+    }
+}
+
+/// Supported policy-document format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyFormat {
+    Json,
+    Toml,
+}
+
+#[derive(Debug, Deserialize)]
+struct TomlPolicyDocument {
+    entries: Vec<ApiCredentialPolicy>,
+}
+
+/// Parses credential policy entries from a JSON/TOML document.
+pub fn parse_policy_document(
+    document: &str,
+    format: PolicyFormat,
+) -> Result<Vec<ApiCredentialPolicy>, AuthError> {
+    let policies: Vec<ApiCredentialPolicy> = match format {
+        PolicyFormat::Json => serde_json::from_str(document).map_err(|e| {
+            AuthError::InvalidToken(format!("failed to parse JSON key policy document: {}", e))
+        })?,
+        PolicyFormat::Toml => toml::from_str::<TomlPolicyDocument>(document)
+            .map(|doc| doc.entries)
+            .map_err(|e| {
+                AuthError::InvalidToken(format!("failed to parse TOML key policy document: {}", e))
+            })?,
+    };
+    validate_policies(policies)
+}
+
+/// Parses a credential policy document by inferring format from path extension.
+pub fn parse_policy_document_from_path(
+    path: impl AsRef<Path>,
+    document: &str,
+) -> Result<Vec<ApiCredentialPolicy>, AuthError> {
+    let format = match path
+        .as_ref()
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("toml") => PolicyFormat::Toml,
+        _ => PolicyFormat::Json,
+    };
+    parse_policy_document(document, format)
+}
+
+fn validate_policies(
+    policies: Vec<ApiCredentialPolicy>,
+) -> Result<Vec<ApiCredentialPolicy>, AuthError> {
+    for policy in &policies {
+        if policy.id.trim().is_empty() {
+            return Err(AuthError::InvalidToken(
+                "key policy entry has empty id".to_string(),
+            ));
+        }
+        if policy.secret.trim().is_empty() {
+            return Err(AuthError::InvalidToken(format!(
+                "key policy entry '{}' has empty secret",
+                policy.id
+            )));
+        }
+        validate_key_format(&policy.secret)?;
+    }
+    Ok(policies)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,5 +392,57 @@ mod tests {
         let test_key = generate_api_key(true);
         assert!(test_key.starts_with(API_KEY_PREFIX_TEST));
         assert!(test_key.len() >= 40);
+    }
+
+    #[test]
+    fn test_parse_policy_document_json() {
+        let doc = r#"
+        [
+          {
+            "id": "ci-promoter",
+            "role": "promoter",
+            "project": "my-project",
+            "benchmark_regex": ".*",
+            "secret": "pg_live_abcdefghijklmnopqrstuvwxyz123456"
+          }
+        ]
+        "#;
+
+        let parsed = parse_policy_document(doc, PolicyFormat::Json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "ci-promoter");
+        assert_eq!(parsed[0].role, Role::Promoter);
+    }
+
+    #[test]
+    fn test_parse_policy_document_toml() {
+        let doc = r#"
+        [[entries]]
+        id = "ci-promoter"
+        role = "promoter"
+        project = "my-project"
+        secret = "pg_live_abcdefghijklmnopqrstuvwxyz123456"
+        "#;
+
+        let parsed = parse_policy_document(doc, PolicyFormat::Toml).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].project, "my-project");
+    }
+
+    #[test]
+    fn test_parse_policy_document_rejects_invalid_secret() {
+        let doc = r#"
+        [
+          {
+            "id": "bad",
+            "role": "viewer",
+            "project": "my-project",
+            "secret": "not-a-key"
+          }
+        ]
+        "#;
+
+        let err = parse_policy_document(doc, PolicyFormat::Json).unwrap_err();
+        assert!(matches!(err, AuthError::InvalidKeyFormat));
     }
 }

--- a/crates/perfgate-server/Cargo.toml
+++ b/crates/perfgate-server/Cargo.toml
@@ -72,6 +72,7 @@ jsonwebtoken = { version = "10", features = ["rust_crypto", "hmac", "sha2"] }
 object_store = { version = "0.11.0", features = ["aws", "gcp", "azure"] }
 futures = "0.3.31"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+humantime = "2.1.0"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -69,6 +69,14 @@ For GitHub Actions CI, use OIDC (`--github-oidc org/repo:project-id:contributor`
 GitLab OIDC and custom OIDC providers are also supported. JWT tokens (HS256)
 are supported via `--jwt-secret`.
 
+For external secret-manager integration, perfgate can load key policy docs from:
+- env var: `--api-keys-env PERFGATE_API_KEYS_JSON`
+- file: `--api-keys-file /etc/perfgate/keys.json`
+- command: `--api-keys-command "op read op://perfgate/api-keys/json"`
+
+Command/file sources are the recommended neutral integration path for Vault,
+1Password, and cloud secret wrappers.
+
 ## Configuration
 
 | Flag | Default | Description |
@@ -78,6 +86,10 @@ are supported via `--jwt-secret`.
 | `--storage-type` | `memory` | `memory`, `sqlite`, or `postgres` |
 | `--database-url` | -- | DB path (SQLite) or connection string (Postgres) |
 | `--api-keys` | -- | `role:key[:project[:benchmark_regex]]` (repeatable) |
+| `--api-keys-env` | -- | Env var containing key policy JSON |
+| `--api-keys-file` | -- | File path to key policy JSON/TOML |
+| `--api-keys-command` | -- | Command that prints key policy JSON/TOML |
+| `--reload-interval` | -- | Intended auth-source reload interval (e.g., `60s`) |
 | `--github-oidc` | -- | `org/repo:project_id:role` (repeatable) |
 | `--gitlab-oidc` | -- | `group/project:project_id:role` (repeatable) |
 | `--oidc-provider` | -- | custom OIDC issuer/JWKS/audience mapping |

--- a/crates/perfgate-server/src/bin/perfgate-server.rs
+++ b/crates/perfgate-server/src/bin/perfgate-server.rs
@@ -92,6 +92,22 @@ struct Args {
     #[arg(long = "api-keys", value_parser = parse_api_key)]
     api_keys: Vec<ApiKeyConfigArg>,
 
+    /// Environment variable that contains JSON key-policy document.
+    #[arg(long = "api-keys-env")]
+    api_keys_env: Option<String>,
+
+    /// File path to JSON/TOML key-policy document.
+    #[arg(long = "api-keys-file")]
+    api_keys_file: Option<String>,
+
+    /// Command that prints JSON/TOML key-policy document to stdout.
+    #[arg(long = "api-keys-command")]
+    api_keys_command: Option<String>,
+
+    /// Reload interval for auth sources like --api-keys-file/--api-keys-command.
+    #[arg(long = "reload-interval")]
+    reload_interval: Option<String>,
+
     /// HS256 secret used to validate `Authorization: Token <jwt>` requests.
     #[arg(long)]
     jwt_secret: Option<String>,
@@ -302,6 +318,20 @@ async fn main() {
     // Add API keys
     for cfg in args.api_keys {
         config = config.scoped_api_key(cfg.key, cfg.role, cfg.project, cfg.benchmark_regex);
+    }
+    if let Some(env_var) = args.api_keys_env {
+        config = config.api_keys_env(env_var);
+    }
+    if let Some(path) = args.api_keys_file {
+        config = config.api_keys_file(path);
+    }
+    if let Some(command) = args.api_keys_command {
+        config = config.api_keys_command(command);
+    }
+    if let Some(interval) = args.reload_interval {
+        let parsed = humantime::parse_duration(&interval)
+            .unwrap_or_else(|_| panic!("Invalid --reload-interval duration: {}", interval));
+        config = config.auth_reload_interval(parsed);
     }
 
     // ----- GitHub OIDC -----

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -5,6 +5,7 @@
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -40,6 +41,7 @@ use crate::storage::{
     ObjectArtifactStore, PostgresStore, SqliteKeyStore, SqliteStore,
 };
 use metrics_exporter_prometheus::PrometheusHandle;
+use perfgate_auth::parse_policy_document_from_path;
 
 /// Shared application state holding all stores.
 #[derive(Clone)]
@@ -162,6 +164,15 @@ pub struct ServerConfig {
     /// API keys for authentication
     pub api_keys: Vec<ApiKeyConfig>,
 
+    /// Optional environment variable containing key-policy JSON.
+    pub api_keys_env: Option<String>,
+
+    /// Optional file path containing key-policy JSON/TOML.
+    pub api_keys_file: Option<PathBuf>,
+
+    /// Optional shell command that prints key-policy JSON/TOML to stdout.
+    pub api_keys_command: Option<String>,
+
     /// Optional JWT validation settings.
     pub jwt: Option<JwtConfig>,
 
@@ -182,6 +193,9 @@ pub struct ServerConfig {
 
     /// Interval between background cleanup passes (in hours).
     pub cleanup_interval_hours: u64,
+
+    /// Optional interval for reloading command/file key sources.
+    pub auth_reload_interval: Option<Duration>,
 }
 
 impl Default for ServerConfig {
@@ -194,6 +208,9 @@ impl Default for ServerConfig {
             postgres_pool: PostgresPoolConfig::default(),
             artifacts_url: None,
             api_keys: vec![],
+            api_keys_env: None,
+            api_keys_file: None,
+            api_keys_command: None,
             jwt: None,
             oidc_configs: vec![],
             cors: true,
@@ -201,6 +218,7 @@ impl Default for ServerConfig {
             local_mode: false,
             retention_days: 0,
             cleanup_interval_hours: 1,
+            auth_reload_interval: None,
         }
     }
 }
@@ -272,6 +290,24 @@ impl ServerConfig {
         self
     }
 
+    /// Reads key-policy document from an environment variable.
+    pub fn api_keys_env(mut self, env_var: impl Into<String>) -> Self {
+        self.api_keys_env = Some(env_var.into());
+        self
+    }
+
+    /// Reads key-policy document from a file.
+    pub fn api_keys_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.api_keys_file = Some(path.into());
+        self
+    }
+
+    /// Reads key-policy document from command stdout.
+    pub fn api_keys_command(mut self, command: impl Into<String>) -> Self {
+        self.api_keys_command = Some(command.into());
+        self
+    }
+
     /// Enables JWT token authentication.
     pub fn jwt(mut self, jwt: JwtConfig) -> Self {
         self.jwt = Some(jwt);
@@ -307,6 +343,12 @@ impl ServerConfig {
     /// Sets the interval (in hours) between background cleanup passes.
     pub fn cleanup_interval_hours(mut self, hours: u64) -> Self {
         self.cleanup_interval_hours = hours;
+        self
+    }
+
+    /// Sets credential reload interval for command/file auth sources.
+    pub fn auth_reload_interval(mut self, interval: Duration) -> Self {
+        self.auth_reload_interval = Some(interval);
         self
     }
 }
@@ -399,7 +441,71 @@ pub(crate) async fn create_key_store(
         info!(role = ?cfg.role, project = %cfg.project, "Added API key");
     }
 
+    if let Some(env_var) = &config.api_keys_env {
+        let source = std::env::var(env_var).map_err(|e| {
+            ConfigError::InvalidValue(format!(
+                "Failed reading API keys from env var '{}': {}",
+                env_var, e
+            ))
+        })?;
+        add_policy_entries(&store, &source, PathBuf::from("api-keys-env.json")).await?;
+        info!(env_var = %env_var, "Loaded API keys from env var");
+    }
+
+    if let Some(path) = &config.api_keys_file {
+        let source = std::fs::read_to_string(path).map_err(|e| {
+            ConfigError::InvalidValue(format!(
+                "Failed reading API keys file '{}': {}",
+                path.display(),
+                e
+            ))
+        })?;
+        add_policy_entries(&store, &source, path.clone()).await?;
+        info!(path = %path.display(), "Loaded API keys from file");
+    }
+
+    if let Some(command) = &config.api_keys_command {
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(command)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| {
+                ConfigError::InvalidValue(format!("Failed executing API keys command: {}", e))
+            })?;
+
+        if !output.status.success() {
+            return Err(ConfigError::InvalidValue(format!(
+                "API keys command exited with status {}: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr)
+            )));
+        }
+
+        let source = String::from_utf8(output.stdout).map_err(|e| {
+            ConfigError::InvalidValue(format!("API keys command returned non-UTF8 stdout: {}", e))
+        })?;
+        add_policy_entries(&store, &source, PathBuf::from("api-keys-command.json")).await?;
+        info!("Loaded API keys from command output");
+    }
+
     Ok(Arc::new(store))
+}
+
+async fn add_policy_entries(
+    store: &ApiKeyStore,
+    source: &str,
+    path_hint: PathBuf,
+) -> Result<(), ConfigError> {
+    let policies = parse_policy_document_from_path(&path_hint, source)
+        .map_err(|e| ConfigError::InvalidValue(format!("Failed parsing policy document: {}", e)))?;
+    for policy in policies {
+        let key = policy.to_api_key();
+        store.add_key(key, &policy.secret).await;
+    }
+    Ok(())
 }
 
 /// Creates the persistent key store based on the storage backend.
@@ -711,6 +817,7 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_server_config_default() {
@@ -809,6 +916,41 @@ mod tests {
         assert_eq!(keys.len(), 2);
         let viewer_key = keys.iter().find(|k| k.role == Role::Viewer).unwrap();
         assert_eq!(viewer_key.project_id, "project-1");
+    }
+
+    #[tokio::test]
+    async fn test_create_key_store_from_env_file_and_command() {
+        let env_doc = r#"[{"id":"env-key","role":"viewer","project":"env","secret":"pg_live_abcdefghijklmnopqrstuvwxyz123456"}]"#;
+        // SAFETY: test-scoped env var mutation.
+        unsafe { std::env::set_var("PERFGATE_TEST_KEYS_ENV", env_doc) };
+
+        let mut temp = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            temp,
+            r#"[{{"id":"file-key","role":"contributor","project":"file","secret":"pg_live_fileabcdefghijklmnopqrstuvwxyz123456"}}]"#
+        )
+        .unwrap();
+
+        let config = ServerConfig::new()
+            .api_keys_env("PERFGATE_TEST_KEYS_ENV")
+            .api_keys_file(temp.path())
+            .api_keys_command(
+                "printf '[{\"id\":\"cmd-key\",\"role\":\"promoter\",\"project\":\"cmd\",\"secret\":\"pg_live_commandabcdefghijklmnopqrstuvwx123456\"}]'",
+            );
+
+        let key_store = create_key_store(&config).await.unwrap();
+        let keys = key_store.list_keys().await;
+        assert_eq!(keys.len(), 3);
+        assert!(keys.iter().any(|k| k.id == "env-key"));
+        assert!(keys.iter().any(|k| k.id == "file-key"));
+        assert!(keys.iter().any(|k| k.id == "cmd-key"));
+    }
+
+    #[tokio::test]
+    async fn test_create_key_store_command_failure_is_clear() {
+        let config = ServerConfig::new().api_keys_command("exit 7");
+        let err = create_key_store(&config).await.unwrap_err();
+        assert!(format!("{}", err).contains("API keys command exited with status"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
### Motivation
- Enable perfgate to consume authentication material from existing secret/key management tooling (env, file, or command output) without becoming a full KMS and while keeping secret origins external.
- Preserve perfgate’s model of storing only authorization metadata and key identifiers while avoiding SDK sprawl by letting wrapper scripts/agents provide secret material.
- Provide a simple integration path (env/file/command) that is compatible with Vault/1Password/AWS/GCP wrappers and can be extended later with JWKS/OIDC reload support.

### Description
- Add `ApiCredentialPolicy` and policy parsing helpers (`parse_policy_document`, `parse_policy_document_from_path`, `PolicyFormat`) to `perfgate-auth` with JSON/TOML support and validation that enforces non-empty ids/secrets and API key format, plus `to_api_key` to convert to runtime metadata.
- Extend `ServerConfig` and CLI to accept external auth sources via `api_keys_env`, `api_keys_file`, `api_keys_command`, and an intended reload interval `auth_reload_interval` with builder helpers and `--api-keys-env/--api-keys-file/--api-keys-command/--reload-interval` flags in the `perfgate-server` binary.
- Wire loading logic into `create_key_store` so env/file/command sources are parsed and their entries are added to the in-memory `ApiKeyStore`, with clear error messages for read/exec/parse failures and a helper `add_policy_entries` to centralize conversion.
- Update documentation (`perfgate-server/README.md`) with examples and recommended UX, add required dependencies (`serde_json`, `toml` in `perfgate-auth`; `humantime` in `perfgate-server`), and include unit tests covering parsing and server-side loading behaviors.

### Testing
- Ran formatter with `cargo fmt --all` and it completed successfully.
- Ran `cargo test -p perfgate-auth` and all added unit tests passed (`6` tests; result: OK).
- Ran `cargo test -p perfgate-server --lib --bins` and unit/bin tests passed (library and CLI tests OK), and added server unit tests covering env/file/command loading passed.
- The full server integration test `real_server_integration` was run and failed in this environment due to a health-check assertion (`health_res.status().is_success()`), which appears unrelated to the new key-loading logic in unit tests but needs follow-up in the CI/integration environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7a5a0743c8333bbff68042fbdd9dc)