### PR TITLE
chore(sha256): upgrade criterion benchmark dependency to 0.8.2

### DIFF
--- a/crates/perfgate-sha256/Cargo.toml
+++ b/crates/perfgate-sha256/Cargo.toml
@@ -21,7 +21,7 @@ std = []
 
 [dev-dependencies]
 proptest = "1.7"
-criterion = "0.5"
+criterion = "0.8.2"
 
 [[bench]]
 name = "sha256_bench"

--- a/crates/perfgate-sha256/benches/sha256_bench.rs
+++ b/crates/perfgate-sha256/benches/sha256_bench.rs
@@ -1,4 +1,6 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use perfgate_sha256::sha256_hex;
 
 fn bench_small_inputs(c: &mut Criterion) {


### PR DESCRIPTION
### Motivation
- Update the perfgate-sha256 crate's benchmark harness to Criterion `0.8.2` to stay on a maintained harness line and avoid deprecated APIs.  
- Replace the deprecated `criterion::black_box` usage with `std::hint::black_box` to satisfy Clippy with `-D warnings` and follow current guidance.

### Description
- Bumped the dev-dependency in `crates/perfgate-sha256/Cargo.toml` from `criterion = "0.5"` to `criterion = "0.8.2"`.  
- Replaced the benchmark import in `crates/perfgate-sha256/benches/sha256_bench.rs` to `use std::hint::black_box;` and kept the existing benchmark groups, throughput markers, and sample sizing unchanged.  
- No library/public API changes; this is a dev-dependency / bench-tooling update only.

### Testing
- Ran `cargo test -p perfgate-sha256` and all unit & doc tests in the crate passed.  
- Built the benchmark target with `cargo bench -p perfgate-sha256 --no-run` and the bench executables were produced successfully.  
- Ran `cargo clippy -p perfgate-sha256 --all-targets --all-features -- -D warnings` and the crate is Clippy-clean.  
- Performed workspace checks: `cargo build --all` succeeded and `cargo clippy --all-targets --all-features -- -D warnings` completed, but `cargo test --all` encountered three failing `perfgate-cli` mock-server tests due to the environment rejecting loopback HTTP targets (`403 - Loopback targets forbidden`), which is an environment limitation rather than a regression in this change.  
- Executed `cargo bench -p perfgate-sha256` after clearing `target/criterion` and the benchmarks ran and reported results with the new harness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fd82abf08333bb15a2269419fdda)