### PR TITLE
chore(sha256): upgrade criterion bench dependency to 0.8.2

### DIFF
--- a/crates/perfgate-sha256/Cargo.toml
+++ b/crates/perfgate-sha256/Cargo.toml
@@ -21,7 +21,7 @@ std = []
 
 [dev-dependencies]
 proptest = "1.7"
-criterion = "0.5"
+criterion = "0.8.2"
 
 [[bench]]
 name = "sha256_bench"

--- a/crates/perfgate-sha256/benches/sha256_bench.rs
+++ b/crates/perfgate-sha256/benches/sha256_bench.rs
@@ -1,4 +1,6 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use perfgate_sha256::sha256_hex;
 
 fn bench_small_inputs(c: &mut Criterion) {


### PR DESCRIPTION
### Motivation
- Bump the perfgate-sha256 benchmark tooling to Criterion 0.8.2 and remove the deprecated `criterion::black_box` usage so the bench compiles cleanly under the repo Clippy policy and newer Criterion APIs.

### Description
- Update `crates/perfgate-sha256/Cargo.toml` to `criterion = "0.8.2"` and modify `crates/perfgate-sha256/benches/sha256_bench.rs` to `use std::hint::black_box;` while keeping the benchmark groups, throughput markers, and sampling unchanged; no public/runtime crate surface was altered.

### Testing
- Ran crate-local and workspace automated checks: `cargo test -p perfgate-sha256` (passed), `cargo bench -p perfgate-sha256 --no-run` (bench built) and `cargo bench -p perfgate-sha256` after removing `target/criterion` (bench executed), `cargo clippy -p perfgate-sha256 --all-targets --all-features -- -D warnings` (passed), `cargo build --all` and `cargo clippy --all-targets --all-features -- -D warnings` (passed), and `cargo test --all` which failed in this environment due to unrelated mock-server tests that are blocked by loopback/network restrictions rather than this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fd82abf08333bb15a2269419fdda)