### PR TITLE
chore(sha256): upgrade Criterion benches to 0.8.2

### DIFF
--- a/crates/perfgate-sha256/Cargo.toml
+++ b/crates/perfgate-sha256/Cargo.toml
@@ -21,7 +21,7 @@ std = []
 
 [dev-dependencies]
 proptest = "1.7"
-criterion = "0.5"
+criterion = "0.8.2"
 
 [[bench]]
 name = "sha256_bench"

--- a/crates/perfgate-sha256/benches/sha256_bench.rs
+++ b/crates/perfgate-sha256/benches/sha256_bench.rs
@@ -1,4 +1,6 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use perfgate_sha256::sha256_hex;
 
 fn bench_small_inputs(c: &mut Criterion) {


### PR DESCRIPTION
### Motivation
- Upgrade the bench tooling to Criterion `0.8.2` and remove use of the deprecated `criterion::black_box` to satisfy current lints and align with newer Criterion releases.

### Description
- Bumped the crate dev-dependency to `criterion = "0.8.2"` in `crates/perfgate-sha256/Cargo.toml` and swapped the bench import to `std::hint::black_box` in `crates/perfgate-sha256/benches/sha256_bench.rs` while leaving benchmark structure, throughput and sample sizing unchanged.

### Testing
- Ran `cargo test -p perfgate-sha256` (passed), `cargo bench -p perfgate-sha256 --no-run` (bench target built, passed), and `cargo clippy -p perfgate-sha256 --all-targets --all-features -- -D warnings` (passed); workspace `cargo build --all` and `cargo clippy --all-targets --all-features -- -D warnings` also completed successfully, and a full `cargo bench -p perfgate-sha256` was exercised after clearing `target/criterion` (bench executed). Note: a separate workspace test run showed unrelated failures in `perfgate-cli` mock-server tests due to an environment restriction (`Loopback targets forbidden`), not caused by this crate-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fd82abf08333bb15a2269419fdda)