### PR TITLE
chore(sha256): upgrade criterion bench dependency to 0.8.2

### DIFF
--- a/crates/perfgate-sha256/Cargo.toml
+++ b/crates/perfgate-sha256/Cargo.toml
@@ -21,7 +21,7 @@ std = []
 
 [dev-dependencies]
 proptest = "1.7"
-criterion = "0.5"
+criterion = "0.8.2"
 
 [[bench]]
 name = "sha256_bench"

--- a/crates/perfgate-sha256/benches/sha256_bench.rs
+++ b/crates/perfgate-sha256/benches/sha256_bench.rs
@@ -1,4 +1,6 @@
-use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use perfgate_sha256::sha256_hex;
 
 fn bench_small_inputs(c: &mut Criterion) {


### PR DESCRIPTION
### Motivation
- Upgrade the Criterion dev-dependency in the `perfgate-sha256` crate to bring the bench harness up to 0.8.x and resolve a deprecated `criterion::black_box` import that triggers Clippy warnings.

### Description
- Bumped `criterion` in `crates/perfgate-sha256/Cargo.toml` from `0.5` to `0.8.2` and updated `crates/perfgate-sha256/benches/sha256_bench.rs` to use `std::hint::black_box` instead of `criterion::black_box`, leaving benchmark groups, sample sizes, and throughput settings unchanged.

### Testing
- Ran `cargo test -p perfgate-sha256`, `cargo bench -p perfgate-sha256 --no-run`, `cargo clippy -p perfgate-sha256 --all-targets --all-features -- -D warnings`, `cargo build --all`, `cargo test --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and re-ran `cargo bench -p perfgate-sha256` after clearing `target/criterion`, and all of the automated checks completed successfully with the bench producing measurements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fd82abf08333bb15a2269419fdda)