### PR TITLE
PR1 Add sticky GitHub PR comments from comment.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,23 @@ perfgate check --config perfgate.toml --bench my-service --profile-on-regression
 
 ```yaml
 # .github/workflows/perf.yml
-- uses: EffortlessMetrics/perfgate@v0.15.1
-  with:
-    config: perfgate.toml
-    all: "true"
+jobs:
+  performance:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EffortlessMetrics/perfgate@v0.15.1
+        with:
+          config: perfgate.toml
+          all: "true"
+          comment: "true"
 ```
 
 Pin `@v0.15.1` for an exact patch release, or use `@v0.15` / `@v0` to follow
-the current compatible action tag.
+the current compatible action tag. Set `comment: "true"` to post or update a
+single sticky PR comment from `artifacts/perfgate/comment.md`.
 
 Exit code `2` = budget violated. That's it.
 
@@ -142,10 +151,10 @@ Validate computational complexity for a benchmark command:
 perfgate scale --name parser --command "./target/release/parser-bench --size {n}" --sizes 100,1000,10000 --expected "O(n)"
 ```
 
-Post or update a PR comment from a compare receipt:
+Post or update a sticky PR comment from the generated markdown artifact:
 
 ```bash
-perfgate comment --compare artifacts/perfgate/compare.json --repo owner/repo --pr 123
+perfgate comment --body-file artifacts/perfgate/comment.md --repo owner/repo --pr 123
 ```
 
 **CI Integration**

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
     required: false
     default: ""
   comment:
-    description: "Post or update a PR comment with perfgate results (requires GITHUB_TOKEN)"
+    description: "Post or update a sticky PR comment from out_dir/comment.md (requires GITHUB_TOKEN)"
     required: false
     default: "false"
   github_token:
@@ -223,34 +223,15 @@ runs:
       run: |
         set -euo pipefail
 
-        # Find a compare or report receipt to comment on.
-        # In standard mode, report.json is a perfgate.report.v1.
-        # In cockpit mode, report.json is a sensor.report.v1 (not
-        # parseable as --report), so we look for extras/ receipts first.
         out="${{ inputs.out_dir }}"
         pr_num="${{ github.event.pull_request.number }}"
-        posted=false
 
-        # 1. Cockpit single-bench extras
-        if [[ "${posted}" == "false" && -f "${out}/extras/perfgate.report.v1.json" ]]; then
-          perfgate comment --report "${out}/extras/perfgate.report.v1.json" --pr "${pr_num}" || true
-          posted=true
-        fi
-
-        # 2. Standard mode report.json (perfgate.report.v1)
-        if [[ "${posted}" == "false" && -f "${out}/report.json" && "${{ inputs.mode }}" != "cockpit" ]]; then
-          perfgate comment --report "${out}/report.json" --pr "${pr_num}" || true
-          posted=true
-        fi
-
-        # 3. Standard mode compare.json
-        if [[ "${posted}" == "false" && -f "${out}/compare.json" ]]; then
-          perfgate comment --compare "${out}/compare.json" --pr "${pr_num}" || true
-          posted=true
-        fi
-
-        if [[ "${posted}" == "false" ]]; then
-          echo "No compare or report receipt found; skipping PR comment." >&2
+        if [[ -f "${out}/comment.md" ]]; then
+          if ! perfgate comment --body-file "${out}/comment.md" --pr "${pr_num}"; then
+            echo "::warning::failed to post perfgate PR comment" >&2
+          fi
+        else
+          echo "::notice::No comment.md artifact found; skipping PR comment." >&2
         fi
 
     - name: Upload perfgate artifacts

--- a/crates/perfgate-app/src/init.rs
+++ b/crates/perfgate-app/src/init.rs
@@ -460,19 +460,26 @@ jobs:
         run: perfgate check --config {config_path} --all --mode cockpit --out-dir artifacts/perfgate
 
       - name: Upload artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: perfgate
           path: artifacts/perfgate/
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         run: |
+          set -euo pipefail
+
           if [ -f artifacts/perfgate/comment.md ]; then
-            gh pr comment ${{{{ github.event.pull_request.number }}}} --body-file artifacts/perfgate/comment.md
+            if ! perfgate comment --body-file artifacts/perfgate/comment.md --pr ${{{{ github.event.pull_request.number }}}}; then
+              echo "warning: failed to post perfgate PR comment" >&2
+            fi
+          else
+            echo "No comment.md artifact found; skipping PR comment." >&2
           fi
         env:
-          GH_TOKEN: ${{{{ secrets.GITHUB_TOKEN }}}}
+          GITHUB_TOKEN: ${{{{ secrets.GITHUB_TOKEN }}}}
 "#
     )
 }
@@ -829,6 +836,9 @@ harness = false
     fn scaffold_github_ci() {
         let content = scaffold_ci(CiPlatform::GitHub, Path::new("perfgate.toml"));
         assert!(content.contains("perfgate check"));
+        assert!(content.contains("if: always()"));
+        assert!(content.contains("perfgate comment --body-file"));
+        assert!(!content.contains("gh pr comment"));
         assert!(content.contains("perfgate.toml"));
         assert!(content.contains("ubuntu-latest"));
     }

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -425,10 +425,10 @@ enum Command {
 
     /// Post or update a performance report comment on a GitHub pull request.
     ///
-    /// Reads a compare or report receipt and posts a rich Markdown comment
-    /// on the specified PR. If a perfgate comment already exists, it is
-    /// updated (idempotent). Supports both GitHub Actions tokens and
-    /// personal access tokens.
+    /// Reads a compare/report receipt or an existing markdown body file and
+    /// posts a Markdown comment on the specified PR. If a perfgate comment
+    /// already exists, it is updated (idempotent). Supports both GitHub
+    /// Actions tokens and personal access tokens.
     ///
     /// Exit codes: 0 for success, 1 for errors.
     Comment(Box<CommentArgs>),
@@ -663,12 +663,16 @@ pub struct BisectArgs {
 #[derive(Debug, Args)]
 pub struct CommentArgs {
     /// Path to a compare receipt (mutually exclusive with --report)
-    #[arg(long, conflicts_with = "report")]
+    #[arg(long, conflicts_with_all = ["report", "body_file"])]
     pub compare: Option<PathBuf>,
 
     /// Path to a report receipt (mutually exclusive with --compare)
-    #[arg(long, conflicts_with = "compare")]
+    #[arg(long, conflicts_with_all = ["compare", "body_file"])]
     pub report: Option<PathBuf>,
+
+    /// Path to an existing markdown body file, such as artifacts/perfgate/comment.md.
+    #[arg(long, conflicts_with_all = ["compare", "report"])]
+    pub body_file: Option<PathBuf>,
 
     /// GitHub token for API authentication.
     /// Can also be set via GITHUB_TOKEN environment variable.
@@ -690,7 +694,7 @@ pub struct CommentArgs {
     pub github_api_url: String,
 
     /// Optional blame text to include in the comment (output from `perfgate blame`).
-    #[arg(long)]
+    #[arg(long, conflicts_with = "body_file")]
     pub blame_text: Option<String>,
 
     /// Dry-run mode: render the comment to stdout instead of posting to GitHub.
@@ -3076,6 +3080,7 @@ fn execute_comment(args: CommentArgs) -> anyhow::Result<()> {
     let CommentArgs {
         compare,
         report,
+        body_file,
         github_token,
         repo,
         pr,
@@ -3085,7 +3090,11 @@ fn execute_comment(args: CommentArgs) -> anyhow::Result<()> {
     } = args;
 
     // Load the receipt data
-    let comment_body = if let Some(compare_path) = compare {
+    let comment_body = if let Some(body_path) = body_file {
+        let markdown = fs::read_to_string(&body_path)
+            .with_context(|| format!("read {}", body_path.display()))?;
+        perfgate_github::prepare_comment_body(&markdown)
+    } else if let Some(compare_path) = compare {
         let receipt: CompareReceipt = read_json(&compare_path)?;
         let options = CommentOptions {
             blame_text,
@@ -3100,7 +3109,7 @@ fn execute_comment(args: CommentArgs) -> anyhow::Result<()> {
         };
         perfgate_github::render_comment_from_report(&report_receipt, &options)
     } else {
-        anyhow::bail!("Either --compare or --report is required");
+        anyhow::bail!("One of --body-file, --compare, or --report is required");
     };
 
     // Dry-run: print and exit

--- a/crates/perfgate-cli/tests/cli_comment_tests.rs
+++ b/crates/perfgate-cli/tests/cli_comment_tests.rs
@@ -1,0 +1,128 @@
+//! Integration tests for `perfgate comment`.
+
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+use wiremock::matchers::{bearer_token, body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+mod common;
+use common::perfgate_cmd;
+
+#[test]
+fn test_comment_dry_run_body_file_injects_marker() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let body_path = temp_dir.path().join("comment.md");
+    fs::write(&body_path, "## perf summary\n\nbody").expect("write comment body");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("comment")
+        .arg("--body-file")
+        .arg(&body_path)
+        .arg("--dry-run");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "<!-- perfgate:comment kind=summary -->",
+        ))
+        .stdout(predicate::str::contains("## perf summary"));
+}
+
+#[tokio::test]
+async fn test_comment_body_file_updates_existing_legacy_comment() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let body_path = temp_dir.path().join("comment.md");
+    fs::write(&body_path, "## perf summary\n\nbody").expect("write comment body");
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/7/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {
+                "id": 42,
+                "body": "<!-- perfgate -->\nold content",
+                "html_url": "https://github.com/owner/repo/pull/7#issuecomment-42",
+                "user": { "login": "perfgate-bot" }
+            }
+        ])))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("PATCH"))
+        .and(path("/repos/owner/repo/issues/comments/42"))
+        .and(bearer_token("test-token"))
+        .and(body_string_contains(
+            "<!-- perfgate:comment kind=summary -->",
+        ))
+        .and(body_string_contains("## perf summary"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": 42,
+            "body": "<!-- perfgate:comment kind=summary -->\n## perf summary\n\nbody",
+            "html_url": "https://github.com/owner/repo/pull/7#issuecomment-42",
+            "user": { "login": "perfgate-bot" }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("comment")
+        .arg("--body-file")
+        .arg(&body_path)
+        .arg("--repo")
+        .arg("owner/repo")
+        .arg("--pr")
+        .arg("7")
+        .arg("--github-token")
+        .arg("test-token")
+        .arg("--github-api-url")
+        .arg(mock_server.uri());
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Updated perfgate comment"));
+}
+
+#[tokio::test]
+async fn test_comment_body_file_uses_github_env_defaults_on_create() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let body_path = temp_dir.path().join("comment.md");
+    fs::write(&body_path, "## perf summary\n\nbody").expect("write comment body");
+
+    Mock::given(method("GET"))
+        .and(path("/repos/owner/repo/issues/9/comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/repos/owner/repo/issues/9/comments"))
+        .and(bearer_token("test-token"))
+        .and(body_string_contains(
+            "<!-- perfgate:comment kind=summary -->",
+        ))
+        .and(body_string_contains("## perf summary"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 84,
+            "body": "<!-- perfgate:comment kind=summary -->\n## perf summary\n\nbody",
+            "html_url": "https://github.com/owner/repo/pull/9#issuecomment-84",
+            "user": { "login": "perfgate-bot" }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("comment")
+        .arg("--body-file")
+        .arg(&body_path)
+        .arg("--github-api-url")
+        .arg(mock_server.uri())
+        .env("GITHUB_TOKEN", "test-token")
+        .env("GITHUB_REPOSITORY", "owner/repo")
+        .env("GITHUB_REF", "refs/pull/9/merge");
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Created perfgate comment"));
+}

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -164,6 +164,17 @@ fn cli_help_github_annotations() {
 }
 
 #[test]
+fn cli_help_comment() {
+    perfgate_cmd()
+        .args(["comment", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("GitHub pull request"))
+        .stdout(predicate::str::contains("--body-file"))
+        .stdout(predicate::str::contains("--compare"));
+}
+
+#[test]
 fn cli_help_cargo_bench() {
     perfgate_cmd()
         .args(["cargo-bench", "--help"])

--- a/crates/perfgate-github/src/client.rs
+++ b/crates/perfgate-github/src/client.rs
@@ -5,8 +5,15 @@ use crate::types::{GitHubComment, GitHubCommentRequest};
 use reqwest::header::{self, HeaderMap, HeaderValue};
 use tracing::debug;
 
-/// Marker embedded in PR comments to identify perfgate comments for idempotent updates.
-pub const COMMENT_MARKER: &str = "<!-- perfgate -->";
+/// Canonical marker embedded in PR comments to identify perfgate comments for idempotent updates.
+pub const COMMENT_MARKER: &str = "<!-- perfgate:comment kind=summary -->";
+
+/// Legacy marker still recognized so old comments converge onto the sticky path.
+pub const LEGACY_COMMENT_MARKER: &str = "<!-- perfgate -->";
+
+fn has_comment_marker(body: &str) -> bool {
+    body.contains(COMMENT_MARKER) || body.contains(LEGACY_COMMENT_MARKER)
+}
 
 /// Client for the GitHub REST API, focused on issue/PR comments.
 #[derive(Clone, Debug)]
@@ -184,7 +191,8 @@ impl GitHubClient {
         let comments = self.list_comments(owner, repo, pr_number).await?;
         Ok(comments
             .into_iter()
-            .find(|c| c.body.contains(COMMENT_MARKER)))
+            .rev()
+            .find(|c| has_comment_marker(&c.body)))
     }
 
     /// Create or update the perfgate comment on a PR (idempotent).
@@ -298,7 +306,7 @@ mod tests {
                 },
                 {
                     "id": 2,
-                    "body": "<!-- perfgate -->\nperfgate results",
+                    "body": "<!-- perfgate:comment kind=summary -->\nperfgate results",
                     "html_url": "https://github.com/owner/repo/pull/1#issuecomment-2",
                     "user": { "login": "perfgate-bot" }
                 }
@@ -385,7 +393,7 @@ mod tests {
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
                 {
                     "id": 50,
-                    "body": "<!-- perfgate -->\nold content",
+                    "body": "<!-- perfgate:comment kind=summary -->\nold content",
                     "html_url": "https://github.com/owner/repo/pull/1#issuecomment-50",
                     "user": { "login": "perfgate-bot" }
                 }
@@ -398,7 +406,7 @@ mod tests {
             .and(path("/repos/owner/repo/issues/comments/50"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
                 "id": 50,
-                "body": "<!-- perfgate -->\nnew content",
+                "body": "<!-- perfgate:comment kind=summary -->\nnew content",
                 "html_url": "https://github.com/owner/repo/pull/1#issuecomment-50",
                 "user": { "login": "perfgate-bot" }
             })))
@@ -407,12 +415,77 @@ mod tests {
 
         let client = GitHubClient::new(&mock_server.uri(), "test-token").unwrap();
         let (comment, created) = client
-            .upsert_comment("owner", "repo", 1, "<!-- perfgate -->\nnew content")
+            .upsert_comment(
+                "owner",
+                "repo",
+                1,
+                "<!-- perfgate:comment kind=summary -->\nnew content",
+            )
             .await
             .unwrap();
 
         assert!(!created);
         assert_eq!(comment.id, 50);
+    }
+
+    #[tokio::test]
+    async fn test_find_perfgate_comment_accepts_legacy_marker() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/issues/1/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 7,
+                    "body": "<!-- perfgate -->\nlegacy content",
+                    "html_url": "https://github.com/owner/repo/pull/1#issuecomment-7",
+                    "user": { "login": "perfgate-bot" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = GitHubClient::new(&mock_server.uri(), "test-token").unwrap();
+        let found = client
+            .find_perfgate_comment("owner", "repo", 1)
+            .await
+            .unwrap();
+
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, 7);
+    }
+
+    #[tokio::test]
+    async fn test_find_perfgate_comment_prefers_newest_marker_match() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/repos/owner/repo/issues/1/comments"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {
+                    "id": 10,
+                    "body": "<!-- perfgate -->\nold content",
+                    "html_url": "https://github.com/owner/repo/pull/1#issuecomment-10",
+                    "user": { "login": "perfgate-bot" }
+                },
+                {
+                    "id": 11,
+                    "body": "<!-- perfgate:comment kind=summary -->\nnew content",
+                    "html_url": "https://github.com/owner/repo/pull/1#issuecomment-11",
+                    "user": { "login": "perfgate-bot" }
+                }
+            ])))
+            .mount(&mock_server)
+            .await;
+
+        let client = GitHubClient::new(&mock_server.uri(), "test-token").unwrap();
+        let found = client
+            .find_perfgate_comment("owner", "repo", 1)
+            .await
+            .unwrap();
+
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, 11);
     }
 
     #[tokio::test]

--- a/crates/perfgate-github/src/comment.rs
+++ b/crates/perfgate-github/src/comment.rs
@@ -3,7 +3,7 @@
 //! Produces rich Markdown that includes a verdict badge, metric comparison table,
 //! trend indicators, optional blame attribution, and collapsible raw data.
 
-use crate::client::COMMENT_MARKER;
+use crate::client::{COMMENT_MARKER, LEGACY_COMMENT_MARKER};
 use perfgate_render::{
     direction_str, format_metric_with_statistic, format_pct, format_value, metric_status_icon,
     render_reason_line,
@@ -19,13 +19,30 @@ pub struct CommentOptions {
     pub explain_text: Option<String>,
 }
 
+/// Wrap a markdown body with the canonical hidden marker used for sticky updates.
+pub fn prepare_comment_body(markdown: &str) -> String {
+    let trimmed = markdown.trim_start();
+
+    if let Some(rest) = trimmed.strip_prefix(COMMENT_MARKER) {
+        return format!(
+            "{COMMENT_MARKER}\n{}",
+            rest.trim_start_matches(['\r', '\n'])
+        );
+    }
+
+    if let Some(rest) = trimmed.strip_prefix(LEGACY_COMMENT_MARKER) {
+        return format!(
+            "{COMMENT_MARKER}\n{}",
+            rest.trim_start_matches(['\r', '\n'])
+        );
+    }
+
+    format!("{COMMENT_MARKER}\n{trimmed}")
+}
+
 /// Render a full PR comment body from a `CompareReceipt`.
 pub fn render_comment(compare: &CompareReceipt, options: &CommentOptions) -> String {
     let mut out = String::new();
-
-    // Marker for idempotent updates
-    out.push_str(COMMENT_MARKER);
-    out.push('\n');
 
     // Verdict header with badge
     out.push_str(&verdict_header(compare.verdict.status));
@@ -107,7 +124,7 @@ pub fn render_comment(compare: &CompareReceipt, options: &CommentOptions) -> Str
     out.push_str("\n---\n");
     out.push_str("*Posted by [perfgate](https://github.com/EffortlessMetrics/perfgate)*\n");
 
-    out
+    prepare_comment_body(&out)
 }
 
 /// Render a full PR comment body from a `PerfgateReport`.
@@ -122,8 +139,6 @@ pub fn render_comment_from_report(report: &PerfgateReport, options: &CommentOpti
     // Minimal report when no compare receipt is available
     let mut out = String::new();
 
-    out.push_str(COMMENT_MARKER);
-    out.push('\n');
     out.push_str(&verdict_header(report.verdict.status));
     out.push_str("\n\n");
 
@@ -150,7 +165,7 @@ pub fn render_comment_from_report(report: &PerfgateReport, options: &CommentOpti
     out.push_str("\n---\n");
     out.push_str("*Posted by [perfgate](https://github.com/EffortlessMetrics/perfgate)*\n");
 
-    out
+    prepare_comment_body(&out)
 }
 
 /// Generate a verdict header line with emoji badge.
@@ -273,7 +288,7 @@ mod tests {
     fn comment_contains_marker() {
         let receipt = make_compare_receipt();
         let body = render_comment(&receipt, &CommentOptions::default());
-        assert!(body.contains(COMMENT_MARKER));
+        assert!(body.starts_with(COMMENT_MARKER));
     }
 
     #[test]
@@ -432,7 +447,7 @@ mod tests {
         };
 
         let body = render_comment_from_report(&report, &CommentOptions::default());
-        assert!(body.contains(COMMENT_MARKER));
+        assert!(body.starts_with(COMMENT_MARKER));
         assert!(body.contains("perfgate: **pass**"));
         assert!(body.contains("1 pass"));
     }
@@ -459,5 +474,19 @@ mod tests {
         let body = render_comment_from_report(&report, &CommentOptions::default());
         assert!(body.contains("`wall_ms`"));
         assert!(body.contains("| Metric |"));
+    }
+
+    #[test]
+    fn prepare_comment_body_adds_marker_to_plain_markdown() {
+        let body = prepare_comment_body("## Summary\n\nBody");
+        assert!(body.starts_with(COMMENT_MARKER));
+        assert!(body.contains("## Summary"));
+    }
+
+    #[test]
+    fn prepare_comment_body_rewrites_legacy_marker() {
+        let body = prepare_comment_body("<!-- perfgate -->\n## Summary");
+        assert!(body.starts_with(COMMENT_MARKER));
+        assert!(!body.contains(LEGACY_COMMENT_MARKER));
     }
 }

--- a/crates/perfgate-github/src/lib.rs
+++ b/crates/perfgate-github/src/lib.rs
@@ -7,7 +7,7 @@
 //! - A GitHub REST API client for creating, updating, and finding PR comments
 //! - Rich Markdown comment rendering with verdict badges, metric tables, trend indicators,
 //!   and blame attribution
-//! - Idempotent comment updates via a marker comment (`<!-- perfgate -->`)
+//! - Idempotent comment updates via a hidden marker comment
 //! - Support for both GitHub Actions (GITHUB_TOKEN) and personal access tokens
 
 pub mod client;
@@ -17,8 +17,8 @@ pub mod types;
 
 pub use client::{COMMENT_MARKER, GitHubClient};
 pub use comment::{
-    CommentOptions, parse_github_repository, parse_pr_number_from_ref, render_comment,
-    render_comment_from_report,
+    CommentOptions, parse_github_repository, parse_pr_number_from_ref, prepare_comment_body,
+    render_comment, render_comment_from_report,
 };
 pub use error::GitHubError;
 pub use types::GitHubComment;

--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -9,13 +9,22 @@ artifacts/perfgate/
 ├── run.json        # perfgate.run.v1 - raw measurement receipt
 ├── compare.json    # perfgate.compare.v1 - comparison result
 ├── report.json     # perfgate.report.v1 - cockpit ingestion format
-└── comment.md      # PR comment markdown
+└── comment.md      # Markdown artifact reused for sticky PR comments
 ```
 
 When no baseline exists:
 - `report.json` and `comment.md` are always written
 - `compare.json` is omitted
 - `report.json` uses verdict reason token `no_baseline`
+
+To post the artifact as a sticky GitHub PR comment, use:
+
+```bash
+perfgate comment --body-file artifacts/perfgate/comment.md --repo owner/repo --pr 123
+```
+
+The hidden sticky marker is added at post time so `comment.md` remains plain
+Markdown for local review and non-GitHub consumers.
 
 ## Cockpit Mode
 

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -3,6 +3,7 @@
 This guide shows a minimal GitHub Actions setup for `perfgate` with:
 - config-driven checks (`perfgate check`)
 - PR artifact upload
+- sticky PR comments via `artifacts/perfgate/comment.md`
 - workflow branching via `--output-github`
 - optional one-line use of the official `perfgate-action`
 
@@ -41,6 +42,8 @@ on:
 jobs:
   performance:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -52,6 +55,7 @@ jobs:
           all: "true"
           out_dir: artifacts/perfgate
           upload_artifact: "true"
+          comment: "true"
 ```
 
 Use `@v0.15.1` when you want an exact patch pin. If you prefer a moving tag,
@@ -65,6 +69,10 @@ Action outputs are available as:
 - `${{ steps.perfgate.outputs.fail_count }}`
 - `${{ steps.perfgate.outputs.bench_count }}`
 - `${{ steps.perfgate.outputs.exit_code }}`
+
+When `comment: "true"` is enabled on pull requests, the action reuses
+`artifacts/perfgate/comment.md` and upserts a single sticky PR comment by
+attaching a hidden perfgate marker to the posted body.
 
 ## 3) Manual PR performance gate workflow
 
@@ -80,6 +88,8 @@ on:
 jobs:
   performance:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -105,6 +115,23 @@ jobs:
           name: perfgate-artifacts
           path: artifacts/perfgate
 
+      - name: Post sticky PR comment
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [ -f artifacts/perfgate/comment.md ]; then
+            if ! perfgate comment \
+              --body-file artifacts/perfgate/comment.md \
+              --pr "${{ github.event.pull_request.number }}"; then
+              echo "warning: failed to post perfgate PR comment" >&2
+            fi
+          else
+            echo "No comment.md artifact found; skipping PR comment." >&2
+          fi
+
       - name: Print verdict
         if: always()
         run: |
@@ -122,7 +149,7 @@ jobs:
 - `bench_count`
 - `exit_code`
 
-## 4) Optional: comment markdown artifact
+## 4) Comment markdown artifact
 
 If you want a custom PR comment body:
 
@@ -135,6 +162,12 @@ perfgate check \
 ```
 
 This writes `artifacts/perfgate/comment.md`.
+
+Post that artifact as a sticky GitHub PR comment:
+
+```bash
+perfgate comment --body-file artifacts/perfgate/comment.md --repo owner/repo --pr 123
+```
 
 ## Common Pitfalls
 


### PR DESCRIPTION
## Summary
This lands PR1 of the visible-loop feature slice by hardening the existing GitHub comment path around the generated `comment.md` artifact instead of maintaining a second receipt-specific posting flow.

## Completed in this PR
- Hardened the existing GitHub PR comment path so perfgate uses a stable hidden marker for sticky updates.
- Reused the existing comment/comment.md rendering flow instead of creating a separate GitHub-only implementation.
- Wired the first-party GitHub Action / CI entry point to post or update a single PR comment.
- Added tests covering marker rendering and idempotent update behavior.
- Updated docs/help/examples touched by this slice.

## Still remaining for full feature
- Add baseline-server `/metrics` and ship a Grafana dashboard starter.
- Add audit logging for server-side mutations.
- Add minimal `perfgate auth create|list|revoke` management flow.
- Add server-backed moving-window baselines via `--baseline-window`.
- Record moving-window provenance in compare/report receipts and regenerate schemas.
- Add Windows `page_faults` and `ctx_switches` parity.

## Suggested next PR
PR2  Add `/metrics`, audit events, minimal auth admin CLI, and Grafana dashboard starter.

## Known limitations after this PR
- Historical trend visualization is still not available from the baseline server.
- Moving-window baselines are not implemented yet.
- Windows metric parity is unchanged.
- GitHub PR comments are the only PR-surface improvement in this slice.
- This PR does not make the overall feature complete.

## Validation run
- `cargo run -p xtask -- ci`
- `cargo run -p xtask -- docs-check`

## Remaining-work checklist
- [ ] PR2: server `/metrics`, Grafana dashboard starter, audit logging, minimal `perfgate auth` admin surface
- [ ] PR3: `--baseline-window`, server `window=N`, merged-sample significance path, receipt provenance, schema regen
- [ ] PR4: Windows `page_faults` and `ctx_switches` parity, capability/docs updates