### PR TITLE
fix: replace dangerous unwrap() calls with proper error handling

### DIFF
--- a/crates/perfgate-app/src/diff.rs
+++ b/crates/perfgate-app/src/diff.rs
@@ -178,7 +178,7 @@ impl<R: ProcessRunner + Clone, H: HostProbe + Clone, C: Clock + Clone> DiffUseCa
                 .benches
                 .iter()
                 .find(|b| &b.name == bench_name)
-                .unwrap();
+                .ok_or_else(|| anyhow::anyhow!("bench '{}' not found in config", bench_name))?;
 
             let outcome = self.run_single_bench(bench_config, &config, &req)?;
 

--- a/crates/perfgate-sensor/src/lib.rs
+++ b/crates/perfgate-sensor/src/lib.rs
@@ -93,7 +93,7 @@ impl SensorReportBuilder {
                 severity: map_severity(f.severity),
                 message: f.message.clone(),
                 fingerprint: None,
-                data: f.data.as_ref().map(|d| serde_json::to_value(d).unwrap()),
+                data: f.data.as_ref().and_then(|d| serde_json::to_value(d).ok()),
             })
             .collect();
 
@@ -261,7 +261,7 @@ impl SensorReportBuilder {
 
                     for f in &report.findings {
                         let mut finding_data =
-                            f.data.as_ref().map(|d| serde_json::to_value(d).unwrap());
+                            f.data.as_ref().and_then(|d| serde_json::to_value(d).ok());
                         if let Some(obj) = finding_data.as_mut().and_then(|v| v.as_object_mut()) {
                             obj.insert("bench_name".to_string(), serde_json::json!(bench_name));
                         } else {


### PR DESCRIPTION
Closes #180

## Changes
- Replace `serde_json::to_value().unwrap()` with `.ok()` in perfgate-sensor (2 locations)
- Replace `.find().unwrap()` with `.ok_or_else()?` in perfgate-app diff.rs

## Test plan
- [x] cargo test -p perfgate-sensor (10 passed)
- [x] cargo test -p perfgate-app (187 passed)
- [x] cargo clippy clean