### PR TITLE
refactor: remove dead code behind #[allow(dead_code)]

### DIFF
--- a/crates/perfgate-app/src/lib.rs
+++ b/crates/perfgate-app/src/lib.rs
@@ -270,7 +270,6 @@ pub struct CompareRequest {
     pub current_ref: CompareRef,
     pub tool: ToolInfo,
     /// Policy for handling host mismatches.
-    #[allow(dead_code)]
     pub host_mismatch_policy: HostMismatchPolicy,
 }
 

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -368,7 +368,7 @@ pub(crate) async fn create_artifacts(
 /// Creates the storage backend based on configuration.
 ///
 /// Returns both a `BaselineStore` and an `AuditStore` backed by the same backend.
-#[allow(dead_code)]
+#[cfg(any(test, feature = "test-utils"))]
 pub(crate) async fn create_storage(
     config: &ServerConfig,
 ) -> Result<(Arc<dyn BaselineStore>, Arc<dyn AuditStore>), ConfigError> {


### PR DESCRIPTION
Closes #181

## Changes
- Replace `#[allow(dead_code)]` with `#[cfg(any(test, feature = "test-utils"))]` on `create_storage()` in `perfgate-server` -- the function is only called from tests and the `testing` module (gated behind the same cfg)
- Remove spurious `#[allow(dead_code)]` from `host_mismatch_policy` field in `perfgate-app::CompareRequest` -- the field is actively read in `CompareUseCase::execute()` on lines 290 and 297

## Test plan
- [x] `cargo build --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test -p perfgate-server` -- 111 tests pass
- [x] `cargo test -p perfgate-app` -- 187 tests pass