### PR TITLE
ci: add cargo-deny for dependency auditing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [ main ]
 
 jobs:
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
   test:
     name: test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,44 @@
+[graph]
+targets = []
+all-features = true
+
+[advisories]
+ignore = [
+    # paste is transitively pulled by statrs -> nalgebra -> simba; no upgrade available
+    { id = "RUSTSEC-2024-0436", reason = "transitive dep via statrs, no safe upgrade yet" },
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "BSL-1.0",
+    "CC0-1.0",
+    "OpenSSL",
+    "CDLA-Permissive-2.0",
+]
+confidence-threshold = 0.8
+
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+highlight = "all"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary
- Add `deny.toml` configuration for cargo-deny with license allowlist, advisory checks, ban policies, and source restrictions
- Add `cargo-deny` as a parallel CI job in `.github/workflows/ci.yml` using `EmbarkStudios/cargo-deny-action@v2`
- Ignore RUSTSEC-2024-0436 (unmaintained `paste` crate) since it is a transitive dependency via statrs with no safe upgrade available
- Add `CDLA-Permissive-2.0` to license allowlist for `webpki-roots`

## Test plan
- [x] `cargo deny check` passes locally (exit 0, warnings only for duplicate crate versions)
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] CI `deny` job passes on GitHub Actions

Closes #185