### PR TITLE
fix: replace .expect() with error handling for user shell input

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -5543,32 +5543,32 @@ mod tests {
     }
 
     #[test]
-    fn normalize_paired_cli_command_splits_single_shell_string() {
+    fn normalize_paired_cli_command_splits_single_shell_string() -> anyhow::Result<()> {
         let parsed =
-            normalize_paired_cli_command(vec!["cmd /c exit 0".to_string()], "--baseline-cmd")
-                .expect("parse shell string");
+            normalize_paired_cli_command(vec!["cmd /c exit 0".to_string()], "--baseline-cmd")?;
         assert_eq!(parsed, vec!["cmd", "/c", "exit", "0"]);
+        Ok(())
     }
 
     #[test]
-    fn normalize_paired_cli_command_keeps_argv_tokens() {
+    fn normalize_paired_cli_command_keeps_argv_tokens() -> anyhow::Result<()> {
         let args = vec![
             "cmd".to_string(),
             "/c".to_string(),
             "exit".to_string(),
             "0".to_string(),
         ];
-        let parsed =
-            normalize_paired_cli_command(args.clone(), "--baseline-cmd").expect("parse argv");
+        let parsed = normalize_paired_cli_command(args.clone(), "--baseline-cmd")?;
         assert_eq!(parsed, args);
+        Ok(())
     }
 
     #[test]
-    fn normalize_paired_cli_command_keeps_single_token() {
+    fn normalize_paired_cli_command_keeps_single_token() -> anyhow::Result<()> {
         let args = vec!["true".to_string()];
-        let parsed =
-            normalize_paired_cli_command(args.clone(), "--baseline-cmd").expect("single token");
+        let parsed = normalize_paired_cli_command(args.clone(), "--baseline-cmd")?;
         assert_eq!(parsed, args);
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Closes #183

## Changes
- Replace `.expect("parse shell string")` with proper `?` error propagation in `normalize_paired_cli_command` tests
- The production code (`normalize_paired_cli_command` function at line 5160 and its callers at lines 2080/2087) already uses `.with_context()` and `?` for proper error handling
- The `.expect()` calls identified in the issue (lines 5549, 5562, 5570) were in test code, but have been converted to use `-> anyhow::Result<()>` with `?` for consistency

## Test plan
- [x] cargo test -p perfgate-cli
- [x] cargo clippy clean
- [x] cargo fmt clean