### PR TITLE
fix: warn on verdict submission failure instead of silent drop

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -3842,10 +3842,14 @@ fn submit_verdict_if_possible(
             git_sha: None,
         };
 
-        let _ = with_tokio_runtime(async {
-            let _ = client.submit_verdict(&project, &request).await;
-            Ok::<(), anyhow::Error>(())
-        });
+        if let Err(e) = with_tokio_runtime(async {
+            client
+                .submit_verdict(&project, &request)
+                .await
+                .map_err(anyhow::Error::from)
+        }) {
+            eprintln!("warning: failed to submit verdict: {:#}", e);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #182

## Changes
- Replace silent `let _ =` error drops with `eprintln!` warning when verdict submission to baseline server fails
- User now sees a warning if the server is unreachable or rejects the verdict

## Test plan
- [x] cargo test -p perfgate-cli
- [x] cargo clippy clean