### PR TITLE
chore: migrate reqwest from deprecated rustls-tls feature

### DIFF
--- a/crates/perfgate-client/Cargo.toml
+++ b/crates/perfgate-client/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["web-programming::http-client", "development-tools"]
 anyhow.workspace = true
 perfgate-types.workspace = true
 perfgate-api.workspace = true
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 tokio = { version = "1", features = ["time", "fs", "io-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/perfgate-github/Cargo.toml
+++ b/crates/perfgate-github/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["development-tools"]
 anyhow.workspace = true
 perfgate-types.workspace = true
 perfgate-render.workspace = true
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/perfgate-server/Cargo.toml
+++ b/crates/perfgate-server/Cargo.toml
@@ -71,7 +71,7 @@ async-trait = "0.1.86"
 jsonwebtoken = { version = "10", features = ["rust_crypto", "hmac", "sha2"] }
 object_store = { version = "0.11.0", features = ["aws", "gcp", "azure"] }
 futures = "0.3.31"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
Closes #188

## Changes
- Replace deprecated `rustls-tls` feature with `rustls-tls-webpki-roots` in 3 crates
- No behavioral change — same TLS backend, updated feature flag name

## Test plan
- [x] cargo build --all
- [x] cargo test -p perfgate-client
- [x] cargo clippy clean