### PR TITLE
refactor: add #[must_use] to pure computation functions

### DIFF
--- a/crates/perfgate-budget/src/lib.rs
+++ b/crates/perfgate-budget/src/lib.rs
@@ -139,6 +139,7 @@ pub struct BudgetResult {
 /// # Errors
 ///
 /// Returns `BudgetError::InvalidBaseline` if baseline is <= 0.
+#[must_use = "pure computation; call site should use the returned BudgetResult"]
 pub fn evaluate_budget(
     baseline: f64,
     current: f64,
@@ -226,6 +227,7 @@ pub fn evaluate_budget(
 /// let reg = calculate_regression(100.0, 90.0, Direction::Higher);
 /// assert!((reg - 0.10).abs() < 1e-10);
 /// ```
+#[must_use = "pure computation; call site should use the returned regression value"]
 pub fn calculate_regression(baseline: f64, current: f64, direction: Direction) -> f64 {
     let pct = (current - baseline) / baseline;
     match direction {
@@ -267,6 +269,7 @@ pub fn calculate_regression(baseline: f64, current: f64, direction: Direction) -
 /// // At exact warn threshold: Warn (not Pass)
 /// assert_eq!(determine_status(0.10, threshold, warn_threshold), MetricStatus::Warn);
 /// ```
+#[must_use = "pure computation; call site should use the returned MetricStatus"]
 pub fn determine_status(regression: f64, threshold: f64, warn_threshold: f64) -> MetricStatus {
     if regression > threshold {
         MetricStatus::Fail
@@ -303,6 +306,7 @@ pub fn determine_status(regression: f64, threshold: f64, warn_threshold: f64) ->
 /// let verdict = aggregate_verdict(&[MetricStatus::Pass, MetricStatus::Pass]);
 /// assert_eq!(verdict.status, VerdictStatus::Pass);
 /// ```
+#[must_use = "pure computation; call site should use the returned Verdict"]
 pub fn aggregate_verdict(statuses: &[MetricStatus]) -> Verdict {
     let mut counts = VerdictCounts {
         pass: 0,
@@ -351,6 +355,7 @@ pub fn aggregate_verdict(statuses: &[MetricStatus]) -> Verdict {
 /// assert_eq!(reason_token(Metric::MaxRssKb, MetricStatus::Fail), "max_rss_kb_fail");
 /// assert_eq!(reason_token(Metric::ThroughputPerS, MetricStatus::Pass), "throughput_per_s_pass");
 /// ```
+#[must_use = "pure computation; call site should use the returned token string"]
 pub fn reason_token(metric: Metric, status: MetricStatus) -> String {
     format!("{}_{}", metric.as_str(), status.as_str())
 }
@@ -368,6 +373,7 @@ pub fn reason_token(metric: Metric, status: MetricStatus) -> String {
 /// # Returns
 ///
 /// A tuple of (deltas map, verdict) where deltas contains per-metric results.
+#[must_use = "pure computation; call site should use the returned deltas and verdict"]
 pub fn evaluate_budgets<'a, I>(
     metrics: I,
     budgets: &BTreeMap<Metric, Budget>,

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -516,6 +516,7 @@ mod tradeoff_tests {
 /// assert_eq!(stats.wall_ms.min, 100);
 /// assert_eq!(stats.wall_ms.max, 120);
 /// ```
+#[must_use = "pure computation; call site should use the returned Stats"]
 pub fn compute_stats(
     samples: &[perfgate_types::Sample],
     work_units: Option<u64>,
@@ -710,6 +711,7 @@ fn aggregate_verdict_from_counts(counts: VerdictCounts, reasons: Vec<String>) ->
 /// let cmp = compare_stats(&baseline, &current, &budgets).unwrap();
 /// assert_eq!(cmp.verdict.status, VerdictStatus::Pass);
 /// ```
+#[must_use = "pure computation; call site should use the returned Comparison"]
 pub fn compare_stats(
     baseline: &Stats,
     current: &Stats,
@@ -719,6 +721,7 @@ pub fn compare_stats(
 }
 
 /// Compare stats under the provided budgets and optional tradeoff rules.
+#[must_use = "pure computation; call site should use the returned Comparison"]
 pub fn compare_stats_with_tradeoffs(
     baseline: &Stats,
     current: &Stats,
@@ -1145,6 +1148,7 @@ pub struct Report {
 /// assert_eq!(report.verdict, VerdictStatus::Pass);
 /// assert!(report.findings.is_empty());
 /// ```
+#[must_use = "pure computation; call site should use the returned Report"]
 pub fn derive_report(receipt: &CompareReceipt) -> Report {
     let mut findings = Vec::new();
 
@@ -1213,6 +1217,7 @@ fn metric_to_string(metric: Metric) -> String {
     metric.as_str().to_string()
 }
 
+#[must_use = "pure computation; call site should use the returned value"]
 pub fn metric_value(stats: &Stats, metric: Metric) -> Option<f64> {
     match metric {
         Metric::BinaryBytes => stats.binary_bytes.as_ref().map(|s| s.median as f64),

--- a/crates/perfgate-scaling/src/chart.rs
+++ b/crates/perfgate-scaling/src/chart.rs
@@ -17,6 +17,7 @@ use crate::report::SizeMeasurement;
 /// * `coefficients` - The fitted coefficients for the best model
 /// * `width` - Chart width in characters (default: 60)
 /// * `height` - Chart height in lines (default: 20)
+#[must_use = "pure computation; call site should use the returned chart string"]
 pub fn render_ascii_chart(
     measurements: &[SizeMeasurement],
     best_fit: ComplexityClass,

--- a/crates/perfgate-scaling/src/fit.rs
+++ b/crates/perfgate-scaling/src/fit.rs
@@ -14,6 +14,7 @@ use crate::report::SizeMeasurement;
 ///
 /// Returns `(complexity_class, r_squared, coefficients)`.
 /// Coefficients are `[a, b]` for `y = a * g(n) + b`.
+#[must_use = "pure computation; call site should use the returned fit result"]
 pub fn fit_model(
     measurements: &[SizeMeasurement],
     class: ComplexityClass,
@@ -26,6 +27,7 @@ pub fn fit_model(
 }
 
 /// Fit all complexity models and return results sorted by fit quality.
+#[must_use = "pure computation; call site should use the returned model fits"]
 pub fn fit_all_models(measurements: &[SizeMeasurement]) -> Vec<(ComplexityClass, f64, Vec<f64>)> {
     ComplexityClass::all()
         .iter()
@@ -37,6 +39,7 @@ pub fn fit_all_models(measurements: &[SizeMeasurement]) -> Vec<(ComplexityClass,
 ///
 /// R^2 = 1 - SS_res / SS_tot
 /// where SS_res = sum((y_i - y_hat_i)^2) and SS_tot = sum((y_i - y_mean)^2)
+#[must_use = "pure computation; call site should use the returned R-squared value"]
 pub fn r_squared(actual: &[f64], predicted: &[f64]) -> f64 {
     if actual.len() != predicted.len() || actual.is_empty() {
         return 0.0;

--- a/crates/perfgate-scaling/src/lib.rs
+++ b/crates/perfgate-scaling/src/lib.rs
@@ -58,6 +58,7 @@ pub const DEFAULT_R_SQUARED_THRESHOLD: f64 = 0.90;
 /// let result = classify_complexity(&measurements, None);
 /// assert!(result.is_ok());
 /// ```
+#[must_use = "pure computation; call site should use the returned ScalingResult"]
 pub fn classify_complexity(
     measurements: &[SizeMeasurement],
     r_squared_threshold: Option<f64>,
@@ -107,6 +108,7 @@ pub fn classify_complexity(
 ///
 /// Returns `true` if the detected complexity is worse (higher order)
 /// than the expected complexity.
+#[must_use = "pure computation; call site should use the returned degradation flag"]
 pub fn is_complexity_degraded(expected: ComplexityClass, actual: ComplexityClass) -> bool {
     actual.order() > expected.order()
 }
@@ -122,6 +124,7 @@ pub fn is_complexity_degraded(expected: ComplexityClass, actual: ComplexityClass
 /// assert_eq!(parse_complexity("O(n)").unwrap(), ComplexityClass::ON);
 /// assert_eq!(parse_complexity("O(n^2)").unwrap(), ComplexityClass::ON2);
 /// ```
+#[must_use = "pure computation; call site should use the returned ComplexityClass"]
 pub fn parse_complexity(s: &str) -> Result<ComplexityClass, ScalingError> {
     let normalized = s.trim().to_lowercase().replace(' ', "").replace("o(", "O(");
 

--- a/crates/perfgate-sha256/src/lib.rs
+++ b/crates/perfgate-sha256/src/lib.rs
@@ -69,6 +69,7 @@ const H0: [u32; 8] = [
 /// assert_eq!(hash.len(), 64);
 /// assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
 /// ```
+#[must_use = "pure computation; call site should use the returned hash string"]
 pub fn sha256_hex(data: &[u8]) -> String {
     let mut h = H0;
 

--- a/crates/perfgate-significance/src/lib.rs
+++ b/crates/perfgate-significance/src/lib.rs
@@ -87,6 +87,7 @@ use statrs::distribution::{ContinuousCDF, StudentsT};
 /// assert!(sig.significant); // Clear performance regression
 /// assert!(sig.p_value.unwrap() < 0.05);
 /// ```
+#[must_use = "pure computation; call site should use the returned Significance"]
 pub fn compute_significance(
     baseline: &[f64],
     current: &[f64],
@@ -171,6 +172,7 @@ pub fn compute_significance(
 /// assert!((mean - 14.0).abs() < 1e-10);
 /// assert!(var > 0.0); // Sample variance with Bessel's correction
 /// ```
+#[must_use = "pure computation; call site should use the returned mean and variance"]
 pub fn mean_and_variance(values: &[f64]) -> Option<(f64, f64)> {
     if values.is_empty() {
         return None;

--- a/crates/perfgate-stats/src/lib.rs
+++ b/crates/perfgate-stats/src/lib.rs
@@ -37,6 +37,7 @@ use std::cmp::Ordering;
 /// assert_eq!(s.min, 10);
 /// assert_eq!(s.max, 30);
 /// ```
+#[must_use = "pure computation; call site should use the returned summary"]
 pub fn summarize_u64(values: &[u64]) -> Result<U64Summary, StatsError> {
     if values.is_empty() {
         return Err(StatsError::NoSamples);
@@ -79,6 +80,7 @@ pub fn summarize_u64(values: &[u64]) -> Result<U64Summary, StatsError> {
 /// assert_eq!(s.min, 1.0);
 /// assert_eq!(s.max, 3.0);
 /// ```
+#[must_use = "pure computation; call site should use the returned summary"]
 pub fn summarize_f64(values: &[f64]) -> Result<F64Summary, StatsError> {
     if values.is_empty() {
         return Err(StatsError::NoSamples);
@@ -104,6 +106,7 @@ pub fn summarize_f64(values: &[f64]) -> Result<F64Summary, StatsError> {
     })
 }
 
+#[must_use = "pure computation; call site should use the returned median"]
 pub fn median_u64_sorted(sorted: &[u64]) -> u64 {
     debug_assert!(!sorted.is_empty());
     let n = sorted.len();
@@ -115,6 +118,7 @@ pub fn median_u64_sorted(sorted: &[u64]) -> u64 {
     }
 }
 
+#[must_use = "pure computation; call site should use the returned median"]
 pub fn median_f64_sorted(sorted: &[f64]) -> f64 {
     debug_assert!(!sorted.is_empty());
     let n = sorted.len();
@@ -141,6 +145,7 @@ pub fn median_f64_sorted(sorted: &[f64]) -> f64 {
 /// let p0 = percentile(vec![10.0, 20.0, 30.0], 0.0).unwrap();
 /// assert_eq!(p0, 10.0);
 /// ```
+#[must_use = "pure computation; call site should use the returned percentile"]
 pub fn percentile(mut values: Vec<f64>, q: f64) -> Option<f64> {
     if values.is_empty() {
         return None;
@@ -183,6 +188,7 @@ pub fn percentile(mut values: Vec<f64>, q: f64) -> Option<f64> {
 /// assert_eq!(mean, 42.0);
 /// assert_eq!(var, 0.0);
 /// ```
+#[must_use = "pure computation; call site should use the returned mean and variance"]
 pub fn mean_and_variance(values: &[f64]) -> Option<(f64, f64)> {
     if values.is_empty() {
         return None;

--- a/crates/perfgate-stats/src/trend.rs
+++ b/crates/perfgate-stats/src/trend.rs
@@ -100,6 +100,7 @@ impl Default for TrendConfig {
 /// assert!((intercept - 1.0).abs() < 1e-10);
 /// assert!((r2 - 1.0).abs() < 1e-10);
 /// ```
+#[must_use = "pure computation; call site should use the returned regression coefficients"]
 pub fn linear_regression(points: &[(f64, f64)]) -> Option<(f64, f64, f64)> {
     let n = points.len();
     if n < 2 {
@@ -158,6 +159,7 @@ pub fn linear_regression(points: &[(f64, f64)]) -> Option<(f64, f64, f64)> {
 /// `direction_lower_is_better` indicates whether lower metric values are desirable.
 /// - `true` (e.g., wall_ms): breach when value rises above threshold.
 /// - `false` (e.g., throughput_per_s): breach when value drops below threshold.
+#[must_use = "pure computation; call site should use the returned breach prediction"]
 pub fn predict_breach_run(
     slope: f64,
     intercept: f64,
@@ -206,6 +208,7 @@ pub fn predict_breach_run(
 /// `current_value` is the metric value at the latest run.
 /// `threshold` is the budget fail threshold (absolute value the metric must not exceed).
 /// `direction_lower_is_better` specifies the metric direction.
+#[must_use = "pure computation; call site should use the returned DriftClass"]
 pub fn classify_drift(
     slope: f64,
     r_squared: f64,
@@ -257,6 +260,7 @@ pub fn classify_drift(
 /// For "higher is better" metrics: headroom = (current - threshold) / threshold * 100.
 ///
 /// Positive headroom means the metric is within budget. Negative means it has exceeded.
+#[must_use = "pure computation; call site should use the returned headroom percentage"]
 pub fn compute_headroom_pct(
     current_value: f64,
     threshold: f64,
@@ -292,6 +296,7 @@ pub fn compute_headroom_pct(
 /// assert_eq!(result.drift, DriftClass::Degrading);
 /// assert!(result.runs_to_breach.is_some());
 /// ```
+#[must_use = "pure computation; call site should use the returned TrendAnalysis"]
 pub fn analyze_trend(
     values: &[f64],
     metric_name: &str,
@@ -364,6 +369,7 @@ pub fn analyze_trend(
 /// let chart = spark_chart(&[1.0, 2.0, 3.0, 4.0, 5.0]);
 /// assert_eq!(chart.len(), 5);
 /// ```
+#[must_use = "pure computation; call site should use the returned spark chart"]
 pub fn spark_chart(values: &[f64]) -> String {
     if values.is_empty() {
         return String::new();


### PR DESCRIPTION
## Summary

- Added `#[must_use]` annotations to 33 pure computation functions across 6 crates (`perfgate-domain`, `perfgate-stats`, `perfgate-significance`, `perfgate-budget`, `perfgate-sha256`, `perfgate-scaling`)
- Covers all public functions that perform pure computation and return values without side effects: stats summarization, significance testing, budget evaluation, SHA-256 hashing, complexity classification, trend analysis, and curve fitting
- No functional changes; only compile-time lint annotations added

Closes #186

## Test plan

- [x] `cargo fmt --all` passes
- [x] `cargo build --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes with zero warnings
- [x] `cargo test --all` passes (all unit, property-based, integration, and doc tests)