### PR TITLE
docs: validate CLI examples in getting started guide

### DIFF
--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -1,8 +1,8 @@
 # Getting Started with the Baseline Server
 
 This guide documents the current, shipped baseline-server workflow in
-`perfgate 0.15.x`. It intentionally focuses on commands and flags that exist
-today.
+`perfgate 0.15.1`. Every CLI example below has been validated against the
+actual binary. It intentionally focuses on commands and flags that exist today.
 
 ## Pick a Mode
 


### PR DESCRIPTION
## Summary
- Validated every CLI example in `docs/GETTING_STARTED_BASELINE_SERVER.md` against the actual `perfgate 0.15.1` binary
- All flags, subcommands, server endpoints, and config fields are correct
- Updated version reference from `0.15.x` to `0.15.1` and noted examples are validated

### Validation performed
Every command in the document was checked against `--help` output:
- `serve --no-open --port 8484`
- `run --name --out`
- `promote --current --to-server --benchmark --version`
- `compare --baseline @server:<bench> --current --out`
- `baseline list`, `baseline history --benchmark`, `baseline download`, `baseline upload`, `baseline delete`, `baseline verdicts`, `baseline submit-verdict`, `baseline migrate`
- `check --config --bench`
- `perfgate-server --storage-type --database-url --api-keys`
- Auth flags: `--api-key`, `--jwt-secret`, `--github-oidc`, `--gitlab-oidc`, `--oidc-provider`
- Config fields: `url`, `api_key`, `project`, `fallback_to_local`
- Server endpoints verified against actual route definitions
- All referenced docs (`README.md`, `CONFIG.md`, `ARCHITECTURE.md`, `perfgate-server/README.md`) exist

No broken examples were found.

Closes #52

## Test plan
- [ ] Verify the doc renders correctly on GitHub
- [ ] No code changes; fmt/clippy/tests unaffected