### PR TITLE
feat: add variance-aware aggregate weighting

### DIFF
--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -317,8 +317,11 @@ fn wall_ms_variance(receipt: &RunReceipt) -> (u32, Option<f64>) {
     }
 
     let mean = values.iter().sum::<f64>() / values.len() as f64;
-    let variance =
-        values.iter().map(|value| (value - mean).powi(2)).sum::<f64>() / (values.len() - 1) as f64;
+    let variance = values
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / (values.len() - 1) as f64;
     (sample_count, Some(variance))
 }
 
@@ -695,8 +698,10 @@ mod tests {
         let stable_b_path = dir.path().join("stable-b.json");
         let noisy_path = dir.path().join("noisy.json");
 
-        let stable_a = mk_receipt_with_wall_samples("1", "linux", "x86_64", 0, &[100, 100, 100, 100]);
-        let stable_b = mk_receipt_with_wall_samples("2", "linux", "x86_64", 0, &[110, 110, 110, 110]);
+        let stable_a =
+            mk_receipt_with_wall_samples("1", "linux", "x86_64", 0, &[100, 100, 100, 100]);
+        let stable_b =
+            mk_receipt_with_wall_samples("2", "linux", "x86_64", 0, &[110, 110, 110, 110]);
         let noisy = mk_receipt_with_wall_samples("3", "linux", "x86_64", 1, &[80, 140, 60, 160]);
 
         fs::write(&stable_a_path, serde_json::to_string(&stable_a).unwrap()).unwrap();
@@ -737,7 +742,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(inverse.aggregate.verdict.status, MetricStatus::Pass);
-        assert_eq!(inverse.aggregate.weight_mode, AggregateWeightMode::InverseVariance);
+        assert_eq!(
+            inverse.aggregate.weight_mode,
+            AggregateWeightMode::InverseVariance
+        );
         assert_eq!(inverse.aggregate.variance_floor, Some(1.0));
         assert_eq!(inverse.aggregate.verdict.outlier_runners, Some(1));
 
@@ -756,7 +764,8 @@ mod tests {
 
         assert!(noisy_input.runner.outlier_reason.is_some());
         assert!(
-            stable_input.runner.effective_weight.unwrap() > noisy_input.runner.effective_weight.unwrap()
+            stable_input.runner.effective_weight.unwrap()
+                > noisy_input.runner.effective_weight.unwrap()
         );
     }
 
@@ -842,7 +851,10 @@ mod tests {
         assert_eq!(outcome.aggregate.schema, AGGREGATE_SCHEMA_V1);
         assert_eq!(outcome.aggregate.benchmark, "bench");
         assert_eq!(outcome.aggregate.policy, AggregationPolicy::All);
-        assert_eq!(outcome.aggregate.weight_mode, AggregateWeightMode::Configured);
+        assert_eq!(
+            outcome.aggregate.weight_mode,
+            AggregateWeightMode::Configured
+        );
         assert_eq!(outcome.aggregate.variance_floor, None);
         assert_eq!(outcome.aggregate.inputs.len(), 2);
         assert_eq!(outcome.aggregate.verdict.status, MetricStatus::Pass);

--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -332,7 +332,7 @@ fn median(values: &[f64]) -> Option<f64> {
     let mut sorted = values.to_vec();
     sorted.sort_by(|a, b| a.total_cmp(b));
     let mid = sorted.len() / 2;
-    Some(if sorted.len() % 2 == 0 {
+    Some(if sorted.len().is_multiple_of(2) {
         (sorted[mid - 1] + sorted[mid]) / 2.0
     } else {
         sorted[mid]

--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -1,10 +1,14 @@
 use perfgate_domain::compute_stats;
 use perfgate_types::{
     AGGREGATE_SCHEMA_V1, AggregateInput, AggregateReceipt, AggregateRunnerMeta, AggregateVerdict,
-    AggregationPolicy, FailIfNOfM, HostInfo, MetricStatus, RunMeta, RunReceipt,
+    AggregateWeightMode, AggregationPolicy, FailIfNOfM, HostInfo, MetricStatus, RunMeta,
+    RunReceipt,
 };
 use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
+
+const DEFAULT_VARIANCE_FLOOR: f64 = 1.0;
+const OUTLIER_VARIANCE_RATIO: f64 = 4.0;
 
 pub struct AggregateRequest {
     pub files: Vec<PathBuf>,
@@ -12,6 +16,8 @@ pub struct AggregateRequest {
     pub quorum: Option<f64>,
     pub fail_if: Option<FailIfNOfM>,
     pub weights: BTreeMap<String, f64>,
+    pub weight_mode: AggregateWeightMode,
+    pub variance_floor: Option<f64>,
     pub runner_class: Option<String>,
     pub lane: Option<String>,
 }
@@ -22,6 +28,13 @@ pub struct AggregateOutcome {
 }
 
 pub struct AggregateUseCase;
+
+struct RunnerWeightProfile {
+    sample_count: u32,
+    wall_ms_variance: Option<f64>,
+    effective_weight: Option<f64>,
+    outlier_reason: Option<String>,
+}
 
 impl AggregateUseCase {
     pub fn execute(&self, req: AggregateRequest) -> anyhow::Result<AggregateOutcome> {
@@ -66,6 +79,8 @@ impl AggregateUseCase {
         let work_units = receipts[0].bench.work_units;
 
         let stats = compute_stats(&combined_samples, work_units)?;
+        let variance_floor = req.variance_floor.unwrap_or(DEFAULT_VARIANCE_FLOOR);
+        let runner_profiles = build_runner_weight_profiles(&receipts, &req, variance_floor);
 
         // Update bench metadata.
         let mut bench = receipts[0].bench.clone();
@@ -100,6 +115,7 @@ impl AggregateUseCase {
         for (idx, r) in receipts.iter().enumerate() {
             let label = format!("{}-{}", r.run.host.os, r.run.host.arch);
             let status = input_status(r);
+            let profile = &runner_profiles[idx];
             inputs.push(AggregateInput {
                 source: sources[idx].clone(),
                 run_id: r.run.id.clone(),
@@ -110,13 +126,26 @@ impl AggregateUseCase {
                     class: req.runner_class.clone(),
                     lane: req.lane.clone(),
                     weight: req.weights.get(&label).copied(),
+                    sample_count: Some(profile.sample_count),
+                    wall_ms_variance: profile.wall_ms_variance,
+                    effective_weight: profile.effective_weight,
+                    outlier_reason: profile.outlier_reason.clone(),
                 },
                 status,
                 reasons: input_reasons(r),
             });
         }
 
-        let warnings = host_mismatch_warnings(&receipts);
+        let mut warnings = host_mismatch_warnings(&receipts);
+        let outlier_runners = runner_profiles
+            .iter()
+            .filter(|profile| profile.outlier_reason.is_some())
+            .count();
+        if outlier_runners > 0 {
+            warnings.push(format!(
+                "{outlier_runners} runner(s) flagged as wall_ms variance outliers"
+            ));
+        }
         let verdict = evaluate_policy(&inputs, &req);
 
         let aggregate = AggregateReceipt {
@@ -127,7 +156,10 @@ impl AggregateUseCase {
             policy: req.policy,
             quorum: req.quorum,
             fail_if: req.fail_if,
+            weight_mode: req.weight_mode,
             weights: req.weights,
+            variance_floor: matches!(req.weight_mode, AggregateWeightMode::InverseVariance)
+                .then_some(variance_floor),
             inputs,
             verdict,
             warnings,
@@ -216,6 +248,94 @@ fn compare_hosts(a: &HostInfo, b: &HostInfo) -> Vec<String> {
     reasons
 }
 
+fn build_runner_weight_profiles(
+    receipts: &[RunReceipt],
+    req: &AggregateRequest,
+    variance_floor: f64,
+) -> Vec<RunnerWeightProfile> {
+    let normalized_variance_floor = variance_floor.max(f64::EPSILON);
+    let mut profiles: Vec<_> = receipts
+        .iter()
+        .map(|receipt| {
+            let (sample_count, wall_ms_variance) = wall_ms_variance(receipt);
+            let label = format!("{}-{}", receipt.run.host.os, receipt.run.host.arch);
+            let configured_weight = req.weights.get(&label).copied().unwrap_or(1.0);
+            let effective_weight = matches!(req.policy, AggregationPolicy::Weighted).then_some(
+                match req.weight_mode {
+                    AggregateWeightMode::Configured => configured_weight,
+                    AggregateWeightMode::InverseVariance => {
+                        configured_weight
+                            / wall_ms_variance
+                                .unwrap_or(normalized_variance_floor)
+                                .max(normalized_variance_floor)
+                    }
+                },
+            );
+            RunnerWeightProfile {
+                sample_count,
+                wall_ms_variance,
+                effective_weight,
+                outlier_reason: None,
+            }
+        })
+        .collect();
+
+    if matches!(req.weight_mode, AggregateWeightMode::InverseVariance)
+        && let Some(median_variance) = median(
+            &profiles
+                .iter()
+                .filter_map(|profile| profile.wall_ms_variance)
+                .collect::<Vec<_>>(),
+        )
+    {
+        let threshold = median_variance.max(normalized_variance_floor) * OUTLIER_VARIANCE_RATIO;
+        for profile in &mut profiles {
+            if let Some(observed_variance) = profile.wall_ms_variance
+                && observed_variance > threshold
+            {
+                profile.outlier_reason = Some(format!(
+                    "wall_ms variance {:.3} exceeds peer median {:.3}",
+                    observed_variance, median_variance
+                ));
+            }
+        }
+    }
+
+    profiles
+}
+
+fn wall_ms_variance(receipt: &RunReceipt) -> (u32, Option<f64>) {
+    let values: Vec<f64> = receipt
+        .samples
+        .iter()
+        .filter(|sample| !sample.warmup)
+        .map(|sample| sample.wall_ms as f64)
+        .collect();
+    let sample_count = values.len() as u32;
+    if values.len() < 2 {
+        return (sample_count, None);
+    }
+
+    let mean = values.iter().sum::<f64>() / values.len() as f64;
+    let variance =
+        values.iter().map(|value| (value - mean).powi(2)).sum::<f64>() / (values.len() - 1) as f64;
+    (sample_count, Some(variance))
+}
+
+fn median(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let mid = sorted.len() / 2;
+    Some(if sorted.len() % 2 == 0 {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    } else {
+        sorted[mid]
+    })
+}
+
 fn evaluate_policy(inputs: &[AggregateInput], req: &AggregateRequest) -> AggregateVerdict {
     let passed = inputs
         .iter()
@@ -226,13 +346,17 @@ fn evaluate_policy(inputs: &[AggregateInput], req: &AggregateRequest) -> Aggrega
 
     let weighted_total: f64 = inputs
         .iter()
-        .map(|i| req.weights.get(&i.runner.label).copied().unwrap_or(1.0))
+        .map(|input| input.runner.effective_weight.unwrap_or(1.0))
         .sum();
     let weighted_pass: f64 = inputs
         .iter()
         .filter(|i| i.status == MetricStatus::Pass)
-        .map(|i| req.weights.get(&i.runner.label).copied().unwrap_or(1.0))
+        .map(|input| input.runner.effective_weight.unwrap_or(1.0))
         .sum();
+    let outlier_runners = inputs
+        .iter()
+        .filter(|input| input.runner.outlier_reason.is_some())
+        .count() as u32;
 
     let mut reasons = Vec::new();
     let status = match req.policy {
@@ -321,6 +445,7 @@ fn evaluate_policy(inputs: &[AggregateInput], req: &AggregateRequest) -> Aggrega
             AggregationPolicy::Weighted | AggregationPolicy::Quorum
         )
         .then_some(req.quorum.unwrap_or(0.5)),
+        outlier_runners: (outlier_runners > 0).then_some(outlier_runners),
         reasons,
     }
 }
@@ -393,6 +518,39 @@ mod tests {
         }
     }
 
+    fn mk_receipt_with_wall_samples(
+        id: &str,
+        os: &str,
+        arch: &str,
+        exit_code: i32,
+        wall_samples: &[u64],
+    ) -> RunReceipt {
+        let mut receipt = mk_receipt(id, os, arch, exit_code);
+        receipt.samples = wall_samples
+            .iter()
+            .map(|wall_ms| Sample {
+                wall_ms: *wall_ms,
+                exit_code,
+                warmup: false,
+                timed_out: false,
+                cpu_ms: None,
+                page_faults: None,
+                ctx_switches: None,
+                max_rss_kb: None,
+                io_read_bytes: None,
+                io_write_bytes: None,
+                network_packets: None,
+                energy_uj: None,
+                binary_bytes: None,
+                stdout: None,
+                stderr: None,
+            })
+            .collect();
+        receipt.bench.repeat = wall_samples.len() as u32;
+        receipt.stats = compute_stats(&receipt.samples, receipt.bench.work_units).unwrap();
+        receipt
+    }
+
     #[test]
     fn majority_policy_passes_when_most_inputs_pass() {
         let inputs = vec![
@@ -406,6 +564,10 @@ mod tests {
                     class: None,
                     lane: None,
                     weight: None,
+                    sample_count: None,
+                    wall_ms_variance: None,
+                    effective_weight: None,
+                    outlier_reason: None,
                 },
                 status: MetricStatus::Pass,
                 reasons: vec![],
@@ -420,6 +582,10 @@ mod tests {
                     class: None,
                     lane: None,
                     weight: None,
+                    sample_count: None,
+                    wall_ms_variance: None,
+                    effective_weight: None,
+                    outlier_reason: None,
                 },
                 status: MetricStatus::Fail,
                 reasons: vec!["non-zero".to_string()],
@@ -434,6 +600,10 @@ mod tests {
                     class: None,
                     lane: None,
                     weight: None,
+                    sample_count: None,
+                    wall_ms_variance: None,
+                    effective_weight: None,
+                    outlier_reason: None,
                 },
                 status: MetricStatus::Pass,
                 reasons: vec![],
@@ -448,6 +618,8 @@ mod tests {
                 quorum: None,
                 fail_if: None,
                 weights: BTreeMap::new(),
+                weight_mode: AggregateWeightMode::Configured,
+                variance_floor: None,
                 runner_class: None,
                 lane: None,
             },
@@ -471,6 +643,10 @@ mod tests {
                     class: None,
                     lane: None,
                     weight: Some(0.8),
+                    sample_count: None,
+                    wall_ms_variance: None,
+                    effective_weight: Some(0.8),
+                    outlier_reason: None,
                 },
                 status: MetricStatus::Pass,
                 reasons: vec![],
@@ -485,6 +661,10 @@ mod tests {
                     class: None,
                     lane: None,
                     weight: Some(0.2),
+                    sample_count: None,
+                    wall_ms_variance: None,
+                    effective_weight: Some(0.2),
+                    outlier_reason: None,
                 },
                 status: MetricStatus::Fail,
                 reasons: vec!["non-zero".to_string()],
@@ -498,12 +678,86 @@ mod tests {
                 quorum: Some(0.7),
                 fail_if: None,
                 weights,
+                weight_mode: AggregateWeightMode::Configured,
+                variance_floor: None,
                 runner_class: None,
                 lane: None,
             },
         );
         assert_eq!(verdict.status, MetricStatus::Pass);
         assert_eq!(verdict.weighted_pass, Some(0.8));
+    }
+
+    #[test]
+    fn inverse_variance_weighting_downranks_noisy_failures_and_marks_outliers() {
+        let dir = tempdir().unwrap();
+        let stable_a_path = dir.path().join("stable-a.json");
+        let stable_b_path = dir.path().join("stable-b.json");
+        let noisy_path = dir.path().join("noisy.json");
+
+        let stable_a = mk_receipt_with_wall_samples("1", "linux", "x86_64", 0, &[100, 100, 100, 100]);
+        let stable_b = mk_receipt_with_wall_samples("2", "linux", "x86_64", 0, &[110, 110, 110, 110]);
+        let noisy = mk_receipt_with_wall_samples("3", "linux", "x86_64", 1, &[80, 140, 60, 160]);
+
+        fs::write(&stable_a_path, serde_json::to_string(&stable_a).unwrap()).unwrap();
+        fs::write(&stable_b_path, serde_json::to_string(&stable_b).unwrap()).unwrap();
+        fs::write(&noisy_path, serde_json::to_string(&noisy).unwrap()).unwrap();
+
+        let configured = AggregateUseCase
+            .execute(AggregateRequest {
+                files: vec![
+                    stable_a_path.clone(),
+                    stable_b_path.clone(),
+                    noisy_path.clone(),
+                ],
+                policy: AggregationPolicy::Weighted,
+                quorum: Some(0.75),
+                fail_if: None,
+                weights: BTreeMap::new(),
+                weight_mode: AggregateWeightMode::Configured,
+                variance_floor: None,
+                runner_class: None,
+                lane: None,
+            })
+            .unwrap();
+        assert_eq!(configured.aggregate.verdict.status, MetricStatus::Fail);
+
+        let inverse = AggregateUseCase
+            .execute(AggregateRequest {
+                files: vec![stable_a_path, stable_b_path, noisy_path],
+                policy: AggregationPolicy::Weighted,
+                quorum: Some(0.75),
+                fail_if: None,
+                weights: BTreeMap::new(),
+                weight_mode: AggregateWeightMode::InverseVariance,
+                variance_floor: Some(1.0),
+                runner_class: None,
+                lane: None,
+            })
+            .unwrap();
+
+        assert_eq!(inverse.aggregate.verdict.status, MetricStatus::Pass);
+        assert_eq!(inverse.aggregate.weight_mode, AggregateWeightMode::InverseVariance);
+        assert_eq!(inverse.aggregate.variance_floor, Some(1.0));
+        assert_eq!(inverse.aggregate.verdict.outlier_runners, Some(1));
+
+        let noisy_input = inverse
+            .aggregate
+            .inputs
+            .iter()
+            .find(|input| input.run_id == "3")
+            .unwrap();
+        let stable_input = inverse
+            .aggregate
+            .inputs
+            .iter()
+            .find(|input| input.run_id == "1")
+            .unwrap();
+
+        assert!(noisy_input.runner.outlier_reason.is_some());
+        assert!(
+            stable_input.runner.effective_weight.unwrap() > noisy_input.runner.effective_weight.unwrap()
+        );
     }
 
     #[test]
@@ -574,6 +828,8 @@ mod tests {
                 quorum: None,
                 fail_if: None,
                 weights: BTreeMap::new(),
+                weight_mode: AggregateWeightMode::Configured,
+                variance_floor: None,
                 runner_class: None,
                 lane: None,
             })
@@ -586,6 +842,8 @@ mod tests {
         assert_eq!(outcome.aggregate.schema, AGGREGATE_SCHEMA_V1);
         assert_eq!(outcome.aggregate.benchmark, "bench");
         assert_eq!(outcome.aggregate.policy, AggregationPolicy::All);
+        assert_eq!(outcome.aggregate.weight_mode, AggregateWeightMode::Configured);
+        assert_eq!(outcome.aggregate.variance_floor, None);
         assert_eq!(outcome.aggregate.inputs.len(), 2);
         assert_eq!(outcome.aggregate.verdict.status, MetricStatus::Pass);
     }

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -40,9 +40,9 @@ use perfgate_scaling::{
 };
 use perfgate_summary::{SummaryRequest, SummaryUseCase};
 use perfgate_types::{
-    AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig, ChangedFilesSummary,
-    CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy, MetricStatus,
-    OtelSpanIdentifiers, PerfgateReport, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
+    AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
+    ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
+    MetricStatus, OtelSpanIdentifiers, PerfgateReport, RatchetConfig, REPAIR_CONTEXT_SCHEMA_V1,
     RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, SensorVerdictStatus,
     ToolInfo, VerdictStatus,
 };
@@ -289,6 +289,14 @@ enum Command {
         /// Runner weights as label=value (repeatable), e.g. linux-x86_64=0.5
         #[arg(long = "weight")]
         weights: Vec<String>,
+
+        /// Weighting mode for weighted policy: configured or inverse_variance
+        #[arg(long, default_value = "configured", value_parser = parse_aggregate_weight_mode)]
+        weight_mode: AggregateWeightMode,
+
+        /// Minimum variance used by inverse-variance weighting when a runner is extremely stable
+        #[arg(long)]
+        variance_floor: Option<f64>,
 
         /// Optional runner class/tag added to each input in the aggregate receipt
         #[arg(long)]
@@ -2162,6 +2170,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
             fail_n,
             fail_m,
             weights,
+            weight_mode,
+            variance_floor,
             runner_class,
             lane,
             out,
@@ -2174,7 +2184,14 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                     resolved_files.push(entry?);
                 }
             }
-            let (quorum, fail_if) = validate_aggregate_options(policy, quorum, fail_n, fail_m)?;
+            let (quorum, fail_if, variance_floor) = validate_aggregate_options(
+                policy,
+                weight_mode,
+                quorum,
+                fail_n,
+                fail_m,
+                variance_floor,
+            )?;
             let weight_map = parse_weight_map(&weights)?;
             let outcome = usecase.execute(perfgate_app::AggregateRequest {
                 files: resolved_files,
@@ -2182,6 +2199,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 quorum,
                 fail_if,
                 weights: weight_map,
+                weight_mode,
+                variance_floor,
                 runner_class,
                 lane,
             })?;
@@ -5099,6 +5118,16 @@ fn parse_aggregation_policy(s: &str) -> Result<AggregationPolicy, String> {
     }
 }
 
+fn parse_aggregate_weight_mode(s: &str) -> Result<AggregateWeightMode, String> {
+    match s {
+        "configured" => Ok(AggregateWeightMode::Configured),
+        "inverse_variance" => Ok(AggregateWeightMode::InverseVariance),
+        _ => Err(format!(
+            "invalid aggregate weight mode: {s} (expected configured|inverse_variance)"
+        )),
+    }
+}
+
 fn parse_weight_map(weights: &[String]) -> anyhow::Result<BTreeMap<String, f64>> {
     let mut map = BTreeMap::new();
     for raw in weights {
@@ -5121,10 +5150,12 @@ fn parse_weight_map(weights: &[String]) -> anyhow::Result<BTreeMap<String, f64>>
 
 fn validate_aggregate_options(
     policy: AggregationPolicy,
+    weight_mode: AggregateWeightMode,
     quorum: Option<f64>,
     fail_n: Option<u32>,
     fail_m: Option<u32>,
-) -> anyhow::Result<(Option<f64>, Option<FailIfNOfM>)> {
+    variance_floor: Option<f64>,
+) -> anyhow::Result<(Option<f64>, Option<FailIfNOfM>, Option<f64>)> {
     if let Some(quorum) = quorum {
         if !quorum.is_finite() || !(0.0..=1.0).contains(&quorum) {
             anyhow::bail!("--quorum must be between 0.0 and 1.0, got {quorum}");
@@ -5134,6 +5165,23 @@ fn validate_aggregate_options(
             AggregationPolicy::Weighted | AggregationPolicy::Quorum
         ) {
             anyhow::bail!("--quorum requires --policy weighted or quorum");
+        }
+    }
+
+    if matches!(weight_mode, AggregateWeightMode::InverseVariance)
+        && !matches!(policy, AggregationPolicy::Weighted)
+    {
+        anyhow::bail!("--weight-mode inverse_variance requires --policy weighted");
+    }
+
+    if let Some(variance_floor) = variance_floor {
+        if !variance_floor.is_finite() || variance_floor <= 0.0 {
+            anyhow::bail!(
+                "--variance-floor must be a positive finite number, got {variance_floor}"
+            );
+        }
+        if !matches!(weight_mode, AggregateWeightMode::InverseVariance) {
+            anyhow::bail!("--variance-floor requires --weight-mode inverse_variance");
         }
     }
 
@@ -5152,13 +5200,13 @@ fn validate_aggregate_options(
                     anyhow::bail!("--fail-m must be greater than or equal to --fail-n");
                 }
             }
-            Ok((quorum, Some(FailIfNOfM { n, m: fail_m })))
+            Ok((quorum, Some(FailIfNOfM { n, m: fail_m }), variance_floor))
         }
         _ => {
             if fail_n.is_some() || fail_m.is_some() {
                 anyhow::bail!("--fail-n and --fail-m require --policy fail_if_n_of_m");
             }
-            Ok((quorum, None))
+            Ok((quorum, None, variance_floor))
         }
     }
 }
@@ -5552,6 +5600,29 @@ mod tests {
             err.to_string().contains("non-negative finite number"),
             "unexpected error: {}",
             err
+        );
+    }
+
+    #[test]
+    fn parse_aggregate_weight_mode_accepts_inverse_variance() {
+        let mode = parse_aggregate_weight_mode("inverse_variance").unwrap();
+        assert_eq!(mode, AggregateWeightMode::InverseVariance);
+    }
+
+    #[test]
+    fn validate_aggregate_options_rejects_inverse_variance_without_weighted_policy() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Majority,
+            AggregateWeightMode::InverseVariance,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("requires --policy weighted"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -42,7 +42,7 @@ use perfgate_summary::{SummaryRequest, SummaryUseCase};
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
-    MetricStatus, OtelSpanIdentifiers, PerfgateReport, RatchetConfig, REPAIR_CONTEXT_SCHEMA_V1,
+    MetricStatus, OtelSpanIdentifiers, PerfgateReport, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
     RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, SensorVerdictStatus,
     ToolInfo, VerdictStatus,
 };

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -602,6 +602,27 @@ impl AggregationPolicy {
     }
 }
 
+/// Weighting mode for runner-aware aggregate verdicts.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum AggregateWeightMode {
+    /// Use configured weights directly, or 1.0 when no explicit weight is set.
+    #[default]
+    Configured,
+    /// Scale configured weights by inverse observed wall-clock variance.
+    InverseVariance,
+}
+
+impl AggregateWeightMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AggregateWeightMode::Configured => "configured",
+            AggregateWeightMode::InverseVariance => "inverse_variance",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct AggregateRunnerMeta {
@@ -616,6 +637,18 @@ pub struct AggregateRunnerMeta {
     /// Optional configured runner weight.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub weight: Option<f64>,
+    /// Number of measured samples considered for runner weighting metadata.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub sample_count: Option<u32>,
+    /// Observed variance of `wall_ms` across measured samples for this runner.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub wall_ms_variance: Option<f64>,
+    /// Effective runner weight after the selected weighting mode is applied.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub effective_weight: Option<f64>,
+    /// Optional note when this runner appears substantially noisier than peers.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub outlier_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
@@ -650,6 +683,9 @@ pub struct AggregateVerdict {
     /// Quorum threshold used by quorum/weighted policies.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub required: Option<f64>,
+    /// Number of runners flagged as variance outliers.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub outlier_runners: Option<u32>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub reasons: Vec<String>,
 }
@@ -674,8 +710,11 @@ pub struct AggregateReceipt {
     pub quorum: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub fail_if: Option<FailIfNOfM>,
+    pub weight_mode: AggregateWeightMode,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub weights: BTreeMap<String, f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub variance_floor: Option<f64>,
     pub inputs: Vec<AggregateInput>,
     pub verdict: AggregateVerdict,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]

--- a/schemas/perfgate.aggregate.v1.schema.json
+++ b/schemas/perfgate.aggregate.v1.schema.json
@@ -41,6 +41,13 @@
     "tool": {
       "$ref": "#/$defs/ToolInfo"
     },
+    "variance_floor": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double"
+    },
     "verdict": {
       "$ref": "#/$defs/AggregateVerdict"
     },
@@ -49,6 +56,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "weight_mode": {
+      "$ref": "#/$defs/AggregateWeightMode"
     },
     "weights": {
       "type": "object",
@@ -64,6 +74,7 @@
     "run",
     "benchmark",
     "policy",
+    "weight_mode",
     "inputs",
     "verdict"
   ],
@@ -118,6 +129,14 @@
             "null"
           ]
         },
+        "effective_weight": {
+          "description": "Effective runner weight after the selected weighting mode is applied.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "label": {
           "description": "Matrix label for this runner (for example: \"ubuntu-x86_64\").",
           "type": "string"
@@ -128,6 +147,30 @@
             "string",
             "null"
           ]
+        },
+        "outlier_reason": {
+          "description": "Optional note when this runner appears substantially noisier than peers.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sample_count": {
+          "description": "Number of measured samples considered for runner weighting metadata.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "wall_ms_variance": {
+          "description": "Observed variance of `wall_ms` across measured samples for this runner.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
         },
         "weight": {
           "description": "Optional configured runner weight.",
@@ -147,6 +190,15 @@
       "properties": {
         "failed": {
           "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "outlier_runners": {
+          "description": "Number of runners flagged as variance outliers.",
+          "type": [
+            "integer",
+            "null"
+          ],
           "format": "uint32",
           "minimum": 0
         },
@@ -199,6 +251,21 @@
         "passed",
         "failed",
         "total"
+      ]
+    },
+    "AggregateWeightMode": {
+      "description": "Weighting mode for runner-aware aggregate verdicts.",
+      "oneOf": [
+        {
+          "description": "Use configured weights directly, or 1.0 when no explicit weight is set.",
+          "type": "string",
+          "const": "configured"
+        },
+        {
+          "description": "Scale configured weights by inverse observed wall-clock variance.",
+          "type": "string",
+          "const": "inverse_variance"
+        }
       ]
     },
     "AggregationPolicy": {


### PR DESCRIPTION
## Summary
- add opt-in inverse_variance weighting for perfgate aggregate
- record per-runner sample count, variance, effective weight, and outlier notes in aggregate receipts
- keep existing configured weighting as the default path and add CLI/tests for the new mode

Closes #81

## Testing
- not run (not requested)