### PR TITLE
feat: track flakiness in verdict history

### DIFF
--- a/crates/perfgate-api/src/lib.rs
+++ b/crates/perfgate-api/src/lib.rs
@@ -118,6 +118,12 @@ pub struct VerdictRecord {
     /// Git commit SHA
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_sha: Option<String>,
+    /// Coefficient of variation for benchmark wall time in this verdict.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wall_ms_cv: Option<f64>,
+    /// Historical flakiness score derived from recent wall-time CV samples.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flakiness_score: Option<f64>,
     /// Creation timestamp
     pub created_at: DateTime<Utc>,
 }
@@ -132,6 +138,8 @@ pub struct SubmitVerdictRequest {
     pub reasons: Vec<String>,
     pub git_ref: Option<String>,
     pub git_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wall_ms_cv: Option<f64>,
 }
 
 /// Request for verdict list operation.

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1387,6 +1387,25 @@ enum BaselineAction {
         status: Option<VerdictStatus>,
     },
 
+    /// Show benchmarks with historically noisy verdicts.
+    Flaky {
+        /// Optional benchmark name to filter by
+        #[arg(long)]
+        benchmark: Option<String>,
+
+        /// Project name (uses --project flag or PERFGATE_PROJECT if not specified)
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Maximum number of recent verdict records to inspect
+        #[arg(long, default_value_t = 200)]
+        limit: u32,
+
+        /// Minimum flakiness score to show (0.0-1.0)
+        #[arg(long, default_value_t = 0.5, value_parser = parse_flakiness_score)]
+        min_score: f64,
+    },
+
     /// Submit a benchmark verdict to the server.
     SubmitVerdict {
         /// Path to a compare receipt
@@ -3448,9 +3467,90 @@ fn execute_baseline_action(
                     );
                     for record in &response.verdicts {
                         let git_ref = record.git_ref.as_deref().unwrap_or("unknown");
+                        let cv_suffix = record
+                            .wall_ms_cv
+                            .map(|cv| format!(", wall_cv={:.2}", cv))
+                            .unwrap_or_default();
+                        let score_suffix = record
+                            .flakiness_score
+                            .map(|score| format!(", flakiness={:.2}", score))
+                            .unwrap_or_default();
                         println!(
-                            "  [{:?}] {} - {} ({})",
-                            record.status, record.benchmark, record.created_at, git_ref
+                            "  [{:?}] {} - {} ({}){}{}",
+                            record.status,
+                            record.benchmark,
+                            record.created_at,
+                            git_ref,
+                            cv_suffix,
+                            score_suffix
+                        );
+                    }
+                }
+
+                Ok::<(), anyhow::Error>(())
+            })?;
+        }
+
+        BaselineAction::Flaky {
+            benchmark,
+            project,
+            limit,
+            min_score,
+        } => {
+            let project = server_config.resolve_project(project)?;
+            let mut query = ListVerdictsQuery::new().with_limit(limit);
+            if let Some(bench) = benchmark {
+                query = query.with_benchmark(bench);
+            }
+
+            rt.block_on(async {
+                let response = client
+                    .list_verdicts(&project, &query)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to get flakiness history for project {}", project)
+                    })?;
+
+                let mut latest_by_benchmark = std::collections::BTreeMap::new();
+                for record in &response.verdicts {
+                    latest_by_benchmark
+                        .entry(record.benchmark.clone())
+                        .or_insert(record);
+                }
+
+                let mut flaky: Vec<_> = latest_by_benchmark
+                    .into_values()
+                    .filter(|record| record.flakiness_score.unwrap_or(0.0) >= min_score)
+                    .collect();
+                flaky.sort_by(|left, right| {
+                    right
+                        .flakiness_score
+                        .unwrap_or(0.0)
+                        .total_cmp(&left.flakiness_score.unwrap_or(0.0))
+                });
+
+                if flaky.is_empty() {
+                    println!(
+                        "No flaky benchmarks found for project '{}' at score >= {:.2}.",
+                        project, min_score
+                    );
+                } else {
+                    println!(
+                        "Flaky benchmarks for {} (score >= {:.2}):",
+                        project, min_score
+                    );
+                    for record in flaky {
+                        let cv = record
+                            .wall_ms_cv
+                            .map(|value| format!("{:.2}", value))
+                            .unwrap_or_else(|| "n/a".to_string());
+                        println!(
+                            "  {:.2}  {}  latest_cv={}  {:?}  {}",
+                            record.flakiness_score.unwrap_or(0.0),
+                            record.benchmark,
+                            cv,
+                            record.status,
+                            record.created_at
                         );
                     }
                 }
@@ -3480,6 +3580,10 @@ fn execute_baseline_action(
                 reasons: compare_receipt.verdict.reasons.clone(),
                 git_ref,
                 git_sha,
+                wall_ms_cv: compare_receipt
+                    .deltas
+                    .get(&perfgate_types::Metric::WallMs)
+                    .and_then(|delta| delta.cv),
             };
 
             rt.block_on(async {
@@ -3871,6 +3975,10 @@ fn submit_verdict_if_possible(
             reasons: compare_receipt.verdict.reasons.clone(),
             git_ref: None, // Could be extracted if needed
             git_sha: None,
+            wall_ms_cv: compare_receipt
+                .deltas
+                .get(&perfgate_types::Metric::WallMs)
+                .and_then(|delta| delta.cv),
         };
 
         if let Err(e) = with_tokio_runtime(async {
@@ -5079,6 +5187,16 @@ fn parse_noise_policy(s: &str) -> Result<perfgate_types::NoisePolicy, String> {
             "invalid noise policy: {s} (expected warn|skip|ignore)"
         )),
     }
+}
+
+fn parse_flakiness_score(s: &str) -> Result<f64, String> {
+    let score: f64 = s
+        .parse()
+        .map_err(|_| "flakiness score must be a number".to_string())?;
+    if !score.is_finite() || !(0.0..=1.0).contains(&score) {
+        return Err("flakiness score must be between 0.0 and 1.0".to_string());
+    }
+    Ok(score)
 }
 
 fn parse_verdict_status(s: &str) -> Result<VerdictStatus, String> {

--- a/crates/perfgate-server/src/handlers/verdicts.rs
+++ b/crates/perfgate-server/src/handlers/verdicts.rs
@@ -15,6 +15,69 @@ use crate::models::{
 };
 use crate::server::AppState;
 
+const HIGH_FLAKINESS_CV_THRESHOLD: f64 = 0.30;
+const FLAKINESS_HISTORY_LIMIT: u32 = 20;
+
+fn score_flakiness_history(cv_history: &[f64]) -> Option<f64> {
+    let filtered: Vec<f64> = cv_history
+        .iter()
+        .copied()
+        .filter(|cv| cv.is_finite() && *cv >= 0.0)
+        .collect();
+    if filtered.is_empty() {
+        return None;
+    }
+
+    let noisy_ratio = filtered
+        .iter()
+        .filter(|cv| **cv > HIGH_FLAKINESS_CV_THRESHOLD)
+        .count() as f64
+        / filtered.len() as f64;
+    let mean_severity = filtered
+        .iter()
+        .map(|cv| (cv / HIGH_FLAKINESS_CV_THRESHOLD).min(2.0) / 2.0)
+        .sum::<f64>()
+        / filtered.len() as f64;
+
+    Some((noisy_ratio * 0.7 + mean_severity * 0.3).min(1.0))
+}
+
+async fn compute_flakiness_score(
+    state: &AppState,
+    project: &str,
+    benchmark: &str,
+    current_wall_ms_cv: Option<f64>,
+) -> Option<f64> {
+    let mut cv_history = Vec::new();
+    if let Some(cv) = current_wall_ms_cv.filter(|cv| cv.is_finite() && *cv >= 0.0) {
+        cv_history.push(cv);
+    }
+
+    let query = ListVerdictsQuery::new()
+        .with_benchmark(benchmark.to_string())
+        .with_limit(FLAKINESS_HISTORY_LIMIT.saturating_sub(1));
+    match state.store.list_verdicts(project, &query).await {
+        Ok(response) => {
+            cv_history.extend(
+                response
+                    .verdicts
+                    .into_iter()
+                    .filter_map(|record| record.wall_ms_cv),
+            );
+        }
+        Err(e) => {
+            warn!(
+                error = %e,
+                project = %project,
+                benchmark = %benchmark,
+                "Failed to load verdict history for flakiness scoring"
+            );
+        }
+    }
+
+    score_flakiness_history(&cv_history)
+}
+
 /// Submit a new benchmark verdict.
 pub async fn submit_verdict(
     Path(project): Path<String>,
@@ -39,6 +102,8 @@ pub async fn submit_verdict(
         ));
     }
 
+    let flakiness_score =
+        compute_flakiness_score(&state, &project, &request.benchmark, request.wall_ms_cv).await;
     let record = VerdictRecord {
         schema: VERDICT_SCHEMA_V1.to_string(),
         id: generate_ulid(),
@@ -50,6 +115,8 @@ pub async fn submit_verdict(
         reasons: request.reasons,
         git_ref: request.git_ref,
         git_sha: request.git_sha,
+        wall_ms_cv: request.wall_ms_cv,
+        flakiness_score,
         created_at: chrono::Utc::now(),
     };
 

--- a/crates/perfgate-server/src/storage/postgres.rs
+++ b/crates/perfgate-server/src/storage/postgres.rs
@@ -198,6 +198,8 @@ impl PostgresStore {
                 reasons JSONB NOT NULL,
                 git_ref VARCHAR(255),
                 git_sha VARCHAR(40),
+                wall_ms_cv DOUBLE PRECISION,
+                flakiness_score DOUBLE PRECISION,
                 created_at TIMESTAMPTZ NOT NULL
             );
 
@@ -232,6 +234,16 @@ impl PostgresStore {
             .execute(&self.pool)
             .await
             .map_err(|e| StoreError::ConnectionError(format!("Failed to init schema: {}", e)))?;
+        sqlx::query("ALTER TABLE verdicts ADD COLUMN IF NOT EXISTS wall_ms_cv DOUBLE PRECISION")
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StoreError::ConnectionError(format!("Failed to migrate schema: {}", e)))?;
+        sqlx::query(
+            "ALTER TABLE verdicts ADD COLUMN IF NOT EXISTS flakiness_score DOUBLE PRECISION",
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StoreError::ConnectionError(format!("Failed to migrate schema: {}", e)))?;
 
         Ok(())
     }
@@ -648,8 +660,8 @@ impl BaselineStore for PostgresStore {
         let sql = r#"
             INSERT INTO verdicts (
                 id, schema_id, project, benchmark, run_id, status, counts, reasons,
-                git_ref, git_sha, created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                git_ref, git_sha, wall_ms_cv, flakiness_score, created_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
         "#;
 
         let counts_json =
@@ -669,6 +681,8 @@ impl BaselineStore for PostgresStore {
             .bind(reasons_json)
             .bind(&record.git_ref)
             .bind(&record.git_sha)
+            .bind(record.wall_ms_cv)
+            .bind(record.flakiness_score)
             .bind(record.created_at)
             .execute(&self.pool)
             .await
@@ -790,6 +804,8 @@ impl PostgresStore {
             reasons,
             git_ref: row.get("git_ref"),
             git_sha: row.get("git_sha"),
+            wall_ms_cv: row.get("wall_ms_cv"),
+            flakiness_score: row.get("flakiness_score"),
             created_at: row.get("created_at"),
         })
     }

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -136,6 +136,8 @@ impl SqliteStore {
                 reasons TEXT NOT NULL,
                 git_ref TEXT,
                 git_sha TEXT,
+                wall_ms_cv REAL,
+                flakiness_score REAL,
                 created_at TEXT NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_verdicts_project_benchmark ON verdicts(project, benchmark);
@@ -156,6 +158,8 @@ impl SqliteStore {
             CREATE INDEX IF NOT EXISTS idx_audit_events_action ON audit_events(action);
             "#,
         )?;
+        let _ = conn.execute("ALTER TABLE verdicts ADD COLUMN wall_ms_cv REAL", []);
+        let _ = conn.execute("ALTER TABLE verdicts ADD COLUMN flakiness_score REAL", []);
         Ok(())
     }
 
@@ -537,8 +541,8 @@ impl BaselineStore for SqliteStore {
             r#"
             INSERT INTO verdicts (
                 id, schema_id, project, benchmark, run_id, status, counts, reasons,
-                git_ref, git_sha, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                git_ref, git_sha, wall_ms_cv, flakiness_score, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
             params![
                 record.id,
@@ -551,6 +555,8 @@ impl BaselineStore for SqliteStore {
                 reasons_json,
                 record.git_ref,
                 record.git_sha,
+                record.wall_ms_cv,
+                record.flakiness_score,
                 created_at_str
             ],
         )?;
@@ -650,7 +656,7 @@ impl SqliteStore {
         let reasons_json: String = row.get(7)?;
         let reasons = serde_json::from_str(&reasons_json).unwrap_or_default();
 
-        let created_at_str: String = row.get(10)?;
+        let created_at_str: String = row.get(12)?;
         let created_at = chrono::DateTime::parse_from_rfc3339(&created_at_str)
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .unwrap_or_else(|_| chrono::Utc::now());
@@ -666,6 +672,8 @@ impl SqliteStore {
             reasons,
             git_ref: row.get(8)?,
             git_sha: row.get(9)?,
+            wall_ms_cv: row.get(10)?,
+            flakiness_score: row.get(11)?,
             created_at,
         })
     }


### PR DESCRIPTION
## Summary
- store benchmark wall-time CV on submitted verdicts and derive a historical flakiness score from recent verdict history
- surface wall_ms_cv and flakiness_score through existing verdict history output and add a new perfgate baseline flaky CLI view
- migrate existing sqlite/postgres verdict tables in place so older baseline-service databases can adopt the new fields

Partial #79

## Testing
- not run (not requested)