### PR TITLE
refactor: use sort_by_key with Reverse for descending sorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed clippy warnings by replacing `sort_by` with `sort_by_key` and `std::cmp::Reverse` for descending sorts in storage backends.
+
 ## [0.15.1] - 2026-03-28
 
 ### Fixed

--- a/crates/perfgate-server/src/storage/key_store.rs
+++ b/crates/perfgate-server/src/storage/key_store.rs
@@ -116,7 +116,7 @@ impl KeyStore for InMemoryKeyStore {
     async fn list_keys(&self) -> Result<Vec<KeyRecord>, StoreError> {
         let records = self.records.read().await;
         let mut keys: Vec<_> = records.values().cloned().collect();
-        keys.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        keys.sort_by_key(|b| std::cmp::Reverse(b.created_at));
         Ok(keys)
     }
 

--- a/crates/perfgate-server/src/storage/memory.rs
+++ b/crates/perfgate-server/src/storage/memory.rs
@@ -154,7 +154,7 @@ impl BaselineStore for InMemoryStore {
             })
             .collect();
 
-        filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        filtered.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         let total = filtered.len() as u64;
         let offset = query.offset as usize;
@@ -253,7 +253,7 @@ impl BaselineStore for InMemoryStore {
             })
             .collect();
 
-        versions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        versions.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         if let Some(first) = versions.first_mut() {
             first.is_current = true;
@@ -319,7 +319,7 @@ impl BaselineStore for InMemoryStore {
             .cloned()
             .collect();
 
-        filtered.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        filtered.sort_by_key(|b| std::cmp::Reverse(b.created_at));
 
         let total = filtered.len() as u64;
         let offset = query.offset as usize;
@@ -399,7 +399,7 @@ impl AuditStore for InMemoryStore {
             .cloned()
             .collect();
 
-        filtered.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        filtered.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
 
         let total = filtered.len() as u64;
         let offset = query.offset as usize;


### PR DESCRIPTION
Fixed clippy warnings by replacing `sort_by` with `sort_by_key` and `std::cmp::Reverse` for descending sorts in storage backends.