### PR TITLE
docs: define 0.16 public surface policy

### DIFF
--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -1,128 +1,145 @@
-# Perfgate Crate Seams and Architecture
+# Perfgate Crate Seams and Public Surface
 
-This document defines the target public crate surface and the absorption plan for internal implementation crates.
+This document is the canonical 0.16 crate-surface contract. It keeps the
+clean-architecture seams that made the workspace useful, but stops treating
+every seam as a public package.
 
 ## Governing Rule
 
-> **Crates are public contracts. Folders are architectural boundaries.**
+> Crates are public contracts. Folders and modules are architectural boundaries.
 
-## Target Public Crates (13)
+The target is a small public package surface backed by enforceable internal
+seams. The product should be easy to depend on without exposing every internal
+refactoring decision as a crates.io package.
 
-### Primary Product / Contract Crates
+## Target Public Crates
 
-| Crate | Purpose |
-|-------|---------|
-| `perfgate` | Umbrella library for local performance-gating workflows |
-| `perfgate-cli` | Installed binary package, command-line UX |
-| `perfgate-server` | Centralized baseline management server |
-| `perfgate-client` | Client SDK for baseline service |
-| `perfgate-api` | Shared baseline-service API contract |
-| `perfgate-types` | Versioned receipt/config/domain DTO contract |
-| `perfgate-config` | Config loading, parsing, merging, normalization |
-| `perfgate-domain` | Pure decision logic: stats, budgets, significance, paired/scaling analysis, host mismatch policy |
+By the end of the 0.16 public-surface collapse, only these packages should be
+publishable:
 
-### Published Support Crates
+| Crate | Role |
+|-------|------|
+| `perfgate` | Main embeddable facade for local performance-gating workflows |
+| `perfgate-cli` | Installs the `perfgate` binary |
+| `perfgate-types` | Stable receipts, schemas, config, and wire contracts |
+| `perfgate-client` | Baseline service client |
+| `perfgate-server` | Baseline service binary/library |
 
-| Crate | Purpose |
-|-------|---------|
-| `perfgate-error` | Shared error surface across the public crate family |
-| `perfgate-render` | Markdown, GitHub annotation text, report rendering |
-| `perfgate-export` | CSV, JSONL, HTML, Prometheus, JUnit export formats |
-| `perfgate-ingest` | Importing Criterion, hyperfine, and external benchmark formats |
-| `perfgate-github` | GitHub API / PR-comment integration |
+All other workspace packages must have one explicit disposition:
 
-## Absorbed Crates
+- absorbed into one of the public crates as an internal module,
+- deleted from the workspace,
+- marked `publish = false`,
+- or kept temporarily as a deprecated compatibility shim.
 
-The following crates will be moved into module folders under their owning crates:
+## Current Landed Moves
 
-| Current Crate | New Location | Owner Crate |
-|---------------|--------------|-------------|
-| `perfgate-validation` | `perfgate-types::validation` | perfgate-types |
-| `perfgate-auth` | `perfgate-api::auth` | perfgate-api |
-| `perfgate-summary` | `perfgate-render::summary` | perfgate-render |
-| `perfgate-stats` | `perfgate-domain::stats` | perfgate-domain |
-| `perfgate-significance` | `perfgate-domain::significance` | perfgate-domain |
-| `perfgate-budget` | `perfgate-domain::budget` | perfgate-domain |
-| `perfgate-paired` | `perfgate-domain::paired` | perfgate-domain |
-| `perfgate-host-detect` | `perfgate-domain::host_mismatch` | perfgate-domain |
-| `perfgate-scaling` | `perfgate-domain::scaling` | perfgate-domain |
-| `perfgate-app` | `perfgate::workflow` | perfgate |
-| `perfgate-adapters` | `perfgate::ops` | perfgate |
-| `perfgate-profile` | `perfgate::diagnostics::profile` | perfgate |
-| `perfgate-sha256` | `perfgate::fingerprint` | perfgate |
-| `perfgate-sensor` | `perfgate::integrations::cockpit` | perfgate |
-| `perfgate-fake` | `tests/support` or `perfgate-testkit` | internal |
-| `perfgate-selfbench` | `benches/` or internal | internal |
+PR #223 started the real collapse and is the current implementation truth:
+
+| Former crate | Current owner | Status |
+|--------------|---------------|--------|
+| `perfgate-validation` | `perfgate_types::validation` | crate deleted |
+| `perfgate-auth` | `perfgate_api::auth` | crate deleted |
+| `perfgate-summary` | `perfgate_render::summary` | crate deleted |
+| `perfgate-stats` | `perfgate_domain::stats` | crate deleted |
+| `perfgate-paired` | `perfgate_domain::paired` | compatibility wrapper remains |
+
+Those paths are intentionally more conservative than the final facade shape.
+Future PRs may re-export or move pieces again, but they must do so with the
+policy files and docs updated in the same change.
+
+## Remaining Absorption Map
+
+`policy/absorbed_crates.txt` is the machine-readable disposition list. The
+high-level target is:
+
+| Current package | Target owner |
+|-----------------|--------------|
+| `perfgate-error` | `perfgate_types::error` |
+| `perfgate-config` | `perfgate_types::config` |
+| `perfgate-api` | `perfgate_types::baseline_service` or shared client/server contract |
+| `perfgate-domain` | `perfgate::domain` |
+| `perfgate-budget` | `perfgate::core::budget` |
+| `perfgate-significance` | `perfgate::core::significance` |
+| `perfgate-host-detect` | `perfgate::domain::host` |
+| `perfgate-scaling` | `perfgate::domain::scaling` |
+| `perfgate-sha256` | `perfgate::core::fingerprint` |
+| `perfgate-render` | `perfgate::presentation::render` |
+| `perfgate-export` | `perfgate::presentation::export` |
+| `perfgate-sensor` | `perfgate::presentation::sensor` |
+| `perfgate-adapters` | `perfgate::runtime` |
+| `perfgate-profile` | `perfgate::runtime::profile` |
+| `perfgate-app` | `perfgate::app` |
+| `perfgate-github` | `perfgate::integrations::github` |
+| `perfgate-ingest` | `perfgate::integrations::ingest` |
+| `perfgate-fake` | `perfgate::test_support` or private dev crate |
+| `perfgate-selfbench` | private workspace crate |
 
 ## Dependency Direction Rules
 
-### Good Dependencies
+These rules preserve the SRP architecture after crate collapse:
 
-```
-perfgate-cli -> perfgate -> perfgate-domain -> perfgate-types
-perfgate-server -> perfgate-api -> perfgate-domain -> perfgate-types
-perfgate-client -> perfgate-api -> perfgate-types
-perfgate-render/export/ingest -> perfgate-types
-perfgate-config -> perfgate-types
-```
-
-### Bad Dependencies (Forbidden)
-
-```
-perfgate-types -> perfgate-domain
-perfgate-config -> perfgate-client
-perfgate-domain -> perfgate-render
-perfgate-domain -> perfgate-config
-perfgate-api -> perfgate-server
-perfgate-client -> perfgate-server
-perfgate-cli -> perfgate-app/adapters/profile/sensor/scaling
+```text
+types must not depend on runtime, app, server, client, or cli
+core/domain must not depend on filesystem, process execution, server, client, or cli
+presentation must not depend on process execution, server, client, or cli
+runtime must not depend on cli, server, or client
+client must not depend on server
+server must not depend on cli
+cli is the outermost adapter
 ```
 
-## Module-Layer Rules
+The current enforcement starts with public-surface disposition. A later
+`xtask arch` check should enforce source/module dependency rules.
 
-1. **One owner crate per concept**
-2. **One folder per absorbed former crate**
-3. **Curated public facades**
-4. **`pub(crate)` by default**
-5. **No deep lateral imports**
-6. **Module-local tests and docs**
+## Enforcement
 
-## Publication Rules
+Run:
 
-- Only the 13 public crates should have `publish = true`
-- All internal/dev-only packages must have `publish = false`
-- Absorbed crates must be removed from `[workspace].members`
-- Absorbed crates must be removed from `[workspace.dependencies]`
-- No absorbed folder should contain its old `Cargo.toml`
+```bash
+cargo run -p xtask -- public-surface
+```
+
+This command fails if a publishable workspace package is neither listed in
+`policy/public_crates.txt` nor assigned a disposition in
+`policy/absorbed_crates.txt`.
+
+Run:
+
+```bash
+cargo run -p xtask -- public-surface --strict
+```
+
+Strict mode is the release-end gate. It fails while any absorbed package is
+still publishable.
 
 ## Migration Order
 
-1. Phase 0: Create this documentation and policy files
-2. Phase 1: Add workspace defaults
-3. Phase 2: Absorb contract-adjacent crates (validation, auth, summary)
-4. Phase 3: Collapse domain shards (stats, significance, budget, paired, host-detect, scaling)
-5. Phase 4: Collapse runtime/orchestration (adapters, profile, sensor, app, sha256)
-6. Phase 5: Clean up config/client dependency direction
-7. Phase 6: Simplify CLI dependencies
-8. Phase 7: Move test-only utilities (fake, selfbench)
-9. Phase 8: Final manifest shrink and validation
+1. Land first seam absorption and compatibility wrappers.
+2. Establish enforceable public-surface policy.
+3. Collapse contract-adjacent crates.
+4. Collapse pure core and domain policy crates.
+5. Collapse presentation, runtime, app, and integration crates.
+6. Convert remaining published packages into deprecated shims or mark them
+   private.
+7. Add `xtask arch` for source/module dependency rules.
+8. Update README, architecture docs, examples, and changelog for 0.16.
 
-## Validation Commands
+## Per-PR Checklist
 
-Run after each phase:
-```bash
-cargo check --workspace --all-targets
-cargo test --workspace
-cargo run -p xtask -- ci
-```
+- Code moved into the target owner module.
+- Workspace imports updated.
+- Compatibility shim kept only when intentionally preserving a published path.
+- Old package removed from `[workspace].members` or marked `publish = false`.
+- `policy/absorbed_crates.txt` status updated.
+- Docs and examples reference the current owner path.
+- `cargo run -p xtask -- public-surface` passes.
+- `cargo run -p xtask -- ci` passes.
 
-Run before publishing:
-```bash
-cargo package --list -p perfgate
-cargo publish --dry-run -p perfgate
-```
+## References
 
-Check for absorbed names:
-```bash
-rg "perfgate-(stats|significance|budget|paired|host-detect|scaling|app|adapters|profile|sha256|sensor|summary|validation|auth)"
-```
+- [REFACTORING_0_16.md](REFACTORING_0_16.md)
+- [MIGRATION_0_16.md](MIGRATION_0_16.md)
+- [ARCHITECTURE.md](ARCHITECTURE.md)
+- [policy/public_crates.txt](../policy/public_crates.txt)
+- [policy/absorbed_crates.txt](../policy/absorbed_crates.txt)

--- a/docs/MIGRATION_0_16.md
+++ b/docs/MIGRATION_0_16.md
@@ -1,0 +1,347 @@
+# Migration Guide: 0.16.0 Public API Refactoring
+
+This guide helps users update their code as perfgate's public crate surface changes in version 0.16.0 and beyond.
+
+---
+
+## What's Changing?
+
+For the 0.16 release line, perfgate's public package surface is being
+reorganized from many microcrates to **5 main crates** with strongly organized
+internal modules.
+
+The collapse is landing PR by PR. Do not assume every old microcrate receives a
+new 0.16 compatibility release. Some internal crates may be deleted directly,
+while already-public paths that need a transition can remain as compatibility
+wrappers for one release.
+
+---
+
+## New Public Crate Surface
+
+| Crate | Purpose | New in 0.16? |
+|-------|---------|------------|
+| `perfgate` | Main embeddable library and facade | Primary entry point |
+| `perfgate-types` | Stable receipts, config, schemas | For parsing JSON receipts |
+| `perfgate-cli` | Installs the `perfgate` binary | No change |
+| `perfgate-client` | Baseline service client | No change |
+| `perfgate-server` | Baseline service binary/library | No change |
+
+All other perfgate crates are moving toward internal-module status inside the
+public packages above.
+
+---
+
+## What Changed and How to Update
+
+### If you import from `perfgate-*` microcrates
+
+**Before (0.15.x)**:
+```rust
+use perfgate_stats::summarize_u64;
+use perfgate_budget::{eval_budget, Verdict};
+use perfgate_domain::CompareResult;
+use perfgate_render::markdown;
+```
+
+**After the relevant absorption PR lands**:
+```rust
+use perfgate_domain::stats::summarize_u64;
+use perfgate::core::budget::{eval_budget, Verdict};
+use perfgate::domain::CompareResult;
+use perfgate::presentation::render::markdown;
+```
+
+---
+
+### Crate-to-Module Mapping
+
+Use this table to find the new import path for any old crate:
+
+| Old Crate | Current / Target Module | Example |
+|-----------|-------------------------|---------|
+| `perfgate-stats` | `perfgate_domain::stats` now; facade path later | `use perfgate_domain::stats::summarize_u64;` |
+| `perfgate-budget` | `perfgate::core::budget` | `use perfgate::core::budget::eval_budget;` |
+| `perfgate-significance` | `perfgate::core::significance` | `use perfgate::core::significance::*;` |
+| `perfgate-paired` | `perfgate_domain::paired` now; facade path later | `use perfgate_domain::paired::*;` |
+| `perfgate-sha256` | `perfgate::core::fingerprint` | `use perfgate::core::fingerprint::*;` |
+| `perfgate-domain` | `perfgate::domain` | `use perfgate::domain::*;` |
+| `perfgate-host-detect` | `perfgate::domain::host` | `use perfgate::domain::host::*;` |
+| `perfgate-scaling` | `perfgate::domain::scaling` | `use perfgate::domain::scaling::*;` |
+| `perfgate-render` | `perfgate::presentation::render` | `use perfgate::presentation::render::*;` |
+| `perfgate-export` | `perfgate::presentation::export` | `use perfgate::presentation::export::*;` |
+| `perfgate-sensor` | `perfgate::presentation::sensor` | `use perfgate::presentation::sensor::*;` |
+| `perfgate-summary` | `perfgate::presentation::summary` | `use perfgate::presentation::summary::*;` |
+| `perfgate-error` | `perfgate_types::error` | `use perfgate_types::error::*;` |
+| `perfgate-validation` | `perfgate_types::validation` | `use perfgate_types::validation::*;` |
+| `perfgate-auth` | `perfgate_api::auth` now; final owner TBD | `use perfgate_api::auth::*;` |
+| `perfgate-config` | `perfgate_types::config` | `use perfgate_types::config::*;` |
+| `perfgate-api` | `perfgate_types::baseline_service` | `use perfgate_types::baseline_service::*;` |
+| `perfgate-fake` | `perfgate::test_support` | `use perfgate::test_support::*;` (requires `test-support` feature) |
+| `perfgate-adapters` | `perfgate::runtime` | `use perfgate::runtime::*;` |
+| `perfgate-app` | `perfgate::app` | `use perfgate::app::*;` |
+
+---
+
+### In Your Cargo.toml
+
+**Before (0.15.x)**:
+```toml
+[dependencies]
+perfgate = "0.15"
+perfgate-stats = "0.15"
+perfgate-budget = "0.15"
+perfgate-domain = "0.15"
+perfgate-types = "0.15"
+```
+
+**Target after the 0.16 collapse**:
+```toml
+[dependencies]
+perfgate = "0.16"
+perfgate-types = "0.16"  # Only if you need types directly
+
+# No need to depend on perfgate-stats, perfgate-budget, perfgate-domain, etc.
+# They are now internal modules accessed through the main crate.
+```
+
+---
+
+### Optional Features
+
+After the feature-gated facade modules land, some modules are behind feature flags:
+
+```toml
+[dependencies]
+perfgate = { version = "0.16", features = ["render", "export", "github"] }
+perfgate-types = "0.16"
+```
+
+Available features:
+- `core` - Core stats, budget, significance (enabled by default)
+- `domain` - Domain logic and policies (enabled by default)
+- `runtime` - System adapters and I/O (enabled by default)
+- `render` - Markdown and terminal rendering
+- `export` - CSV, JSONL, HTML, Prometheus export
+- `sensor` - Cockpit mode and sensor reports
+- `github` - GitHub annotations and integration
+- `ingest` - Data ingestion adapters
+- `test-support` - Test data generators (dev-only)
+
+---
+
+## Examples
+
+### Example 1: Computing Statistics
+
+**Before (0.15.x)**:
+```rust
+use perfgate_stats::summarize_u64;
+
+fn analyze() -> Result<(), Box<dyn std::error::Error>> {
+    let stats = summarize_u64(&[10, 30, 20])?;
+    println!("Median: {}", stats.median);
+    Ok(())
+}
+```
+
+**After the stats absorption**:
+```rust
+use perfgate_domain::stats::summarize_u64;
+
+fn analyze() -> Result<(), Box<dyn std::error::Error>> {
+    let stats = summarize_u64(&[10, 30, 20])?;
+    println!("Median: {}", stats.median);
+    Ok(())
+}
+```
+
+### Example 2: Evaluating Budgets
+
+**Before (0.15.x)**:
+```rust
+use perfgate_budget::eval_budget;
+use perfgate_types::{Budget, Run};
+
+fn check(run: &Run, budget: &Budget) {
+    let verdict = eval_budget(run, budget);
+    println!("Verdict: {}", verdict);
+}
+```
+
+**Target after the corresponding absorption PR**:
+```rust
+use perfgate::core::budget::eval_budget;
+use perfgate_types::{Budget, Run};
+
+fn check(run: &Run, budget: &Budget) {
+    let verdict = eval_budget(run, budget);
+    println!("Verdict: {}", verdict);
+}
+```
+
+### Example 3: Comparing Runs
+
+**Before (0.15.x)**:
+```rust
+use perfgate_domain::compare;
+use perfgate_types::{Run, CompareConfig};
+
+fn compare_runs(baseline: &Run, current: &Run, config: &CompareConfig) {
+    let result = compare(baseline, current, config);
+    println!("Comparison: {:?}", result);
+}
+```
+
+**Target after the corresponding absorption PR**:
+```rust
+use perfgate::domain::compare;
+use perfgate_types::{Run, CompareConfig};
+
+fn compare_runs(baseline: &Run, current: &Run, config: &CompareConfig) {
+    let result = compare(baseline, current, config);
+    println!("Comparison: {:?}", result);
+}
+```
+
+### Example 4: Using Test Fixtures
+
+**Before (0.15.x)**:
+```rust
+use perfgate_fake::fake_run;
+
+#[test]
+fn test_my_thing() {
+    let run = fake_run();
+    assert!(!run.samples.is_empty());
+}
+```
+
+**Target after the corresponding absorption PR**:
+```rust
+#[cfg(test)]
+use perfgate::test_support::fake_run;
+
+#[test]
+fn test_my_thing() {
+    let run = fake_run();
+    assert!(!run.samples.is_empty());
+}
+```
+
+Or add `test-support` feature to your dev-dependencies:
+```toml
+[dev-dependencies]
+perfgate = { version = "0.16", features = ["test-support"] }
+```
+
+---
+
+## What About Deprecation Warnings?
+
+During the transition, some old crate paths may remain as compatibility shims
+and emit deprecation warnings:
+
+```
+warning: use of deprecated crate `perfgate_stats`
+  --> src/main.rs:1:5
+   |
+1  | use perfgate_stats::describe;
+   |     ^^^^^^^^^^^^^^
+   |
+   = note: Use perfgate::core::stats instead
+```
+
+**Action**: Update your imports to the new paths. The warnings will go away.
+
+**Deadline**: Compatibility shims are temporary. Internal-only crates may be
+deleted without a new shim release, so prefer the owner paths listed in
+`policy/absorbed_crates.txt`.
+
+---
+
+## Troubleshooting
+
+### "Module not found" after updating to 0.16.0
+
+Make sure you have:
+1. Updated `Cargo.toml` to use `perfgate = "0.16"`
+2. Updated your imports to use the new module paths from the mapping table
+3. Added necessary features if you use render, export, or other optional modules
+
+### Old crate import still works but shows deprecation warning
+
+That crate is currently a compatibility shim. Update your imports to the owner
+path listed in this guide or `policy/absorbed_crates.txt`.
+
+### Feature not available in the module I'm importing
+
+Check if the module is feature-gated. For example, if you import from `perfgate::presentation::render`, add the `render` feature to Cargo.toml:
+
+```toml
+[dependencies]
+perfgate = { version = "0.16", features = ["render"] }
+```
+
+### Can't find a symbol that was in the old crate
+
+The symbol might have moved to a different module or been renamed. Check the old crate's documentation and cross-reference with the new module path.
+
+---
+
+## Frequently Asked Questions
+
+### Will my code break when I update to 0.16.0?
+
+**No**. In 0.16.0, old imports still work with deprecation warnings. You have until 0.17.0 (or later) to update your code.
+
+### Do I need to update my Cargo.toml?
+
+Not immediately in 0.16.0. But to remove deprecation warnings and prepare for 0.17.0, update your `Cargo.toml`:
+1. Remove `perfgate-stats`, `perfgate-budget`, etc. from dependencies
+2. Keep only `perfgate` and `perfgate-types`
+3. Add features if you use optional modules
+
+### What if I'm using many internal crates?
+
+Use the mapping table above to find the new module path for each old crate. Then update imports in your code.
+
+### Should I use `perfgate` or the individual internal modules?
+
+Use `perfgate::prelude::*` for most common types and functions:
+
+```rust
+use perfgate::prelude::*;
+```
+
+This gives you clean access to the public API without importing every module. For specific modules (like `perfgate::core::stats`), import them directly as needed.
+
+---
+
+## Timeline
+
+| Version | Status | Action |
+|---------|--------|--------|
+| 0.15.x and earlier | Published | Broad microcrate surface |
+| 0.16.0 | Target release line | Owner modules plus temporary shims where needed |
+| 0.17.0+ | Future | Remove remaining transition shims after migration |
+
+---
+
+## Resources
+
+- [REFACTORING_0_16.md](REFACTORING_0_16.md) - The refactoring strategy
+- [CRATE_SEAMS.md](CRATE_SEAMS.md) - Why the refactoring happened
+- [docs/ARCHITECTURE.md](ARCHITECTURE.md) - Updated architecture documentation
+- [CHANGELOG.md](../CHANGELOG.md) - Release notes for 0.16.0
+
+---
+
+## Questions?
+
+If you encounter issues with the migration, please:
+1. Check this guide and the mapping table
+2. Consult the updated ARCHITECTURE.md
+3. Open an issue on GitHub with your migration question
+
+We want the transition to be smooth. Feedback is welcome!

--- a/docs/REFACTORING_0_16.md
+++ b/docs/REFACTORING_0_16.md
@@ -1,0 +1,416 @@
+# Public API Refactoring for 0.16.0
+
+## Overview
+
+This document describes the planned refactoring of perfgate's public crate surface. The goal is to collapse the current 26+ microcrates into a cleaner public facade while preserving the strong internal separation of concerns that makes the architecture maintainable.
+
+**Current state**: Public surface is still too broad. PR #223 already absorbed `perfgate-validation`, `perfgate-auth`, `perfgate-summary`, and `perfgate-stats`, and moved the paired implementation into `perfgate-domain` behind a `perfgate-paired` compatibility wrapper. Many remaining internal seams are still publishable crates (`perfgate-budget`, `perfgate-render`, `perfgate-host-detect`, etc.), which makes the package ecosystem confusing for users and couples the public API tightly to internal refactoring decisions.
+
+**Target state**: Five public crates with strongly organized internal modules. Users depend on `perfgate`, `perfgate-types`, `perfgate-cli`, `perfgate-client`, and `perfgate-server` only. The SRP boundaries remain enforced but move from crate level to module level.
+
+---
+
+## Target Public Crate Surface
+
+Only these crates should be published:
+
+| Crate | Purpose | Keep? |
+|-------|---------|-------|
+| `perfgate-cli` | Installs the `perfgate` binary | Yes |
+| `perfgate` | Main embeddable library and facade | Yes |
+| `perfgate-types` | Stable receipts, config, schemas, wire contracts | Yes |
+| `perfgate-client` | Baseline service client for external automation | Yes |
+| `perfgate-server` | Baseline service binary/library | Yes |
+
+Everything else will be absorbed into one of these crates as modules, marked `publish = false`, or deleted.
+
+---
+
+## Absorption Map
+
+### Into `perfgate-types`
+These are contract-adjacent and belong with the public receipt/config model:
+
+| Current Crate | New Home | Reason |
+|---------------|----------|--------|
+| `perfgate-error` | `perfgate_types::error` | Error types are part of the contract |
+| `perfgate-validation` | `perfgate_types::validation` | Schema validation is contract-adjacent |
+| `perfgate-config` | `perfgate_types::config` | Config model is a receipt type |
+| `perfgate-api` (shared DTOs) | `perfgate_types::baseline_service` | Wire format for baseline service |
+
+**Current state**: `perfgate-types` depends on `perfgate-validation` and `perfgate-error`. This will become a clean internal relationship.
+
+**Why first**: The types crate must be standalone and self-describing. Absorbing these dependencies first unblocks all downstream refactoring.
+
+---
+
+### Into `perfgate::core`
+Pure logic with no runtime dependencies:
+
+| Current Crate | New Module | Why |
+|---------------|-----------|-----|
+| `perfgate-stats` | `perfgate_domain::stats` now; facade re-export later | Statistical descriptors (median, p95, etc.) |
+| `perfgate-budget` | `perfgate::core::budget` | Budget evaluation and verdict logic |
+| `perfgate-significance` | `perfgate::core::significance` | Welch's t-test and statistical testing |
+| `perfgate-paired` | `perfgate_domain::paired` now; facade re-export later | Paired benchmarking computation |
+| `perfgate-sha256` | `perfgate::core::fingerprint` | Minimal SHA-256 for baseline fingerprints |
+
+These should be feature-gated minimally (or always-on) and have no dependency on runtime, CLI, or server code.
+
+---
+
+### Into `perfgate::domain`
+Product policy and comparison semantics (I/O-free):
+
+| Current Crate | New Module | Why |
+|---------------|-----------|-----|
+| `perfgate-domain` | `perfgate::domain` | Core business logic |
+| `perfgate-host-detect` | `perfgate::domain::host` | Host fingerprinting and mismatch detection |
+| `perfgate-scaling` | `perfgate::domain::scaling` | Autoscaling policy and trend analysis |
+
+These remain I/O-free but depend on `core::*` modules and define product verdicts.
+
+---
+
+### Into `perfgate::presentation`
+Output surfaces (optional features):
+
+| Current Crate | New Module | Feature Gate |
+|---------------|-----------|--------------|
+| `perfgate-render` | `perfgate::presentation::render` | `render` |
+| `perfgate-export` | `perfgate::presentation::export` | `export` |
+| `perfgate-sensor` | `perfgate::presentation::sensor` | `sensor` |
+| `perfgate-summary` | `perfgate::presentation::summary` | optional |
+
+These should be behind feature flags to keep the default build lightweight.
+
+---
+
+### Into `perfgate::runtime`
+I/O and external interactions:
+
+| Current Crate | New Module | Why |
+|---------------|-----------|-----|
+| `perfgate-adapters` | `perfgate::runtime` | System adapters (rusage, process execution) |
+| `perfgate-profile` | `perfgate::runtime::profile` | Profiling data collection |
+
+Keep ports/interfaces separate from stdlib implementations:
+```
+perfgate::runtime::ports::ProcessRunner
+perfgate::runtime::ports::HostProbe
+perfgate::runtime::std::StdProcessRunner
+perfgate::runtime::std::SystemHostProbe
+```
+
+---
+
+### Into `perfgate::app`
+Application orchestration:
+
+| Current Crate | New Module | Why |
+|---------------|-----------|-----|
+| `perfgate-app` | `perfgate::app` | CLI/server command orchestration |
+
+This stays at a high level and coordinates lower modules.
+
+---
+
+### Into `perfgate::integrations`
+Feature-gated external integrations:
+
+| Current Crate | New Module | Feature Gate |
+|---------------|-----------|--------------|
+| `perfgate-github` | `perfgate::integrations::github` | `github` |
+| `perfgate-ingest` | `perfgate::integrations::ingest` | `ingest` |
+
+These are not core to the product and should be optional.
+
+---
+
+### Dev-Only / Internal (Unpublished)
+
+These remain in the workspace but with `publish = false`:
+
+| Current Crate | New Status |
+|---------------|-----------|
+| `perfgate-fake` | Module `perfgate::test_support` (feature-gated) or private workspace crate |
+| `perfgate-selfbench` | Private workspace crate, `publish = false` |
+| `perfgate-tests` | Already `publish = false` |
+| `xtask` | Already workspace-only |
+
+---
+
+## Proposed Internal Module Tree
+
+```
+crates/
+  perfgate/
+    src/
+      lib.rs
+      prelude.rs
+      core/
+        mod.rs
+        stats.rs
+        budget.rs
+        significance.rs
+        paired.rs
+        fingerprint.rs
+      domain/
+        mod.rs
+        verdict.rs
+        host.rs
+        scaling.rs
+        blame.rs
+        bisect.rs
+        explain.rs
+      runtime/
+        mod.rs
+        ports.rs
+        process.rs
+        host.rs
+        fs.rs
+        clock.rs
+        profile.rs
+      app/
+        mod.rs
+        run.rs
+        compare.rs
+        check.rs
+        promote.rs
+        report.rs
+        aggregate.rs
+      presentation/
+        mod.rs
+        render.rs
+        export.rs
+        sensor.rs
+        summary.rs
+      integrations/
+        mod.rs
+        github.rs
+        ingest.rs
+      test_support/
+        mod.rs
+      error.rs
+      prelude.rs
+  perfgate-types/
+    src/
+      lib.rs
+      receipt/
+      config/
+      schema/
+      validation/
+      error/
+      baseline_service/
+  perfgate-client/
+  perfgate-server/
+  perfgate-cli/
+```
+
+---
+
+## Feature Gates
+
+```toml
+[package]
+name = "perfgate"
+
+[features]
+default = ["core", "runtime"]
+core = []                    # Always needed: stats, budget, significance, paired
+runtime = []                 # Always needed: adapters, process, host, clock
+domain = []                  # Always needed: domain, host detection, scaling
+app = []                     # Always needed: app orchestration
+render = []                  # Optional: markdown/terminal rendering
+export = ["render"]          # Optional: CSV, JSONL, HTML, Prometheus export
+html = ["export"]            # Optional: HTML rendering dependencies
+sensor = []                  # Optional: cockpit mode and sensor reports
+github = []                  # Optional: GitHub annotations and links
+ingest = []                  # Optional: data ingestion adapters
+test-support = []            # Dev-only: fake data generators
+all = ["core", "runtime", "domain", "app", "render", "export", "html", "sensor", "github", "ingest"]
+```
+
+---
+
+## Critical Packaging Rule
+
+**This cannot be solved only with `publish = false`.** If `perfgate` (a public crate) depends on unpublished internal path crates, it creates packaging conflicts when publishing.
+
+**The real move**:
+1. Move code into modules inside public crates
+2. Remove the dependency from the public crate to the old microcrate
+3. Mark the old crate `publish = false` or delete it
+
+For already-published crates that must preserve a public import path for one
+transition release, provide a deprecation shim or compatibility wrapper:
+```rust
+// crates/perfgate-paired/src/lib.rs
+pub use perfgate_domain::paired::*;
+```
+
+This allows a transition release before removing the crate from future
+messaging. Crates that were internal-only may be deleted directly, as PR #223
+did for validation, auth, summary, and stats.
+
+---
+
+## Dependency Layer Rules
+
+Once modules replace crates, enforce these rules via `xtask arch`:
+
+```
+types must not use perfgate::runtime/app/presentation/integrations
+core must not use runtime/app/cli/server/client/presentation/integrations
+domain must not use runtime/cli/server/client/integrations
+presentation must not use runtime/app/cli/server/client/integrations
+runtime must not use cli/server/client
+app must not use cli/server/client
+integrations may use any module except cli/server/client
+cli may use anything public
+server may use anything public
+client may use anything public
+```
+
+Implement this as a Cargo metadata or source-level check in xtask.
+
+---
+
+## Migration Sequence
+
+### Phase 1: Policy & Visibility (current PR)
+Create:
+- `policy/public_crates.txt` - List of intended public crates
+- `policy/absorbed_crates.txt` - Mapping of absorbed crates
+- `docs/CRATE_SEAMS.md` - Detailed seam analysis
+- `xtask public-surface` check - Fails if a publishable package has no public or absorbed disposition
+
+The default check enforces complete disposition coverage during the transition.
+`cargo run -p xtask -- public-surface --strict` is the final release gate that
+fails until only the five target public crates are publishable.
+
+### Phase 2: Collapse Contracts (PR 2)
+Move into `perfgate-types`:
+- `perfgate-error` -> `perfgate_types::error`
+- `perfgate-validation` -> `perfgate_types::validation`
+- `perfgate-config` -> `perfgate_types::config`
+- `perfgate-api` shared DTOs -> `perfgate_types::baseline_service`
+
+Update all downstream crate imports. Verify `perfgate-types` remains self-contained.
+
+### Phase 3: Collapse Core Logic (PR 3)
+Move into `perfgate::core`:
+- `perfgate-stats` -> already landed in `perfgate_domain::stats`; add facade path later
+- `perfgate-budget` -> `perfgate::core::budget`
+- `perfgate-significance` -> `perfgate::core::significance`
+- `perfgate-paired` -> implementation already landed in `perfgate_domain::paired`; add facade path later
+- `perfgate-sha256` -> `perfgate::core::fingerprint`
+
+Provide deprecation shims if crates are published. Update `perfgate` prelude.
+
+### Phase 4: Collapse Domain (PR 4)
+Move into `perfgate::domain`:
+- `perfgate-domain` -> `perfgate::domain`
+- `perfgate-host-detect` -> `perfgate::domain::host`
+- `perfgate-scaling` -> `perfgate::domain::scaling`
+
+Verify domain remains I/O-free.
+
+### Phase 5: Collapse Presentation (PR 5)
+Move into `perfgate::presentation`:
+- `perfgate-render` -> `perfgate::presentation::render` (feature-gated)
+- `perfgate-export` -> `perfgate::presentation::export` (feature-gated)
+- `perfgate-sensor` -> `perfgate::presentation::sensor` (feature-gated)
+- `perfgate-summary` -> `perfgate::presentation::summary`
+
+Add feature gates and verify default build is lightweight.
+
+### Phase 6: Collapse Runtime & App (PR 6)
+Move into `perfgate`:
+- `perfgate-adapters` -> `perfgate::runtime`
+- `perfgate-profile` -> `perfgate::runtime::profile`
+- `perfgate-app` -> `perfgate::app`
+- `perfgate-github` -> `perfgate::integrations::github` (feature-gated)
+- `perfgate-ingest` -> `perfgate::integrations::ingest` (feature-gated)
+
+Simplify `perfgate-cli` dependencies to mostly: `perfgate`, `perfgate-types`, `perfgate-client`, `perfgate-server`.
+
+### Phase 7: Cleanup & Documentation (PR 7)
+For every absorbed crate:
+- Delete if not published and not needed
+- Convert to deprecated shim if published
+- Mark `publish = false` if it remains workspace-only
+
+Update documentation:
+- `README.md` - Remove 26-crate architecture mention
+- `docs/ARCHITECTURE.md` - Describe public packages + internal modules
+- `CLAUDE.md` - Update developer guidance
+- Crate READMEs - Point users to main `perfgate` crate
+
+Add `xtask arch` check for module-layer violations.
+
+### Phase 8: First Release (0.16.0)
+- Publish with new surface
+- Deprecation shims live for one release
+- Document migration path in `CHANGELOG.md`
+
+### Phase 9: Second Release (0.17.0 or later)
+- Remove deprecation shims
+- Finalize cleanup
+
+---
+
+## Definition of Done
+
+The refactoring is complete when:
+
+1. `policy/public_crates.txt` lists exactly: `perfgate`, `perfgate-cli`, `perfgate-types`, `perfgate-client`, `perfgate-server`
+2. `cargo publish --dry-run -p perfgate` does not require publishing internal microcrates
+3. `perfgate-cli` depends on public packages, not every internal seam crate
+4. All microcrates are either deleted, `publish = false`, or deprecated shims
+5. `docs/ARCHITECTURE.md` describes public packages + internal modules
+6. `xtask arch` prevents module-layer violations
+7. Users are taught to use:
+   ```rust
+   use perfgate::prelude::*;
+   use perfgate_types::*;
+   use perfgate_client::*;
+   ```
+   Not:
+   ```rust
+   use perfgate_budget::*;
+   use perfgate_stats::*;
+   use perfgate_render::*;
+   ```
+8. Examples and tutorials updated
+9. All tests pass; mutation test targets maintained
+10. CHANGELOG documents migration path for 0.16.0
+
+---
+
+## Key Principles
+
+- **One facade crate**: Users import `perfgate`, not 20 different microcrates.
+- **SRP preserved at module level**: Same boundaries, but inside `perfgate` as modules.
+- **No breaking changes in 0.16.0**: Deprecation shims allow gradual migration.
+- **Feature-gated optional surfaces**: Render, export, sensor, github, ingest are all optional.
+- **Types always self-contained**: `perfgate-types` never depends on other perfgate crates.
+- **Domain stays I/O-free**: `perfgate::domain` has no runtime dependencies.
+- **Strict module-layer checks**: Enforce via CI to prevent architectural decay.
+
+---
+
+## Timeline
+
+Target completion: **0.16.0 release** (Q3 2026 or later).
+
+Phases 1-7 can proceed in parallel with other 0.16.0 work, but PRs should be reviewed in order to avoid merge conflicts.
+
+---
+
+## References
+
+- [docs/ARCHITECTURE.md](ARCHITECTURE.md) - Current architecture (will be updated)
+- `policy/public_crates.txt` - Policy enforcement
+- `policy/absorbed_crates.txt` - Absorption map
+- [docs/CRATE_SEAMS.md](CRATE_SEAMS.md) - Detailed seam analysis

--- a/policy/absorbed_crates.txt
+++ b/policy/absorbed_crates.txt
@@ -1,16 +1,47 @@
-perfgate-validation
-perfgate-auth
-perfgate-summary
-perfgate-stats
-perfgate-significance
-perfgate-budget
-perfgate-paired
-perfgate-host-detect
-perfgate-scaling
-perfgate-app
-perfgate-adapters
-perfgate-profile
-perfgate-sha256
-perfgate-sensor
-perfgate-fake
-perfgate-selfbench
+# Crate absorption map for the 0.16 public-surface collapse.
+#
+# Format:
+# old-package-name -> new owner path or disposition
+#
+# A package listed here has an explicit non-public disposition. During the
+# transition it may still be publishable as a compatibility shim. The strict
+# public-surface check fails until those packages are deleted, marked
+# `publish = false`, or intentionally converted into deprecated shims.
+
+# Landed in PR #223.
+perfgate-validation -> perfgate_types::validation [deleted]
+perfgate-auth -> perfgate_api::auth [deleted]
+perfgate-summary -> perfgate_render::summary [deleted]
+perfgate-stats -> perfgate_domain::stats [deleted]
+perfgate-paired -> perfgate_domain::paired [compatibility wrapper]
+
+# Contract-adjacent.
+perfgate-error -> perfgate_types::error
+perfgate-config -> perfgate_types::config
+perfgate-api -> perfgate_types::baseline_service or shared client/server contract
+
+# Pure core and domain policy.
+perfgate-domain -> perfgate::domain
+perfgate-budget -> perfgate::core::budget or perfgate_domain::budget
+perfgate-significance -> perfgate::core::significance or perfgate_domain::significance
+perfgate-host-detect -> perfgate::domain::host
+perfgate-scaling -> perfgate::domain::scaling
+perfgate-sha256 -> perfgate::core::fingerprint
+
+# Presentation.
+perfgate-render -> perfgate::presentation::render
+perfgate-export -> perfgate::presentation::export
+perfgate-sensor -> perfgate::presentation::sensor
+
+# Runtime, app, and integrations.
+perfgate-adapters -> perfgate::runtime
+perfgate-profile -> perfgate::runtime::profile
+perfgate-app -> perfgate::app
+perfgate-github -> perfgate::integrations::github
+perfgate-ingest -> perfgate::integrations::ingest
+
+# Dev-only packages.
+perfgate-fake -> perfgate::test_support or private dev crate
+perfgate-selfbench -> private workspace crate
+perfgate-tests -> private workspace root package
+xtask -> private workspace automation crate

--- a/policy/public_crates.txt
+++ b/policy/public_crates.txt
@@ -1,13 +1,14 @@
+# Target public crates for the 0.16 public-surface collapse.
+#
+# `cargo run -p xtask -- public-surface` enforces that every publishable
+# workspace package is either listed here or has a disposition in
+# `policy/absorbed_crates.txt`.
+#
+# `cargo run -p xtask -- public-surface --strict` enforces this file as the
+# final publishable package allowlist.
+
 perfgate
 perfgate-cli
-perfgate-server
-perfgate-client
-perfgate-api
 perfgate-types
-perfgate-config
-perfgate-domain
-perfgate-error
-perfgate-render
-perfgate-export
-perfgate-ingest
-perfgate-github
+perfgate-client
+perfgate-server

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -117,6 +117,21 @@ enum Command {
     /// Validate workspace packaging metadata for crates.io publication.
     PublishCheck,
 
+    /// Validate the target public crate policy and transition dispositions.
+    PublicSurface {
+        /// Target public crate policy file.
+        #[arg(long, default_value = "policy/public_crates.txt")]
+        public_policy: PathBuf,
+
+        /// Absorbed/internal crate disposition file.
+        #[arg(long, default_value = "policy/absorbed_crates.txt")]
+        absorbed_policy: PathBuf,
+
+        /// Fail if any absorbed package is still publishable.
+        #[arg(long)]
+        strict: bool,
+    },
+
     /// Validate JSON fixtures against the vendored sensor.report.v1 schema.
     Conform {
         /// Directory of fixtures to validate (default: golden fixtures)
@@ -197,6 +212,11 @@ fn main() -> anyhow::Result<()> {
         Command::SchemaCheck { schemas_dir } => cmd_schema_check(&schemas_dir),
         Command::Ci => cmd_ci(),
         Command::PublishCheck => cmd_publish_check(),
+        Command::PublicSurface {
+            public_policy,
+            absorbed_policy,
+            strict,
+        } => cmd_public_surface(&public_policy, &absorbed_policy, strict),
         Command::Conform { fixtures, file } => cmd_conform(fixtures, file),
         Command::SyncFixtures => cmd_sync_fixtures(),
         Command::Mutants {
@@ -268,6 +288,11 @@ fn cmd_ci() -> anyhow::Result<()> {
     cmd_schema_check(Path::new("schemas"))?;
     cmd_conform(None, None)?;
     cmd_publish_check()?;
+    cmd_public_surface(
+        Path::new("policy/public_crates.txt"),
+        Path::new("policy/absorbed_crates.txt"),
+        false,
+    )?;
     Ok(())
 }
 
@@ -372,6 +397,185 @@ fn collect_publish_errors(metadata: &CargoMetadata) -> Vec<String> {
                 ));
             }
         }
+    }
+
+    errors
+}
+
+fn cmd_public_surface(
+    public_policy: &Path,
+    absorbed_policy: &Path,
+    strict: bool,
+) -> anyhow::Result<()> {
+    let metadata = load_cargo_metadata()?;
+    let public_crates = read_public_crate_policy(public_policy)?;
+    let absorbed_crates = read_absorbed_crate_policy(absorbed_policy)?;
+    let errors = collect_public_surface_errors(&metadata, &public_crates, &absorbed_crates, strict);
+
+    if !errors.is_empty() {
+        println!("Found {} public-surface policy error(s):", errors.len());
+        for error in &errors {
+            println!("  - {}", error);
+        }
+
+        anyhow::bail!(
+            "{} public-surface policy issue(s) found. Update policy or crate publication state.",
+            errors.len()
+        );
+    }
+
+    let publishable: Vec<_> = metadata
+        .packages
+        .iter()
+        .filter(|package| is_publishable(package))
+        .map(|package| package.name.as_str())
+        .collect();
+    let transitional: Vec<_> = publishable
+        .iter()
+        .copied()
+        .filter(|name| !public_crates.contains(*name) && absorbed_crates.contains_key(*name))
+        .collect();
+
+    println!(
+        "  OK  public-surface policy accounts for {} publishable package(s)",
+        publishable.len()
+    );
+    println!("      target public packages: {}", public_crates.len());
+    if !transitional.is_empty() {
+        println!(
+            "      transition publishable packages with dispositions: {}",
+            transitional.len()
+        );
+    }
+
+    Ok(())
+}
+
+fn read_public_crate_policy(path: &Path) -> anyhow::Result<BTreeSet<String>> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let mut names = BTreeSet::new();
+
+    for (idx, raw_line) in content.lines().enumerate() {
+        let line = strip_policy_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.contains("->") {
+            anyhow::bail!(
+                "{}:{} public crate policy entries must be plain package names",
+                path.display(),
+                idx + 1
+            );
+        }
+        names.insert(line.to_string());
+    }
+
+    if names.is_empty() {
+        anyhow::bail!("{} contains no public crate entries", path.display());
+    }
+
+    Ok(names)
+}
+
+fn read_absorbed_crate_policy(path: &Path) -> anyhow::Result<BTreeMap<String, String>> {
+    let content = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    let mut dispositions = BTreeMap::new();
+
+    for (idx, raw_line) in content.lines().enumerate() {
+        let line = strip_policy_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let Some((package, disposition)) = line.split_once("->") else {
+            anyhow::bail!(
+                "{}:{} absorbed crate entries must use `package -> disposition`",
+                path.display(),
+                idx + 1
+            );
+        };
+
+        let Some(package_name) = package.split_whitespace().next() else {
+            anyhow::bail!("{}:{} missing package name", path.display(), idx + 1);
+        };
+        let disposition = disposition.trim();
+        if disposition.is_empty() {
+            anyhow::bail!("{}:{} missing disposition", path.display(), idx + 1);
+        }
+
+        dispositions.insert(package_name.to_string(), disposition.to_string());
+    }
+
+    Ok(dispositions)
+}
+
+fn strip_policy_comment(line: &str) -> &str {
+    line.split_once('#')
+        .map(|(before, _)| before)
+        .unwrap_or(line)
+}
+
+fn collect_public_surface_errors(
+    metadata: &CargoMetadata,
+    public_crates: &BTreeSet<String>,
+    absorbed_crates: &BTreeMap<String, String>,
+    strict: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    for public_crate in public_crates {
+        let Some(package) = metadata
+            .packages
+            .iter()
+            .find(|package| package.name == *public_crate)
+        else {
+            errors.push(format!(
+                "policy lists public crate {} but no workspace package has that name",
+                public_crate
+            ));
+            continue;
+        };
+
+        if !is_publishable(package) {
+            errors.push(format!(
+                "policy lists public crate {} but the package is not publishable",
+                public_crate
+            ));
+        }
+    }
+
+    for public_crate in public_crates {
+        if absorbed_crates.contains_key(public_crate) {
+            errors.push(format!(
+                "{} is listed as both public and absorbed/internal",
+                public_crate
+            ));
+        }
+    }
+
+    for package in metadata
+        .packages
+        .iter()
+        .filter(|package| is_publishable(package))
+    {
+        if public_crates.contains(&package.name) {
+            continue;
+        }
+
+        if absorbed_crates.contains_key(&package.name) {
+            if strict {
+                errors.push(format!(
+                    "{} is still publishable but is listed as absorbed/internal",
+                    package.name
+                ));
+            }
+            continue;
+        }
+
+        errors.push(format!(
+            "{} is publishable but is not listed in {} or {}",
+            package.name, "policy/public_crates.txt", "policy/absorbed_crates.txt"
+        ));
     }
 
     errors
@@ -1962,6 +2166,16 @@ mod tests {
         }
     }
 
+    fn test_package(name: &str, publish: Option<Vec<String>>) -> MetadataPackage {
+        MetadataPackage {
+            name: name.to_string(),
+            manifest_path: PathBuf::from(format!("crates/{name}/Cargo.toml")),
+            publish,
+            readme: None,
+            dependencies: Vec::new(),
+        }
+    }
+
     #[test]
     fn collect_publish_errors_reports_missing_readme() {
         let metadata = CargoMetadata {
@@ -2036,6 +2250,67 @@ mod tests {
 
         let errors = collect_publish_errors(&metadata);
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn public_surface_allows_publishable_packages_with_transition_dispositions() {
+        let metadata = CargoMetadata {
+            packages: vec![
+                test_package("perfgate", None),
+                test_package("perfgate-budget", None),
+                test_package("perfgate-tests", Some(Vec::new())),
+            ],
+        };
+        let public_crates = ["perfgate"].into_iter().map(String::from).collect();
+        let absorbed_crates = [(
+            "perfgate-budget".to_string(),
+            "perfgate::core::budget".to_string(),
+        )]
+        .into_iter()
+        .collect();
+
+        let errors =
+            collect_public_surface_errors(&metadata, &public_crates, &absorbed_crates, false);
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn public_surface_strict_rejects_publishable_absorbed_packages() {
+        let metadata = CargoMetadata {
+            packages: vec![
+                test_package("perfgate", None),
+                test_package("perfgate-budget", None),
+            ],
+        };
+        let public_crates = ["perfgate"].into_iter().map(String::from).collect();
+        let absorbed_crates = [(
+            "perfgate-budget".to_string(),
+            "perfgate::core::budget".to_string(),
+        )]
+        .into_iter()
+        .collect();
+
+        let errors =
+            collect_public_surface_errors(&metadata, &public_crates, &absorbed_crates, true);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("still publishable"));
+    }
+
+    #[test]
+    fn public_surface_rejects_unclassified_publishable_packages() {
+        let metadata = CargoMetadata {
+            packages: vec![
+                test_package("perfgate", None),
+                test_package("perfgate-surprise", None),
+            ],
+        };
+        let public_crates = ["perfgate"].into_iter().map(String::from).collect();
+        let absorbed_crates = BTreeMap::new();
+
+        let errors =
+            collect_public_surface_errors(&metadata, &public_crates, &absorbed_crates, false);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("perfgate-surprise is publishable"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Define the 0.16 public-surface contract after PR #223 and make the policy enforceable during the transition.

This PR now:
- rebases the 0.16 refactor plan on top of the landed #223 seam absorption
- keeps the target public package surface at five crates: `perfgate`, `perfgate-cli`, `perfgate-types`, `perfgate-client`, `perfgate-server`
- updates `docs/CRATE_SEAMS.md`, `docs/REFACTORING_0_16.md`, and `docs/MIGRATION_0_16.md` so they distinguish landed moves from future facade paths
- adds `policy/public_crates.txt` and `policy/absorbed_crates.txt` as the public-surface contract
- adds `cargo run -p xtask -- public-surface`, wired into `xtask ci`

## Enforcement Model

`cargo run -p xtask -- public-surface` fails if a publishable workspace package is neither a target public crate nor listed with an absorption disposition.

`cargo run -p xtask -- public-surface --strict` is the final release gate. It is expected to fail until the remaining transition packages are deleted, marked `publish = false`, or intentionally converted into compatibility shims.

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p xtask -- public-surface`
- `cargo test -p xtask --all-features`
- `cargo run -p xtask -- ci`
- `git diff --check origin/main..HEAD`