### PR TITLE
chore: bump Rust MSRV to 1.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.93.0
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: 1.93.0
           components: rustfmt, clippy
 
       - name: Run CI Suite (xtask)

--- a/.github/workflows/perfgate-nightly.yml
+++ b/.github/workflows/perfgate-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.93.0
 
       - name: Build release binary
         run: cargo build --release -p perfgate-cli --bin perfgate

--- a/.github/workflows/perfgate-nightly.yml
+++ b/.github/workflows/perfgate-nightly.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
 
       - name: Build release binary
         run: cargo build --release -p perfgate-cli --bin perfgate

--- a/.github/workflows/perfgate-self.yml
+++ b/.github/workflows/perfgate-self.yml
@@ -34,7 +34,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
       - name: Build release binary
         run: cargo build --release -p perfgate-cli --bin perfgate
       - name: Make scripts executable
@@ -64,7 +66,9 @@ jobs:
           ref: main
           path: main
 
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
 
       - name: Build current binary
         run: cd current && cargo build --release -p perfgate-cli --bin perfgate && cargo build --release -p perfgate-selfbench

--- a/.github/workflows/perfgate-self.yml
+++ b/.github/workflows/perfgate-self.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.93.0
       - name: Build release binary
         run: cargo build --release -p perfgate-cli --bin perfgate
       - name: Make scripts executable
@@ -64,7 +64,7 @@ jobs:
           ref: main
           path: main
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.93.0
 
       - name: Build current binary
         run: cd current && cargo build --release -p perfgate-cli --bin perfgate && cargo build --release -p perfgate-selfbench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bumped Rust minimum supported version (MSRV) to 1.93.
+
 ### Fixed
 - Fixed clippy warnings by replacing `sort_by` with `sort_by_key` and `std::cmp::Reverse` for descending sorts in storage backends.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = [
 [workspace.package]
 version = "0.15.1"
 edition = "2024"
-rust-version = "1.92"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/EffortlessMetrics/perfgate"
 authors = ["Effortless Metrics"]

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,9 @@ runs:
 
     - name: Install Rust toolchain
       if: steps.install_binary.outputs.installed != 'true'
-      uses: dtolnay/rust-toolchain@1.93.0
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: 1.93.0
 
     - name: Install perfgate (cargo install fallback)
       if: steps.install_binary.outputs.installed != 'true'

--- a/action.yml
+++ b/action.yml
@@ -153,7 +153,7 @@ runs:
 
     - name: Install Rust toolchain
       if: steps.install_binary.outputs.installed != 'true'
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@1.93.0
 
     - name: Install perfgate (cargo install fallback)
       if: steps.install_binary.outputs.installed != 'true'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.93.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Bumps perfgate's enforced Rust floor from 1.92 to 1.93 as a narrow toolchain/MSRV PR.

- Updated `Cargo.toml` workspace MSRV to `1.93`
- Pinned `rust-toolchain.toml` to exact `1.93.0` release
- Updated CI workflows to use `@1.93.0`: `ci.yml`, `perfgate-self.yml`, `perfgate-nightly.yml`
- Updated composite `action.yml` fallback to `@1.93.0`
- Added Unreleased changelog entry

## Validation

✓ `cargo check --workspace` passed  
✓ `cargo run -p xtask -- ci` (fmt, clippy, tests, schema, conform) passed  
✓ `cargo run -p xtask -- docs-check` passed  
✓ `cargo llvm-cov --all-features --workspace --fail-under-lines 80` passed  

No new Rust 1.93 clippy warnings or fmt issues; all validation gates green on local repo override.

## Test plan

- [ ] Wait for CI workflows to complete (`ci.yml` on Ubuntu/Windows, `perfgate-self.yml` smoke/perf/paired, `perfgate-nightly.yml`)
- [ ] Confirm coverage remains ≥80%
- [ ] If baseline drift is compiler-only (paired comparison shows no source regression), approve baseline refresh as separate follow-up PR
- [ ] Merge once all gates pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01KynaEhx6bFwMHiEuo3gg5c)_