### PR TITLE
feat: add API key management CLI

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -22,6 +22,7 @@ use perfgate_app::{
     render_markdown_template, render_terminal_diff,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
+use perfgate_client::types::{CreateKeyRequest, KeyEntry};
 use perfgate_client::{
     AuthMethod, BaselineClient, ClientConfig, ListBaselinesQuery, ListVerdictsQuery,
     SubmitVerdictRequest, UploadBaselineRequest,
@@ -251,6 +252,12 @@ enum Command {
     Baseline {
         #[command(subcommand)]
         action: BaselineAction,
+    },
+
+    /// Administer baseline service operations.
+    Admin {
+        #[command(subcommand)]
+        action: AdminAction,
     },
 
     /// Summarize one or more compare receipts in a terminal table.
@@ -1270,6 +1277,81 @@ pub struct WatchArgs {
     pub env: Vec<(String, String)>,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum KeyRole {
+    Viewer,
+    Contributor,
+    Promoter,
+    Admin,
+}
+
+impl From<KeyRole> for perfgate_api::auth::Role {
+    fn from(role: KeyRole) -> Self {
+        match role {
+            KeyRole::Viewer => Self::Viewer,
+            KeyRole::Contributor => Self::Contributor,
+            KeyRole::Promoter => Self::Promoter,
+            KeyRole::Admin => Self::Admin,
+        }
+    }
+}
+
+/// Subcommands for baseline service administration.
+#[derive(Debug, Subcommand)]
+enum AdminAction {
+    /// Manage API keys.
+    Keys {
+        #[command(subcommand)]
+        action: KeyAction,
+    },
+}
+
+/// Subcommands for API key lifecycle management.
+#[derive(Debug, Subcommand)]
+enum KeyAction {
+    /// Create a new API key. The plaintext key is printed once.
+    Create {
+        /// Project this key is scoped to.
+        #[arg(long)]
+        project: String,
+
+        /// Role to grant.
+        #[arg(long)]
+        role: KeyRole,
+
+        /// Human-readable key description.
+        #[arg(long)]
+        description: Option<String>,
+
+        /// Optional benchmark glob/regex pattern enforced by the server.
+        #[arg(long)]
+        pattern: Option<String>,
+    },
+
+    /// List API keys. Key material is redacted.
+    List {
+        /// Filter by project.
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Include revoked keys.
+        #[arg(long, default_value_t = false)]
+        include_revoked: bool,
+    },
+
+    /// Revoke an API key by ID.
+    Revoke {
+        /// Key ID to revoke.
+        key_id: String,
+    },
+
+    /// Create a replacement key with the same scope, then revoke the old key.
+    Rotate {
+        /// Key ID to rotate.
+        key_id: String,
+    },
+}
+
 /// Subcommands for baseline management.
 #[derive(Debug, Subcommand)]
 enum BaselineAction {
@@ -2164,6 +2246,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
         }
 
         Command::Baseline { action } => execute_baseline_action(action, &server_flags),
+
+        Command::Admin { action } => execute_admin_action(action, &server_flags),
 
         Command::Fleet { action } => execute_fleet_action(action, &server_flags),
 
@@ -3216,6 +3300,172 @@ fn execute_comment(args: CommentArgs) -> anyhow::Result<()> {
 
         Ok(())
     })
+}
+
+/// Execute baseline service administration actions.
+fn execute_admin_action(action: AdminAction, server_flags: &ServerFlags) -> anyhow::Result<()> {
+    let (server_config, _config_file) = resolve_server_config_from_path(server_flags, None)?;
+    let client = server_config.require_fallback_client(None, BASELINE_SERVER_NOT_CONFIGURED)?;
+    let rt = tokio::runtime::Runtime::new()?;
+
+    match action {
+        AdminAction::Keys { action } => match action {
+            KeyAction::Create {
+                project,
+                role,
+                description,
+                pattern,
+            } => {
+                let role: perfgate_api::auth::Role = role.into();
+                let description =
+                    description.unwrap_or_else(|| format!("{} key for {}", role, project));
+                let request = CreateKeyRequest {
+                    description,
+                    role,
+                    project,
+                    pattern,
+                    expires_at: None,
+                };
+
+                rt.block_on(async {
+                    let response = client.create_key(&request).await.with_context(|| {
+                        format!(
+                            "Failed to create API key (project: {}, role: {})",
+                            request.project, request.role
+                        )
+                    })?;
+
+                    eprintln!(
+                        "Created API key {} for project {} with role {}",
+                        response.id, response.project, response.role
+                    );
+                    eprintln!("Store this key now; it will not be shown again.");
+                    println!("id\trole\tproject\tkey");
+                    println!(
+                        "{}\t{}\t{}\t{}",
+                        response.id, response.role, response.project, response.key
+                    );
+
+                    Ok::<(), anyhow::Error>(())
+                })?
+            }
+            KeyAction::List {
+                project,
+                include_revoked,
+            } => {
+                let project_filter = project.or_else(|| server_config.project.clone());
+
+                rt.block_on(async {
+                    let response = client
+                        .list_keys()
+                        .await
+                        .context("Failed to list API keys")?;
+                    let mut keys = response.keys;
+
+                    if let Some(project) = project_filter {
+                        keys.retain(|key| key.project == project);
+                    }
+                    if !include_revoked {
+                        keys.retain(|key| key.revoked_at.is_none());
+                    }
+
+                    print_key_table(&keys);
+                    Ok::<(), anyhow::Error>(())
+                })?
+            }
+            KeyAction::Revoke { key_id } => rt.block_on(async {
+                let response = client
+                    .revoke_key(&key_id)
+                    .await
+                    .with_context(|| format!("Failed to revoke API key {}", key_id))?;
+
+                eprintln!(
+                    "Revoked API key {} at {}",
+                    response.id,
+                    response.revoked_at.to_rfc3339()
+                );
+                Ok::<(), anyhow::Error>(())
+            })?,
+            KeyAction::Rotate { key_id } => rt.block_on(async {
+                let keys = client
+                    .list_keys()
+                    .await
+                    .context("Failed to list API keys before rotation")?
+                    .keys;
+                let old_key = keys
+                    .into_iter()
+                    .find(|key| key.id == key_id)
+                    .ok_or_else(|| anyhow::anyhow!("API key {} not found", key_id))?;
+                if old_key.revoked_at.is_some() {
+                    anyhow::bail!("API key {} is already revoked", key_id);
+                }
+
+                let request = CreateKeyRequest {
+                    description: old_key.description.clone(),
+                    role: old_key.role,
+                    project: old_key.project.clone(),
+                    pattern: old_key.pattern.clone(),
+                    expires_at: old_key.expires_at,
+                };
+                let replacement = client
+                    .create_key(&request)
+                    .await
+                    .with_context(|| format!("Failed to create replacement key for {}", key_id))?;
+
+                if let Err(e) = client.revoke_key(&key_id).await {
+                    println!("id\trole\tproject\tkey");
+                    println!(
+                        "{}\t{}\t{}\t{}",
+                        replacement.id, replacement.role, replacement.project, replacement.key
+                    );
+                    anyhow::bail!(
+                        "Created replacement key {} but failed to revoke old key {}: {}",
+                        replacement.id,
+                        key_id,
+                        e
+                    );
+                }
+
+                eprintln!("Rotated API key {} -> {}", key_id, replacement.id);
+                eprintln!("Store this key now; it will not be shown again.");
+                println!("old_id\tnew_id\trole\tproject\tkey");
+                println!(
+                    "{}\t{}\t{}\t{}\t{}",
+                    key_id, replacement.id, replacement.role, replacement.project, replacement.key
+                );
+                Ok::<(), anyhow::Error>(())
+            })?,
+        },
+    }
+
+    Ok(())
+}
+
+fn print_key_table(keys: &[KeyEntry]) {
+    println!("id\trole\tproject\tprefix\tstatus\tcreated_at\texpires_at\tdescription");
+    for key in keys {
+        let status = if key.revoked_at.is_some() {
+            "revoked"
+        } else {
+            "active"
+        };
+        let expires_at = key
+            .expires_at
+            .as_ref()
+            .map(|ts| ts.to_rfc3339())
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            key.id,
+            key.role,
+            key.project,
+            key.key_prefix,
+            status,
+            key.created_at.to_rfc3339(),
+            expires_at,
+            key.description
+        );
+    }
 }
 
 /// Execute baseline management actions.

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -88,6 +88,28 @@ fn add_success_command(cmd: &mut assert_cmd::Command) {
     }
 }
 
+fn mock_plaintext_key() -> String {
+    ["pg_live_", "fixtureonlynotsecret0000000000000000"].concat()
+}
+
+fn key_entry(id: &str, project: &str, revoked: bool) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "key_prefix": "pg_live_fixt...***",
+        "description": format!("{} key", project),
+        "role": "promoter",
+        "project": project,
+        "pattern": null,
+        "created_at": "2026-01-01T00:00:00Z",
+        "expires_at": null,
+        "revoked_at": if revoked {
+            serde_json::Value::String("2026-01-02T00:00:00Z".to_string())
+        } else {
+            serde_json::Value::Null
+        }
+    })
+}
+
 #[tokio::test]
 async fn test_run_upload_with_mock_server() {
     let mock_server = MockServer::start().await;
@@ -136,6 +158,167 @@ async fn test_run_upload_with_mock_server() {
         .stderr(predicate::str::contains("Uploaded baseline"));
 
     assert!(output_path.exists());
+}
+
+#[tokio::test]
+async fn test_admin_keys_create_with_mock_server() {
+    let mock_server = MockServer::start().await;
+    let plaintext = mock_plaintext_key();
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/keys"))
+        .and(header("Authorization", "Bearer admin-key"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "key-new",
+            "key": plaintext,
+            "description": "promotion key",
+            "role": "promoter",
+            "project": "my-project",
+            "pattern": null,
+            "created_at": "2026-01-01T00:00:00Z",
+            "expires_at": null
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("admin-key")
+        .arg("admin")
+        .arg("keys")
+        .arg("create")
+        .arg("--project")
+        .arg("my-project")
+        .arg("--role")
+        .arg("promoter")
+        .arg("--description")
+        .arg("promotion key");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("key-new"))
+        .stdout(predicate::str::contains("my-project"))
+        .stdout(predicate::str::contains("pg_live_"))
+        .stderr(predicate::str::contains("Created API key key-new"));
+}
+
+#[tokio::test]
+async fn test_admin_keys_list_filters_project_and_revoked_keys() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "keys": [
+                key_entry("key-active", "my-project", false),
+                key_entry("key-other", "other-project", false),
+                key_entry("key-revoked", "my-project", true)
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("admin-key")
+        .arg("admin")
+        .arg("keys")
+        .arg("list")
+        .arg("--project")
+        .arg("my-project");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("key-active"))
+        .stdout(predicate::str::contains("key-other").not())
+        .stdout(predicate::str::contains("key-revoked").not());
+}
+
+#[tokio::test]
+async fn test_admin_keys_revoke_with_mock_server() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api/v1/keys/key-active"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "key-active",
+            "revoked_at": "2026-01-02T00:00:00Z"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("admin-key")
+        .arg("admin")
+        .arg("keys")
+        .arg("revoke")
+        .arg("key-active");
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Revoked API key key-active"));
+}
+
+#[tokio::test]
+async fn test_admin_keys_rotate_with_mock_server() {
+    let mock_server = MockServer::start().await;
+    let plaintext = mock_plaintext_key();
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "keys": [key_entry("key-old", "my-project", false)]
+        })))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/keys"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "key-new",
+            "key": plaintext,
+            "description": "my-project key",
+            "role": "promoter",
+            "project": "my-project",
+            "pattern": null,
+            "created_at": "2026-01-03T00:00:00Z",
+            "expires_at": null
+        })))
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/api/v1/keys/key-old"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "key-old",
+            "revoked_at": "2026-01-03T00:01:00Z"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("admin-key")
+        .arg("admin")
+        .arg("keys")
+        .arg("rotate")
+        .arg("key-old");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("key-old"))
+        .stdout(predicate::str::contains("key-new"))
+        .stdout(predicate::str::contains("pg_live_"))
+        .stderr(predicate::str::contains(
+            "Rotated API key key-old -> key-new",
+        ));
 }
 
 #[tokio::test]

--- a/crates/perfgate-cli/tests/cli_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_server_tests.rs
@@ -460,6 +460,19 @@ fn test_global_server_flags_in_help() {
         .stdout(predicate::str::contains("--project"));
 }
 
+#[test]
+fn test_admin_keys_subcommands_exist() {
+    let mut cmd = perfgate_cmd();
+    cmd.arg("admin").arg("keys").arg("--help");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("create"))
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("revoke"))
+        .stdout(predicate::str::contains("rotate"));
+}
+
 /// Test compare with @server:benchmark reference (when server is not available).
 #[test]
 fn test_compare_server_reference_without_server() {

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -19,6 +19,7 @@ Commands:
   check Config-driven one-command workflow
   paired Run paired benchmark: interleave baseline and current commands for reduced noise
   baseline Manage baselines on the baseline server
+  admin Administer baseline service operations
   summary Summarize one or more compare receipts in a terminal table
   aggregate Aggregate multiple run receipts (e.g. from a fleet) into a formal aggregate receipt
   bisect Automatically find the commit that introduced a performance regression

--- a/crates/perfgate-client/src/client.rs
+++ b/crates/perfgate-client/src/client.rs
@@ -391,6 +391,101 @@ impl BaselineClient {
         }
     }
 
+    /// Creates a new API key. The plaintext key is returned exactly once.
+    pub async fn create_key(
+        &self,
+        request: &CreateKeyRequest,
+    ) -> Result<CreateKeyResponse, ClientError> {
+        self.execute_with_retry(|| {
+            let url = self.url("keys");
+            debug!(url = %url, role = %request.role, project = %request.project, "Creating API key");
+
+            let client = self.inner.clone();
+            let request = request.clone();
+            async move {
+                let response = client
+                    .post(url)
+                    .json(&request)
+                    .send()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+
+                if !response.status().is_success() {
+                    let status = response.status().as_u16();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(ClientError::from_http(status, &body));
+                }
+
+                let body = response
+                    .json::<CreateKeyResponse>()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+                Ok(body)
+            }
+        })
+        .await
+    }
+
+    /// Lists API keys. Returned key material is redacted by the server.
+    pub async fn list_keys(&self) -> Result<ListKeysResponse, ClientError> {
+        self.execute_with_retry(|| {
+            let url = self.url("keys");
+            debug!(url = %url, "Listing API keys");
+
+            let client = self.inner.clone();
+            async move {
+                let response = client
+                    .get(url)
+                    .send()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+
+                if !response.status().is_success() {
+                    let status = response.status().as_u16();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(ClientError::from_http(status, &body));
+                }
+
+                let body = response
+                    .json::<ListKeysResponse>()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+                Ok(body)
+            }
+        })
+        .await
+    }
+
+    /// Revokes an API key by ID.
+    pub async fn revoke_key(&self, id: &str) -> Result<RevokeKeyResponse, ClientError> {
+        self.execute_with_retry(|| {
+            let url = self.url(&format!("keys/{}", id));
+            debug!(url = %url, key_id = %id, "Revoking API key");
+
+            let client = self.inner.clone();
+            async move {
+                let response = client
+                    .delete(url)
+                    .send()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+
+                if !response.status().is_success() {
+                    let status = response.status().as_u16();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(ClientError::from_http(status, &body));
+                }
+
+                let body = response
+                    .json::<RevokeKeyResponse>()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+                Ok(body)
+            }
+        })
+        .await
+    }
+
     // -----------------------------------------------------------------------
     // Fleet-wide dependency regression detection
     // -----------------------------------------------------------------------

--- a/crates/perfgate-client/src/fallback.rs
+++ b/crates/perfgate-client/src/fallback.rs
@@ -184,6 +184,24 @@ impl FallbackClient {
         self.client.is_healthy().await
     }
 
+    /// Creates an API key (server only, no fallback).
+    pub async fn create_key(
+        &self,
+        request: &CreateKeyRequest,
+    ) -> Result<CreateKeyResponse, ClientError> {
+        self.client.create_key(request).await
+    }
+
+    /// Lists API keys (server only, no fallback).
+    pub async fn list_keys(&self) -> Result<ListKeysResponse, ClientError> {
+        self.client.list_keys().await
+    }
+
+    /// Revokes an API key (server only, no fallback).
+    pub async fn revoke_key(&self, id: &str) -> Result<RevokeKeyResponse, ClientError> {
+        self.client.revoke_key(id).await
+    }
+
     /// Checks if fallback storage is available.
     pub fn has_fallback(&self) -> bool {
         self.fallback.is_some()

--- a/crates/perfgate-server/src/handlers/keys.rs
+++ b/crates/perfgate-server/src/handlers/keys.rs
@@ -11,8 +11,10 @@ use tracing::{error, info, warn};
 
 use crate::auth::{AuthContext, Scope};
 use crate::models::{
-    ApiError, CreateKeyRequest, CreateKeyResponse, KeyEntry, ListKeysResponse, RevokeKeyResponse,
+    ApiError, AuditAction, AuditEvent, AuditResourceType, CreateKeyRequest, CreateKeyResponse,
+    KeyEntry, ListKeysResponse, RevokeKeyResponse,
 };
+use crate::server::AppState;
 use crate::storage::{KeyRecord, KeyStore, hash_key, key_prefix};
 
 /// POST /api/v1/keys — create a new API key (admin-only).
@@ -20,7 +22,8 @@ use crate::storage::{KeyRecord, KeyStore, hash_key, key_prefix};
 /// Returns the plaintext key exactly once in the response.
 pub async fn create_key(
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn KeyStore>>,
+    Extension(store): Extension<Arc<dyn KeyStore>>,
+    State(state): State<AppState>,
     Json(request): Json<CreateKeyRequest>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     // Admin scope check — use a wildcard project since key management is global.
@@ -61,11 +64,22 @@ pub async fn create_key(
     })?;
 
     info!(
+        actor = %auth_ctx.api_key.id,
         key_id = %id,
         role = %record.role,
         project = %record.project,
         "API key created"
     );
+
+    emit_key_audit(
+        &state,
+        &auth_ctx,
+        AuditAction::Create,
+        &id,
+        &record.project,
+        Some(record.role),
+    )
+    .await;
 
     Ok((
         StatusCode::CREATED,
@@ -85,7 +99,7 @@ pub async fn create_key(
 /// GET /api/v1/keys — list all API keys (admin-only, redacted).
 pub async fn list_keys(
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn KeyStore>>,
+    Extension(store): Extension<Arc<dyn KeyStore>>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_admin(&auth_ctx)?;
 
@@ -119,9 +133,18 @@ pub async fn list_keys(
 pub async fn revoke_key(
     Path(id): Path<String>,
     Extension(auth_ctx): Extension<AuthContext>,
-    State(store): State<Arc<dyn KeyStore>>,
+    Extension(store): Extension<Arc<dyn KeyStore>>,
+    State(state): State<AppState>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
     check_admin(&auth_ctx)?;
+
+    let key_for_audit = match store.list_keys().await {
+        Ok(records) => records.into_iter().find(|record| record.id == id),
+        Err(e) => {
+            warn!(error = %e, key_id = %id, "Failed to load key metadata for audit");
+            None
+        }
+    };
 
     let revoked_at = store.revoke_key(&id).await.map_err(|e| {
         error!(error = %e, key_id = %id, "Failed to revoke API key");
@@ -133,7 +156,21 @@ pub async fn revoke_key(
 
     match revoked_at {
         Some(ts) => {
-            info!(key_id = %id, "API key revoked");
+            info!(actor = %auth_ctx.api_key.id, key_id = %id, "API key revoked");
+            let audit_project = key_for_audit
+                .as_ref()
+                .map(|record| record.project.as_str())
+                .unwrap_or(&auth_ctx.api_key.project_id);
+            let audit_role = key_for_audit.as_ref().map(|record| record.role);
+            emit_key_audit(
+                &state,
+                &auth_ctx,
+                AuditAction::Delete,
+                &id,
+                audit_project,
+                audit_role,
+            )
+            .await;
             Ok(Json(RevokeKeyResponse { id, revoked_at: ts }))
         }
         None => {
@@ -161,4 +198,34 @@ fn check_admin(auth_ctx: &AuthContext) -> Result<(), (StatusCode, Json<ApiError>
         ));
     }
     Ok(())
+}
+
+async fn emit_key_audit(
+    state: &AppState,
+    auth_ctx: &AuthContext,
+    action: AuditAction,
+    key_id: &str,
+    project: &str,
+    role: Option<perfgate_api::auth::Role>,
+) {
+    let metadata = serde_json::json!({
+        "source": "api_key",
+        "request_id": null,
+        "source_ip": auth_ctx.source_ip.clone(),
+        "role": role.map(|r| r.to_string()),
+    });
+    let event = AuditEvent {
+        id: crate::models::generate_ulid(),
+        timestamp: chrono::Utc::now(),
+        actor: auth_ctx.api_key.id.clone(),
+        action,
+        resource_type: AuditResourceType::Key,
+        resource_id: key_id.to_string(),
+        project: project.to_string(),
+        metadata,
+    };
+
+    if let Err(e) = state.audit.log_event(&event).await {
+        warn!(error = %e, key_id = %key_id, "Failed to log key audit event");
+    }
 }

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -508,11 +508,12 @@ pub(crate) fn create_router(
         .route("/keys", post(create_key))
         .route("/keys", get(list_keys))
         .route("/keys/{id}", delete(revoke_key))
-        .with_state(persistent_key_store)
+        .layer(axum::Extension(persistent_key_store))
         .layer(middleware::from_fn_with_state(
             auth_state.clone(),
             auth_middleware,
-        ));
+        ))
+        .with_state(state.clone());
 
     // Admin routes (require admin auth, never skipped even in local mode)
     let admin_routes = Router::new()

--- a/crates/perfgate-server/tests/real_server_integration.rs
+++ b/crates/perfgate-server/tests/real_server_integration.rs
@@ -1,5 +1,8 @@
 //! Integration tests with a real in-memory server.
 
+use perfgate_client::types::{
+    AuditAction, AuditResourceType, CreateKeyRequest, ListAuditEventsResponse,
+};
 use perfgate_client::{BaselineClient, ClientConfig};
 use perfgate_server::auth::Role;
 use perfgate_server::server::{ServerConfig, StorageBackend};
@@ -78,4 +81,65 @@ async fn test_server_end_to_end_workflow() {
         .await
         .expect("list failed");
     assert_eq!(list_after.baselines.len(), 0);
+}
+
+#[tokio::test]
+async fn test_key_management_writes_audit_events() {
+    let config = ServerConfig::new()
+        .storage_backend(StorageBackend::Memory)
+        .api_key(ADMIN_KEY, Role::Admin);
+
+    let server = spawn_test_server(config).await;
+    let admin_client =
+        BaselineClient::new(ClientConfig::new(&server.url).with_api_key(ADMIN_KEY)).unwrap();
+
+    let created = admin_client
+        .create_key(&CreateKeyRequest {
+            description: "promotion key".to_string(),
+            role: Role::Promoter,
+            project: "test-proj".to_string(),
+            pattern: Some("^bench-.*$".to_string()),
+            expires_at: None,
+        })
+        .await
+        .expect("create key failed");
+    assert_eq!(created.role, Role::Promoter);
+    assert_eq!(created.project, "test-proj");
+
+    let listed = admin_client.list_keys().await.expect("list keys failed");
+    assert!(listed.keys.iter().any(|key| key.id == created.id));
+
+    admin_client
+        .revoke_key(&created.id)
+        .await
+        .expect("revoke key failed");
+
+    let audit: ListAuditEventsResponse = reqwest::Client::new()
+        .get(format!("{}/audit", server.url))
+        .bearer_auth(ADMIN_KEY)
+        .send()
+        .await
+        .expect("audit request failed")
+        .json()
+        .await
+        .expect("audit response should decode");
+
+    let create_event = audit
+        .events
+        .iter()
+        .find(|event| event.resource_id == created.id && event.action == AuditAction::Create)
+        .expect("create key audit event should exist");
+    assert_eq!(create_event.resource_type, AuditResourceType::Key);
+    assert_eq!(create_event.project, "test-proj");
+    assert_eq!(create_event.metadata["source"].as_str(), Some("api_key"));
+    assert_eq!(create_event.metadata["role"].as_str(), Some("promoter"));
+
+    let revoke_event = audit
+        .events
+        .iter()
+        .find(|event| event.resource_id == created.id && event.action == AuditAction::Delete)
+        .expect("revoke key audit event should exist");
+    assert_eq!(revoke_event.resource_type, AuditResourceType::Key);
+    assert_eq!(revoke_event.project, "test-proj");
+    assert_eq!(revoke_event.metadata["source"].as_str(), Some("api_key"));
 }


### PR DESCRIPTION
## Summary
- add `perfgate admin keys create|list|revoke|rotate` for baseline service API key lifecycle
- expose key create/list/revoke methods on `perfgate-client` and `FallbackClient`
- write key create/revoke audit events with actor, project, key id, role/source metadata

## Validation
- cargo test -p perfgate-cli --test cli_mock_server_tests -- --nocapture
- cargo test -p perfgate-cli --test cli_server_tests test_admin_keys_subcommands_exist -- --nocapture
- cargo test -p perfgate-server --test real_server_integration test_key_management_writes_audit_events -- --nocapture
- cargo test -p perfgate-cli --test cli_help_snapshot_tests snapshot_help_main -- --nocapture
- cargo run -p xtask -- ci
- git diff --check