### PR TITLE
harden: configure sqlite wal connections

### DIFF
--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -105,6 +105,11 @@ Loaded policy `id`, `role`, `project`, optional `benchmark_regex`, and optional
 | **sqlite** | Single-node production | Disk | `--database-url ./perfgate.db` |
 | **postgres** | Multi-node / HA | Disk | `--database-url postgresql://host/db` |
 
+SQLite file databases are opened with `journal_mode=WAL` and a 5 second
+`busy_timeout` on every server-managed connection. This keeps readers from
+blocking writers in normal single-node deployments. In-memory SQLite databases
+skip WAL because SQLite reports `journal_mode=memory` for those connections.
+
 ## Library usage
 
 ```rust

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -39,6 +39,7 @@ use crate::storage::fleet::{FleetStore, InMemoryFleetStore};
 use crate::storage::{
     ArtifactStore, AuditStore, BaselineStore, InMemoryKeyStore, InMemoryStore, KeyStore,
     ObjectArtifactStore, PostgresStore, SqliteKeyStore, SqliteStore,
+    open_configured_sqlite_connection,
 };
 use metrics_exporter_prometheus::PrometheusHandle;
 
@@ -631,7 +632,7 @@ pub async fn run_server(config: ServerConfig) -> Result<(), Box<dyn std::error::
             .sqlite_path
             .clone()
             .unwrap_or_else(|| PathBuf::from("perfgate.db"));
-        let conn = rusqlite::Connection::open(&path).map_err(|e| {
+        let conn = open_configured_sqlite_connection(&path).map_err(|e| {
             ConfigError::InvalidValue(format!("Failed to open SQLite for key store: {}", e))
         })?;
         Some(Arc::new(std::sync::Mutex::new(conn)))

--- a/crates/perfgate-server/src/storage/mod.rs
+++ b/crates/perfgate-server/src/storage/mod.rs
@@ -16,6 +16,7 @@ pub use key_store::{InMemoryKeyStore, KeyRecord, KeyStore, SqliteKeyStore, hash_
 pub use memory::InMemoryStore;
 pub use postgres::PostgresStore;
 pub use sqlite::SqliteStore;
+pub(crate) use sqlite::open_configured_connection as open_configured_sqlite_connection;
 
 use crate::error::StoreError;
 use crate::models::{

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -39,9 +39,7 @@ impl SqliteStore {
             std::fs::create_dir_all(parent)?;
         }
 
-        let is_memory = path.as_os_str() == ":memory:";
-        let conn = rusqlite::Connection::open(&path)?;
-        Self::configure_pragmas(&conn, is_memory)?;
+        let conn = open_configured_connection(&path)?;
 
         let store = Self {
             _path: path,
@@ -55,8 +53,7 @@ impl SqliteStore {
 
     /// Creates an in-memory SQLite database (for testing).
     pub fn in_memory() -> Result<Self, StoreError> {
-        let conn = rusqlite::Connection::open_in_memory()?;
-        Self::configure_pragmas(&conn, true)?;
+        let conn = open_configured_memory_connection()?;
 
         let store = Self {
             _path: std::path::PathBuf::from(":memory:"),
@@ -67,35 +64,54 @@ impl SqliteStore {
         store.initialize()?;
         Ok(store)
     }
+}
 
-    /// Configures SQLite pragmas for performance and concurrent access.
-    ///
-    /// - `journal_mode=WAL`: enables write-ahead logging so readers do not
-    ///   block writers and vice-versa.  Verified via the returned mode string
-    ///   so that silent fallbacks (e.g. read-only filesystem) become hard
-    ///   errors.  Skipped for in-memory databases where WAL is not applicable.
-    /// - `busy_timeout=5000`: waits up to 5 seconds when the database is
-    ///   locked instead of returning SQLITE_BUSY immediately.
-    fn configure_pragmas(conn: &rusqlite::Connection, is_memory: bool) -> Result<(), StoreError> {
-        conn.execute_batch("PRAGMA busy_timeout=5000;")?;
+/// Opens a SQLite file database and applies the server's required pragmas.
+pub(crate) fn open_configured_connection<P: AsRef<Path>>(
+    path: P,
+) -> Result<rusqlite::Connection, StoreError> {
+    let path = path.as_ref();
+    let is_memory = path.as_os_str() == ":memory:";
+    let conn = rusqlite::Connection::open(path)?;
+    configure_pragmas(&conn, is_memory)?;
+    Ok(conn)
+}
 
-        // GOTCHA: In-memory SQLite databases cannot use WAL mode. Executing
-        // `PRAGMA journal_mode=WAL` on an in-memory DB silently succeeds but
-        // returns "memory" instead of "wal". You MUST check the returned
-        // string — a bare `execute_batch("PRAGMA journal_mode=WAL")` will
-        // appear to work but leave you without WAL's concurrency benefits.
-        if !is_memory {
-            let mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
-            if mode.to_lowercase() != "wal" {
-                return Err(StoreError::Other(format!(
-                    "failed to enable WAL journal mode (got '{mode}')"
-                )));
-            }
+fn open_configured_memory_connection() -> Result<rusqlite::Connection, StoreError> {
+    let conn = rusqlite::Connection::open_in_memory()?;
+    configure_pragmas(&conn, true)?;
+    Ok(conn)
+}
+
+/// Configures SQLite pragmas for performance and concurrent access.
+///
+/// - `journal_mode=WAL`: enables write-ahead logging so readers do not
+///   block writers and vice-versa. Verified via the returned mode string
+///   so that silent fallbacks (e.g. read-only filesystem) become hard
+///   errors. Skipped for in-memory databases where WAL is not applicable.
+/// - `busy_timeout=5000`: waits up to 5 seconds when the database is
+///   locked instead of returning SQLITE_BUSY immediately.
+fn configure_pragmas(conn: &rusqlite::Connection, is_memory: bool) -> Result<(), StoreError> {
+    conn.execute_batch("PRAGMA busy_timeout=5000;")?;
+
+    // GOTCHA: In-memory SQLite databases cannot use WAL mode. Executing
+    // `PRAGMA journal_mode=WAL` on an in-memory DB silently succeeds but
+    // returns "memory" instead of "wal". You MUST check the returned
+    // string — a bare `execute_batch("PRAGMA journal_mode=WAL")` will
+    // appear to work but leave you without WAL's concurrency benefits.
+    if !is_memory {
+        let mode: String = conn.query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))?;
+        if mode.to_lowercase() != "wal" {
+            return Err(StoreError::Other(format!(
+                "failed to enable WAL journal mode (got '{mode}')"
+            )));
         }
-
-        Ok(())
     }
 
+    Ok(())
+}
+
+impl SqliteStore {
     fn initialize(&self) -> Result<(), StoreError> {
         let conn = self
             .conn
@@ -940,6 +956,68 @@ mod tests {
             .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
             .unwrap();
         assert_eq!(busy_timeout, 5000);
+    }
+
+    #[test]
+    fn test_in_memory_database_skips_wal_but_sets_busy_timeout() {
+        let conn = open_configured_memory_connection().unwrap();
+
+        let journal_mode: String = conn
+            .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(journal_mode.to_lowercase(), "memory");
+
+        let busy_timeout: i64 = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(busy_timeout, 5000);
+    }
+
+    #[test]
+    fn test_wal_allows_writer_while_reader_transaction_is_open() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("wal_concurrent_read.db");
+
+        let setup = open_configured_connection(&db_path).unwrap();
+        setup
+            .execute_batch(
+                r#"
+                CREATE TABLE items (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+                INSERT INTO items (value) VALUES ('before');
+                "#,
+            )
+            .unwrap();
+        drop(setup);
+
+        let reader = open_configured_connection(&db_path).unwrap();
+        let writer = open_configured_connection(&db_path).unwrap();
+
+        reader.execute_batch("BEGIN;").unwrap();
+        let reader_count: i64 = reader
+            .query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(reader_count, 1);
+
+        writer
+            .execute_batch(
+                r#"
+                BEGIN IMMEDIATE;
+                INSERT INTO items (value) VALUES ('during-read');
+                COMMIT;
+                "#,
+            )
+            .unwrap();
+
+        let reader_snapshot_count: i64 = reader
+            .query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(reader_snapshot_count, 1);
+        reader.execute_batch("COMMIT;").unwrap();
+
+        let final_count: i64 = reader
+            .query_row("SELECT COUNT(*) FROM items", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(final_count, 2);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -39,6 +39,12 @@ The current server binary supports:
 For local development, prefer `perfgate serve`. For a shared deployment,
 prefer `perfgate-server` directly.
 
+The SQLite backend is intended for one server process. File-backed SQLite
+connections are configured with WAL mode and a 5 second busy timeout so normal
+dashboard reads and CI writes can proceed without immediate lock failures.
+In-memory SQLite is still supported for tests and local sandboxing, but WAL is
+not applicable there.
+
 For local mode, `perfgate serve` runs with API auth disabled for single-user
 workflows.
 

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -77,6 +77,10 @@ perfgate-server \
   --api-keys viewer:pg_live_<32+alnum>:my-project
 ```
 
+SQLite file storage is configured for single-node service use: the server
+enables WAL mode and applies a 5 second busy timeout on its SQLite connections.
+Use PostgreSQL instead when multiple server instances need to share storage.
+
 Then configure the CLI:
 
 ```bash


### PR DESCRIPTION
## Summary
- share SQLite connection setup so baseline/audit storage and the persistent key store all apply the same pragmas
- verify file-backed SQLite uses WAL, in-memory SQLite skips WAL while keeping busy timeout, and a writer can commit while a reader transaction remains open
- document SQLite single-node WAL and busy-timeout behavior in baseline-server docs

## Validation
- cargo test -p perfgate-server --lib storage::sqlite::tests -- --nocapture
- cargo test -p perfgate-cli --test cli_server_tests live_server_cli_workflow_sqlite -- --nocapture
- cargo check -p perfgate-server --all-targets
- cargo run -p xtask -- ci
- git diff --check