### PR TITLE
docs: document baseline server operator controls

### DIFF
--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -33,7 +33,7 @@ cargo run -p perfgate-cli -- serve --no-open
 | **Web dashboard** | Embedded SPA served at `/` -- no extra deployment needed |
 | **Fleet analytics** | Dependency-change impact tracking and cross-project alerts |
 | **Verdict history** | Record and query pass/warn/fail verdicts over time |
-| **Observability** | Structured JSON logging, request IDs, `/health` endpoint |
+| **Observability** | Structured JSON logging, request IDs, `/health`, `/metrics` |
 | **Graceful shutdown** | Handles SIGTERM / Ctrl-C cleanly |
 
 ## REST API
@@ -43,7 +43,9 @@ All data endpoints live under `/api/v1`. The health check and dashboard are at t
 | Method | Path | Auth | Description |
 |--------|------|:----:|-------------|
 | `GET` | `/health` | -- | Health check with storage status |
+| `GET` | `/metrics` | -- | Prometheus metrics |
 | `GET` | `/` | -- | Web dashboard |
+| `GET` | `/api/v1/info` | -- | Server info and local-mode status |
 | `POST` | `/api/v1/projects/{project}/baselines` | Y | Upload a baseline |
 | `GET` | `/api/v1/projects/{project}/baselines` | Y | List baselines (filterable) |
 | `GET` | `/api/v1/projects/{project}/baselines/{bench}/latest` | Y | Get latest baseline |
@@ -52,6 +54,11 @@ All data endpoints live under `/api/v1`. The health check and dashboard are at t
 | `POST` | `/api/v1/projects/{project}/baselines/{bench}/promote` | Y | Promote a version |
 | `POST` | `/api/v1/projects/{project}/verdicts` | Y | Submit a verdict |
 | `GET` | `/api/v1/projects/{project}/verdicts` | Y | List verdicts |
+| `GET` | `/api/v1/audit` | Y | List audit events |
+| `POST` | `/api/v1/keys` | Y | Create an API key |
+| `GET` | `/api/v1/keys` | Y | List API keys |
+| `DELETE` | `/api/v1/keys/{id}` | Y | Revoke an API key |
+| `DELETE` | `/api/v1/admin/cleanup` | Y | Run artifact cleanup |
 | `POST` | `/api/v1/fleet/dependency-event` | Y | Record dependency change events |
 | `GET` | `/api/v1/fleet/alerts` | Y | List fleet-wide alerts |
 | `GET` | `/api/v1/fleet/dependency/{dep}/impact` | Y | Query dependency impact |
@@ -84,6 +91,12 @@ Loaded policy `id`, `role`, `project`, optional `benchmark_regex`, and optional
 | `--port` | `8080` | Port |
 | `--storage-type` | `memory` | `memory`, `sqlite`, or `postgres` |
 | `--database-url` | -- | DB path (SQLite) or connection string (Postgres) |
+| `--pg-max-connections` | `10` | Maximum PostgreSQL pool connections |
+| `--pg-min-connections` | `2` | Minimum idle PostgreSQL pool connections |
+| `--pg-idle-timeout` | `300` | Idle connection timeout in seconds |
+| `--pg-max-lifetime` | `1800` | Maximum connection lifetime in seconds |
+| `--pg-acquire-timeout` | `5` | Timeout for acquiring a pooled connection in seconds |
+| `--pg-statement-timeout` | `30` | PostgreSQL statement timeout set on new connections in seconds |
 | `--api-keys` | -- | `role:key[:project[:benchmark_regex]]` (repeatable) |
 | `--api-keys-env` | -- | env var containing one API-key policy document |
 | `--api-keys-file` | -- | file containing one API-key policy document |
@@ -96,6 +109,8 @@ Loaded policy `id`, `role`, `project`, optional `benchmark_regex`, and optional
 | `--timeout` | `30` | Request timeout (seconds) |
 | `--log-level` | `info` | `trace`, `debug`, `info`, `warn`, `error` |
 | `--log-format` | `json` | `json` or `pretty` |
+| `--retention-days` | `0` | Artifact retention period; `0` disables background cleanup |
+| `--cleanup-interval-hours` | `1` | Interval between background artifact cleanup passes |
 
 ## Storage backends
 
@@ -109,6 +124,28 @@ SQLite file databases are opened with `journal_mode=WAL` and a 5 second
 `busy_timeout` on every server-managed connection. This keeps readers from
 blocking writers in normal single-node deployments. In-memory SQLite databases
 skip WAL because SQLite reports `journal_mode=memory` for those connections.
+
+PostgreSQL storage uses a sqlx connection pool. The pool pings connections
+before reuse, applies `statement_timeout` on new connections, retries transient
+connection failures, and exposes pool occupancy from `/health`:
+
+```bash
+perfgate-server \
+  --storage-type postgres \
+  --database-url postgresql://perfgate:secret@db.example.com/perfgate \
+  --pg-max-connections 20 \
+  --pg-min-connections 4 \
+  --pg-acquire-timeout 10 \
+  --pg-statement-timeout 30
+```
+
+For artifact object storage, embedded deployments can set
+`ServerConfig::artifacts_url` to an `object_store` URL such as `s3://...`,
+`gs://...`, `az://...`, or `file://...`. The server binary exposes retention
+cadence flags, but cleanup only runs when an artifact store is configured. When
+using S3, GCS, Azure, or another managed object store, configure provider-side
+lifecycle policies as the durable retention backstop and use perfgate cleanup
+as application-level hygiene.
 
 ## Library usage
 

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides a REST API server for storing and managing performance
 //! baselines. It supports multiple storage backends (in-memory, SQLite, PostgreSQL)
-//! and includes authentication via API keys.
+//! and includes authentication via API keys, JWT, and OIDC mappings.
 //!
 //! Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 //!
@@ -12,7 +12,7 @@
 //! - **Version history**: Track baseline versions over time
 //! - **Rich metadata**: Git refs, tags, custom metadata
 //! - **Access control**: Role-based permissions (Viewer, Contributor, Promoter, Admin)
-//! - **Multiple backends**: In-memory, SQLite, PostgreSQL (planned)
+//! - **Multiple backends**: In-memory, SQLite, PostgreSQL
 //!
 //! # Quick Start
 //!
@@ -34,13 +34,17 @@
 //!
 //! | Method | Path | Description |
 //! |--------|------|-------------|
-//! | POST | `/projects/{project}/baselines` | Upload a baseline |
-//! | GET | `/projects/{project}/baselines/{benchmark}/latest` | Get latest baseline |
-//! | GET | `/projects/{project}/baselines/{benchmark}/versions/{version}` | Get specific version |
-//! | GET | `/projects/{project}/baselines` | List baselines |
-//! | DELETE | `/projects/{project}/baselines/{benchmark}/versions/{version}` | Delete baseline |
-//! | POST | `/projects/{project}/baselines/{benchmark}/promote` | Promote version |
-//! | GET | `/audit` | List audit events (admin only) |
+//! | POST | `/api/v1/projects/{project}/baselines` | Upload a baseline |
+//! | GET | `/api/v1/projects/{project}/baselines/{benchmark}/latest` | Get latest baseline |
+//! | GET | `/api/v1/projects/{project}/baselines/{benchmark}/versions/{version}` | Get specific version |
+//! | GET | `/api/v1/projects/{project}/baselines` | List baselines |
+//! | DELETE | `/api/v1/projects/{project}/baselines/{benchmark}/versions/{version}` | Delete baseline |
+//! | POST | `/api/v1/projects/{project}/baselines/{benchmark}/promote` | Promote version |
+//! | GET | `/api/v1/audit` | List audit events (admin only) |
+//! | POST | `/api/v1/keys` | Create an API key (admin only) |
+//! | GET | `/api/v1/keys` | List API keys (admin only) |
+//! | DELETE | `/api/v1/keys/{id}` | Revoke an API key (admin only) |
+//! | DELETE | `/api/v1/admin/cleanup` | Run artifact cleanup (admin only) |
 //! | GET | `/health` | Health check |
 //! | GET | `/metrics` | Prometheus metrics |
 

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -22,9 +22,11 @@ The baseline service currently ships as these pieces:
   - `promote --to-server`
   - `compare --baseline @server:<bench>`
   - `baseline list|download|upload|delete|history|verdicts|submit-verdict|migrate`
+  - `admin keys create|list|revoke|rotate`
   - config-driven use via `[baseline_server]` in `perfgate.toml`
 - `perfgate serve`: local single-user dashboard/server wrapper around
   `perfgate-server` with local mode enabled
+- `/health` and `/metrics` for basic production observability
 
 ## Storage Backends
 
@@ -44,6 +46,20 @@ connections are configured with WAL mode and a 5 second busy timeout so normal
 dashboard reads and CI writes can proceed without immediate lock failures.
 In-memory SQLite is still supported for tests and local sandboxing, but WAL is
 not applicable there.
+
+The PostgreSQL backend is intended for multi-node or managed database
+deployments. The server binary exposes pool-size, idle-timeout,
+connection-lifetime, acquire-timeout, and statement-timeout flags. The storage
+layer pings pooled connections before reuse, retries transient connection
+failures, and reports pool metrics from `/health`.
+
+Artifact retention is implemented for deployments with an object artifact
+store. The binary exposes `--retention-days` and
+`--cleanup-interval-hours`, and embedded deployments can attach an object store
+through `ServerConfig::artifacts_url`. If retention is configured without an
+artifact store, the server logs that cleanup is skipped. Provider-side lifecycle
+rules should still be used for managed stores such as S3, GCS, or Azure Blob
+Storage.
 
 For local mode, `perfgate serve` runs with API auth disabled for single-user
 workflows.
@@ -90,8 +106,9 @@ Public routes currently exposed by the server are:
 | Route | Purpose |
 |-------|---------|
 | `GET /health` | health check |
-| `GET /info` | server info and local-mode flag |
+| `GET /metrics` | Prometheus metrics |
 | `GET /` | dashboard |
+| `GET /api/v1/info` | server info and local-mode flag |
 | `POST /api/v1/projects/{project}/baselines` | upload a baseline |
 | `GET /api/v1/projects/{project}/baselines` | list baselines |
 | `GET /api/v1/projects/{project}/baselines/{benchmark}/latest` | fetch latest baseline |
@@ -105,6 +122,7 @@ Public routes currently exposed by the server are:
 | `POST /api/v1/keys` | create an API key |
 | `GET /api/v1/keys` | list API keys |
 | `DELETE /api/v1/keys/{id}` | revoke an API key |
+| `DELETE /api/v1/admin/cleanup` | run artifact cleanup |
 | `POST /api/v1/fleet/dependency-event` | record dependency events |
 | `GET /api/v1/fleet/alerts` | list fleet alerts |
 | `GET /api/v1/fleet/dependency/{dep_name}/impact` | query dependency impact |
@@ -128,6 +146,10 @@ The main server-aware CLI workflows are:
 | `fleet alerts` | list fleet-wide dependency regression alerts |
 | `fleet impact` | inspect the project impact of a dependency |
 | `fleet record-event` | record a dependency change event with performance delta |
+| `admin keys create` | create a scoped API key |
+| `admin keys list` | list scoped API keys |
+| `admin keys revoke` | revoke an API key |
+| `admin keys rotate` | create a replacement key and revoke the old key |
 | `serve` | run a local baseline server/dashboard in local mode |
 
 Cross-project compare is currently a CLI-side lookup override for baseline
@@ -159,6 +181,24 @@ perfgate-server \
 
 Or PostgreSQL instead of SQLite when you need a shared database layer.
 
+For PostgreSQL, start with a small bounded pool and raise it only when CI
+parallelism requires it:
+
+```bash
+perfgate-server \
+  --storage-type postgres \
+  --database-url postgresql://perfgate:secret@db.example.com/perfgate \
+  --pg-max-connections 20 \
+  --pg-min-connections 4 \
+  --pg-acquire-timeout 10 \
+  --pg-statement-timeout 30 \
+  --api-keys promoter:pg_live_<32+alnum>:my-project
+```
+
+Use `/health` to verify storage readiness and PostgreSQL pool occupancy before
+making the server a required CI dependency. Use `/metrics` for Prometheus
+scraping once the service is shared by more than one workflow.
+
 ## What This Document No Longer Claims
 
 This document intentionally does not treat the following as current product
@@ -183,7 +223,6 @@ These remain reasonable follow-up items, but they should be treated as backlog,
 not current guaranteed surface:
 
 - expose non-API-key auth flows more directly in the CLI
-- add stronger operator docs for key management and audit review
 - tighten shared-server deployment guides and examples
 - continue aligning crate READMEs, docs, and `--help` output from one source of
   truth

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -81,6 +81,22 @@ SQLite file storage is configured for single-node service use: the server
 enables WAL mode and applies a 5 second busy timeout on its SQLite connections.
 Use PostgreSQL instead when multiple server instances need to share storage.
 
+For PostgreSQL-backed deployments, tune the built-in pool explicitly instead of
+relying on database defaults:
+
+```bash
+perfgate-server \
+  --storage-type postgres \
+  --database-url postgresql://perfgate:secret@db.example.com/perfgate \
+  --pg-max-connections 20 \
+  --pg-min-connections 4 \
+  --pg-idle-timeout 300 \
+  --pg-max-lifetime 1800 \
+  --pg-acquire-timeout 10 \
+  --pg-statement-timeout 30 \
+  --api-keys promoter:pg_live_<32+alnum>:my-project
+```
+
 Then configure the CLI:
 
 ```bash
@@ -151,8 +167,9 @@ The current CLI surfaces that talk to the baseline service are:
 The server exposes these top-level surfaces:
 
 - `GET /health`: health check
+- `GET /metrics`: Prometheus metrics
 - `GET /`: web dashboard
-- `GET /info`: server info, including local-mode status
+- `GET /api/v1/info`: server info, including local-mode status
 - `POST /api/v1/projects/{project}/baselines`: upload a baseline
 - `GET /api/v1/projects/{project}/baselines`: list baselines
 - `GET /api/v1/projects/{project}/baselines/{benchmark}/latest`: fetch latest
@@ -166,9 +183,46 @@ The server exposes these top-level surfaces:
   data
 - `POST /api/v1/projects/{project}/verdicts`: submit a verdict
 - `GET /api/v1/projects/{project}/verdicts`: list verdicts
+- `GET /api/v1/audit`: list audit events
+- `POST /api/v1/keys`: create an API key
+- `GET /api/v1/keys`: list API keys
+- `DELETE /api/v1/keys/{id}`: revoke an API key
+- `DELETE /api/v1/admin/cleanup`: run artifact cleanup
 
 Point the CLI at the versioned API root, for example
 `http://localhost:8080/api/v1`, not just `http://localhost:8080`.
+
+## Operational Checks
+
+Use `/health` for liveness and storage readiness. PostgreSQL deployments also
+include current pool occupancy:
+
+```json
+{
+  "status": "healthy",
+  "version": "0.15.1",
+  "storage": {
+    "backend": "postgres",
+    "status": "healthy"
+  },
+  "pool": {
+    "idle": 2,
+    "active": 1,
+    "max": 20
+  }
+}
+```
+
+`/metrics` exposes Prometheus counters and histograms for request volume,
+request latency, storage operations, upload failures, auth failures, and
+storage errors.
+
+The server binary accepts `--retention-days` and
+`--cleanup-interval-hours` for background artifact cleanup. Cleanup only runs
+when an artifact store exists; embedded deployments configure that with
+`ServerConfig::artifacts_url`. For managed object stores such as S3, GCS, or
+Azure Blob Storage, keep provider lifecycle rules enabled as the durable
+retention backstop.
 
 ## Authentication Notes
 


### PR DESCRIPTION
## Summary
- document PostgreSQL pool flags, health pool metrics, and metrics endpoint in baseline-server docs
- clarify current artifact retention behavior and the library-only object-store configuration boundary
- refresh server route docs for API keys, audit, admin cleanup, and the versioned info route

## Validation
- cargo run -p xtask -- doc-test
- cargo test -p perfgate-server test_cli_args -- --nocapture
- cargo run -p perfgate-server -- --help
- cargo run -p xtask -- ci
- git diff --check