### PR TITLE
fix: harden baseline server fallback semantics

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -104,7 +104,7 @@ impl ServerFlags {
 
 enum BaselineSelector {
     Local(PathBuf),
-    Server { benchmark: String },
+    Server { benchmark: String, explicit: bool },
 }
 
 fn parse_baseline_selector(
@@ -122,6 +122,7 @@ fn parse_baseline_selector(
 
         return Ok(BaselineSelector::Server {
             benchmark: server_ref.to_string(),
+            explicit: true,
         });
     }
 
@@ -138,6 +139,7 @@ fn parse_baseline_selector(
 
     Ok(BaselineSelector::Server {
         benchmark: baseline.to_string(),
+        explicit: false,
     })
 }
 
@@ -1711,10 +1713,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
             if upload {
                 let (server_config, _config_file) =
                     resolve_server_config_from_path(&server_flags, None)?;
-                let client = server_config.require_fallback_client(
-                    Some(Path::new(DEFAULT_FALLBACK_BASELINE_DIR)),
-                    BASELINE_SERVER_NOT_CONFIGURED,
-                )?;
+                let client = server_config.require_client(BASELINE_SERVER_NOT_CONFIGURED)?;
                 let project = server_config.resolve_project(upload_project)?;
 
                 let request = UploadBaselineRequest {
@@ -1784,24 +1783,43 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 resolve_server_config_from_path(&server_flags, None)?;
             let baseline_selector = parse_baseline_selector(&baseline, &server_config)?;
             let (baseline_receipt, baseline_ref) = match baseline_selector {
-                BaselineSelector::Server { benchmark } => {
-                    let client = server_config.require_fallback_client(
-                        Some(Path::new(DEFAULT_FALLBACK_BASELINE_DIR)),
-                        BASELINE_SERVER_NOT_CONFIGURED,
-                    )?;
+                BaselineSelector::Server {
+                    benchmark,
+                    explicit,
+                } => {
                     let explicit_baseline_project = baseline_project.is_some();
                     let project = server_config.resolve_project(baseline_project)?;
-                    let record = with_tokio_runtime(async {
-                        let record: perfgate_api::BaselineRecord = client
-                            .get_latest_baseline(&project, &benchmark)
-                            .await
-                            .with_context(|| {
-                                format!(
-                                    "Failed to fetch baseline '{benchmark}' from server (project: {project})"
-                                )
-                            })?;
-                        Ok::<perfgate_api::BaselineRecord, anyhow::Error>(record)
-                    })?;
+                    let record = if explicit {
+                        let client =
+                            server_config.require_client(BASELINE_SERVER_NOT_CONFIGURED)?;
+                        with_tokio_runtime(async {
+                            let record: perfgate_api::BaselineRecord = client
+                                .get_latest_baseline(&project, &benchmark)
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "Failed to fetch baseline '{benchmark}' from server (project: {project})"
+                                    )
+                                })?;
+                            Ok::<perfgate_api::BaselineRecord, anyhow::Error>(record)
+                        })?
+                    } else {
+                        let client = server_config.require_fallback_client(
+                            Some(Path::new(DEFAULT_FALLBACK_BASELINE_DIR)),
+                            BASELINE_SERVER_NOT_CONFIGURED,
+                        )?;
+                        with_tokio_runtime(async {
+                            let record: perfgate_api::BaselineRecord = client
+                                .get_latest_baseline(&project, &benchmark)
+                                .await
+                                .with_context(|| {
+                                    format!(
+                                        "Failed to fetch baseline '{benchmark}' from server (project: {project})"
+                                    )
+                                })?;
+                            Ok::<perfgate_api::BaselineRecord, anyhow::Error>(record)
+                        })?
+                    };
 
                     let receipt = record.receipt;
                     let ref_info = CompareRef {
@@ -1967,10 +1985,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 let (server_config, _config_file) =
                     resolve_server_config_from_path(&server_flags, None)?;
                 // Promote to server
-                let client = server_config.require_fallback_client(
-                    Some(Path::new(DEFAULT_FALLBACK_BASELINE_DIR)),
-                    BASELINE_SERVER_NOT_CONFIGURED,
-                )?;
+                let client = server_config.require_client(BASELINE_SERVER_NOT_CONFIGURED)?;
                 let project = server_config.resolve_project(promote_project)?;
 
                 let benchmark_name = benchmark.ok_or_else(|| {

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -79,6 +79,22 @@ fn write_run_receipt(path: &std::path::Path, run_id: &str, benchmark: &str, wall
     .unwrap();
 }
 
+fn write_fallback_baseline(
+    root: &std::path::Path,
+    project: &str,
+    benchmark: &str,
+    run_id: &str,
+    wall_ms: u64,
+) {
+    let project_dir = root.join("baselines").join(project);
+    fs::create_dir_all(&project_dir).unwrap();
+    fs::write(
+        project_dir.join(format!("{benchmark}-v1.json")),
+        serde_json::to_string(&baseline_record(project, benchmark, run_id, wall_ms)).unwrap(),
+    )
+    .unwrap();
+}
+
 fn add_success_command(cmd: &mut assert_cmd::Command) {
     cmd.arg("--");
     if cfg!(windows) {
@@ -456,6 +472,77 @@ fn test_compare_bare_baseline_without_server_uses_existing_local_error() {
     );
 }
 
+#[test]
+fn test_compare_explicit_server_baseline_without_config_hard_errors() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let current_path = temp_dir.path().join("current.json");
+    let compare_path = temp_dir.path().join("compare.json");
+
+    write_run_receipt(&current_path, "current-run", "contract-bench", 110);
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("compare")
+        .arg("--baseline")
+        .arg("@server:contract-bench")
+        .arg("--current")
+        .arg(&current_path)
+        .arg("--out")
+        .arg(&compare_path);
+
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "baseline server is not configured",
+    ));
+    assert!(
+        !compare_path.exists(),
+        "explicit server compare must not write a compare receipt after configuration failure"
+    );
+}
+
+#[test]
+fn test_compare_explicit_server_baseline_does_not_use_local_fallback() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let current_path = temp_dir.path().join("current.json");
+    let compare_path = temp_dir.path().join("compare.json");
+    let config_path = temp_dir.path().join("perfgate.toml");
+
+    write_run_receipt(&current_path, "current-run", "explicit-contract", 110);
+    write_fallback_baseline(
+        temp_dir.path(),
+        "test-project",
+        "explicit-contract",
+        "fallback-run",
+        90,
+    );
+    fs::write(
+        &config_path,
+        "[baseline_server]\nfallback_to_local = true\n",
+    )
+    .unwrap();
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("compare")
+        .arg("--baseline")
+        .arg("@server:explicit-contract")
+        .arg("--current")
+        .arg(&current_path)
+        .arg("--baseline-server")
+        .arg("http://127.0.0.1:9/api/v1")
+        .arg("--project")
+        .arg("test-project")
+        .arg("--out")
+        .arg(&compare_path);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to fetch baseline"));
+    assert!(
+        !compare_path.exists(),
+        "explicit @server baseline must not silently compare against local fallback storage"
+    );
+}
+
 #[tokio::test]
 async fn test_run_upload_failure_preserves_local_receipt_and_exits_nonzero() {
     let mock_server = MockServer::start().await;
@@ -489,6 +576,47 @@ async fn test_run_upload_failure_preserves_local_receipt_and_exits_nonzero() {
     assert!(output_path.exists(), "run receipt should be preserved");
 }
 
+#[test]
+fn test_run_upload_connection_failure_does_not_write_local_fallback() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let output_path = temp_dir.path().join("run.json");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    fs::write(
+        &config_path,
+        "[baseline_server]\nfallback_to_local = true\n",
+    )
+    .unwrap();
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("run")
+        .arg("--name")
+        .arg("explicit-upload")
+        .arg("--repeat")
+        .arg("1")
+        .arg("--out")
+        .arg(&output_path)
+        .arg("--upload")
+        .arg("--baseline-server")
+        .arg("http://127.0.0.1:9/api/v1")
+        .arg("--project")
+        .arg("test-project");
+    add_success_command(&mut cmd);
+
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Failed to upload baseline to server",
+    ));
+    assert!(output_path.exists(), "run receipt should be preserved");
+    assert!(
+        !temp_dir
+            .path()
+            .join("baselines")
+            .join("test-project")
+            .exists(),
+        "explicit upload must not write a local fallback baseline"
+    );
+}
+
 #[tokio::test]
 async fn test_promote_to_server_failure_hard_errors() {
     let mock_server = MockServer::start().await;
@@ -518,6 +646,45 @@ async fn test_promote_to_server_failure_hard_errors() {
     cmd.assert().failure().stderr(predicate::str::contains(
         "Failed to promote baseline to server",
     ));
+}
+
+#[test]
+fn test_promote_to_server_connection_failure_does_not_write_local_fallback() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let current_path = temp_dir.path().join("current.json");
+    let config_path = temp_dir.path().join("perfgate.toml");
+
+    write_run_receipt(&current_path, "current-run", "explicit-promote", 100);
+    fs::write(
+        &config_path,
+        "[baseline_server]\nfallback_to_local = true\n",
+    )
+    .unwrap();
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("promote")
+        .arg("--current")
+        .arg(&current_path)
+        .arg("--to-server")
+        .arg("--benchmark")
+        .arg("explicit-promote")
+        .arg("--baseline-server")
+        .arg("http://127.0.0.1:9/api/v1")
+        .arg("--project")
+        .arg("test-project");
+
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Failed to promote baseline to server",
+    ));
+    assert!(
+        !temp_dir
+            .path()
+            .join("baselines")
+            .join("test-project")
+            .exists(),
+        "explicit promote must not write a local fallback baseline"
+    );
 }
 
 #[tokio::test]

--- a/crates/perfgate-config/src/lib.rs
+++ b/crates/perfgate-config/src/lib.rs
@@ -75,6 +75,13 @@ impl ResolvedServerConfig {
         Ok(Some(FallbackClient::new(client, fallback)))
     }
 
+    /// Returns a baseline client for explicit server operations, or an error
+    /// if the server is not configured.
+    pub fn require_client(&self, error_msg: &str) -> anyhow::Result<BaselineClient> {
+        self.create_client()?
+            .ok_or_else(|| anyhow::anyhow!(error_msg.to_string()))
+    }
+
     /// Returns a baseline client for server operations, or an error if not configured.
     pub fn require_fallback_client(
         &self,

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -156,6 +156,23 @@ Cross-project compare is currently a CLI-side lookup override for baseline
 fetches. It does not change server-side auth or the project used by other
 server-backed workflows.
 
+## Baseline Resolution Contract
+
+The CLI keeps local and remote baseline semantics deliberately explicit:
+
+| Input | Server configured? | Behavior |
+|-------|:------------------:|----------|
+| `--baseline ./baseline.json` and file exists | yes/no | use the local file |
+| `--baseline @server:bench` | yes | fetch the server baseline |
+| `--baseline @server:bench` | no | hard error |
+| `--baseline bench` and no local file/path is selected | yes | fetch the server baseline |
+| `--baseline bench` and no local file/path is selected | no | use the existing local read error |
+| `run --upload` upload fails | yes | preserve the local run receipt and exit nonzero |
+| `promote --to-server` server fails | yes | hard error with no local fallback write |
+
+In short: explicit local paths win, explicit remote operations hard-fail, and
+fallback is only allowed for implicit remote behavior.
+
 ## Recommended Deployment Shapes
 
 ### Local developer workflow

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -144,6 +144,13 @@ perfgate check --config perfgate.toml --bench my-bench
 `fallback_to_local = true` allows config-driven workflows to fall back to the
 local `baselines/` directory when the server is unavailable.
 
+Fallback is intentionally limited. Explicit local paths always use the file you
+named. Explicit remote operations such as `compare --baseline @server:my-bench`,
+`run --upload`, and `promote --to-server` hard-fail when the server cannot be
+used; they do not silently write to or read from local fallback storage. Bare
+benchmark selectors such as `--baseline my-bench` may use the server only when
+no local file/path is selected and the server is configured.
+
 ## Supported CLI Workflows
 
 The current CLI surfaces that talk to the baseline service are:


### PR DESCRIPTION
## Summary
- distinguish explicit @server:<bench> baseline selectors from implicit server fallback
- route explicit remote operations (compare @server, un --upload, promote --to-server) through a non-fallback baseline client
- add regression tests proving explicit remote failures do not read from or write to local fallback storage
- document the baseline resolution contract in the baseline service docs

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p perfgate-cli --test cli_mock_server_tests -- --nocapture
- cargo test -p perfgate-config
- cargo run -p xtask -- doc-test
- cargo check -p perfgate-cli -p perfgate-config
- cargo run -p xtask -- ci