### PR TITLE
Stop depending on perfgate-error internally

### DIFF
--- a/crates/perfgate-adapters/Cargo.toml
+++ b/crates/perfgate-adapters/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["development-tools"]
 
 [dependencies]
 perfgate-types.workspace = true
-perfgate-error.workspace = true
 perfgate-sha256.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true

--- a/crates/perfgate-adapters/src/lib.rs
+++ b/crates/perfgate-adapters/src/lib.rs
@@ -25,8 +25,8 @@ mod fake;
 
 pub use fake::FakeProcessRunner;
 
-pub use perfgate_error::AdapterError;
 use perfgate_sha256::sha256_hex;
+pub use perfgate_types::error::AdapterError;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 

--- a/crates/perfgate-api/Cargo.toml
+++ b/crates/perfgate-api/Cargo.toml
@@ -18,7 +18,6 @@ serde.workspace = true
 serde_json.workspace = true
 chrono = { version = "0.4.39", features = ["serde"] }
 perfgate-types.workspace = true
-perfgate-error.workspace = true
 schemars.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true

--- a/crates/perfgate-api/src/auth.rs
+++ b/crates/perfgate-api/src/auth.rs
@@ -15,7 +15,7 @@
 //! ```
 
 use chrono::{DateTime, Utc};
-use perfgate_error::AuthError;
+use perfgate_types::error::AuthError;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/crates/perfgate-app/Cargo.toml
+++ b/crates/perfgate-app/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["development-tools"]
 
 [dependencies]
 perfgate-types.workspace = true
-perfgate-error.workspace = true
 perfgate-domain.workspace = true
 perfgate-adapters.workspace = true
 perfgate-config.workspace = true

--- a/crates/perfgate-app/src/check.rs
+++ b/crates/perfgate-app/src/check.rs
@@ -241,7 +241,7 @@ impl<R: ProcessRunner + Clone, H: HostProbe + Clone, C: Clock + Clone> CheckUseC
         } else {
             // No baseline
             if req.require_baseline {
-                use perfgate_error::IoError;
+                use perfgate_types::error::IoError;
                 return Err(PerfgateError::Io(IoError::BaselineNotFound {
                     path: format!("bench '{}'", req.bench_name),
                 })

--- a/crates/perfgate-app/src/sensor_report.rs
+++ b/crates/perfgate-app/src/sensor_report.rs
@@ -13,7 +13,7 @@ pub use perfgate_sensor::{
 
 use crate::{CheckRequest, CheckUseCase, Clock};
 use perfgate_adapters::{HostProbe, ProcessRunner};
-use perfgate_error::{AdapterError, ConfigValidationError, IoError, PerfgateError};
+use perfgate_types::error::{AdapterError, ConfigValidationError, IoError, PerfgateError};
 use perfgate_types::{
     BASELINE_REASON_NO_BASELINE, ConfigFile, ERROR_KIND_EXEC, ERROR_KIND_IO, ERROR_KIND_PARSE,
     HostMismatchPolicy, MAX_FINDINGS_DEFAULT, RunReceipt, STAGE_BASELINE_RESOLVE,

--- a/crates/perfgate-cli/Cargo.toml
+++ b/crates/perfgate-cli/Cargo.toml
@@ -19,7 +19,6 @@ path = "src/main.rs"
 
 [dependencies]
 perfgate-types.workspace = true
-perfgate-error.workspace = true
 perfgate-client.workspace = true
 perfgate-config.workspace = true
 perfgate-api.workspace = true

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -32,7 +32,6 @@ use perfgate_config::{
     preview_ratchet_toml_changes, resolve_server_config,
 };
 use perfgate_domain::{DependencyChangeType, SignificancePolicy};
-use perfgate_error::{ConfigValidationError, IoError, PerfgateError};
 use perfgate_github::{CommentOptions, GitHubClient};
 use perfgate_ingest::IngestFormat;
 use perfgate_profile::{ProfileRequest, capture_flamegraph};
@@ -40,6 +39,7 @@ use perfgate_render::summary::{SummaryRequest, SummaryUseCase};
 use perfgate_scaling::{
     ScalingReport, SizeMeasurement, classify_complexity, parse_complexity, render_ascii_chart,
 };
+use perfgate_types::error::{ConfigValidationError, IoError, PerfgateError};
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,

--- a/crates/perfgate-domain/Cargo.toml
+++ b/crates/perfgate-domain/Cargo.toml
@@ -15,7 +15,6 @@ categories = ["algorithms", "development-tools"]
 
 [dependencies]
 perfgate-types.workspace = true
-perfgate-error.workspace = true
 perfgate-host-detect.workspace = true
 perfgate-budget.workspace = true
 perfgate-significance.workspace = true

--- a/crates/perfgate-domain/src/lib.rs
+++ b/crates/perfgate-domain/src/lib.rs
@@ -39,7 +39,7 @@ use perfgate_types::{
 };
 use std::collections::BTreeMap;
 
-pub use perfgate_error::StatsError;
+pub use perfgate_types::error::StatsError;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DomainError {

--- a/crates/perfgate-domain/src/paired.rs
+++ b/crates/perfgate-domain/src/paired.rs
@@ -80,7 +80,7 @@ use perfgate_types::{
     PairedDiffSummary, PairedSample, PairedStats, Significance, SignificancePolicy,
 };
 
-pub use perfgate_error::PairedError;
+pub use perfgate_types::error::PairedError;
 
 /// Compute summary statistics from paired benchmark samples.
 ///

--- a/crates/perfgate-domain/src/stats/mod.rs
+++ b/crates/perfgate-domain/src/stats/mod.rs
@@ -12,7 +12,7 @@
 
 pub mod trend;
 
-pub use perfgate_error::StatsError;
+pub use perfgate_types::error::StatsError;
 
 // Re-export trend module items
 pub use trend::{

--- a/crates/perfgate-profile/Cargo.toml
+++ b/crates/perfgate-profile/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["performance", "profiling", "flamegraph", "regression"]
 categories = ["development-tools"]
 
 [dependencies]
-perfgate-error.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/perfgate-server/Cargo.toml
+++ b/crates/perfgate-server/Cargo.toml
@@ -45,7 +45,6 @@ sqlx = { version = "0.8.3", default-features = false, features = ["postgres", "r
 
 # Validation
 perfgate-types.workspace = true
-perfgate-error.workspace = true
 perfgate-api = { workspace = true, features = ["server"] }
 perfgate-domain.workspace = true
 

--- a/crates/perfgate-server/src/auth.rs
+++ b/crates/perfgate-server/src/auth.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, errors::ErrorKind};
 pub use perfgate_api::auth::{ApiKey, JwtClaims, Role, Scope, validate_key_format};
-use perfgate_error::AuthError;
+use perfgate_types::error::AuthError;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/perfgate-server/src/error.rs
+++ b/crates/perfgate-server/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types for the perfgate server.
 
-pub use perfgate_error::AuthError;
+pub use perfgate_types::error::AuthError;
 use thiserror::Error;
 
 /// Storage-related errors.

--- a/crates/perfgate-server/src/oidc.rs
+++ b/crates/perfgate-server/src/oidc.rs
@@ -7,7 +7,7 @@
 
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header, jwk::JwkSet};
 use perfgate_api::auth::{ApiKey, Role};
-use perfgate_error::AuthError;
+use perfgate_types::error::AuthError;
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashMap;

--- a/crates/perfgate/Cargo.toml
+++ b/crates/perfgate/Cargo.toml
@@ -18,7 +18,6 @@ perfgate-types.workspace = true
 perfgate-domain.workspace = true
 perfgate-adapters.workspace = true
 perfgate-app.workspace = true
-perfgate-error.workspace = true
 perfgate-significance.workspace = true
 perfgate-budget.workspace = true
 perfgate-render.workspace = true

--- a/crates/perfgate/src/lib.rs
+++ b/crates/perfgate/src/lib.rs
@@ -24,7 +24,6 @@ pub use perfgate_app as app;
 pub use perfgate_budget as budget;
 pub use perfgate_domain as domain;
 pub use perfgate_domain::stats;
-pub use perfgate_error as error;
 pub use perfgate_export as export;
 pub use perfgate_host_detect as host_detect;
 pub use perfgate_paired as paired;
@@ -33,6 +32,7 @@ pub use perfgate_sensor as sensor;
 pub use perfgate_sha256 as sha256;
 pub use perfgate_significance as significance;
 pub use perfgate_types as types;
+pub use perfgate_types::error;
 // validation is now part of types
 pub use perfgate_types::validation;
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,7 +104,7 @@ Dependencies flow inward toward the core types and domain logic:
 - **perfgate-significance**: P-value and statistical significance testing.
 - **perfgate-render**: Markdown and terminal rendering logic.
 - **perfgate-export**: Multi-format data exporters (CSV, Prometheus, etc.).
-- **perfgate-error**: Shared error taxonomy across all crates.
+- **perfgate-types::error**: Shared error taxonomy; `perfgate-error` is a compatibility wrapper.
 - **perfgate-sha256**: High-performance fingerprinting for reports.
 
 ### Client/Server Stack (v2.0)

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -89,7 +89,7 @@ The perfgate architecture is modularized into 26 workspace crates:
 | `perfgate-significance` | Statistical significance testing (Welch's t-test) |
 | `perfgate-host-detect` | Host fingerprinting and mismatch detection |
 | `perfgate-paired` | Compatibility wrapper for paired benchmarking APIs |
-| `perfgate-error` | Shared error types and categorization |
+| `perfgate-error` | Compatibility wrapper for `perfgate_types::error` |
 | `perfgate-sha256` | Minimal SHA-256 implementation for fingerprints |
 | `perfgate-fake` | Test fixtures and mock data generators |
 | `perfgate-profile` | Profiling diagnostics and flamegraph capture |


### PR DESCRIPTION
## Summary
- switch production crates from the perfgate-error compatibility shim to perfgate_types::error
- remove perfgate-error from internal crate manifests where it is no longer needed
- update architecture docs to describe perfgate-error as a compatibility wrapper

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo check --workspace --all-targets
- cargo tree --workspace -e=no-dev -i perfgate-error
- cargo run -p xtask -- public-surface
- cargo run -p xtask -- arch
- cargo run -p xtask -- publish-check
- cargo run -p xtask -- doc-test
- cargo run -p xtask -- ci

## Note
The first local ci attempt failed because D: had about 5 MB free and the CLI help subprocess could not build. I removed this repo's generated target directory, reran doc-test, and reran full xtask ci successfully.