### PR TITLE
Warn on weak inverse-variance aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Exit codes: `0` pass, `1` error, `2` fail, `3` warn (with `--fail-on-warn`).
 
 **How-To Guides** -- solve specific problems:
 - [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md) -- reduce noise in flaky CI
+- [Fleet Aggregation](docs/FLEET_AGGREGATION.md) -- combine matrix or fleet receipts into one gate
 - [Cockpit Integration](docs/COCKPIT_MODE.md) -- dashboard integration via sensor.report.v1
 - [Exporting Data](docs/EXPORT.md) -- CSV, JSONL, HTML, Prometheus, JUnit
 - [Host Mismatch Detection](docs/HOST_MISMATCH.md) -- comparing across different hardware

--- a/crates/perfgate-app/src/aggregate.rs
+++ b/crates/perfgate-app/src/aggregate.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 const DEFAULT_VARIANCE_FLOOR: f64 = 1.0;
 const OUTLIER_VARIANCE_RATIO: f64 = 4.0;
+const MIN_INVERSE_VARIANCE_SAMPLE_COUNT: u32 = 5;
 
 pub struct AggregateRequest {
     pub files: Vec<PathBuf>,
@@ -145,6 +146,27 @@ impl AggregateUseCase {
             warnings.push(format!(
                 "{outlier_runners} runner(s) flagged as wall_ms variance outliers"
             ));
+        }
+        if matches!(req.weight_mode, AggregateWeightMode::InverseVariance) {
+            let low_sample_runners = runner_profiles
+                .iter()
+                .filter(|profile| profile.sample_count < MIN_INVERSE_VARIANCE_SAMPLE_COUNT)
+                .count();
+            if low_sample_runners > 0 {
+                warnings.push(format!(
+                    "{low_sample_runners} runner(s) have fewer than {MIN_INVERSE_VARIANCE_SAMPLE_COUNT} measured sample(s); inverse-variance weights may be unstable"
+                ));
+            }
+
+            let missing_variance_runners = runner_profiles
+                .iter()
+                .filter(|profile| profile.wall_ms_variance.is_none())
+                .count();
+            if missing_variance_runners > 0 {
+                warnings.push(format!(
+                    "{missing_variance_runners} runner(s) do not have enough wall_ms samples to estimate variance; using variance floor"
+                ));
+            }
         }
         let verdict = evaluate_policy(&inputs, &req);
 
@@ -766,6 +788,48 @@ mod tests {
         assert!(
             stable_input.runner.effective_weight.unwrap()
                 > noisy_input.runner.effective_weight.unwrap()
+        );
+    }
+
+    #[test]
+    fn inverse_variance_warns_when_sample_counts_are_low() {
+        let dir = tempdir().unwrap();
+        let first_path = dir.path().join("first.json");
+        let second_path = dir.path().join("second.json");
+
+        let first = mk_receipt_with_wall_samples("1", "linux", "x86_64", 0, &[100]);
+        let second = mk_receipt_with_wall_samples("2", "linux", "x86_64", 0, &[110]);
+
+        fs::write(&first_path, serde_json::to_string(&first).unwrap()).unwrap();
+        fs::write(&second_path, serde_json::to_string(&second).unwrap()).unwrap();
+
+        let outcome = AggregateUseCase
+            .execute(AggregateRequest {
+                files: vec![first_path, second_path],
+                policy: AggregationPolicy::Weighted,
+                quorum: Some(0.5),
+                fail_if: None,
+                weights: BTreeMap::new(),
+                weight_mode: AggregateWeightMode::InverseVariance,
+                variance_floor: Some(1.0),
+                runner_class: None,
+                lane: None,
+            })
+            .unwrap();
+
+        assert!(
+            outcome
+                .aggregate
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("fewer than 5 measured sample(s)"))
+        );
+        assert!(
+            outcome
+                .aggregate
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("using variance floor"))
         );
     }
 

--- a/docs/FLEET_AGGREGATION.md
+++ b/docs/FLEET_AGGREGATION.md
@@ -1,0 +1,83 @@
+# Fleet Aggregation
+
+`perfgate aggregate` combines run receipts from matrix or fleet runners into a
+single `perfgate.aggregate.v1` receipt and an aggregate run receipt. Use it when
+one benchmark is intentionally measured on more than one runner and you need one
+policy decision for CI.
+
+## Policies
+
+Use the simplest policy that matches the release risk:
+
+| Policy | Use when |
+|--------|----------|
+| `all` | every runner is authoritative and any failure should block |
+| `majority` | runners are equivalent and one isolated failure should not block |
+| `quorum` | you need a required pass ratio without per-runner weights |
+| `weighted` | runner classes have different trust levels |
+| `fail_if_n_of_m` | CI is sharded and a fixed number of failures should block |
+
+## Inverse-Variance Weighting
+
+`--weight-mode inverse_variance` is for matrix CI where runner variance is not
+equal. It downweights runners with high wall-time variance and records each
+runner's `sample_count`, `wall_ms_variance`, `effective_weight`, and
+`outlier_reason` in the aggregate receipt.
+
+Use it for:
+
+- self-hosted stable runners mixed with shared hosted runners
+- matrix CI where one OS or runner image is known to be noisy
+- observe-first fleet gates where a noisy failure should not dominate stable
+  runners
+
+Do not use it as a substitute for enough samples. The aggregate receipt warns
+when a runner has fewer than five measured samples, or when there are not enough
+samples to estimate variance and the variance floor is used.
+
+```bash
+perfgate aggregate \
+  artifacts/linux/perfgate.run.v1.json \
+  artifacts/windows/perfgate.run.v1.json \
+  artifacts/macos/perfgate.run.v1.json \
+  --policy weighted \
+  --weight-mode inverse_variance \
+  --quorum 0.75 \
+  --variance-floor 1.0 \
+  --runner-class github-hosted \
+  --lane pr \
+  --out artifacts/perfgate/aggregate.json
+```
+
+## Runner Classes
+
+Treat runner class as operator metadata, not a magic trust override:
+
+| Runner class | Suggested use |
+|--------------|---------------|
+| `self-hosted-stable` | authoritative gate if hardware and load are controlled |
+| `github-hosted` | useful gate with enough repeats and variance-aware aggregation |
+| `dev-laptop` | local diagnosis or observe-only trends |
+
+For stable self-hosted runners, start with `all` or `weighted` with configured
+weights. For GitHub-hosted shared runners, prefer `weighted` plus
+`inverse_variance` and at least five measured samples per runner. For laptops,
+prefer local `paired` runs and avoid making them required gates.
+
+## Matrix CI Example
+
+Each matrix job should write a run receipt as an artifact. A final aggregation
+job downloads those receipts and makes the policy decision:
+
+```bash
+perfgate aggregate "artifacts/**/perfgate.run.v1.json" \
+  --policy weighted \
+  --weight linux-x86_64=0.6 \
+  --weight windows-x86_64=0.2 \
+  --weight macos-aarch64=0.2 \
+  --quorum 0.70 \
+  --out artifacts/perfgate/aggregate.json
+```
+
+When the aggregate verdict fails, the command exits `2`; use normal CI shell
+control flow if later artifact upload or reporting steps must still run.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2269,6 +2269,7 @@ fn default_doc_files() -> anyhow::Result<Vec<PathBuf>> {
     for name in [
         "README.md",
         "docs/CONFIG.md",
+        "docs/FLEET_AGGREGATION.md",
         "docs/PIPELINE.md",
         "docs/BASELINE_SERVICE_DESIGN.md",
     ] {


### PR DESCRIPTION
## Summary
- warn when inverse-variance aggregation has fewer than five measured samples or cannot estimate runner variance
- add fleet aggregation guidance for policies, runner classes, matrix CI, and inverse-variance weighting
- include the new fleet aggregation guide in `xtask doc-test`

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p perfgate-app inverse_variance -- --nocapture`
- `cargo test -p perfgate-cli --test cli_aggregate_tests`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- ci`