### PR TITLE
Document paired retry contract

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1149,13 +1149,13 @@ pub struct PairedArgs {
     #[arg(long)]
     pub significance_min_samples: Option<u32>,
 
-    /// Maximum number of additional pairs to run if significance is not reached.
+    /// Maximum retry batches to collect when significance is required but not reached.
+    /// Each retry adds an adaptive number of measured pairs.
     #[arg(long, default_value_t = 0)]
     pub max_retries: u32,
 
-    /// CV threshold for early termination of retries.
-    /// If the coefficient of variation of wall-time differences exceeds this value,
-    /// retries are aborted because the benchmark is too noisy. Default: 0.5 (50%).
+    /// Optional CV threshold for early termination of significance retries.
+    /// If wall-time diff CV exceeds this value, retries stop because the benchmark is too noisy.
     #[arg(long)]
     pub cv_threshold: Option<f64>,
 

--- a/docs/PAIRED_BENCHMARKING.md
+++ b/docs/PAIRED_BENCHMARKING.md
@@ -28,7 +28,7 @@ The output is a standard `perfgate.compare.v1` receipt, compatible with `md`,
 ## Significance-based Retries
 
 The `paired` command supports automatic retries if statistical significance is
-not reached:
+required but not reached:
 
 ```bash
 perfgate paired \
@@ -36,10 +36,32 @@ perfgate paired \
   --baseline-cmd "./bench-old" \
   --current-cmd "./bench-new" \
   --repeat 10 \
-  --max-retries 3 \
   --significance-alpha 0.05 \
+  --require-significance \
+  --max-retries 3 \
   --out compare.json
 ```
 
-If the initial run doesn't reach significance, perfgate will retry up to
-`--max-retries` times with the same parameters before reporting the final result.
+Retries only run when `--require-significance` is set. If the initial measured
+pairs do not reach significance, each retry collects an adaptive extra batch:
+retry 1 collects 2 extra pairs, retry 2 collects 3 extra pairs, retry 3 collects
+5 extra pairs, and so on.
+
+Use `--cv-threshold` to stop retrying early when the paired wall-time
+differences are too noisy to trust:
+
+```bash
+perfgate paired \
+  --name my-bench \
+  --baseline-cmd "./bench-old" \
+  --current-cmd "./bench-new" \
+  --repeat 10 \
+  --significance-alpha 0.05 \
+  --require-significance \
+  --max-retries 3 \
+  --cv-threshold 0.50 \
+  --out compare.json
+```
+
+The receipt includes noise diagnostics when retries are enabled, including CV,
+noise level, retries used, and whether early termination occurred.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2270,6 +2270,7 @@ fn default_doc_files() -> anyhow::Result<Vec<PathBuf>> {
         "README.md",
         "docs/CONFIG.md",
         "docs/FLEET_AGGREGATION.md",
+        "docs/PAIRED_BENCHMARKING.md",
         "docs/PIPELINE.md",
         "docs/BASELINE_SERVICE_DESIGN.md",
     ] {


### PR DESCRIPTION
## Summary
- correct paired retry docs to state that retries require `--require-significance`
- document adaptive extra-pair batches and `--cv-threshold` early termination
- add paired benchmarking docs to `xtask doc-test`
- clarify paired retry and CV threshold help text

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -p xtask -- doc-test`
- `cargo test -p perfgate-cli cli_help_paired -- --nocapture`
- `cargo test -p perfgate-app paired_run_ -- --nocapture`
- `cargo run -p xtask -- ci`