### PR TITLE
Document flakiness score contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Exit codes: `0` pass, `1` error, `2` fail, `3` warn (with `--fail-on-warn`).
 
 **How-To Guides** -- solve specific problems:
 - [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md) -- reduce noise in flaky CI
+- [Flakiness History](docs/FLAKINESS.md) -- interpret historical benchmark noise
 - [Fleet Aggregation](docs/FLEET_AGGREGATION.md) -- combine matrix or fleet receipts into one gate
 - [Cockpit Integration](docs/COCKPIT_MODE.md) -- dashboard integration via sensor.report.v1
 - [Exporting Data](docs/EXPORT.md) -- CSV, JSONL, HTML, Prometheus, JUnit

--- a/crates/perfgate-server/assets/index.html
+++ b/crates/perfgate-server/assets/index.html
@@ -286,6 +286,9 @@
         .badge-warn { background: #fff8c5; color: #735c0f; }
         .badge-fail { background: #ffdce0; color: #9e1c23; }
         .badge-skip { background: #e1e4e8; color: #586069; }
+        .badge-noise-low { background: #dcffe4; color: #176328; }
+        .badge-noise-elevated { background: #fff8c5; color: #735c0f; }
+        .badge-noise-high { background: #ffdce0; color: #9e1c23; }
 
         code {
             font-family: var(--font-mono);
@@ -672,6 +675,7 @@
                     <label><input type="checkbox" id="verdictWarn" checked onchange="loadVerdicts()"> Warn</label>
                     <label><input type="checkbox" id="verdictFail" checked onchange="loadVerdicts()"> Fail</label>
                     <label><input type="checkbox" id="verdictSkip" onchange="loadVerdicts()"> Skip</label>
+                    <label><input type="checkbox" id="verdictFlakyOnly" onchange="loadVerdicts()"> Flaky</label>
                 </div>
             </div>
 
@@ -684,11 +688,13 @@
                             <th>Pass</th>
                             <th>Warn</th>
                             <th>Fail</th>
+                            <th>CV</th>
+                            <th>Flakiness</th>
                             <th>Created</th>
                         </tr>
                     </thead>
                     <tbody id="verdictsBody">
-                        <tr><td colspan="6" class="empty-state"><p>Load a project to see verdicts</p></td></tr>
+                        <tr><td colspan="8" class="empty-state"><p>Load a project to see verdicts</p></td></tr>
                     </tbody>
                 </table>
             </div>
@@ -817,6 +823,11 @@
             return d.toLocaleDateString() + ' ' + d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
         }
 
+        function fmtPercentRatio(value) {
+            if (typeof value !== 'number' || !isFinite(value)) return '-';
+            return (value * 100).toFixed(0) + '%';
+        }
+
         function getMetricValue(receipt, metric) {
             if (!receipt || !receipt.stats) return null;
             const stat = receipt.stats[metric];
@@ -828,6 +839,20 @@
             const safe = escHtml(status);
             const cls = 'badge badge-' + safe;
             return '<span class="' + cls + '">' + safe + '</span>';
+        }
+
+        function flakinessBadge(score) {
+            if (typeof score !== 'number' || !isFinite(score)) return '-';
+            var label = 'low';
+            var cls = 'badge-noise-low';
+            if (score >= 0.75) {
+                label = 'high';
+                cls = 'badge-noise-high';
+            } else if (score >= 0.50) {
+                label = 'elevated';
+                cls = 'badge-noise-elevated';
+            }
+            return '<span class="badge ' + cls + '">' + score.toFixed(2) + ' ' + label + '</span>';
         }
 
         /* ======= API fetch ======= */
@@ -974,13 +999,14 @@
         async function loadVerdicts() {
             var project = getProject();
             var body = document.getElementById('verdictsBody');
-            body.innerHTML = loadingRow(6);
+            body.innerHTML = loadingRow(8);
 
             var statusFilters = [];
             if (document.getElementById('verdictPass').checked) statusFilters.push('pass');
             if (document.getElementById('verdictWarn').checked) statusFilters.push('warn');
             if (document.getElementById('verdictFail').checked) statusFilters.push('fail');
             if (document.getElementById('verdictSkip').checked) statusFilters.push('skip');
+            var flakyOnly = document.getElementById('verdictFlakyOnly').checked;
 
             // Fetch all verdicts (the API supports status filter one at a time)
             // We'll fetch without status filter and filter client-side
@@ -990,18 +1016,20 @@
 
             var data = await fetchApi(url);
             if (!data) {
-                body.innerHTML = emptyRow(6, 'Failed to load verdicts.');
+                body.innerHTML = emptyRow(8, 'Failed to load verdicts.');
                 document.getElementById('verdictPagination').style.display = 'none';
                 return;
             }
 
             var verdicts = (data.verdicts || []).filter(function(v) {
-                return statusFilters.indexOf(v.status) !== -1;
+                if (statusFilters.indexOf(v.status) === -1) return false;
+                if (flakyOnly && (!v.flakiness_score || v.flakiness_score < 0.50)) return false;
+                return true;
             });
             totalVerdicts = data.pagination ? data.pagination.total : verdicts.length;
 
             if (verdicts.length === 0) {
-                body.innerHTML = emptyRow(6, 'No verdicts match your filters.');
+                body.innerHTML = emptyRow(8, 'No verdicts match your filters.');
                 document.getElementById('verdictPagination').style.display = 'none';
                 return;
             }
@@ -1009,12 +1037,15 @@
             body.innerHTML = '';
             verdicts.forEach(function(v) {
                 var row = document.createElement('tr');
+                var cv = fmtPercentRatio(v.wall_ms_cv);
                 row.innerHTML =
                     '<td><strong>' + escHtml(v.benchmark) + '</strong></td>'
                     + '<td>' + verdictBadge(v.status) + '</td>'
                     + '<td>' + v.counts.pass + '</td>'
                     + '<td>' + v.counts.warn + '</td>'
                     + '<td>' + v.counts.fail + '</td>'
+                    + '<td><code>' + cv + '</code></td>'
+                    + '<td>' + flakinessBadge(v.flakiness_score) + '</td>'
                     + '<td>' + fmtDate(v.created_at) + '</td>';
                 body.appendChild(row);
             });

--- a/crates/perfgate-server/src/handlers/verdicts.rs
+++ b/crates/perfgate-server/src/handlers/verdicts.rs
@@ -18,6 +18,10 @@ use crate::server::AppState;
 const HIGH_FLAKINESS_CV_THRESHOLD: f64 = 0.30;
 const FLAKINESS_HISTORY_LIMIT: u32 = 20;
 
+/// Scores recent wall-time CV history from 0.0 (stable) to 1.0 (highly noisy).
+///
+/// The score combines frequency and severity so a benchmark is not marked flaky
+/// from one small wobble, but repeated high-CV verdicts become visible quickly.
 fn score_flakiness_history(cv_history: &[f64]) -> Option<f64> {
     let filtered: Vec<f64> = cv_history
         .iter()
@@ -176,5 +180,42 @@ pub async fn list_verdicts(
                 Json(ApiError::internal_error(&e.to_string())),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_close(actual: Option<f64>, expected: f64) {
+        let actual = actual.expect("score should be present");
+        assert!(
+            (actual - expected).abs() < 0.000_001,
+            "expected {expected}, got {actual}"
+        );
+    }
+
+    #[test]
+    fn flakiness_score_ignores_missing_invalid_and_negative_cv_values() {
+        assert_eq!(score_flakiness_history(&[]), None);
+        assert_eq!(
+            score_flakiness_history(&[f64::NAN, f64::INFINITY, -0.01]),
+            None
+        );
+    }
+
+    #[test]
+    fn flakiness_score_stays_low_for_stable_history() {
+        assert_close(score_flakiness_history(&[0.06, 0.09, 0.12]), 0.045);
+    }
+
+    #[test]
+    fn flakiness_score_combines_noisy_frequency_and_severity() {
+        assert_close(score_flakiness_history(&[0.60, 0.12]), 0.53);
+    }
+
+    #[test]
+    fn flakiness_score_caps_extreme_cv_at_one() {
+        assert_close(score_flakiness_history(&[0.90, 1.20]), 1.0);
     }
 }

--- a/crates/perfgate-server/tests/real_server_integration.rs
+++ b/crates/perfgate-server/tests/real_server_integration.rs
@@ -1,15 +1,24 @@
 //! Integration tests with a real in-memory server.
 
 use perfgate_client::types::{
-    AuditAction, AuditResourceType, CreateKeyRequest, ListAuditEventsResponse,
+    AuditAction, AuditResourceType, CreateKeyRequest, ListAuditEventsResponse, SubmitVerdictRequest,
 };
 use perfgate_client::{BaselineClient, ClientConfig};
 use perfgate_server::auth::Role;
 use perfgate_server::server::{ServerConfig, StorageBackend};
 use perfgate_server::testing::spawn_test_server;
+use perfgate_types::{VerdictCounts, VerdictStatus};
 
 mod common;
 use common::{ADMIN_KEY, CONTRIBUTOR_KEY, create_test_upload_request};
+
+fn assert_score_close(actual: Option<f64>, expected: f64) {
+    let actual = actual.expect("flakiness score should be present");
+    assert!(
+        (actual - expected).abs() < 0.000_001,
+        "expected flakiness score {expected}, got {actual}"
+    );
+}
 
 #[tokio::test]
 async fn test_server_end_to_end_workflow() {
@@ -142,4 +151,61 @@ async fn test_key_management_writes_audit_events() {
     assert_eq!(revoke_event.resource_type, AuditResourceType::Key);
     assert_eq!(revoke_event.project, "test-proj");
     assert_eq!(revoke_event.metadata["source"].as_str(), Some("api_key"));
+}
+
+#[tokio::test]
+async fn test_verdict_submission_scores_flakiness_from_recent_cv_history() {
+    let config = ServerConfig::new()
+        .storage_backend(StorageBackend::Memory)
+        .scoped_api_key(CONTRIBUTOR_KEY, Role::Contributor, "test-proj", None);
+
+    let server = spawn_test_server(config).await;
+    let client =
+        BaselineClient::new(ClientConfig::new(&server.url).with_api_key(CONTRIBUTOR_KEY)).unwrap();
+
+    let first = client
+        .submit_verdict(
+            "test-proj",
+            &SubmitVerdictRequest {
+                benchmark: "flaky-bench".to_string(),
+                run_id: "run-1".to_string(),
+                status: VerdictStatus::Pass,
+                counts: VerdictCounts {
+                    pass: 1,
+                    warn: 0,
+                    fail: 0,
+                    skip: 0,
+                },
+                reasons: vec![],
+                git_ref: Some("main".to_string()),
+                git_sha: Some("abc123".to_string()),
+                wall_ms_cv: Some(0.12),
+            },
+        )
+        .await
+        .expect("first verdict should submit");
+    assert_score_close(first.flakiness_score, 0.06);
+
+    let second = client
+        .submit_verdict(
+            "test-proj",
+            &SubmitVerdictRequest {
+                benchmark: "flaky-bench".to_string(),
+                run_id: "run-2".to_string(),
+                status: VerdictStatus::Warn,
+                counts: VerdictCounts {
+                    pass: 0,
+                    warn: 1,
+                    fail: 0,
+                    skip: 0,
+                },
+                reasons: vec!["wall_ms.noisy".to_string()],
+                git_ref: Some("main".to_string()),
+                git_sha: Some("def456".to_string()),
+                wall_ms_cv: Some(0.60),
+            },
+        )
+        .await
+        .expect("second verdict should submit");
+    assert_score_close(second.flakiness_score, 0.53);
 }

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -24,6 +24,7 @@ The baseline service currently ships as these pieces:
   - `baseline list|download|upload|delete|history|verdicts|submit-verdict|migrate`
   - `admin keys create|list|revoke|rotate`
   - config-driven use via `[baseline_server]` in `perfgate.toml`
+- verdict history with wall-time CV and historical flakiness scores
 - `perfgate serve`: local single-user dashboard/server wrapper around
   `perfgate-server` with local mode enabled
 - `/health` and `/metrics` for basic production observability
@@ -141,6 +142,7 @@ The main server-aware CLI workflows are:
 | `baseline list` | query project baselines |
 | `baseline history` | inspect versions for one benchmark |
 | `baseline verdicts` | inspect pass/warn/fail history |
+| `baseline flaky` | inspect benchmarks with elevated historical noise |
 | `baseline submit-verdict` | persist compare verdicts |
 | `baseline migrate` | upload local baseline JSON files recursively |
 | `fleet alerts` | list fleet-wide dependency regression alerts |
@@ -247,6 +249,7 @@ not current guaranteed surface:
 ## Related Docs
 
 - [Getting Started with Baseline Server](GETTING_STARTED_BASELINE_SERVER.md)
+- [Flakiness History](FLAKINESS.md)
 - [perfgate-server README](../crates/perfgate-server/README.md)
 - [Configuration](CONFIG.md)
 - [Architecture](ARCHITECTURE.md)

--- a/docs/FLAKINESS.md
+++ b/docs/FLAKINESS.md
@@ -1,0 +1,70 @@
+# Flakiness History
+
+Perfgate treats noisy benchmark data as part of the signal. A regression gate
+is useful only when teams can tell the difference between a real slowdown and a
+benchmark that is too unstable to trust.
+
+The baseline service stores two wall-time noise fields on
+`perfgate.verdict.v1` records:
+
+| Field | Meaning |
+|-------|---------|
+| `wall_ms_cv` | The coefficient of variation for the current verdict's wall-time samples. This is stored as a ratio, so `0.30` means 30%. |
+| `flakiness_score` | A 0.0 to 1.0 score derived from recent wall-time CV history for the same project and benchmark. |
+
+## Score Contract
+
+When a verdict is submitted, the server combines the current verdict's
+`wall_ms_cv` with up to 19 previous verdicts for the same project and
+benchmark. Invalid, missing, infinite, NaN, and negative CV values are ignored.
+If no valid CV remains, `flakiness_score` is omitted.
+
+The current scoring threshold for high wall-time noise is `0.30`.
+
+```text
+noisy_ratio = count(cv > 0.30) / valid_cv_count
+mean_severity = average(min(cv / 0.30, 2.0) / 2.0)
+flakiness_score = min(1.0, noisy_ratio * 0.7 + mean_severity * 0.3)
+```
+
+This intentionally gives more weight to repeated noisy verdicts than to one
+isolated spike, while still surfacing severe single-run instability.
+
+## Interpreting Scores
+
+| Score | Meaning |
+|-------|---------|
+| `< 0.50` | Usually stable enough to read as a normal pass/warn/fail signal. |
+| `0.50..0.74` | Elevated noise; inspect sample count, runner class, and benchmark setup. |
+| `>= 0.75` | High noise; treat the benchmark as flaky until the cause is understood. |
+
+These bands are display guidance, not automatic policy changes. Budget verdicts
+still come from the compare receipt and configured noise policy.
+
+## Operator Workflow
+
+List the latest noisy benchmarks for a project:
+
+```bash
+perfgate baseline flaky --project my-project --min-score 0.50
+```
+
+Limit the scan to one benchmark:
+
+```bash
+perfgate baseline flaky --project my-project --benchmark parser --min-score 0.25
+```
+
+The dashboard verdict table also shows the latest wall-time CV and flakiness
+score. Use the `Flaky` filter to focus on verdicts with score `>= 0.50`.
+
+## Improving A Flaky Benchmark
+
+Start with the runner and sampling setup before changing budgets:
+
+1. Prefer a stable self-hosted runner for required gates.
+2. Raise paired sample count or use `perfgate paired` for noisy A/B comparisons.
+3. Increase warmups for benchmarks with one-time initialization cost.
+4. Split benchmarks that mix unrelated workloads.
+5. Set `noise_policy = "warn"` only when the benchmark is still useful but
+   inherently noisy.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2269,6 +2269,7 @@ fn default_doc_files() -> anyhow::Result<Vec<PathBuf>> {
     for name in [
         "README.md",
         "docs/CONFIG.md",
+        "docs/FLAKINESS.md",
         "docs/FLEET_AGGREGATION.md",
         "docs/PAIRED_BENCHMARKING.md",
         "docs/PIPELINE.md",


### PR DESCRIPTION
## Summary
- document the baseline-service flakiness score formula and operator workflow
- expose wall-time CV and flakiness score in the dashboard verdict table with a flaky filter
- add unit and real-server integration coverage for scoring current plus historical CV values
- include `docs/FLAKINESS.md` in `xtask doc-test`

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p perfgate-server flakiness_score -- --nocapture`
- `cargo test -p perfgate-server test_verdict_submission_scores_flakiness_from_recent_cv_history -- --nocapture`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- ci`