### PR TITLE
Align architecture docs with public-surface policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Exit codes: `0` pass, `1` error, `2` fail, `3` warn (with `--fail-on-warn`).
 - [Configuration](docs/CONFIG.md) -- `perfgate.toml` options and per-metric budgets
 - [Output Schemas](docs/SCHEMAS.md) -- perfgate.run.v1, compare.v1, report.v1, sensor.report.v1
 - [Artifact Layouts](docs/ARTIFACTS.md) -- standard and cockpit mode output structure
-- [Architecture](docs/ARCHITECTURE.md) -- 26-crate workspace, clean-architecture layers
+- [Architecture](docs/ARCHITECTURE.md) -- public crate surface and clean-architecture layers
 - [ADRs](docs/adrs/) -- architectural decision records
 
 **Explanation**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,19 +60,52 @@ Significant architectural changes are documented in [ADRs](adrs/). See:
 
 ## Crate Boundaries
 
-perfgate follows a highly modular micro-crate architecture with strictly layered dependencies. The workspace is split into 26 crates to enforce boundaries and improve build times.
+perfgate keeps strict clean-architecture boundaries, but those boundaries are
+no longer intended to map one-to-one to public crates. The 0.16 public-surface
+contract is:
+
+| Public package | Role |
+|----------------|------|
+| `perfgate` | Main embeddable facade |
+| `perfgate-cli` | Installs the `perfgate` binary |
+| `perfgate-types` | Stable receipts, schemas, config, and API contracts |
+| `perfgate-client` | Baseline service client |
+| `perfgate-server` | Baseline service binary/library |
+
+The remaining workspace packages are internal seams, transition packages, or
+compatibility wrappers until the public-surface collapse finishes. The current
+policy files are:
+
+- [`policy/public_crates.txt`](../policy/public_crates.txt)
+- [`policy/absorbed_crates.txt`](../policy/absorbed_crates.txt)
+- [`docs/CRATE_SEAMS.md`](CRATE_SEAMS.md)
+
+Architecture enforcement is executable:
+
+```bash
+cargo run -p xtask -- public-surface
+cargo run -p xtask -- arch
+```
+
+`cargo run -p xtask -- public-surface --strict` is the final release gate. It
+is expected to fail until absorbed/internal transition packages are deleted,
+marked `publish = false`, or reduced to intentional compatibility shims.
 
 ### Component Layers
 
+The current source layout still has named crates for several internal seams.
+Treat this diagram as the enforced dependency direction, not as a public API
+promise:
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                        perfgate-cli                              │
-│                (User Interface, CLI parsing)                    │
+│                    perfgate-cli / perfgate-server                │
+│                    (outer adapters and binaries)                 │
 ├─────────────────────────────────────────────────────────────────┤
 │       perfgate-render | perfgate-export | perfgate-sensor        │
 │                    (Presentation Layer)                         │
 ├─────────────────────────────────────────────────────────────────┤
-│                perfgate-app | perfgate-paired                    │
+│                  perfgate-app | perfgate-client                  │
 │                    (Use-Case Orchestration)                     │
 ├─────────────────────────────────────────────────────────────────┤
 │            perfgate-adapters | perfgate-host-detect             │
@@ -97,7 +130,7 @@ Dependencies flow inward toward the core types and domain logic:
 5. **Presentation**: `perfgate-render`, `perfgate-export`, and `perfgate-sensor` format the results for various consumers.
 6. **CLI**: `perfgate-cli` is the thin entry point.
 
-### Crate Responsibilities (Updated)
+### Internal Seam Responsibilities
 
 - **perfgate-domain::stats**: Pure statistical aggregators (U64Summary, F64Summary).
 - **perfgate-budget**: Logic for comparing metrics against thresholds.
@@ -107,12 +140,12 @@ Dependencies flow inward toward the core types and domain logic:
 - **perfgate-types::error**: Shared error taxonomy; `perfgate-error` is a compatibility wrapper.
 - **perfgate-sha256**: High-performance fingerprinting for reports.
 
-### Client/Server Stack (v2.0)
+### Baseline Service Stack
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                      perfgate-server                             │
-│            (REST API, SQLite/in-memory storage)                 │
+│        (REST API, memory/SQLite/PostgreSQL storage)             │
 ├─────────────────────────────────────────────────────────────────┤
 │                      perfgate-client                             │
 │       (API client, fallback storage, retry logic)               │
@@ -194,7 +227,7 @@ perfgate-cli (integrates client)
 - SHOULD use atomic writes for output files
 - MAY integrate perfgate-client for server-backed baseline operations
 
-#### perfgate-client (v2.0)
+#### perfgate-client
 
 - MUST provide async API client for baseline service communication
 - MUST implement automatic retry logic with exponential backoff
@@ -202,10 +235,10 @@ perfgate-cli (integrates client)
 - MUST handle authentication via API keys
 - SHALL NOT depend on perfgate-server implementation details
 
-#### perfgate-server (v2.0)
+#### perfgate-server
 
 - MUST provide REST API for baseline CRUD operations
-- MUST support multiple storage backends (in-memory, SQLite)
+- MUST support multiple storage backends (in-memory, SQLite, PostgreSQL)
 - MUST implement role-based access control (viewer, contributor, promoter, admin)
 - MUST support multi-tenancy via project namespacing
 - MUST track baseline version history

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -67,9 +67,24 @@ When adding a new metric type:
 - Report findings MUST be ordered by metric (BTreeMap iteration order)
 - These orderings MUST be verified by property tests
 
-## Architectural Components (26-Crate Workspace)
+## Architectural Components (Public Surface Transition)
 
-The perfgate architecture is modularized into 26 workspace crates:
+The 0.16 public-surface contract is intentionally smaller than the current
+workspace layout. These packages are the target publishable surface:
+
+| Public package | Responsibility |
+|----------------|----------------|
+| `perfgate` | Unified facade library |
+| `perfgate-cli` | Command-line interface and `perfgate` binary |
+| `perfgate-types` | Stable receipts, schemas, config, and API contracts |
+| `perfgate-client` | Baseline service client |
+| `perfgate-server` | Baseline service binary/library |
+
+The remaining packages below are internal seams, transition packages, or
+compatibility wrappers while the 0.16 collapse proceeds. The transition is
+enforced by `cargo run -p xtask -- public-surface` and
+`cargo run -p xtask -- arch`; strict public-surface mode is the final release
+gate once transition packages stop being publishable.
 
 | Crate | Responsibility |
 |-------|----------------|
@@ -106,7 +121,7 @@ The perfgate architecture is modularized into 26 workspace crates:
 **Status:** Implemented (v0.4.0)
 
 Centralized storage for fleet-scale performance monitoring:
-- REST API with Axum and multi-backend support (SQLite, PostgreSQL planned)
+- REST API with Axum and multi-backend support (memory, SQLite, PostgreSQL)
 - Multi-tenancy (projects) and versioned baselines
 - Client-side fallback to local/cloud storage for resilience
 - `baseline` command group for management


### PR DESCRIPTION
## Summary
- replace stale 26-crate public-architecture wording with the 0.16 five-package public-surface contract
- point architecture readers at the enforced policy files and `xtask public-surface` / `xtask arch` gates
- refresh baseline-service storage wording now that memory, SQLite, and PostgreSQL are all current backends

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -p xtask -- public-surface`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- doc-test`