### PR TITLE
Make perfgate-fake private

### DIFF
--- a/crates/perfgate-fake/Cargo.toml
+++ b/crates/perfgate-fake/Cargo.toml
@@ -9,9 +9,9 @@ homepage.workspace = true
 authors.workspace = true
 description = "Test utilities and fake implementations for perfgate testing"
 readme = "README.md"
-documentation = "https://docs.rs/perfgate-fake"
 keywords = ["testing", "fake", "mock", "benchmarking"]
 categories = ["development-tools::testing"]
+publish = false
 
 [dependencies]
 perfgate-adapters.workspace = true

--- a/crates/perfgate-fake/README.md
+++ b/crates/perfgate-fake/README.md
@@ -1,8 +1,10 @@
 # perfgate-fake
 
-Test utilities and fake implementations for perfgate testing.
+Private test utilities and fake implementations for perfgate testing.
 
-Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate)
+workspace. This crate is workspace-private and is not part of the public
+package surface.
 
 ## Overview
 

--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -44,6 +44,7 @@ PR #223 started the real collapse and is the current implementation truth:
 | `perfgate-stats` | `perfgate_domain::stats` | crate deleted |
 | `perfgate-paired` | `perfgate_domain::paired` | compatibility wrapper remains |
 | `perfgate-error` | `perfgate_types::error` | compatibility wrapper remains |
+| `perfgate-fake` | private workspace crate | marked `publish = false` |
 
 Those paths are intentionally more conservative than the final facade shape.
 Future PRs may re-export or move pieces again, but they must do so with the
@@ -72,7 +73,7 @@ high-level target is:
 | `perfgate-app` | `perfgate::app` |
 | `perfgate-github` | `perfgate::integrations::github` |
 | `perfgate-ingest` | `perfgate::integrations::ingest` |
-| `perfgate-fake` | `perfgate::test_support` or private dev crate |
+| `perfgate-fake` | private workspace crate |
 | `perfgate-selfbench` | private workspace crate |
 
 ## Dependency Direction Rules

--- a/docs/MIGRATION_0_16.md
+++ b/docs/MIGRATION_0_16.md
@@ -77,7 +77,7 @@ Use this table to find the new import path for any old crate:
 | `perfgate-auth` | `perfgate_api::auth` now; final owner TBD | `use perfgate_api::auth::*;` |
 | `perfgate-config` | `perfgate_types::config` | `use perfgate_types::config::*;` |
 | `perfgate-api` | `perfgate_types::baseline_service` | `use perfgate_types::baseline_service::*;` |
-| `perfgate-fake` | `perfgate::test_support` | `use perfgate::test_support::*;` (requires `test-support` feature) |
+| `perfgate-fake` | private workspace crate | No public replacement yet; keep local test helpers in your own crate. |
 | `perfgate-adapters` | `perfgate::runtime` | `use perfgate::runtime::*;` |
 | `perfgate-app` | `perfgate::app` | `use perfgate::app::*;` |
 
@@ -126,7 +126,6 @@ Available features:
 - `sensor` - Cockpit mode and sensor reports
 - `github` - GitHub annotations and integration
 - `ingest` - Data ingestion adapters
-- `test-support` - Test data generators (dev-only)
 
 ---
 
@@ -217,22 +216,24 @@ fn test_my_thing() {
 }
 ```
 
-**Target after the corresponding absorption PR**:
+**After the public-surface collapse**:
+
+`perfgate-fake` is a workspace-private crate. There is no supported public
+replacement in 0.16 yet. If you depended on it, copy the small fixture helpers
+you need into your own test module or build receipts directly with
+`perfgate-types`.
+
+For example:
+
 ```rust
 #[cfg(test)]
-use perfgate::test_support::fake_run;
+mod test_support;
 
 #[test]
 fn test_my_thing() {
-    let run = fake_run();
+    let run = test_support::fake_run();
     assert!(!run.samples.is_empty());
 }
-```
-
-Or add `test-support` feature to your dev-dependencies:
-```toml
-[dev-dependencies]
-perfgate = { version = "0.16", features = ["test-support"] }
 ```
 
 ---

--- a/policy/absorbed_crates.txt
+++ b/policy/absorbed_crates.txt
@@ -41,7 +41,7 @@ perfgate-github -> perfgate::integrations::github
 perfgate-ingest -> perfgate::integrations::ingest
 
 # Dev-only packages.
-perfgate-fake -> perfgate::test_support or private dev crate
+perfgate-fake -> private workspace crate [publish=false]
 perfgate-selfbench -> private workspace crate
 perfgate-tests -> private workspace root package
 xtask -> private workspace automation crate


### PR DESCRIPTION
## Summary
- make `perfgate-fake` a workspace-private crate with `publish = false`
- remove docs.rs package metadata for the private test-helper crate
- update public-surface policy/docs to record `perfgate-fake` as private instead of a future public test-support surface

## Validation
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- public-surface`
- `cargo run -p xtask -- public-surface --strict` fails as expected with 18 remaining transition packages
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- publish-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- ci`
- `git diff --check`

## Notes
This is a narrow public-surface cleanup. It reduces the strict transition list by one package and leaves compatibility wrappers untouched.