### PR TITLE
Add baseline server operational metrics

### DIFF
--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -147,6 +147,21 @@ using S3, GCS, Azure, or another managed object store, configure provider-side
 lifecycle policies as the durable retention backstop and use perfgate cleanup
 as application-level hygiene.
 
+## Metrics
+
+`/metrics` exposes Prometheus text output for request volume/latency and the
+server operations that matter when the service becomes CI-critical:
+
+```text
+perfgate_server_requests_total
+perfgate_server_request_duration_seconds
+perfgate_baselines_total
+perfgate_verdicts_total
+perfgate_upload_failures_total
+perfgate_auth_failures_total
+perfgate_storage_errors_total
+```
+
 ## Library usage
 
 ```rust

--- a/crates/perfgate-server/src/auth.rs
+++ b/crates/perfgate-server/src/auth.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::warn;
 
+use crate::metrics;
 use crate::models::ApiError;
 use crate::oidc::OidcRegistry;
 use crate::storage::KeyStore;
@@ -206,6 +207,11 @@ fn unauthorized(message: &str) -> (StatusCode, Json<ApiError>) {
     )
 }
 
+fn auth_failure(reason: &'static str, message: &str) -> (StatusCode, Json<ApiError>) {
+    metrics::record_auth_failure(reason);
+    unauthorized(message)
+}
+
 async fn authenticate_api_key(
     auth_state: &AuthState,
     api_key_str: &str,
@@ -216,14 +222,14 @@ async fn authenticate_api_key(
             key_prefix = &api_key_str[..10.min(api_key_str.len())],
             "Invalid API key format"
         );
-        unauthorized("Invalid API key format")
+        auth_failure("invalid_api_key_format", "Invalid API key format")
     })?;
 
     // Try the in-memory store first (CLI-provided keys)
     if let Some(api_key) = auth_state.key_store.get_key(api_key_str).await {
         if api_key.is_expired() {
             warn!(key_id = %api_key.id, "API key expired");
-            return Err(unauthorized("API key has expired"));
+            return Err(auth_failure("expired_api_key", "API key has expired"));
         }
         return Ok(AuthContext {
             api_key,
@@ -256,7 +262,7 @@ async fn authenticate_api_key(
         key_prefix = &api_key_str[..10.min(api_key_str.len())],
         "Invalid API key"
     );
-    Err(unauthorized("Invalid API key"))
+    Err(auth_failure("invalid_api_key", "Invalid API key"))
 }
 
 fn validate_jwt(token: &str, config: &JwtConfig) -> Result<JwtClaims, AuthError> {
@@ -297,7 +303,11 @@ async fn authenticate_jwt(
                         AuthError::InvalidToken(_) => warn!("Invalid JWT token"),
                         _ => {}
                     }
-                    return Err(unauthorized(&e.to_string()));
+                    let reason = match &e {
+                        AuthError::ExpiredToken => "expired_jwt",
+                        _ => "invalid_jwt",
+                    };
+                    return Err(auth_failure(reason, &e.to_string()));
                 }
             }
         }
@@ -318,13 +328,20 @@ async fn authenticate_jwt(
                     AuthError::InvalidToken(msg) => warn!("Invalid OIDC token: {}", msg),
                     _ => {}
                 }
-                return Err(unauthorized(&e.to_string()));
+                let reason = match &e {
+                    AuthError::ExpiredToken => "expired_oidc",
+                    _ => "invalid_oidc",
+                };
+                return Err(auth_failure(reason, &e.to_string()));
             }
         }
     }
 
     warn!("JWT token received but no JWT or OIDC authentication is configured");
-    Err(unauthorized("JWT/OIDC authentication is not configured"))
+    Err(auth_failure(
+        "jwt_unconfigured",
+        "JWT/OIDC authentication is not configured",
+    ))
 }
 
 fn api_key_from_jwt_claims(claims: &JwtClaims) -> ApiKey {
@@ -366,6 +383,7 @@ pub async fn auth_middleware(
             authenticate_jwt(&auth_state, &token, request.headers()).await?
         }
         None => {
+            metrics::record_auth_failure("missing_credentials");
             warn!("Missing authentication header");
             return Err(unauthorized("Missing authentication header"));
         }
@@ -407,6 +425,7 @@ pub fn check_scope(
     let ctx = match auth_ctx {
         Some(ctx) => ctx,
         None => {
+            metrics::record_auth_failure("missing_auth_context");
             return Err((
                 StatusCode::UNAUTHORIZED,
                 Json(ApiError::unauthorized("Authentication required")),
@@ -422,6 +441,7 @@ pub fn check_scope(
             actual_role = %ctx.api_key.role,
             "Insufficient permissions: scope mismatch"
         );
+        metrics::record_auth_failure("insufficient_scope");
         return Err((
             StatusCode::FORBIDDEN,
             Json(ApiError::forbidden(&format!(
@@ -441,6 +461,7 @@ pub fn check_scope(
             requested_project = %project_id,
             "Insufficient permissions: project isolation violation"
         );
+        metrics::record_auth_failure("project_mismatch");
         return Err((
             StatusCode::FORBIDDEN,
             Json(ApiError::forbidden(&format!(
@@ -455,6 +476,7 @@ pub fn check_scope(
     if let (Some(regex_str), Some(bench)) = (&ctx.api_key.benchmark_regex, benchmark) {
         let regex = regex::Regex::new(regex_str).map_err(|e| {
             warn!(key_id = %ctx.api_key.id, regex = %regex_str, error = %e, "Invalid benchmark regex in API key");
+            metrics::record_auth_failure("invalid_benchmark_regex");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ApiError::internal_error("Invalid security configuration")),
@@ -468,6 +490,7 @@ pub fn check_scope(
                 regex = %regex_str,
                 "Insufficient permissions: benchmark restriction violation"
             );
+            metrics::record_auth_failure("benchmark_restricted");
             return Err((
                 StatusCode::FORBIDDEN,
                 Json(ApiError::forbidden(&format!(
@@ -601,6 +624,34 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_auth_middleware_records_missing_and_invalid_credentials() {
+        let auth_state = AuthState::new(Arc::new(ApiKeyStore::new()), None, Default::default());
+
+        let missing = auth_test_router(auth_state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+        let invalid = auth_test_router(auth_state)
+            .oneshot(
+                Request::builder()
+                    .uri("/protected")
+                    .header(header::AUTHORIZATION, "Bearer invalid")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/crates/perfgate-server/src/handlers/baselines.rs
+++ b/crates/perfgate-server/src/handlers/baselines.rs
@@ -34,6 +34,7 @@ pub async fn upload_baseline(
     )?;
 
     if let Err(e) = perfgate_types::validation::validate_bench_name(&request.benchmark) {
+        metrics::record_upload_failure(&project, "validation");
         return Err((
             StatusCode::BAD_REQUEST,
             Json(ApiError::validation(&format!(
@@ -92,14 +93,19 @@ pub async fn upload_baseline(
                 Json(response),
             ))
         }
-        Err(StoreError::AlreadyExists(_)) => Err((
-            StatusCode::CONFLICT,
-            Json(ApiError::already_exists(&format!(
-                "{}/{}",
-                request.benchmark, version
-            ))),
-        )),
+        Err(StoreError::AlreadyExists(_)) => {
+            metrics::record_upload_failure(&project, "conflict");
+            Err((
+                StatusCode::CONFLICT,
+                Json(ApiError::already_exists(&format!(
+                    "{}/{}",
+                    request.benchmark, version
+                ))),
+            ))
+        }
         Err(e) => {
+            metrics::record_upload_failure(&project, "storage");
+            metrics::record_storage_error("upload_baseline");
             error!(error = %e, "Failed to upload baseline");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -132,10 +138,13 @@ pub async fn get_latest_baseline(
                 benchmark
             ))),
         )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )),
+        Err(e) => {
+            metrics::record_storage_error("get_latest_baseline");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
     }
 }
 
@@ -162,10 +171,13 @@ pub async fn get_baseline(
                 benchmark, version
             ))),
         )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )),
+        Err(e) => {
+            metrics::record_storage_error("get_baseline");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
     }
 }
 
@@ -180,12 +192,16 @@ pub async fn list_baselines(
     match state.store.list(&project, &query).await {
         Ok(response) => {
             metrics::record_storage_list();
+            metrics::record_baselines_total(&project, response.pagination.total);
             Ok(Json(response).into_response())
         }
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )),
+        Err(e) => {
+            metrics::record_storage_error("list_baselines");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
     }
 }
 
@@ -231,10 +247,13 @@ pub async fn delete_baseline(
                 benchmark, version
             ))),
         )),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )),
+        Err(e) => {
+            metrics::record_storage_error("delete_baseline");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
     }
 }
 
@@ -262,6 +281,7 @@ pub async fn promote_baseline(
             ));
         }
         Err(e) => {
+            metrics::record_storage_error("promote_source_lookup");
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ApiError::internal_error(&e.to_string())),
@@ -274,6 +294,7 @@ pub async fn promote_baseline(
         .get(&project, &benchmark, &request.to_version)
         .await
         .map_err(|e| {
+            metrics::record_storage_error("promote_target_lookup");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ApiError::internal_error(&e.to_string())),
@@ -333,10 +354,13 @@ pub async fn promote_baseline(
                 }),
             ))
         }
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ApiError::internal_error(&e.to_string())),
-        )),
+        Err(e) => {
+            metrics::record_storage_error("promote_baseline");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
     }
 }
 
@@ -362,6 +386,300 @@ async fn emit_audit(
     };
 
     if let Err(e) = audit.log_event(&event).await {
+        metrics::record_storage_error("audit_log");
         warn!(error = %e, "Failed to log audit event");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{ApiKey, Role};
+    use crate::models::{
+        BaselineVersion, ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesResponse,
+        ListVerdictsQuery, ListVerdictsResponse, PaginationInfo, VerdictRecord,
+    };
+    use crate::storage::{AuditStore, BaselineStore, StorageHealth};
+    use async_trait::async_trait;
+    use perfgate_types::{
+        BenchMeta, HostInfo, RunMeta, RunReceipt, Sample, Stats, ToolInfo, U64Summary,
+    };
+
+    #[derive(Debug)]
+    struct FailingStore;
+
+    fn storage_failure() -> StoreError {
+        StoreError::Other("injected storage failure".to_string())
+    }
+
+    #[async_trait]
+    impl BaselineStore for FailingStore {
+        async fn create(&self, _record: &BaselineRecord) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn get(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+            _version: &str,
+        ) -> Result<Option<BaselineRecord>, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn get_latest(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+        ) -> Result<Option<BaselineRecord>, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list(
+            &self,
+            _project: &str,
+            _query: &ListBaselinesQuery,
+        ) -> Result<ListBaselinesResponse, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn update(&self, _record: &BaselineRecord) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn delete(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+            _version: &str,
+        ) -> Result<bool, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn hard_delete(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+            _version: &str,
+        ) -> Result<bool, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list_versions(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+        ) -> Result<Vec<BaselineVersion>, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn health_check(&self) -> Result<StorageHealth, StoreError> {
+            Err(storage_failure())
+        }
+
+        fn backend_type(&self) -> &'static str {
+            "failing"
+        }
+
+        async fn create_verdict(&self, _record: &VerdictRecord) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list_verdicts(
+            &self,
+            _project: &str,
+            _query: &ListVerdictsQuery,
+        ) -> Result<ListVerdictsResponse, StoreError> {
+            Err(storage_failure())
+        }
+    }
+
+    #[async_trait]
+    impl AuditStore for FailingStore {
+        async fn log_event(&self, _event: &AuditEvent) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list_events(
+            &self,
+            _query: &ListAuditEventsQuery,
+        ) -> Result<ListAuditEventsResponse, StoreError> {
+            Ok(ListAuditEventsResponse {
+                events: Vec::new(),
+                pagination: PaginationInfo {
+                    total: 0,
+                    offset: 0,
+                    limit: 100,
+                    has_more: false,
+                },
+            })
+        }
+    }
+
+    fn app_state() -> AppState {
+        let store = Arc::new(FailingStore);
+        AppState {
+            store: store.clone(),
+            audit: store,
+        }
+    }
+
+    fn auth_ctx() -> AuthContext {
+        AuthContext {
+            api_key: ApiKey::new(
+                "admin-key".to_string(),
+                "Admin".to_string(),
+                "project".to_string(),
+                Role::Admin,
+            ),
+            source_ip: None,
+        }
+    }
+
+    fn upload_request() -> UploadBaselineRequest {
+        UploadBaselineRequest {
+            benchmark: "bench".to_string(),
+            version: Some("v1".to_string()),
+            git_ref: Some("main".to_string()),
+            git_sha: Some("abc123".to_string()),
+            receipt: RunReceipt {
+                schema: "perfgate.run.v1".to_string(),
+                tool: ToolInfo {
+                    name: "perfgate".to_string(),
+                    version: "test".to_string(),
+                },
+                run: RunMeta {
+                    id: "run-1".to_string(),
+                    started_at: "2024-01-01T00:00:00Z".to_string(),
+                    ended_at: "2024-01-01T00:00:01Z".to_string(),
+                    host: HostInfo {
+                        os: "linux".to_string(),
+                        arch: "x86_64".to_string(),
+                        hostname_hash: None,
+                        cpu_count: None,
+                        memory_bytes: None,
+                    },
+                },
+                bench: BenchMeta {
+                    name: "bench".to_string(),
+                    command: vec!["true".to_string()],
+                    repeat: 1,
+                    warmup: 0,
+                    timeout_ms: None,
+                    cwd: None,
+                    work_units: None,
+                },
+                samples: vec![Sample {
+                    wall_ms: 1,
+                    exit_code: 0,
+                    warmup: false,
+                    timed_out: false,
+                    max_rss_kb: None,
+                    io_read_bytes: None,
+                    io_write_bytes: None,
+                    network_packets: None,
+                    energy_uj: None,
+                    cpu_ms: None,
+                    page_faults: None,
+                    ctx_switches: None,
+                    binary_bytes: None,
+                    stdout: None,
+                    stderr: None,
+                }],
+                stats: Stats {
+                    wall_ms: U64Summary::new(1, 1, 1),
+                    max_rss_kb: None,
+                    io_read_bytes: None,
+                    io_write_bytes: None,
+                    network_packets: None,
+                    energy_uj: None,
+                    cpu_ms: None,
+                    page_faults: None,
+                    ctx_switches: None,
+                    binary_bytes: None,
+                    throughput_per_s: None,
+                },
+            },
+            metadata: std::collections::BTreeMap::new(),
+            tags: Vec::new(),
+            normalize: false,
+        }
+    }
+
+    fn assert_internal_error<T>(result: Result<T, (StatusCode, Json<ApiError>)>) {
+        match result {
+            Ok(_) => panic!("handler should return an internal server error"),
+            Err((status, _)) => assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR),
+        }
+    }
+
+    #[tokio::test]
+    async fn storage_failures_return_500_from_baseline_handlers() {
+        let state = app_state();
+        let auth = auth_ctx();
+
+        assert_internal_error(
+            upload_baseline(
+                Path("project".to_string()),
+                Extension(auth.clone()),
+                State(state.clone()),
+                Json(upload_request()),
+            )
+            .await,
+        );
+
+        assert_internal_error(
+            get_latest_baseline(
+                Path(("project".to_string(), "bench".to_string())),
+                Extension(auth.clone()),
+                State(state.clone()),
+            )
+            .await,
+        );
+
+        assert_internal_error(
+            get_baseline(
+                Path(("project".to_string(), "bench".to_string(), "v1".to_string())),
+                Extension(auth.clone()),
+                State(state.clone()),
+            )
+            .await,
+        );
+
+        assert_internal_error(
+            list_baselines(
+                Path("project".to_string()),
+                Extension(auth.clone()),
+                State(state.clone()),
+                Query(ListBaselinesQuery::new()),
+            )
+            .await,
+        );
+
+        assert_internal_error(
+            delete_baseline(
+                Path(("project".to_string(), "bench".to_string(), "v1".to_string())),
+                Extension(auth.clone()),
+                State(state.clone()),
+            )
+            .await,
+        );
+
+        assert_internal_error(
+            promote_baseline(
+                Path(("project".to_string(), "bench".to_string())),
+                Extension(auth),
+                State(state),
+                Json(PromoteBaselineRequest {
+                    from_version: "v1".to_string(),
+                    to_version: "v2".to_string(),
+                    git_ref: None,
+                    git_sha: None,
+                    tags: Vec::new(),
+                    normalize: false,
+                }),
+            )
+            .await,
+        );
     }
 }

--- a/crates/perfgate-server/src/handlers/verdicts.rs
+++ b/crates/perfgate-server/src/handlers/verdicts.rs
@@ -9,6 +9,7 @@ use axum::{
 use tracing::{error, info, warn};
 
 use crate::auth::{AuthContext, Scope, check_scope};
+use crate::metrics;
 use crate::models::{
     ApiError, AuditAction, AuditEvent, AuditResourceType, ListVerdictsQuery, SubmitVerdictRequest,
     VERDICT_SCHEMA_V1, VerdictRecord, generate_ulid,
@@ -70,6 +71,7 @@ async fn compute_flakiness_score(
             );
         }
         Err(e) => {
+            metrics::record_storage_error("flakiness_history");
             warn!(
                 error = %e,
                 project = %project,
@@ -126,6 +128,7 @@ pub async fn submit_verdict(
 
     match state.store.create_verdict(&record).await {
         Ok(_) => {
+            metrics::record_verdict_submit(&project, record.status.as_str());
             info!(
                 project = %project,
                 benchmark = %record.benchmark,
@@ -147,12 +150,14 @@ pub async fn submit_verdict(
                 }),
             };
             if let Err(e) = state.audit.log_event(&audit_event).await {
+                metrics::record_storage_error("audit_log");
                 warn!(error = %e, "Failed to log audit event");
             }
 
             Ok((StatusCode::CREATED, Json(record)))
         }
         Err(e) => {
+            metrics::record_storage_error("submit_verdict");
             error!(error = %e, "Failed to submit verdict");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -174,6 +179,7 @@ pub async fn list_verdicts(
     match state.store.list_verdicts(&project, &query).await {
         Ok(response) => Ok(Json(response)),
         Err(e) => {
+            metrics::record_storage_error("list_verdicts");
             error!(error = %e, "Failed to list verdicts");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/perfgate-server/src/metrics.rs
+++ b/crates/perfgate-server/src/metrics.rs
@@ -19,6 +19,12 @@ use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 
 /// Metric name constants.
 pub mod names {
+    /// Histogram: perfgate server request duration in seconds, labeled by method, path, status.
+    pub const SERVER_REQUEST_DURATION_SECONDS: &str = "perfgate_server_request_duration_seconds";
+    /// Counter: total perfgate server HTTP requests, labeled by method, path, status.
+    pub const SERVER_REQUESTS_TOTAL: &str = "perfgate_server_requests_total";
+    /// Gauge: number of in-flight perfgate server requests.
+    pub const SERVER_REQUESTS_IN_FLIGHT: &str = "perfgate_server_requests_in_flight";
     /// Histogram: request duration in seconds, labeled by method, path, status.
     pub const HTTP_REQUEST_DURATION_SECONDS: &str = "http_request_duration_seconds";
     /// Counter: total HTTP requests, labeled by method, path, status.
@@ -31,6 +37,16 @@ pub mod names {
     pub const BASELINE_DOWNLOADS_TOTAL: &str = "perfgate_baseline_downloads_total";
     /// Counter: total storage operations, labeled by operation.
     pub const STORAGE_OPERATIONS_TOTAL: &str = "perfgate_storage_operations_total";
+    /// Gauge: most recent known number of baselines, labeled by project.
+    pub const BASELINES_TOTAL: &str = "perfgate_baselines_total";
+    /// Counter: total submitted verdicts, labeled by project and status.
+    pub const VERDICTS_TOTAL: &str = "perfgate_verdicts_total";
+    /// Counter: total failed baseline uploads, labeled by project and reason.
+    pub const UPLOAD_FAILURES_TOTAL: &str = "perfgate_upload_failures_total";
+    /// Counter: total authentication or authorization failures, labeled by reason.
+    pub const AUTH_FAILURES_TOTAL: &str = "perfgate_auth_failures_total";
+    /// Counter: total storage errors, labeled by operation.
+    pub const STORAGE_ERRORS_TOTAL: &str = "perfgate_storage_errors_total";
 }
 
 /// Installs the Prometheus recorder and returns a handle for rendering metrics.
@@ -112,13 +128,15 @@ fn normalize_path(path: &str) -> String {
 /// Middleware that records HTTP request metrics.
 ///
 /// Records:
-/// - `http_request_duration_seconds` histogram
-/// - `http_requests_total` counter
-/// - `http_requests_in_flight` gauge
+/// - `perfgate_server_request_duration_seconds` histogram
+/// - `perfgate_server_requests_total` counter
+/// - `perfgate_server_requests_in_flight` gauge
+/// - compatibility `http_*` metrics with the same labels
 pub async fn metrics_middleware(request: Request, next: Next) -> Response {
     let method = request.method().to_string();
     let path = normalize_path(request.uri().path());
 
+    gauge!(names::SERVER_REQUESTS_IN_FLIGHT).increment(1);
     gauge!(names::HTTP_REQUESTS_IN_FLIGHT).increment(1);
     let start = Instant::now();
 
@@ -133,8 +151,11 @@ pub async fn metrics_middleware(request: Request, next: Next) -> Response {
         ("status", status.clone()),
     ];
 
+    histogram!(names::SERVER_REQUEST_DURATION_SECONDS, &labels).record(duration);
+    counter!(names::SERVER_REQUESTS_TOTAL, &labels).increment(1);
     histogram!(names::HTTP_REQUEST_DURATION_SECONDS, &labels).record(duration);
     counter!(names::HTTP_REQUESTS_TOTAL, &labels).increment(1);
+    gauge!(names::SERVER_REQUESTS_IN_FLIGHT).decrement(1);
     gauge!(names::HTTP_REQUESTS_IN_FLIGHT).decrement(1);
 
     response
@@ -165,6 +186,41 @@ pub fn record_storage_delete() {
 /// Records a storage promote operation.
 pub fn record_storage_promote() {
     counter!(names::STORAGE_OPERATIONS_TOTAL, "operation" => "promote").increment(1);
+}
+
+/// Records the latest known baseline count for a project.
+pub fn record_baselines_total(project: &str, total: u64) {
+    gauge!(names::BASELINES_TOTAL, "project" => project.to_string()).set(total as f64);
+}
+
+/// Records a submitted verdict.
+pub fn record_verdict_submit(project: &str, status: &str) {
+    counter!(
+        names::VERDICTS_TOTAL,
+        "project" => project.to_string(),
+        "status" => status.to_string()
+    )
+    .increment(1);
+}
+
+/// Records a failed baseline upload.
+pub fn record_upload_failure(project: &str, reason: &'static str) {
+    counter!(
+        names::UPLOAD_FAILURES_TOTAL,
+        "project" => project.to_string(),
+        "reason" => reason
+    )
+    .increment(1);
+}
+
+/// Records an authentication or authorization failure.
+pub fn record_auth_failure(reason: &'static str) {
+    counter!(names::AUTH_FAILURES_TOTAL, "reason" => reason).increment(1);
+}
+
+/// Records a storage-layer error.
+pub fn record_storage_error(operation: &'static str) {
+    counter!(names::STORAGE_ERRORS_TOTAL, "operation" => operation).increment(1);
 }
 
 #[cfg(test)]
@@ -224,5 +280,30 @@ mod tests {
     #[test]
     fn test_normalize_path_root() {
         assert_eq!(normalize_path("/"), "/");
+    }
+
+    #[test]
+    fn operational_metrics_render_perfgate_prefixed_names() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+
+        metrics::with_local_recorder(&recorder, || {
+            record_baseline_upload("proj");
+            record_baseline_download("proj");
+            record_baselines_total("proj", 2);
+            record_verdict_submit("proj", "pass");
+            record_upload_failure("proj", "storage");
+            record_auth_failure("missing_credentials");
+            record_storage_error("upload_baseline");
+        });
+
+        let rendered = handle.render();
+        assert!(rendered.contains(names::BASELINE_UPLOADS_TOTAL));
+        assert!(rendered.contains(names::BASELINE_DOWNLOADS_TOTAL));
+        assert!(rendered.contains(names::BASELINES_TOTAL));
+        assert!(rendered.contains(names::VERDICTS_TOTAL));
+        assert!(rendered.contains(names::UPLOAD_FAILURES_TOTAL));
+        assert!(rendered.contains(names::AUTH_FAILURES_TOTAL));
+        assert!(rendered.contains(names::STORAGE_ERRORS_TOTAL));
     }
 }

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -216,7 +216,18 @@ perfgate-server \
 
 Use `/health` to verify storage readiness and PostgreSQL pool occupancy before
 making the server a required CI dependency. Use `/metrics` for Prometheus
-scraping once the service is shared by more than one workflow.
+scraping once the service is shared by more than one workflow. The operational
+series include:
+
+```text
+perfgate_server_requests_total
+perfgate_server_request_duration_seconds
+perfgate_baselines_total
+perfgate_verdicts_total
+perfgate_upload_failures_total
+perfgate_auth_failures_total
+perfgate_storage_errors_total
+```
 
 ## What This Document No Longer Claims
 

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -222,7 +222,17 @@ include current pool occupancy:
 
 `/metrics` exposes Prometheus counters and histograms for request volume,
 request latency, storage operations, upload failures, auth failures, and
-storage errors.
+storage errors:
+
+```text
+perfgate_server_requests_total
+perfgate_server_request_duration_seconds
+perfgate_baselines_total
+perfgate_verdicts_total
+perfgate_upload_failures_total
+perfgate_auth_failures_total
+perfgate_storage_errors_total
+```
 
 The server binary accepts `--retention-days` and
 `--cleanup-interval-hours` for background artifact cleanup. Cleanup only runs


### PR DESCRIPTION
## Summary
- add perfgate-prefixed Prometheus series for server requests, baseline counts, verdict submissions, upload failures, auth failures, and storage errors
- wire the new counters into auth, baseline, promotion, verdict, and audit failure paths
- document the operational `/metrics` series in the baseline server docs and server crate README

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-server`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- public-surface`
- `cargo run -p xtask -- ci`
- `git diff --check`

## Notes
The existing generic `http_*` metrics remain in place. This PR adds the product-level perfgate series alongside them so operators can alert on CI-critical server behavior.