### PR TITLE
Mark compatibility wrappers private

### DIFF
--- a/crates/perfgate-error/Cargo.toml
+++ b/crates/perfgate-error/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/perfgate-error"
 keywords = ["error", "error-handling", "performance", "benchmarking"]
 categories = ["development-tools"]
+publish = false
 
 [dependencies]
 perfgate-types.workspace = true

--- a/crates/perfgate-error/README.md
+++ b/crates/perfgate-error/README.md
@@ -7,8 +7,8 @@ Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
 ## Status
 
 The concrete error types have moved to `perfgate_types::error` as part of the
-0.16 public-surface collapse. This crate temporarily re-exports that module so
-existing `perfgate_error` imports keep compiling during the migration.
+0.16 public-surface collapse. This crate is now a workspace-only migration shim
+for internal tests and is not part of the target public package surface.
 
 ## Error Categories
 
@@ -45,7 +45,7 @@ assert_eq!(unified.exit_code(), 1);
 assert!(!unified.is_recoverable());
 ```
 
-New code should prefer:
+Use the public contract path instead:
 
 ```rust
 use perfgate_types::error::{PerfgateError, ValidationError, validate_bench_name};

--- a/crates/perfgate-error/src/lib.rs
+++ b/crates/perfgate-error/src/lib.rs
@@ -1,6 +1,7 @@
 //! Compatibility wrapper for perfgate's absorbed error contract.
 //!
 //! Error types now live in [`perfgate_types::error`]. This crate remains as a
-//! temporary 0.16 compatibility shim for existing `perfgate_error` imports.
+//! workspace-only migration shim while internal tests move off
+//! `perfgate_error` imports.
 
 pub use perfgate_types::error::*;

--- a/crates/perfgate-paired/Cargo.toml
+++ b/crates/perfgate-paired/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 documentation = "https://docs.rs/perfgate-paired"
 keywords = ["paired", "benchmarking", "statistics", "ab-testing"]
 categories = ["mathematics", "development-tools"]
+publish = false
 
 [dependencies]
 perfgate-domain.workspace = true

--- a/crates/perfgate-paired/README.md
+++ b/crates/perfgate-paired/README.md
@@ -10,6 +10,9 @@ environmental noise affects both sides equally and cancels out in the paired
 difference.
 
 Part of the [perfgate](https://github.com/EffortlessMetrics/perfgate) workspace.
+The implementation now lives in `perfgate_domain::paired`; this crate is a
+workspace-only migration shim and is not part of the target public package
+surface.
 
 ## How it works
 

--- a/crates/perfgate-paired/src/lib.rs
+++ b/crates/perfgate-paired/src/lib.rs
@@ -1,6 +1,7 @@
 //! Compatibility wrapper for paired benchmarking statistics.
 //!
-//! The implementation now lives in `perfgate-domain`; this crate preserves the
-//! existing `perfgate_paired` public import path for downstream users.
+//! The implementation now lives in `perfgate-domain`; this crate remains as a
+//! workspace-only migration shim while tests and fuzz targets move to the owner
+//! crate.
 
 pub use perfgate_domain::paired::*;

--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -42,8 +42,8 @@ PR #223 started the real collapse and is the current implementation truth:
 | `perfgate-auth` | `perfgate_api::auth` | crate deleted |
 | `perfgate-summary` | `perfgate_render::summary` | crate deleted |
 | `perfgate-stats` | `perfgate_domain::stats` | crate deleted |
-| `perfgate-paired` | `perfgate_domain::paired` | compatibility wrapper remains |
-| `perfgate-error` | `perfgate_types::error` | compatibility wrapper remains |
+| `perfgate-paired` | `perfgate_domain::paired` | workspace-only compatibility wrapper, `publish = false` |
+| `perfgate-error` | `perfgate_types::error` | workspace-only compatibility wrapper, `publish = false` |
 | `perfgate-fake` | private workspace crate | marked `publish = false` |
 | `perfgate-profile` | `perfgate::runtime::profile` | crate deleted |
 

--- a/docs/REFACTORING_0_16.md
+++ b/docs/REFACTORING_0_16.md
@@ -4,7 +4,7 @@
 
 This document describes the planned refactoring of perfgate's public crate surface. The goal is to collapse the current 26+ microcrates into a cleaner public facade while preserving the strong internal separation of concerns that makes the architecture maintainable.
 
-**Current state**: Public surface is still too broad. PR #223 already absorbed `perfgate-validation`, `perfgate-auth`, `perfgate-summary`, and `perfgate-stats`, and moved the paired implementation into `perfgate-domain` behind a `perfgate-paired` compatibility wrapper. The error contract now lives in `perfgate_types::error` behind a `perfgate-error` compatibility wrapper, and the profiling implementation now lives under `perfgate::runtime::profile`. Many remaining internal seams are still publishable crates (`perfgate-budget`, `perfgate-render`, `perfgate-host-detect`, etc.), which makes the package ecosystem confusing for users and couples the public API tightly to internal refactoring decisions.
+**Current state**: Public surface is still too broad. PR #223 already absorbed `perfgate-validation`, `perfgate-auth`, `perfgate-summary`, and `perfgate-stats`, and moved the paired implementation into `perfgate-domain` behind a workspace-only `perfgate-paired` compatibility wrapper. The error contract now lives in `perfgate_types::error` behind a workspace-only `perfgate-error` compatibility wrapper, and the profiling implementation now lives under `perfgate::runtime::profile`. Many remaining internal seams are still publishable crates (`perfgate-budget`, `perfgate-render`, `perfgate-host-detect`, etc.), which makes the package ecosystem confusing for users and couples the public API tightly to internal refactoring decisions.
 
 **Target state**: Five public crates with strongly organized internal modules. Users depend on `perfgate`, `perfgate-types`, `perfgate-cli`, `perfgate-client`, and `perfgate-server` only. The SRP boundaries remain enforced but move from crate level to module level.
 
@@ -38,7 +38,7 @@ These are contract-adjacent and belong with the public receipt/config model:
 | `perfgate-config` | `perfgate_types::config` | Config model is a receipt type |
 | `perfgate-api` (shared DTOs) | `perfgate_types::baseline_service` | Wire format for baseline service |
 
-**Current state**: `perfgate-validation` has been deleted, and `perfgate-error` now re-exports `perfgate_types::error` as a compatibility wrapper. `perfgate-config` and shared baseline-service DTOs are the remaining contract-adjacent seams.
+**Current state**: `perfgate-validation` has been deleted, and `perfgate-error` now re-exports `perfgate_types::error` as a workspace-only compatibility wrapper. `perfgate-config` and shared baseline-service DTOs are the remaining contract-adjacent seams.
 
 **Why first**: The types crate must be standalone and self-describing. Absorbing these dependencies first unblocks all downstream refactoring.
 

--- a/policy/absorbed_crates.txt
+++ b/policy/absorbed_crates.txt
@@ -13,8 +13,8 @@ perfgate-validation -> perfgate_types::validation [deleted]
 perfgate-auth -> perfgate_api::auth [deleted]
 perfgate-summary -> perfgate_render::summary [deleted]
 perfgate-stats -> perfgate_domain::stats [deleted]
-perfgate-paired -> perfgate_domain::paired [compatibility wrapper]
-perfgate-error -> perfgate_types::error [compatibility wrapper]
+perfgate-paired -> perfgate_domain::paired [compatibility wrapper] [publish=false]
+perfgate-error -> perfgate_types::error [compatibility wrapper] [publish=false]
 
 # Contract-adjacent.
 perfgate-config -> perfgate_types::config


### PR DESCRIPTION
## Summary

- marks the absorbed `perfgate-error` and `perfgate-paired` compatibility wrappers as `publish = false`
- updates public-surface policy and crate-seam docs to record them as workspace-only migration shims
- keeps the wrappers available for internal tests/fuzzing while removing them from the publishable transition surface

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p perfgate-error`
- `cargo test -p perfgate-paired`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- public-surface`
- `cargo run -p xtask -- publish-check`
- `cargo run -p xtask -- ci`

`cargo run -p xtask -- public-surface --strict` still fails as expected for the remaining migration crates, now reporting 15 transition packages after making both wrappers non-publishable.