### PR TITLE
Route CLI through public facade

### DIFF
--- a/crates/perfgate-cli/Cargo.toml
+++ b/crates/perfgate-cli/Cargo.toml
@@ -20,8 +20,6 @@ path = "src/main.rs"
 [dependencies]
 perfgate-types.workspace = true
 perfgate-client.workspace = true
-perfgate-app.workspace = true
-perfgate-domain.workspace = true
 perfgate-server.workspace = true
 perfgate = { workspace = true, features = ["github"] }
 anyhow.workspace = true

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -4,6 +4,8 @@ use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use glob::glob;
 use object_store::{ObjectStore, path::Path as ObjectPath};
+use perfgate::app as perfgate_app;
+use perfgate::domain as perfgate_domain;
 use perfgate::integrations::github::{self, CommentOptions, GitHubClient};
 use perfgate::integrations::ingest::{self, IngestFormat};
 use perfgate::runtime::profile::{ProfileRequest, capture_flamegraph};

--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -120,7 +120,8 @@ cargo run -p xtask -- public-surface --strict
 ```
 
 Strict mode is the release-end gate. It fails while any absorbed package is
-still publishable.
+still publishable, or while a target public package directly depends on an
+absorbed/internal workspace package.
 
 ## Migration Order
 

--- a/policy/public_crates.txt
+++ b/policy/public_crates.txt
@@ -5,7 +5,8 @@
 # `policy/absorbed_crates.txt`.
 #
 # `cargo run -p xtask -- public-surface --strict` enforces this file as the
-# final publishable package allowlist.
+# final publishable package allowlist and rejects target public crates that
+# still depend directly on absorbed/internal workspace packages.
 
 perfgate
 perfgate-cli

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -615,6 +615,48 @@ fn collect_public_surface_errors(
         metadata,
         absorbed_crates,
     ));
+    if strict {
+        errors.extend(collect_strict_public_internal_dependency_errors(
+            metadata,
+            public_crates,
+            absorbed_crates,
+        ));
+    }
+
+    errors
+}
+
+fn collect_strict_public_internal_dependency_errors(
+    metadata: &CargoMetadata,
+    public_crates: &BTreeSet<String>,
+    absorbed_crates: &BTreeMap<String, String>,
+) -> Vec<String> {
+    let package_names: BTreeSet<&str> = metadata
+        .packages
+        .iter()
+        .map(|package| package.name.as_str())
+        .collect();
+    let mut errors = Vec::new();
+
+    for package in metadata
+        .packages
+        .iter()
+        .filter(|package| public_crates.contains(&package.name))
+    {
+        for dependency in package
+            .dependencies
+            .iter()
+            .filter(|dependency| dependency.kind.as_deref() != Some("dev"))
+            .filter(|dependency| dependency.path.is_some())
+            .filter(|dependency| package_names.contains(dependency.name.as_str()))
+            .filter(|dependency| absorbed_crates.contains_key(dependency.name.as_str()))
+        {
+            errors.push(format!(
+                "{} is a target public crate but depends on absorbed/internal package {}; absorb or route it through an allowed public crate before strict release",
+                package.name, dependency.name
+            ));
+        }
+    }
 
     errors
 }
@@ -3098,6 +3140,31 @@ mod tests {
             collect_public_surface_errors(&metadata, &public_crates, &absorbed_crates, true);
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("still publishable"));
+    }
+
+    #[test]
+    fn public_surface_strict_rejects_public_deps_on_absorbed_packages() {
+        let metadata = CargoMetadata {
+            packages: vec![
+                test_package_with_deps("perfgate", None, vec![workspace_dep("perfgate-app")]),
+                test_package("perfgate-app", Some(Vec::new())),
+            ],
+        };
+        let public_crates = ["perfgate"].into_iter().map(String::from).collect();
+        let absorbed_crates = [("perfgate-app".to_string(), "perfgate::app".to_string())]
+            .into_iter()
+            .collect();
+
+        let errors =
+            collect_public_surface_errors(&metadata, &public_crates, &absorbed_crates, true);
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains(
+                "perfgate is a target public crate but depends on absorbed/internal package perfgate-app"
+            ),
+            "unexpected errors: {:?}",
+            errors
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route `perfgate-cli` app/domain usage through the public `perfgate` facade instead of direct internal crate dependencies
- remove direct `perfgate-app` and `perfgate-domain` dependencies from `perfgate-cli`
- harden `public-surface --strict` so target public crates cannot depend directly on absorbed/internal workspace packages

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perfgate-cli --all-targets --all-features`
- `cargo test -p xtask public_surface --all-targets`
- `cargo run -p xtask -- public-surface`
- `cargo run -p xtask -- public-surface --strict` expected failure: 5 remaining blockers (`perfgate-domain`, `perfgate-app`, plus `perfgate -> app/domain` and `perfgate-server -> domain` direct internal deps)
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- ci`
- `git diff --check`

## Notes
This does not finish the strict public-surface collapse. It removes `perfgate-cli` from the direct internal-dependency set and makes the remaining blockers explicit for the final app/domain absorption work.