### PR TITLE
Route server trend through public facade

### DIFF
--- a/crates/perfgate-server/Cargo.toml
+++ b/crates/perfgate-server/Cargo.toml
@@ -45,7 +45,7 @@ sqlx = { version = "0.8.3", default-features = false, features = ["postgres", "r
 
 # Validation
 perfgate-types.workspace = true
-perfgate-domain.workspace = true
+perfgate.workspace = true
 
 # Error handling
 thiserror = { workspace = true }

--- a/crates/perfgate-server/src/handlers/trend.rs
+++ b/crates/perfgate-server/src/handlers/trend.rs
@@ -15,8 +15,8 @@ use tracing::error;
 use crate::auth::{AuthContext, Scope, check_scope};
 use crate::models::ApiError;
 use crate::server::AppState;
-use perfgate_domain::stats::trend::{TrendAnalysis, analyze_trend, spark_chart};
-use perfgate_domain::{TrendConfig, metric_value};
+use perfgate::domain::stats::trend::{TrendAnalysis, analyze_trend, spark_chart};
+use perfgate::domain::{TrendConfig, metric_value};
 use perfgate_types::Metric;
 
 /// Query parameters for trend analysis.


### PR DESCRIPTION
## Summary
- route server trend-analysis domain usage through the public `perfgate` facade
- remove direct `perfgate-domain` dependency from `perfgate-server`
- reduce strict public-surface blockers from 5 to 4, leaving only `perfgate -> app/domain` and the still-publishable internal app/domain packages

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perfgate-server --all-targets --all-features`
- `cargo run -p xtask -- public-surface`
- `cargo run -p xtask -- public-surface --strict` expected failure: 4 remaining blockers
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`