### PR TITLE
Document public surface release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped Rust minimum supported version (MSRV) to 1.93.
+- Collapsed the 0.16 public crate surface to the five intended publishable
+  packages: `perfgate`, `perfgate-cli`, `perfgate-types`,
+  `perfgate-client`, and `perfgate-server`.
+- Moved former domain and application implementation crates under the public
+  facade as `perfgate::domain` and `perfgate::app`, leaving the old
+  `perfgate-domain` and `perfgate-app` packages as workspace-only
+  compatibility wrappers.
+- Extended `xtask arch` and `xtask public-surface --strict` so CI enforces the
+  collapsed module/package boundaries for the 0.16 release line.
 
 ### Fixed
 - Fixed clippy warnings by replacing `sort_by` with `sort_by_key` and `std::cmp::Reverse` for descending sorts in storage backends.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,9 +72,8 @@ contract is:
 | `perfgate-client` | Baseline service client |
 | `perfgate-server` | Baseline service binary/library |
 
-The remaining workspace packages are internal seams, transition packages, or
-compatibility wrappers until the public-surface collapse finishes. The current
-policy files are:
+The remaining workspace packages are internal seams, private test/dev packages,
+or workspace-only compatibility wrappers. The current policy files are:
 
 - [`policy/public_crates.txt`](../policy/public_crates.txt)
 - [`policy/absorbed_crates.txt`](../policy/absorbed_crates.txt)
@@ -88,8 +87,7 @@ cargo run -p xtask -- arch
 ```
 
 `cargo run -p xtask -- public-surface --strict` is the final release gate. It
-is expected to fail until absorbed/internal transition packages are deleted,
-marked `publish = false`, or reduced to intentional compatibility shims.
+now passes on `main` and enforces the five-package publishable allowlist above.
 
 ### Component Layers
 

--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -14,8 +14,8 @@ refactoring decision as a crates.io package.
 
 ## Target Public Crates
 
-By the end of the 0.16 public-surface collapse, only these packages should be
-publishable:
+For the 0.16 public-surface collapse, only these packages should be
+publishable. This is now enforced by `cargo run -p xtask -- public-surface --strict`:
 
 | Crate | Role |
 |-------|------|
@@ -65,16 +65,18 @@ Those paths are intentionally more conservative than the final facade shape.
 Future PRs may re-export or move pieces again, but they must do so with the
 policy files and docs updated in the same change.
 
-## Remaining Absorption Map
+## Remaining Private Surface
 
 `policy/absorbed_crates.txt` is the machine-readable disposition list. The
-high-level target is:
+public-surface blockers have been resolved; remaining non-public workspace
+packages are private/dev packages or compatibility wrappers:
 
-| Current package | Target owner |
-|-----------------|--------------|
-| `perfgate-config` | `perfgate_types::config` and `perfgate_client::ResolvedServerConfig` |
-| `perfgate-fake` | private workspace crate |
+| Package | Disposition |
+|---------|-------------|
+| `perfgate-fake` | private workspace crate, `publish = false` |
 | `perfgate-selfbench` | private workspace crate |
+| `perfgate-tests` | private workspace root package |
+| `xtask` | private workspace automation crate |
 
 ## Dependency Direction Rules
 
@@ -119,11 +121,11 @@ Run:
 cargo run -p xtask -- public-surface --strict
 ```
 
-Strict mode is the release-end gate. It fails while any absorbed package is
-still publishable, or while a target public package directly depends on an
-absorbed/internal workspace package.
+Strict mode is the release-end gate. It fails if any absorbed package is still
+publishable, or if a target public package directly depends on an
+absorbed/internal workspace package. It now passes on `main`.
 
-## Migration Order
+## Completed Migration Order
 
 1. Land first seam absorption and compatibility wrappers.
 2. Establish enforceable public-surface policy.

--- a/docs/REFACTORING_0_16.md
+++ b/docs/REFACTORING_0_16.md
@@ -2,17 +2,17 @@
 
 ## Overview
 
-This document describes the planned refactoring of perfgate's public crate surface. The goal is to collapse the current 26+ microcrates into a cleaner public facade while preserving the strong internal separation of concerns that makes the architecture maintainable.
+This document records the 0.16 refactoring of perfgate's public crate surface. The goal was to collapse the broad microcrate surface into a cleaner public facade while preserving the strong internal separation of concerns that makes the architecture maintainable.
 
-**Current state**: The public-surface collapse has landed across the former leaf crates and the final structural seams. Domain logic now lives in `perfgate::domain`, app orchestration and runtime adapters live under `perfgate::app` / `perfgate::runtime`, and old `perfgate-domain` / `perfgate-app` packages are workspace-only compatibility wrappers. Strict public-surface mode is expected to pass with only the five target public packages publishable.
+**Current state**: The public-surface collapse has landed across the former leaf crates and the final structural seams. Domain logic now lives in `perfgate::domain`, app orchestration and runtime adapters live under `perfgate::app` / `perfgate::runtime`, and old `perfgate-domain` / `perfgate-app` packages are workspace-only compatibility wrappers. Strict public-surface mode passes with only the five target public packages publishable.
 
 **Target state**: Five public crates with strongly organized internal modules. Users depend on `perfgate`, `perfgate-types`, `perfgate-cli`, `perfgate-client`, and `perfgate-server` only. The SRP boundaries remain enforced but move from crate level to module level.
 
 ---
 
-## Target Public Crate Surface
+## Public Crate Surface
 
-Only these crates should be published:
+Only these crates are intended to be publishable:
 
 | Crate | Purpose | Keep? |
 |-------|---------|-------|
@@ -22,7 +22,7 @@ Only these crates should be published:
 | `perfgate-client` | Baseline service client for external automation | Yes |
 | `perfgate-server` | Baseline service binary/library | Yes |
 
-Everything else will be absorbed into one of these crates as modules, marked `publish = false`, or deleted.
+Everything else has been absorbed into one of these crates as modules, marked `publish = false`, or deleted.
 
 ---
 
@@ -278,8 +278,8 @@ Implement this as a Cargo metadata or source-level check in xtask.
 
 ## Migration Sequence
 
-### Phase 1: Policy & Visibility (current PR)
-Create:
+### Phase 1: Policy & Visibility
+Created:
 - `policy/public_crates.txt` - List of intended public crates
 - `policy/absorbed_crates.txt` - Mapping of absorbed crates
 - `docs/CRATE_SEAMS.md` - Detailed seam analysis
@@ -365,7 +365,7 @@ Add `xtask arch` check for module-layer violations.
 The refactoring is complete when:
 
 1. `policy/public_crates.txt` lists exactly: `perfgate`, `perfgate-cli`, `perfgate-types`, `perfgate-client`, `perfgate-server`
-2. `cargo publish --dry-run -p perfgate` does not require publishing internal microcrates
+2. `cargo run -p xtask -- publish-check` passes and publishable crates do not depend on unpublished internal path crates
 3. `perfgate-cli` depends on public packages, not every internal seam crate
 4. All microcrates are either deleted, `publish = false`, or deprecated shims
 5. `docs/ARCHITECTURE.md` describes public packages + internal modules
@@ -385,6 +385,10 @@ The refactoring is complete when:
 8. Examples and tutorials updated
 9. All tests pass; mutation test targets maintained
 10. CHANGELOG documents migration path for 0.16.0
+
+As of the final app/domain absorption, the enforceable public-surface criteria
+are satisfied by `cargo run -p xtask -- public-surface --strict`,
+`cargo run -p xtask -- arch`, and `cargo run -p xtask -- publish-check`.
 
 ---
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,12 +1,42 @@
-# Release Readiness: v0.15.1
+# Release Readiness
 
 Last verified: 2026-03-28 after publishing `v0.15.1`, publishing crates.io packages, and merging the release workflow and publish-preflight fixes.
 
-Current-main note: this file is the historical readiness record for `v0.15.1`.
-Since that release, `main` has added API key management CLI support, audit
-logging, and executable documentation example validation. For the current
-baseline-service surface, see [Baseline Service Notes](BASELINE_SERVICE_DESIGN.md)
-and [Getting Started with the Baseline Server](GETTING_STARTED_BASELINE_SERVER.md).
+## Current Main Snapshot
+
+Verified on 2026-05-07 after merging the 0.16 public-surface collapse through
+PR #268.
+
+The current `main` branch is not a published release, but the 0.16 public crate
+surface is now in its intended release shape:
+
+| Gate | Status | Evidence |
+|------|--------|----------|
+| Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
+| Architecture boundary enforcement | Passing | `cargo run -p xtask -- arch` |
+| Publish metadata preflight | Passing | `cargo run -p xtask -- publish-check` |
+| Full repo CI | Passing | Hosted `ci`, `fuzz`, and `perfgate-self` on PR #268 |
+
+The only publishable packages allowed by policy are:
+
+```text
+perfgate
+perfgate-cli
+perfgate-types
+perfgate-client
+perfgate-server
+```
+
+Former implementation packages such as `perfgate-domain` and `perfgate-app`
+are workspace-only compatibility wrappers. Domain logic lives under
+`perfgate::domain`; app orchestration and runtime adapters live under
+`perfgate::app` and `perfgate::runtime`.
+
+For the current baseline-service surface, see
+[Baseline Service Notes](BASELINE_SERVICE_DESIGN.md) and
+[Getting Started with the Baseline Server](GETTING_STARTED_BASELINE_SERVER.md).
+
+## Historical Record: v0.15.1
 
 ## Patch Scope
 


### PR DESCRIPTION
## Summary
- record that the 0.16 public-surface collapse has landed and strict mode now passes on `main`
- update release-readiness notes with the current public package allowlist and verification gates
- add the public-surface collapse to the Unreleased changelog
- remove stale future-tense wording from architecture/refactoring docs

## Validation
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- publish-check`
- `git diff --check`