### PR TITLE
Add baseline service schema compatibility fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Extended `xtask schema-compat` with baseline-service and fleet record
+  fixtures so the 0.16 server API contract is checked alongside receipt
+  compatibility.
+
 ### Changed
 - Bumped Rust minimum supported version (MSRV) to 1.93.
 - Collapsed the 0.16 public crate surface to the five intended publishable

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -2,7 +2,7 @@
 
 perfgate uses versioned JSON receipts at every stage of the pipeline.
 
-## Receipt Types
+## Receipt And Service Types
 
 | Schema | Produced by | Description |
 |--------|-------------|-------------|
@@ -10,6 +10,11 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 | `perfgate.compare.v1` | `compare`, `check`, `paired` | Comparison of current run against baseline |
 | `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
 | `sensor.report.v1` | `check --mode cockpit` | Sensor integration envelope for dashboards |
+| `perfgate.baseline.v1` | baseline service | Stored baseline record returned by the server |
+| `perfgate.verdict.v1` | baseline service | Stored verdict history, including optional noise history fields |
+| `perfgate.audit.v1` | baseline service | Append-only audit event for baseline, verdict, and key mutations; inferred by fixture filename because current audit events do not include a `schema` field |
+| `perfgate.dependency_event.v1` | fleet API | Dependency-change event with performance impact |
+| `perfgate.fleet_alert.v1` | fleet API | Fleet-wide dependency regression alert |
 
 ## Additional Generated Schemas
 
@@ -55,8 +60,11 @@ This schema is hand-written (not auto-generated) to maintain a stable contract
 with external consumers.
 
 Historical compatibility fixtures live under `fixtures/schema/<release>/`.
-`schema-compat` currently checks v0.15 examples for `perfgate.run.v1`,
+`schema-compat` checks v0.15 examples for `perfgate.run.v1`,
 `perfgate.compare.v1`, `perfgate.report.v1`, and `sensor.report.v1`.
+It also checks v0.16 baseline-service and fleet contract fixtures for
+`perfgate.baseline.v1`, `perfgate.verdict.v1`, `perfgate.audit.v1`,
+`perfgate.dependency_event.v1`, and `perfgate.fleet_alert.v1`.
 
 ## Versioning Policy
 

--- a/fixtures/schema/v0.16/perfgate.audit.v1.json
+++ b/fixtures/schema/v0.16/perfgate.audit.v1.json
@@ -1,0 +1,13 @@
+{
+  "id": "audit-compat-001",
+  "timestamp": "2026-05-07T00:00:00Z",
+  "actor": "key-admin",
+  "action": "promote",
+  "resource_type": "baseline",
+  "resource_id": "baseline-compat-001",
+  "project": "compat-project",
+  "metadata": {
+    "source": "api_key",
+    "request_id": "req-compat-001"
+  }
+}

--- a/fixtures/schema/v0.16/perfgate.baseline.v1.json
+++ b/fixtures/schema/v0.16/perfgate.baseline.v1.json
@@ -1,0 +1,58 @@
+{
+  "schema": "perfgate.baseline.v1",
+  "id": "baseline-compat-001",
+  "project": "compat-project",
+  "benchmark": "compat-bench",
+  "version": "v1",
+  "git_ref": "refs/heads/main",
+  "git_sha": "0123456789abcdef",
+  "receipt": {
+    "schema": "perfgate.run.v1",
+    "tool": {
+      "name": "perfgate",
+      "version": "0.16.0"
+    },
+    "run": {
+      "id": "run-compat-001",
+      "started_at": "2026-05-07T00:00:00Z",
+      "ended_at": "2026-05-07T00:00:01Z",
+      "host": {
+        "os": "linux",
+        "arch": "x86_64"
+      }
+    },
+    "bench": {
+      "name": "compat-bench",
+      "command": [
+        "echo",
+        "compat"
+      ],
+      "repeat": 1,
+      "warmup": 0
+    },
+    "samples": [
+      {
+        "wall_ms": 100,
+        "exit_code": 0
+      }
+    ],
+    "stats": {
+      "wall_ms": {
+        "median": 100,
+        "min": 100,
+        "max": 100
+      }
+    }
+  },
+  "metadata": {
+    "runner": "gha-ubuntu-24.04-x86_64"
+  },
+  "tags": [
+    "stable"
+  ],
+  "created_at": "2026-05-07T00:00:00Z",
+  "updated_at": "2026-05-07T00:00:00Z",
+  "content_hash": "sha256-compat",
+  "source": "promote",
+  "deleted": false
+}

--- a/fixtures/schema/v0.16/perfgate.dependency_event.v1.json
+++ b/fixtures/schema/v0.16/perfgate.dependency_event.v1.json
@@ -1,0 +1,12 @@
+{
+  "schema": "perfgate.dependency_event.v1",
+  "id": "dependency-event-compat-001",
+  "project": "compat-project",
+  "benchmark": "compat-bench",
+  "dep_name": "example-crate",
+  "old_version": "1.2.3",
+  "new_version": "1.2.4",
+  "metric": "wall_ms",
+  "delta_pct": 0.12,
+  "created_at": "2026-05-07T00:00:00Z"
+}

--- a/fixtures/schema/v0.16/perfgate.fleet_alert.v1.json
+++ b/fixtures/schema/v0.16/perfgate.fleet_alert.v1.json
@@ -1,0 +1,24 @@
+{
+  "schema": "perfgate.fleet_alert.v1",
+  "id": "fleet-alert-compat-001",
+  "dependency": "example-crate",
+  "old_version": "1.2.3",
+  "new_version": "1.2.4",
+  "affected_projects": [
+    {
+      "project": "compat-project",
+      "benchmark": "compat-bench",
+      "metric": "wall_ms",
+      "delta_pct": 0.12
+    },
+    {
+      "project": "compat-project-two",
+      "benchmark": "compat-bench",
+      "metric": "wall_ms",
+      "delta_pct": 0.08
+    }
+  ],
+  "confidence": 0.75,
+  "avg_delta_pct": 0.10,
+  "first_seen": "2026-05-07T00:00:00Z"
+}

--- a/fixtures/schema/v0.16/perfgate.verdict.v1.json
+++ b/fixtures/schema/v0.16/perfgate.verdict.v1.json
@@ -1,0 +1,22 @@
+{
+  "schema": "perfgate.verdict.v1",
+  "id": "verdict-compat-001",
+  "project": "compat-project",
+  "benchmark": "compat-bench",
+  "run_id": "run-compat-001",
+  "status": "warn",
+  "counts": {
+    "pass": 0,
+    "warn": 1,
+    "fail": 0,
+    "skip": 0
+  },
+  "reasons": [
+    "wall_ms.noisy"
+  ],
+  "git_ref": "refs/heads/main",
+  "git_sha": "0123456789abcdef",
+  "wall_ms_cv": 0.42,
+  "flakiness_score": 0.61,
+  "created_at": "2026-05-07T00:00:00Z"
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1663,7 +1663,8 @@ fn cmd_schema_compat(fixtures_dir: &Path) -> anyhow::Result<()> {
             .get("schema")
             .or_else(|| value.get("report_type"))
             .and_then(serde_json::Value::as_str)
-            .map(str::to_string);
+            .map(str::to_string)
+            .or_else(|| infer_schema_from_fixture_path(path));
 
         let Some(schema) = schema else {
             errors.push(format!(
@@ -1685,6 +1686,26 @@ fn cmd_schema_compat(fixtures_dir: &Path) -> anyhow::Result<()> {
             }
             "sensor.report.v1" => {
                 serde_json::from_value::<perfgate_types::SensorReport>(value).map(|_| ())
+            }
+            "perfgate.baseline.v1" => {
+                serde_json::from_value::<perfgate_types::baseline_service::BaselineRecord>(value)
+                    .map(|_| ())
+            }
+            "perfgate.verdict.v1" => {
+                serde_json::from_value::<perfgate_types::baseline_service::VerdictRecord>(value)
+                    .map(|_| ())
+            }
+            "perfgate.audit.v1" => {
+                serde_json::from_value::<perfgate_types::baseline_service::AuditEvent>(value)
+                    .map(|_| ())
+            }
+            "perfgate.dependency_event.v1" => {
+                serde_json::from_value::<perfgate_types::baseline_service::DependencyEvent>(value)
+                    .map(|_| ())
+            }
+            "perfgate.fleet_alert.v1" => {
+                serde_json::from_value::<perfgate_types::baseline_service::FleetAlert>(value)
+                    .map(|_| ())
             }
             other => {
                 errors.push(format!("{}: unsupported schema {}", path.display(), other));
@@ -1740,6 +1761,11 @@ fn collect_schema_compat_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> anyho
         }
     }
     Ok(())
+}
+
+fn infer_schema_from_fixture_path(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    (name == "perfgate.audit.v1.json").then(|| "perfgate.audit.v1".to_string())
 }
 
 fn check_schema_mirror_at(generated_dir: &Path, committed_dir: &Path) -> anyhow::Result<()> {
@@ -3813,6 +3839,55 @@ mod tests {
         .expect("write fixture");
 
         cmd_schema_compat(&root).expect("compat fixture should deserialize");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn cmd_schema_compat_accepts_baseline_service_fixture() {
+        let root = unique_temp_dir("perfgate_schema_compat_baseline_service");
+        let version_dir = root.join("v0.16");
+        fs::create_dir_all(&version_dir).expect("create fixture dir");
+        fs::write(
+            version_dir.join("perfgate.verdict.v1.json"),
+            r#"{
+  "schema": "perfgate.verdict.v1",
+  "id": "verdict-compat-1",
+  "project": "compat-project",
+  "benchmark": "compat-bench",
+  "run_id": "run-1",
+  "status": "warn",
+  "counts": {"pass": 0, "warn": 1, "fail": 0, "skip": 0},
+  "reasons": ["wall_ms.noisy"],
+  "created_at": "2026-05-07T00:00:00Z"
+}"#,
+        )
+        .expect("write fixture");
+
+        cmd_schema_compat(&root).expect("baseline service compat fixture should deserialize");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn cmd_schema_compat_accepts_schema_less_audit_fixture_by_filename() {
+        let root = unique_temp_dir("perfgate_schema_compat_audit");
+        let version_dir = root.join("v0.16");
+        fs::create_dir_all(&version_dir).expect("create fixture dir");
+        fs::write(
+            version_dir.join("perfgate.audit.v1.json"),
+            r#"{
+  "id": "audit-compat-1",
+  "timestamp": "2026-05-07T00:00:00Z",
+  "actor": "key-admin",
+  "action": "create",
+  "resource_type": "key",
+  "resource_id": "key-1",
+  "project": "compat-project",
+  "metadata": {"source": "api_key"}
+}"#,
+        )
+        .expect("write fixture");
+
+        cmd_schema_compat(&root).expect("schema-less audit fixture should deserialize");
         let _ = fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## Summary
- extend `xtask schema-compat` to deserialize schema-bearing baseline-service and fleet records
- add v0.16 compatibility fixtures for baseline, project, verdict, audit, dependency-event, and fleet-alert contracts
- update schema docs and changelog so the API compatibility gate is visible for release proof

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `git diff --cached --check`
- `CARGO_TARGET_DIR=C:\Users\steven\AppData\Local\Temp\perfgate-target-verify cargo test -p xtask cmd_schema_compat`
- `CARGO_TARGET_DIR=C:\Users\steven\AppData\Local\Temp\perfgate-target-verify cargo test -p xtask --all-features`
- `CARGO_TARGET_DIR=C:\Users\steven\AppData\Local\Temp\perfgate-target-verify cargo run -p xtask -- schema-compat`
- `CARGO_TARGET_DIR=C:\Users\steven\AppData\Local\Temp\perfgate-target-verify cargo run -p xtask -- docs-check`
- `CARGO_TARGET_DIR=C:\Users\steven\AppData\Local\Temp\perfgate-target-verify cargo run -p xtask -- doc-test`

Note: local Cargo validation used a target dir on `C:` because the repo drive `D:` was out of space. The repo-local `target/` directory was removed after path verification to restore enough Git workspace space.
