### PR TITLE
Add CLI setup doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `perfgate doctor` to diagnose local setup, config loading, benchmark
+  command availability, baseline presence, artifact directory writability, CI
+  detection, and baseline-server health.
 - Extended `xtask schema-compat` with baseline-service and fleet record
   fixtures so the 0.16 server API contract is checked alongside receipt
   compatibility.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ cargo binstall perfgate-cli
 cargo install perfgate-cli
 ```
 
+Verify the local install and project setup:
+
+```bash
+perfgate doctor
+```
+
 ## What Gets Measured
 
 | Metric | Description | Unix | Windows |
@@ -164,6 +170,7 @@ perfgate comment --compare artifacts/perfgate/compare.json --repo owner/repo --p
 | Command | Description |
 |---------|-------------|
 | **`check`** | **Config-driven workflow (start here)** |
+| `doctor` | Diagnose config, benchmark commands, baselines, artifacts, CI, and server reachability |
 | `run` | Execute a benchmark, emit a run receipt |
 | `compare` | Compare a run against a baseline |
 | `diff` | Run a quick local regression check against discovered config/baselines |

--- a/crates/perfgate-cli/README.md
+++ b/crates/perfgate-cli/README.md
@@ -19,6 +19,12 @@ cargo install perfgate-cli
 cargo install --path crates/perfgate-cli
 ```
 
+Check the local install and project setup:
+
+```bash
+perfgate doctor
+```
+
 ## Quick Start
 
 ```bash
@@ -81,6 +87,7 @@ Commands are organized by workflow stage.
 | Command  | Purpose |
 |----------|---------|
 | `check`  | Config-driven end-to-end workflow: run, compare, report, gate |
+| `doctor` | Diagnose config, benchmark commands, baselines, artifacts, CI, and server reachability |
 | `bisect` | Binary-search for the commit that introduced a regression |
 
 ## Exit Codes

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -32,7 +32,8 @@ use perfgate_client::types::auth::Role;
 use perfgate_client::types::{BaselineRecord, CreateKeyRequest, KeyEntry};
 use perfgate_client::{
     AuthMethod, BaselineClient, ClientConfig, ListBaselinesQuery, ListVerdictsQuery,
-    ResolvedServerConfig, SubmitVerdictRequest, UploadBaselineRequest, resolve_server_config,
+    ResolvedServerConfig, RetryConfig, SubmitVerdictRequest, UploadBaselineRequest,
+    resolve_server_config,
 };
 use perfgate_domain::scaling::{
     ScalingReport, SizeMeasurement, classify_complexity, parse_complexity, render_ascii_chart,
@@ -243,6 +244,9 @@ enum Command {
     /// - 2: fail (budget violated)
     /// - 3: warn treated as failure (with --fail-on-warn)
     Check(Box<CheckArgs>),
+
+    /// Diagnose local setup, config, baselines, artifacts, CI, and server reachability.
+    Doctor(Box<DoctorArgs>),
 
     /// Run paired benchmark: interleave baseline and current commands for reduced noise.
     ///
@@ -1082,6 +1086,21 @@ pub struct CheckArgs {
 }
 
 #[derive(Debug, Args)]
+pub struct DoctorArgs {
+    /// Path to the config file (TOML or JSON)
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Output directory checked for artifact writability
+    #[arg(long, default_value = "artifacts/perfgate")]
+    pub out_dir: PathBuf,
+
+    /// Exit non-zero if doctor finds a failed required check
+    #[arg(long, default_value_t = false)]
+    pub strict: bool,
+}
+
+#[derive(Debug, Args)]
 pub struct PairedArgs {
     /// Bench identifier (used for baselines and reporting)
     #[arg(long)]
@@ -1647,6 +1666,431 @@ fn resolve_bench_names(
     anyhow::bail!("either --bench or --all must be specified")
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DoctorStatus {
+    Ok,
+    Warn,
+    Fail,
+}
+
+impl DoctorStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::Warn => "WARN",
+            Self::Fail => "FAIL",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DoctorCheck {
+    status: DoctorStatus,
+    name: &'static str,
+    detail: String,
+}
+
+impl DoctorCheck {
+    fn ok(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            status: DoctorStatus::Ok,
+            name,
+            detail: detail.into(),
+        }
+    }
+
+    fn warn(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            status: DoctorStatus::Warn,
+            name,
+            detail: detail.into(),
+        }
+    }
+
+    fn fail(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            status: DoctorStatus::Fail,
+            name,
+            detail: detail.into(),
+        }
+    }
+}
+
+fn execute_doctor(args: DoctorArgs, server_flags: ServerFlags) -> anyhow::Result<()> {
+    let mut checks = Vec::new();
+    checks.push(DoctorCheck::ok(
+        "version",
+        env!("CARGO_PKG_VERSION").to_string(),
+    ));
+    checks.push(DoctorCheck::ok(
+        "platform",
+        format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+    ));
+
+    let config = if args.config.exists() {
+        match load_config_file(&args.config) {
+            Ok(config) => {
+                match config.validate() {
+                    Ok(()) => checks.push(DoctorCheck::ok(
+                        "config",
+                        format!(
+                            "{} found ({} benchmark{})",
+                            args.config.display(),
+                            config.benches.len(),
+                            plural(config.benches.len())
+                        ),
+                    )),
+                    Err(error) => checks.push(DoctorCheck::fail(
+                        "config",
+                        format!("{} is invalid: {error}", args.config.display()),
+                    )),
+                }
+                Some(config)
+            }
+            Err(error) => {
+                checks.push(DoctorCheck::fail(
+                    "config",
+                    format!("failed to load {}: {error}", args.config.display()),
+                ));
+                None
+            }
+        }
+    } else {
+        checks.push(DoctorCheck::fail(
+            "config",
+            format!(
+                "{} not found; run `perfgate init` or pass --config",
+                args.config.display()
+            ),
+        ));
+        None
+    };
+
+    checks.push(doctor_git_check());
+    checks.push(doctor_ci_check());
+
+    if let Some(config) = &config {
+        checks.push(doctor_benchmark_commands(config));
+        checks.push(doctor_baselines(config, &server_flags));
+        checks.push(doctor_server(config, &server_flags));
+    } else {
+        checks.push(DoctorCheck::warn(
+            "benchmarks",
+            "skipped because config could not be loaded",
+        ));
+        checks.push(DoctorCheck::warn(
+            "baselines",
+            "skipped because config could not be loaded",
+        ));
+        checks.push(doctor_server(&ConfigFile::default(), &server_flags));
+    }
+
+    checks.push(doctor_artifact_dir(&args.out_dir));
+
+    println!("perfgate doctor");
+    println!();
+    for check in &checks {
+        println!(
+            "{:<4} {:<18} {}",
+            check.status.as_str(),
+            check.name,
+            check.detail
+        );
+    }
+
+    let failed = checks
+        .iter()
+        .filter(|check| check.status == DoctorStatus::Fail)
+        .count();
+    let warned = checks
+        .iter()
+        .filter(|check| check.status == DoctorStatus::Warn)
+        .count();
+    println!();
+    println!(
+        "Summary: {failed} failed, {warned} warning{}",
+        plural(warned)
+    );
+
+    if args.strict && failed > 0 {
+        anyhow::bail!("doctor found {failed} failed check{}", plural(failed));
+    }
+
+    Ok(())
+}
+
+fn plural(count: usize) -> &'static str {
+    if count == 1 { "" } else { "s" }
+}
+
+fn doctor_git_check() -> DoctorCheck {
+    match run_git_capture(&["rev-parse", "--is-inside-work-tree"]) {
+        Some(value) if value == "true" => {
+            let branch = run_git_capture(&["rev-parse", "--abbrev-ref", "HEAD"])
+                .unwrap_or_else(|| "unknown".to_string());
+            DoctorCheck::ok("git", format!("repository detected ({branch})"))
+        }
+        _ => DoctorCheck::ok("git", "not a git repository"),
+    }
+}
+
+fn doctor_ci_check() -> DoctorCheck {
+    match detect_ci_provider() {
+        Some(provider) => DoctorCheck::ok("ci", format!("detected {provider}")),
+        None => DoctorCheck::ok("ci", "not detected"),
+    }
+}
+
+fn detect_ci_provider() -> Option<&'static str> {
+    if std::env::var_os("GITHUB_ACTIONS").is_some() {
+        Some("GitHub Actions")
+    } else if std::env::var_os("GITLAB_CI").is_some() {
+        Some("GitLab CI")
+    } else if std::env::var_os("BITBUCKET_BUILD_NUMBER").is_some() {
+        Some("Bitbucket Pipelines")
+    } else if std::env::var_os("CIRCLECI").is_some() {
+        Some("CircleCI")
+    } else if std::env::var_os("CI").is_some() {
+        Some("generic CI")
+    } else {
+        None
+    }
+}
+
+fn doctor_benchmark_commands(config: &ConfigFile) -> DoctorCheck {
+    if config.benches.is_empty() {
+        return DoctorCheck::fail("benchmarks", "no [[bench]] entries configured");
+    }
+
+    let mut runnable = 0usize;
+    let mut missing = Vec::new();
+    for bench in &config.benches {
+        match bench_command_runnable(bench) {
+            Ok(true) => runnable += 1,
+            Ok(false) => missing.push(bench.name.clone()),
+            Err(error) => missing.push(format!("{} ({error})", bench.name)),
+        }
+    }
+
+    if missing.is_empty() {
+        DoctorCheck::ok(
+            "benchmarks",
+            format!(
+                "{}/{} command{} runnable",
+                runnable,
+                config.benches.len(),
+                plural(config.benches.len())
+            ),
+        )
+    } else {
+        DoctorCheck::fail(
+            "benchmarks",
+            format!(
+                "{}/{} command{} runnable; not runnable: {}",
+                runnable,
+                config.benches.len(),
+                plural(config.benches.len()),
+                missing.join(", ")
+            ),
+        )
+    }
+}
+
+fn bench_command_runnable(bench: &perfgate_types::BenchConfigFile) -> anyhow::Result<bool> {
+    let Some(program) = bench.command.first() else {
+        return Ok(false);
+    };
+
+    let cwd = resolve_bench_cwd(bench.cwd.as_deref());
+    if !cwd.exists() {
+        anyhow::bail!("cwd does not exist: {}", cwd.display());
+    }
+
+    Ok(program_is_runnable(program, &cwd))
+}
+
+fn resolve_bench_cwd(cwd: Option<&str>) -> PathBuf {
+    match cwd {
+        Some(cwd) => PathBuf::from(cwd),
+        None => PathBuf::from("."),
+    }
+}
+
+fn program_is_runnable(program: &str, cwd: &Path) -> bool {
+    let path = Path::new(program);
+    if path.is_absolute() || program.contains('/') || program.contains('\\') {
+        let candidate = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            cwd.join(path)
+        };
+        return executable_candidate_exists(&candidate);
+    }
+
+    find_program_on_path(program).is_some()
+}
+
+fn find_program_on_path(program: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(program);
+        if executable_candidate_exists(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn executable_candidate_exists(path: &Path) -> bool {
+    if path.is_file() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let Ok(metadata) = path.metadata() else {
+                return false;
+            };
+            return metadata.permissions().mode() & 0o111 != 0;
+        }
+
+        #[cfg(not(unix))]
+        {
+            return true;
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        if path.extension().is_none() {
+            let pathext =
+                std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string());
+            for ext in pathext.split(';').filter(|ext| !ext.is_empty()) {
+                let ext = ext.trim_start_matches('.');
+                if path.with_extension(ext).is_file() {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+fn doctor_baselines(config: &ConfigFile, server_flags: &ServerFlags) -> DoctorCheck {
+    if config.benches.is_empty() {
+        return DoctorCheck::warn("baselines", "skipped because no benchmarks are configured");
+    }
+
+    let server_config = server_flags.resolve(&config.baseline_server);
+    if server_config.is_configured() {
+        return DoctorCheck::ok("baselines", "baseline server configured");
+    }
+
+    let mut local = 0usize;
+    let mut found = 0usize;
+    let mut remote = 0usize;
+    for bench in &config.benches {
+        let path = resolve_baseline_path(&None, &bench.name, config);
+        let path_text = path.to_string_lossy();
+        if is_remote_storage_uri(&path_text) {
+            remote += 1;
+            continue;
+        }
+        local += 1;
+        if path.exists() {
+            found += 1;
+        }
+    }
+
+    if local == 0 && remote > 0 {
+        return DoctorCheck::ok(
+            "baselines",
+            format!(
+                "{remote} remote baseline URI{} configured; not probed",
+                plural(remote)
+            ),
+        );
+    }
+
+    if found == local {
+        DoctorCheck::ok(
+            "baselines",
+            format!("{found}/{local} local baseline{} found", plural(local)),
+        )
+    } else {
+        DoctorCheck::warn(
+            "baselines",
+            format!(
+                "{found}/{local} local baseline{} found; create missing baselines with `perfgate promote --current <run.json> --to <baseline.json>`",
+                plural(local)
+            ),
+        )
+    }
+}
+
+fn doctor_server(config: &ConfigFile, server_flags: &ServerFlags) -> DoctorCheck {
+    let server_config = server_flags.resolve(&config.baseline_server);
+    if !server_config.is_configured() {
+        return DoctorCheck::ok("baseline server", "not configured");
+    }
+
+    let Some(url) = server_config.url.as_ref() else {
+        return DoctorCheck::ok("baseline server", "not configured");
+    };
+
+    let mut client_config = ClientConfig::new(url)
+        .with_timeout(Duration::from_secs(2))
+        .with_retry(RetryConfig::new().with_max_retries(0));
+    if let Some(api_key) = &server_config.api_key {
+        client_config = client_config.with_api_key(api_key);
+    }
+
+    let client = match BaselineClient::new(client_config) {
+        Ok(client) => client,
+        Err(error) => {
+            return DoctorCheck::fail("baseline server", format!("{url} invalid: {error}"));
+        }
+    };
+
+    match with_tokio_runtime(async { client.health_check().await.map_err(anyhow::Error::from) }) {
+        Ok(health) if health.status == "healthy" => {
+            let project = server_config.project.as_deref().unwrap_or("not configured");
+            DoctorCheck::ok(
+                "baseline server",
+                format!("{url} reachable (project: {project})"),
+            )
+        }
+        Ok(health) => DoctorCheck::fail(
+            "baseline server",
+            format!("{url} returned unhealthy status: {}", health.status),
+        ),
+        Err(error) => {
+            DoctorCheck::fail("baseline server", format!("{url} not reachable: {error:#}"))
+        }
+    }
+}
+
+fn doctor_artifact_dir(out_dir: &Path) -> DoctorCheck {
+    match ensure_artifact_dir_writable(out_dir) {
+        Ok(()) => DoctorCheck::ok(
+            "artifact directory",
+            format!("{} writable", out_dir.display()),
+        ),
+        Err(error) => DoctorCheck::fail(
+            "artifact directory",
+            format!("{} not writable: {error}", out_dir.display()),
+        ),
+    }
+}
+
+fn ensure_artifact_dir_writable(out_dir: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(out_dir)?;
+    let probe = out_dir.join(".perfgate-doctor-write-test");
+    fs::write(&probe, b"perfgate doctor\n")?;
+    fs::remove_file(probe)?;
+    Ok(())
+}
+
 fn main() -> ExitCode {
     match real_main() {
         Ok(_) => ExitCode::from(0),
@@ -2183,6 +2627,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 OutputMode::Cockpit => run_check_cockpit(req),
             }
         }
+
+        Command::Doctor(args) => execute_doctor(*args, server_flags),
 
         Command::Paired(args) => {
             let PairedArgs {

--- a/crates/perfgate-cli/tests/cli_doctor_tests.rs
+++ b/crates/perfgate-cli/tests/cli_doctor_tests.rs
@@ -1,0 +1,150 @@
+//! Integration tests for `perfgate doctor`.
+
+use predicates::prelude::*;
+use std::fs;
+use tempfile::tempdir;
+
+mod common;
+use common::perfgate_cmd;
+
+#[cfg(unix)]
+fn success_command() -> Vec<&'static str> {
+    vec!["true"]
+}
+
+#[cfg(windows)]
+fn success_command() -> Vec<&'static str> {
+    vec!["cmd", "/c", "exit", "0"]
+}
+
+fn write_config(dir: &std::path::Path) -> std::path::PathBuf {
+    let config_path = dir.join("perfgate.toml");
+    let command = success_command()
+        .iter()
+        .map(|part| format!("\"{}\"", part))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        &config_path,
+        format!(
+            r#"[defaults]
+repeat = 1
+warmup = 0
+baseline_dir = "baselines"
+
+[[bench]]
+name = "doctor-bench"
+command = [{command}]
+"#
+        ),
+    )
+    .expect("write config");
+    config_path
+}
+
+#[test]
+fn doctor_reports_local_setup_without_running_benchmarks() {
+    let dir = tempdir().expect("tempdir");
+    let config = write_config(dir.path());
+    let out_dir = dir.path().join("artifacts/perfgate");
+
+    perfgate_cmd()
+        .args(["doctor", "--config"])
+        .arg(&config)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("perfgate doctor"))
+        .stdout(predicate::str::contains("OK   version"))
+        .stdout(predicate::str::contains("OK   config"))
+        .stdout(predicate::str::contains("OK   benchmarks"))
+        .stdout(predicate::str::contains("WARN baselines"))
+        .stdout(predicate::str::contains("OK   artifact directory"))
+        .stdout(predicate::str::contains("Summary: 0 failed"));
+}
+
+#[test]
+fn doctor_strict_fails_when_required_setup_is_missing() {
+    let dir = tempdir().expect("tempdir");
+    let missing_config = dir.path().join("missing-perfgate.toml");
+
+    perfgate_cmd()
+        .args(["doctor", "--strict", "--config"])
+        .arg(&missing_config)
+        .arg("--out-dir")
+        .arg(dir.path().join("artifacts/perfgate"))
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("FAIL config"))
+        .stdout(predicate::str::contains("Summary: 1 failed"))
+        .stderr(predicate::str::contains("doctor found 1 failed check"));
+}
+
+#[test]
+fn doctor_uses_current_directory_for_relative_config_paths_like_check() {
+    let dir = tempdir().expect("tempdir");
+    let project_dir = dir.path().join("project");
+    fs::create_dir(&project_dir).expect("create project dir");
+    fs::create_dir(project_dir.join("baselines")).expect("create project baselines");
+    fs::write(project_dir.join("bench.cmd"), "@echo off\r\nexit /b 0\r\n").expect("write bench");
+    fs::write(
+        project_dir.join("baselines/doctor-bench.json"),
+        r#"{"schema":"perfgate.run.v1"}"#,
+    )
+    .expect("write baseline marker");
+    let config = project_dir.join("perfgate.toml");
+    fs::write(
+        &config,
+        r#"[defaults]
+baseline_dir = "baselines"
+
+[[bench]]
+name = "doctor-bench"
+command = ["./bench.cmd"]
+"#,
+    )
+    .expect("write config");
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["doctor", "--config"])
+        .arg(&config)
+        .arg("--out-dir")
+        .arg(dir.path().join("artifacts/perfgate"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FAIL benchmarks"))
+        .stdout(predicate::str::contains("WARN baselines"))
+        .stdout(predicate::str::contains("0/1 local baseline found"));
+}
+
+#[cfg(unix)]
+#[test]
+fn doctor_rejects_non_executable_relative_programs_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("tempdir");
+    let script = dir.path().join("bench.sh");
+    fs::write(&script, "#!/bin/sh\nexit 0\n").expect("write script");
+    fs::set_permissions(&script, fs::Permissions::from_mode(0o644)).expect("chmod script");
+    let config = dir.path().join("perfgate.toml");
+    fs::write(
+        &config,
+        r#"[[bench]]
+name = "doctor-bench"
+command = ["./bench.sh"]
+"#,
+    )
+    .expect("write config");
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["doctor", "--config"])
+        .arg(&config)
+        .arg("--out-dir")
+        .arg(dir.path().join("artifacts/perfgate"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("FAIL benchmarks"));
+}

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -21,6 +21,7 @@ fn cli_help_main() {
         .stdout(predicate::str::contains("run"))
         .stdout(predicate::str::contains("compare"))
         .stdout(predicate::str::contains("check"))
+        .stdout(predicate::str::contains("doctor"))
         .stdout(predicate::str::contains("paired"))
         .stdout(predicate::str::contains("md"))
         .stdout(predicate::str::contains("export"))
@@ -69,6 +70,18 @@ fn cli_help_check() {
         .stdout(predicate::str::contains("--bench"))
         .stdout(predicate::str::contains("--out-dir"))
         .stdout(predicate::str::contains("--emit-repair-context"));
+}
+
+#[test]
+fn cli_help_doctor() {
+    perfgate_cmd()
+        .args(["doctor", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Diagnose local setup"))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--strict"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 241
+assertion_line: 280
 expression: "help_output(&[\"--help\"])"
 ---
 Perf budgets and baseline diffs for CI / PR bots
@@ -17,6 +17,7 @@ Commands:
   ratchet Preview or apply conservative budget ratcheting from compare evidence
   report Generate a cockpit-compatible report from a compare receipt
   check Config-driven one-command workflow
+  doctor Diagnose local setup, config, baselines, artifacts, CI, and server reachability
   paired Run paired benchmark: interleave baseline and current commands for reduced noise
   baseline Manage baselines on the baseline server
   admin Administer baseline service operations


### PR DESCRIPTION
## Summary
- add `perfgate doctor` for local setup diagnostics: version/platform, config, git/CI, benchmark command availability, baseline presence, artifact writability, and baseline-server health
- keep diagnostics aligned with `check` path semantics for relative config/cwd/baseline paths
- document the new command in README surfaces and changelog

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-cli --test cli_doctor_tests`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests`
- `cargo test -p perfgate-cli --all-features`
- `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- publish-check`
- `PERFGATE_CI_TARGET_DIR=C:\Users\steven\AppData\Local\Temp\perfgate-ci-target cargo run -p xtask -- ci`
- `git diff --check`