### PR TITLE
Add release package proof gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,21 +28,27 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             cross: true
+            smoke: true
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             cross: true
+            smoke: true
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
             cross: true
+            smoke: false
           - target: x86_64-apple-darwin
             runner: macos-15-intel
             cross: false
+            smoke: true
           - target: aarch64-apple-darwin
             runner: macos-15
             cross: false
+            smoke: true
           - target: x86_64-pc-windows-msvc
             runner: windows-latest
             cross: false
+            smoke: true
 
     steps:
       - uses: actions/checkout@v6
@@ -85,6 +91,30 @@ jobs:
           cd target/${{ matrix.target }}/release
           7z a ../../../perfgate-${{ matrix.target }}.zip perfgate.exe
           cd ../../..
+
+      - name: Smoke packaged archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          smoke_dir="packaged-smoke-${{ matrix.target }}"
+          rm -rf "$smoke_dir"
+          mkdir -p "$smoke_dir"
+
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            7z x -y "perfgate-${{ matrix.target }}.zip" "-o$smoke_dir"
+            binary="$smoke_dir/perfgate.exe"
+          else
+            tar xzf "perfgate-${{ matrix.target }}.tar.gz" -C "$smoke_dir"
+            binary="$smoke_dir/perfgate"
+          fi
+
+          test -f "$binary"
+          if [ "${{ matrix.smoke }}" = "true" ]; then
+            "$binary" --version
+            "$binary" doctor --help
+          else
+            echo "Skipping execution smoke for non-native target ${{ matrix.target }}"
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v6

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -15,6 +15,8 @@ surface is now in its intended release shape:
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
 | Architecture boundary enforcement | Passing | `cargo run -p xtask -- arch` |
 | Publish metadata preflight | Passing | `cargo run -p xtask -- publish-check` |
+| Package file-list proof | Release-prep gate | `cargo run -p xtask -- publish-check --package-list` |
+| Publish dry-run proof | Per-package release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
 | Full repo CI | Passing | Hosted `ci`, `fuzz`, and `perfgate-self` on PR #268 |
 
 The only publishable packages allowed by policy are:
@@ -26,6 +28,32 @@ perfgate-types
 perfgate-client
 perfgate-server
 ```
+
+Before cutting a 0.16 release, run the package proof without `--allow-dirty`:
+
+```bash
+cargo run -p xtask -- public-surface --strict
+cargo run -p xtask -- arch
+cargo run -p xtask -- publish-check --package-list
+cargo run -p xtask -- publish-check --dry-run --package perfgate-types
+cargo run -p xtask -- docs-check
+cargo run -p xtask -- doc-test
+cargo run -p xtask -- ci
+```
+
+Run `publish-check --dry-run --package <name>` immediately before publishing each
+crate in dependency order. Cargo verifies packaged dependencies against
+crates.io, so downstream crates such as `perfgate` and `perfgate-cli` cannot be
+dry-run verified until their same-release workspace dependencies have already
+been published.
+
+For PR validation before the branch is committed or while release notes are still
+being edited, `publish-check` also accepts `--allow-dirty`. Release operators
+should omit it.
+
+The GitHub release workflow builds the platform archives, unpacks each generated
+archive, verifies the binary exists, and runs `perfgate --version` plus
+`perfgate doctor --help` on native targets before uploading release assets.
 
 Former implementation packages such as `perfgate-domain` and `perfgate-app`
 are workspace-only compatibility wrappers. Domain logic lives under

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -6,7 +6,8 @@ Developer automation crate for the perfgate workspace.
 
 - Generates and checks JSON schemas (`schema`, `schema-check`, `schema-compat`).
 - Runs the standard CI command bundle (`ci`).
-- Validates crates.io packaging metadata before release (`publish-check`).
+- Validates crates.io packaging metadata before release (`publish-check`), with
+  opt-in package-list and publish dry-run proof for release prep.
 - Validates public crate dispositions and compatibility-wrapper isolation (`public-surface`).
 - Enforces workspace architecture dependency rules (`arch`).
 - Validates documentation CLI examples plus TOML, JSON, and YAML snippets (`doc-test`).
@@ -26,6 +27,8 @@ cargo run -p xtask -- schema-check
 cargo run -p xtask -- schema-compat
 cargo run -p xtask -- ci
 cargo run -p xtask -- publish-check
+cargo run -p xtask -- publish-check --package-list
+cargo run -p xtask -- publish-check --dry-run --package perfgate-types
 cargo run -p xtask -- public-surface
 cargo run -p xtask -- arch
 cargo run -p xtask -- doc-test

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+const TARGET_PUBLIC_PACKAGES: [&str; 5] = [
+    "perfgate-types",
+    "perfgate",
+    "perfgate-client",
+    "perfgate-server",
+    "perfgate-cli",
+];
+
 const SCHEMA_FILES: [&str; 8] = [
     "perfgate.run.v1.schema.json",
     "perfgate.compare.v1.schema.json",
@@ -116,7 +124,23 @@ enum Command {
     Ci,
 
     /// Validate workspace packaging metadata for crates.io publication.
-    PublishCheck,
+    PublishCheck {
+        /// Limit package-list or dry-run checks to one or more publishable packages.
+        #[arg(long = "package", value_name = "PACKAGE")]
+        packages: Vec<String>,
+
+        /// Run `cargo package --list` for every publishable workspace package.
+        #[arg(long)]
+        package_list: bool,
+
+        /// Run `cargo publish --dry-run` for selected publishable packages.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Pass `--allow-dirty` to Cargo packaging commands.
+        #[arg(long)]
+        allow_dirty: bool,
+    },
 
     /// Validate the target public crate policy and transition dispositions.
     PublicSurface {
@@ -216,7 +240,12 @@ fn main() -> anyhow::Result<()> {
         Command::SchemaCheck { schemas_dir } => cmd_schema_check(&schemas_dir),
         Command::SchemaCompat { fixtures_dir } => cmd_schema_compat(&fixtures_dir),
         Command::Ci => cmd_ci(),
-        Command::PublishCheck => cmd_publish_check(),
+        Command::PublishCheck {
+            packages,
+            package_list,
+            dry_run,
+            allow_dirty,
+        } => cmd_publish_check(packages, package_list, dry_run, allow_dirty),
         Command::PublicSurface {
             public_policy,
             absorbed_policy,
@@ -294,7 +323,7 @@ fn cmd_ci() -> anyhow::Result<()> {
     cmd_schema_check(Path::new("schemas"))?;
     cmd_schema_compat(Path::new("fixtures/schema"))?;
     cmd_conform(None, None)?;
-    cmd_publish_check()?;
+    cmd_publish_check(Vec::new(), false, false, false)?;
     cmd_public_surface(
         Path::new("policy/public_crates.txt"),
         Path::new("policy/absorbed_crates.txt"),
@@ -326,24 +355,53 @@ struct MetadataDependency {
     path: Option<PathBuf>,
 }
 
-fn cmd_publish_check() -> anyhow::Result<()> {
+fn cmd_publish_check(
+    packages: Vec<String>,
+    package_list: bool,
+    dry_run: bool,
+    allow_dirty: bool,
+) -> anyhow::Result<()> {
     let metadata = load_cargo_metadata()?;
     let errors = collect_publish_errors(&metadata);
 
-    if errors.is_empty() {
-        println!("  OK  publishable workspace packages pass static packaging checks");
-        return Ok(());
+    if !errors.is_empty() {
+        println!("Found {} publish metadata error(s):", errors.len());
+        for error in &errors {
+            println!("  - {}", error);
+        }
+
+        anyhow::bail!(
+            "{} publish metadata issue(s) found. Fix packaging before release.",
+            errors.len()
+        );
     }
 
-    println!("Found {} publish metadata error(s):", errors.len());
-    for error in &errors {
-        println!("  - {}", error);
+    println!("  OK  publishable workspace packages pass static packaging checks");
+
+    if dry_run && packages.is_empty() {
+        anyhow::bail!(
+            "`publish-check --dry-run` requires at least one `--package <name>` because \
+             Cargo verifies package dependencies against crates.io, not unpublished workspace crates"
+        );
     }
 
-    anyhow::bail!(
-        "{} publish metadata issue(s) found. Fix packaging before release.",
-        errors.len()
-    );
+    if package_list || dry_run {
+        let packages = select_publishable_packages(&metadata, &packages)?;
+        println!("      publishable packages: {}", packages.join(", "));
+
+        for package in &packages {
+            if package_list {
+                run_cargo_args(cargo_package_list_args(package, allow_dirty))
+                    .with_context(|| format!("checking package file list for {package}"))?;
+            }
+            if dry_run {
+                run_cargo_args(cargo_publish_dry_run_args(package, allow_dirty))
+                    .with_context(|| format!("running publish dry-run for {package}"))?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 fn load_cargo_metadata() -> anyhow::Result<CargoMetadata> {
@@ -409,6 +467,94 @@ fn collect_publish_errors(metadata: &CargoMetadata) -> Vec<String> {
     }
 
     errors
+}
+
+fn ordered_publishable_packages(metadata: &CargoMetadata) -> Vec<String> {
+    let mut publishable: BTreeSet<String> = metadata
+        .packages
+        .iter()
+        .filter(|package| is_publishable(package))
+        .map(|package| package.name.clone())
+        .collect();
+
+    let mut ordered = Vec::new();
+    for package in TARGET_PUBLIC_PACKAGES {
+        if publishable.remove(package) {
+            ordered.push(package.to_string());
+        }
+    }
+    ordered.extend(publishable);
+    ordered
+}
+
+fn select_publishable_packages(
+    metadata: &CargoMetadata,
+    requested: &[String],
+) -> anyhow::Result<Vec<String>> {
+    let ordered = ordered_publishable_packages(metadata);
+    if requested.is_empty() {
+        return Ok(ordered);
+    }
+
+    let publishable: BTreeSet<&str> = ordered.iter().map(String::as_str).collect();
+    let requested: BTreeSet<&str> = requested.iter().map(String::as_str).collect();
+    let unknown: Vec<_> = requested
+        .iter()
+        .filter(|package| !publishable.contains(**package))
+        .copied()
+        .collect();
+    if !unknown.is_empty() {
+        anyhow::bail!(
+            "requested package(s) are not publishable workspace packages: {}",
+            unknown.join(", ")
+        );
+    }
+
+    Ok(ordered
+        .into_iter()
+        .filter(|package| requested.contains(package.as_str()))
+        .collect())
+}
+
+fn cargo_package_list_args(package: &str, allow_dirty: bool) -> Vec<String> {
+    let mut args = vec![
+        "package".to_string(),
+        "-p".to_string(),
+        package.to_string(),
+        "--list".to_string(),
+    ];
+    if allow_dirty {
+        args.push("--allow-dirty".to_string());
+    }
+    args
+}
+
+fn cargo_publish_dry_run_args(package: &str, allow_dirty: bool) -> Vec<String> {
+    let mut args = vec![
+        "publish".to_string(),
+        "-p".to_string(),
+        package.to_string(),
+        "--dry-run".to_string(),
+    ];
+    if allow_dirty {
+        args.push("--allow-dirty".to_string());
+    }
+    args
+}
+
+fn run_cargo_args(args: Vec<String>) -> anyhow::Result<()> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    println!("      running: {} {}", cargo, args.join(" "));
+    let status = std::process::Command::new(&cargo)
+        .args(&args)
+        .status()
+        .with_context(|| format!("running {} {}", cargo, args.join(" ")))?;
+
+    if !status.success() {
+        anyhow::bail!("{} {} failed: {}", cargo, args.join(" "), status);
+    }
+
+    Ok(())
 }
 
 fn cmd_public_surface(
@@ -3212,6 +3358,79 @@ mod tests {
 
         let errors = collect_publish_errors(&metadata);
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn ordered_publishable_packages_uses_release_order_then_extra_names() {
+        let metadata = CargoMetadata {
+            packages: vec![
+                test_package("perfgate-cli", None),
+                test_package("perfgate-extra", None),
+                test_package("perfgate-types", None),
+                test_package("perfgate-internal", Some(Vec::new())),
+                test_package("perfgate", None),
+            ],
+        };
+
+        assert_eq!(
+            ordered_publishable_packages(&metadata),
+            vec![
+                "perfgate-types",
+                "perfgate",
+                "perfgate-cli",
+                "perfgate-extra"
+            ]
+        );
+    }
+
+    #[test]
+    fn select_publishable_packages_filters_requested_packages_in_release_order() {
+        let metadata = CargoMetadata {
+            packages: vec![
+                test_package("perfgate-cli", None),
+                test_package("perfgate-types", None),
+                test_package("perfgate", None),
+            ],
+        };
+        let requested = vec!["perfgate-cli".to_string(), "perfgate-types".to_string()];
+
+        assert_eq!(
+            select_publishable_packages(&metadata, &requested).expect("selected packages"),
+            vec!["perfgate-types", "perfgate-cli"]
+        );
+    }
+
+    #[test]
+    fn select_publishable_packages_rejects_unknown_packages() {
+        let metadata = CargoMetadata {
+            packages: vec![test_package("perfgate-types", None)],
+        };
+        let requested = vec!["perfgate-domain".to_string()];
+
+        let err = select_publishable_packages(&metadata, &requested).unwrap_err();
+        assert!(err.to_string().contains("not publishable"));
+    }
+
+    #[test]
+    fn cargo_packaging_args_include_optional_allow_dirty() {
+        assert_eq!(
+            cargo_package_list_args("perfgate-cli", false),
+            vec!["package", "-p", "perfgate-cli", "--list"]
+        );
+        assert_eq!(
+            cargo_package_list_args("perfgate-cli", true),
+            vec!["package", "-p", "perfgate-cli", "--list", "--allow-dirty"]
+        );
+        assert_eq!(
+            cargo_publish_dry_run_args("perfgate-cli", true),
+            vec![
+                "publish",
+                "-p",
+                "perfgate-cli",
+                "--dry-run",
+                "--allow-dirty"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend `xtask publish-check` with opt-in `--package-list`, per-package `--dry-run`, `--package`, and `--allow-dirty` release-prep flags
- document the 0.16 package proof sequence and the Cargo registry dependency-order constraint for multi-crate dry-runs
- smoke generated release archives before upload by unpacking them, checking the binary exists, and running `perfgate --version` / `perfgate doctor --help` on native targets

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p xtask --all-features`
- `cargo clippy -p xtask --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- publish-check --package-list --allow-dirty`
- `cargo run -p xtask -- publish-check --dry-run --package perfgate-types --allow-dirty`
- `cargo run -p xtask -- publish-check --dry-run --allow-dirty` fails intentionally with a scoped-package explanation
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release.yml').read_text()); print('release workflow YAML parses')"`
- `git diff --check`