### PR TITLE
ci(coverage): extract coverage into advisory workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,24 +31,6 @@ jobs:
       - name: Run CI Suite (xtask)
         run: cargo run -p xtask -- ci
 
-      - name: Install cargo-llvm-cov
-        if: matrix.os == 'ubuntu-latest'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-llvm-cov
-
-      - name: Generate coverage report
-        if: matrix.os == 'ubuntu-latest'
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info --fail-under-lines 80
-
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false # Don't block CI if Codecov is down
-
   server-integration:
     name: server integration (memory/sqlite/postgres)
     runs-on: ubuntu-latest

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,137 @@
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "tests/**"
+      - "xtask/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "tests/**"
+      - "xtask/**"
+      - ".github/workflows/coverage.yml"
+      - "codecov.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUSTFLAGS: "-C debuginfo=0"
+
+jobs:
+  coverage:
+    name: Codecov Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.93.0"
+          components: llvm-tools-preview
+
+      - name: Use larger target dir
+        run: echo "CARGO_TARGET_DIR=${RUNNER_TEMP}/target" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-directories: ${{ runner.temp }}/target
+          shared-key: coverage-1.93
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,cargo-nextest
+
+      - name: Generate coverage
+        env:
+          CI: true
+        run: |
+          set -euo pipefail
+          cargo llvm-cov clean --workspace
+
+          cargo llvm-cov nextest \
+            --workspace \
+            --locked \
+            --all-features \
+            --no-report
+
+          cargo llvm-cov report --json --output-path coverage.json
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --text | tee coverage.txt
+
+      - name: Validate coverage output
+        run: |
+          set -euo pipefail
+          test -s coverage.json
+          test -s coverage.txt
+          test -s lcov.info
+
+      - name: Detect Codecov token
+        id: codecov-token
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if [ -n "${CODECOV_TOKEN:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload coverage to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: perfgate-rust-core
+          fail_ci_if_error: true
+
+      - name: Upload coverage to Codecov (advisory)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-core
+          name: perfgate-rust-core
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: |
+            coverage.json
+            coverage.txt
+            lcov.info
+          retention-days: 14


### PR DESCRIPTION
## Summary

Moves cargo-llvm-cov and Codecov upload from required CI into a dedicated advisory workflow. This is **PR 1 of 7** in the perfgate Codecov rollout.

## CI economics

**Before:** Coverage adds ~10-15 minutes to every PR's ubuntu-latest test job.
**After:** Coverage runs only on `main`, manual dispatch, and PRs labeled `coverage` / `full-ci`.

- **Default PR LEM impact:** -10-15 min (faster ordinary PR CI)
- **Workflow touched:** `.github/workflows/ci.yml` (removed 18 lines), new `.github/workflows/coverage.yml`
- **Branch protection impact:** None (coverage is advisory, not required)
- **Failure mode caught:** Broken coverage config detected on manual trigger
- **Cheaper signal considered:** None; this is the cost-control move
- **Rollback path:** Restore coverage steps to ci.yml and delete coverage.yml

## Claim boundary

Codecov coverage is execution-surface evidence only. It does not prove:
- statistical validity of performance decisions
- benchmark stability or sample representativeness
- baseline correctness or trustworthiness
- baseline-server production readiness
- mutation test adequacy
- publish readiness

## Next steps

PR 2 will quiet codecov.yml (informational statuses, no comments).
PR 3 will add the Codecov badge to README.

## Validation

- [x] `git diff --check` (no trailing whitespace)
- [x] Removed coverage steps from ci.yml
- [x] Created coverage.yml with proper guards and concurrency
- [x] Coverage runs on `main`, `workflow_dispatch`, and labeled PRs only
- [x] Codecov token check is conditional and upload is non-blocking on PRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQyBN4EJJVVUUxh1KrQ7sq)_