### PR TITLE
ci(codecov): quiet and scope Codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,40 +2,33 @@
 # https://docs.codecov.com/docs/codecov-yaml
 
 coverage:
-  # Coverage status checks
+  precision: 2
+  round: down
+  range: "50...85"
+
   status:
-    # Project-level coverage thresholds
     project:
       default:
-        # Fail if coverage drops below 80% line coverage
-        target: 80%
-        # Allow 1% decrease from base coverage
-        threshold: 1%
-        # Only check against the base commit
-        base: auto
-        # Require CI to pass before reporting
-        if_ci_failed: error
+        target: auto
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-core
 
-    # Patch-level coverage (for new code in PRs)
     patch:
       default:
-        # New code should have at least 70% coverage
         target: 70%
-        # Allow some flexibility for edge cases
-        threshold: 5%
+        threshold: 20%
+        informational: true
+        flags:
+          - rust-core
 
-# Comment configuration for PRs
-comment:
-  # Post coverage report as PR comment
-  layout: "reach,diff,flags,files"
-  # Update existing comment instead of creating new ones
-  behavior: default
-  # Require both project and patch checks to pass
-  require_changes: false
+comment: false
 
-# Ignore certain paths from coverage
+github_checks:
+  annotations: false
+
 ignore:
+  - "target/**"
   - "fuzz/**"
-  - "**/tests/**"
-  - "**/proptest-regressions/**"
-  - "xtask/**"
+  - "crates/perfgate-selfbench/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -18,7 +18,7 @@ coverage:
     patch:
       default:
         target: 70%
-        threshold: 20%
+        threshold: 10%
         informational: true
         flags:
           - rust-core


### PR DESCRIPTION
## Summary

Updates `codecov.yml` to advisory statuses and disables noisy comments. This is **PR 2 of 7** in the perfgate Codecov rollout.

Codecov status checks transition from **blocking** to **informational**, removing noise while real coverage data accumulates on `main`.

## CI economics

- **Default PR LEM impact:** None (depends on PR 1 merge; if merged, slightly faster)
- **Workflow touched:** `codecov.yml` only
- **Branch protection impact:** None (all checks informational, never blocking)
- **Failure mode caught:** Broken codecov.yml syntax (caught by CI)
- **Cheaper signal considered:** Disable Codecov entirely; chose quiet-advisory instead
- **Rollback path:** Restore previous codecov.yml with strict targets and comments enabled

## Changes

| Setting | Before | After | Reason |
|---------|--------|-------|--------|
| Project target | 80% | auto | Informational only |
| Patch target | 70% | 70% | Remains informational |
| Comments | enabled | **disabled** | Reduce noise in PRs |
| Annotations | default | **disabled** | Cleaner UI |
| Ignore paths | fuzz, tests, xtask | target/, selfbench, etc. | Cleaner signals |

## Claim boundary

Codecov is execution-surface evidence only. Configuration changes do not affect claim boundaries.

## Next steps

PR 3 will add the Codecov badge to README.
PR 4 will document the coverage lane in docs/ci/coverage.md.

## Validation

- [x] `codecov.yml` parses with `yaml.safe_load()`
- [x] All status checks are `informational: true`
- [x] Comments and annotations disabled
- [x] `git diff --check` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQyBN4EJJVVUUxh1KrQ7sq)_