### PR TITLE
docs(readme): add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/perfgate-cli.svg)](https://crates.io/crates/perfgate-cli)
 [![ci](https://github.com/EffortlessMetrics/perfgate/actions/workflows/ci.yml/badge.svg)](https://github.com/EffortlessMetrics/perfgate/actions/workflows/ci.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/perfgate/branch/main/graph/badge.svg)](https://codecov.io/gh/EffortlessMetrics/perfgate)
 [![license](https://img.shields.io/crates/l/perfgate-cli.svg)](https://github.com/EffortlessMetrics/perfgate#license)
 
 **Catch performance regressions in CI before they ship.**


### PR DESCRIPTION
## Summary

Adds Codecov coverage badge to the README badge block. This is **PR 3 of 7** in the perfgate Codecov rollout.

Badge placed after the CI badge, before the license badge.

## CI economics

- **Default PR LEM impact:** None (documentation only)
- **Workflow touched:** None
- **Branch protection impact:** None
- **Failure mode caught:** None (static content)
- **Rollback path:** Remove the badge line from README.md

## Claim boundary

Codecov badge is a visibility signal only. Badge presence does not prove coverage adequacy.

## Validation

- [x] `git diff --check` passes
- [x] Badge placed in correct position (after CI, before license)
- [x] URL correct: `https://codecov.io/gh/EffortlessMetrics/perfgate`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQyBN4EJJVVUUxh1KrQ7sq)_