### PR TITLE
docs(ci): document coverage lane

### DIFF
--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -1,0 +1,47 @@
+# Coverage
+
+Codecov coverage is execution-surface evidence.
+
+It answers:
+
+> Did tests execute this Rust surface?
+
+It does not answer:
+
+- whether performance-regression decisions are statistically valid,
+- whether benchmark samples are stable,
+- whether baselines are trustworthy,
+- whether host mismatch detection is correct,
+- whether the baseline server is production-ready,
+- whether mutation adequacy is strong,
+- whether publish readiness is proven.
+
+Those are separate proof lanes.
+
+## Workflow
+
+The Coverage workflow runs on:
+
+- push to `main`,
+- `workflow_dispatch` (manual trigger),
+- PRs labeled `coverage` or `full-ci`.
+
+## Evidence Artifacts
+
+Coverage workflow emits:
+
+- `coverage.json` -- JSON summary of coverage by file and function
+- `coverage.txt` -- Text report of line/branch/function coverage
+- `lcov.info` -- Standard LCOV format for tool integration
+- GitHub Actions artifact `coverage-report` (14-day retention)
+- Codecov dashboard
+
+## Configuration
+
+See `codecov.yml` for Codecov status and reporting settings.
+Current configuration uses informational (non-blocking) checks while real data accumulates on `main`.
+
+## Ratcheting
+
+Once stable main-branch data exists, thresholds will be ratcheted incrementally
+to match actual coverage levels, then improved over time.


### PR DESCRIPTION
## Summary

Adds `docs/ci/coverage.md` explaining the coverage lane purpose, claim boundaries, triggers, and artifacts. This is **PR 4 of 7** in the perfgate Codecov rollout.

## CI economics

- **Default PR LEM impact:** None (documentation only)
- **Workflow touched:** None
- **Branch protection impact:** None
- **Failure mode caught:** None (static content)
- **Rollback path:** Remove docs/ci/coverage.md

## What This Covers

- What coverage evidence answers (execution-surface)
- What it does NOT answer (statistical validity, stability, correctness, readiness)
- Workflow triggers (main, dispatch, labeled PRs)
- Evidence artifacts (coverage.json, coverage.txt, lcov.info)
- Configuration reference (codecov.yml)
- Ratcheting strategy (incremental after real data exists)

## Claim boundary

Documentation clarifies that coverage is execution-surface proof only.

## Validation

- [x] `git diff --check` passes
- [x] File created at correct path: `docs/ci/coverage.md`
- [x] Claim boundaries documented
- [x] Workflow triggers listed
- [x] Evidence artifacts enumerated

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQyBN4EJJVVUUxh1KrQ7sq)_