### PR TITLE
ci(codecov): add coverage receipt artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,6 +94,41 @@ jobs:
           test -s coverage.txt
           test -s lcov.info
 
+      - name: Write coverage receipt
+        if: always()
+        run: |
+          mkdir -p target/coverage
+          python3 - <<'PY'
+          import json
+          import pathlib
+
+          receipt = {
+              "schema_version": 1,
+              "repo": "perfgate",
+              "lane": "coverage",
+              "flag": "rust-core",
+              "workflow": "Coverage",
+              "artifacts": {
+                  "coverage_json": pathlib.Path("coverage.json").exists(),
+                  "coverage_text": pathlib.Path("coverage.txt").exists(),
+                  "lcov": pathlib.Path("lcov.info").exists(),
+              },
+              "claim_boundary": [
+                  "execution_surface_only",
+                  "not_statistical_validity",
+                  "not_benchmark_stability",
+                  "not_baseline_correctness",
+                  "not_baseline_server_readiness",
+                  "not_mutation_adequacy",
+                  "not_publish_readiness"
+              ],
+          }
+
+          pathlib.Path("target/coverage/coverage-receipt.json").write_text(
+              json.dumps(receipt, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PY
       - name: Detect Codecov token
         id: codecov-token
         env:
@@ -134,4 +169,5 @@ jobs:
             coverage.json
             coverage.txt
             lcov.info
+            target/coverage/coverage-receipt.json
           retention-days: 14


### PR DESCRIPTION
## Summary

Adds coverage receipt generation to the coverage workflow. This is **PR 5 of 7** in the perfgate Codecov rollout.

**Note:** This PR depends on PR 1 (extract coverage into coverage.yml). If PR 1 merges first, this can rebase cleanly.

## Receipt Structure

```json
{
  "schema_version": 1,
  "repo": "perfgate",
  "lane": "coverage",
  "flag": "rust-core",
  "workflow": "Coverage",
  "artifacts": {
    "coverage_json": true,
    "coverage_text": true,
    "lcov": true
  },
  "claim_boundary": [
    "execution_surface_only",
    "not_statistical_validity",
    "not_benchmark_stability",
    "not_baseline_correctness",
    "not_baseline_server_readiness",
    "not_mutation_adequacy",
    "not_publish_readiness"
  ]
}
```

## CI economics

- **Default PR LEM impact:** ~5 seconds (JSON write)
- **Workflow touched:** `.github/workflows/coverage.yml`
- **Branch protection impact:** None
- **Failure mode caught:** Missing coverage output detected in receipt check
- **Cheaper signal considered:** Inline artifact check; chose durable receipt instead
- **Rollback path:** Remove receipt generation and upload steps from coverage.yml

## Artifacts

Receipt is uploaded as part of the GitHub Actions `coverage-report` artifact alongside coverage.json, coverage.txt, and lcov.info.

## Validation

- [x] `coverage.yml` parses with `yaml.safe_load()`
- [x] Receipt Python script is valid
- [x] Receipt uploaded to GitHub Actions artifact
- [x] `git diff --check` passes
- [x] Claim boundaries enumerated in receipt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TQyBN4EJJVVUUxh1KrQ7sq)_