### PR TITLE
ci(coverage): exclude cucumber harness from nextest

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,7 +86,7 @@ jobs:
 
           cargo llvm-cov report --json --output-path coverage.json
           cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov report --text | tee coverage.txt
+          cargo llvm-cov report --text --output-path coverage.txt
 
       - name: Validate coverage output
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,7 +89,6 @@ jobs:
             --locked \
             --all-features \
             --no-run \
-            --no-clean \
             --json \
             --output-path coverage.json
 
@@ -99,7 +98,6 @@ jobs:
             --locked \
             --all-features \
             --no-run \
-            --no-clean \
             --lcov \
             --output-path lcov.info
 
@@ -109,7 +107,6 @@ jobs:
             --locked \
             --all-features \
             --no-run \
-            --no-clean \
             --summary-only \
             | tee coverage.txt
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,9 +83,35 @@ jobs:
             --all-features \
             --no-report
 
-          cargo llvm-cov report --json --output-path coverage.json
-          cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov report --summary-only | tee coverage.txt
+          cargo llvm-cov \
+            --workspace \
+            --exclude perfgate-tests \
+            --locked \
+            --all-features \
+            --no-run \
+            --no-clean \
+            --json \
+            --output-path coverage.json
+
+          cargo llvm-cov \
+            --workspace \
+            --exclude perfgate-tests \
+            --locked \
+            --all-features \
+            --no-run \
+            --no-clean \
+            --lcov \
+            --output-path lcov.info
+
+          cargo llvm-cov \
+            --workspace \
+            --exclude perfgate-tests \
+            --locked \
+            --all-features \
+            --no-run \
+            --no-clean \
+            --summary-only \
+            | tee coverage.txt
 
       - name: Validate coverage output
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,7 +86,7 @@ jobs:
 
           cargo llvm-cov report --json --output-path coverage.json
           cargo llvm-cov report --lcov --output-path lcov.info
-          cargo llvm-cov report --text --output-path coverage.txt
+          cargo llvm-cov report --summary-only | tee coverage.txt
 
       - name: Validate coverage output
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,6 +79,7 @@ jobs:
 
           cargo llvm-cov nextest \
             --workspace \
+            --exclude perfgate-tests \
             --locked \
             --all-features \
             --no-report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,7 +34,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
-  RUSTFLAGS: "-C debuginfo=0"
 
 jobs:
   coverage:

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -41,6 +41,11 @@ Coverage workflow emits:
 See `codecov.yml` for Codecov status and reporting settings.
 Current configuration uses informational (non-blocking) checks while real data accumulates on `main`.
 
+The coverage command uses `cargo llvm-cov nextest` for libtest-compatible
+workspace packages and excludes the root `perfgate-tests` package. That package
+owns the `harness = false` Cucumber/BDD test binary, which normal CI runs
+directly because nextest cannot enumerate it.
+
 ## Ratcheting
 
 Once stable main-branch data exists, thresholds will be ratcheted incrementally

--- a/docs/ci/coverage.md
+++ b/docs/ci/coverage.md
@@ -31,7 +31,7 @@ The Coverage workflow runs on:
 Coverage workflow emits:
 
 - `coverage.json` -- JSON summary of coverage by file and function
-- `coverage.txt` -- Text report of line/branch/function coverage
+- `coverage.txt` -- Text coverage summary
 - `lcov.info` -- Standard LCOV format for tool integration
 - GitHub Actions artifact `coverage-report` (14-day retention)
 - Codecov dashboard


### PR DESCRIPTION
## Summary
- exclude the root `perfgate-tests` package from the `cargo llvm-cov nextest` coverage command
- emit reports through the same workspace package set used for the coverage test run
- emit `coverage.txt` as a non-empty summary text artifact
- document that the Cucumber/BDD `harness = false` package is still run by normal CI, because nextest cannot enumerate it

## Why
Latest `main` failed in the Codecov Coverage workflow when nextest tried to list `perfgate-tests::cucumber` with `--list --format terse`; the Cucumber runner rejects `--list`.

Hosted reruns on this PR proved the exclusion works: nextest built and ran 1506 tests successfully. They also exposed two coverage-lane artifact bugs: the `cargo llvm-cov report` subcommand was reporting the root package context instead of the workspace package set, and the text artifact should use the stable summary form.

## Validation
- `git diff --check`
- `CARGO_TARGET_DIR=E:\codex-target\perfgate-coverage-fix\docs-check cargo run -p xtask -- docs-check`
- downloaded hosted coverage artifact from run `25528040531` and confirmed the old report path produced empty LCOV/zero-summary output
- hosted run `25528669406` confirmed `--no-run --no-clean` is not supported by the installed cargo-llvm-cov, so the workflow now uses supported `--no-run` report generation

The full local nextest coverage reproduction was not completed on this Windows machine because the prior cold compile timed out and the repo drive ran out of space. This PR relies on the hosted Coverage workflow to prove the exact Linux lane.