### PR TITLE
docs: compress README around paved-road setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,46 @@
 
 **Catch performance regressions in CI before they ship.**
 
-> Your CI is green. But is it *fast*? Someone adds a dependency, tweaks an
-> allocator, or refactors a hot path -- and the service quietly gets 15% slower.
-> Nobody notices until users complain. perfgate runs your benchmarks, compares
-> against baselines, applies statistical significance testing, and fails the
-> build when things get slower.
+perfgate runs benchmarks, compares the current run against explicit baselines and
+budgets, writes versioned receipts/reports, and exits nonzero only when the
+configured policy says the build should stop.
 
-```
-perfgate: warn
+## Install
 
-Bench: pst_extract
+Use the binary installer path first:
 
-| metric    | baseline | current  | delta   | budget | status |
-|-----------|----------|----------|---------|--------|--------|
-| wall_ms   | 793 ms   | 892 ms   | +12.48% | 15.0%  | pass   |
-| cpu_ms    | 31 ms    | 35 ms    | +12.90% | 20.0%  | pass   |
-| max_rss_kb| 8220 KB  | 8220 KB  | 0.00%   | 20.0%  | pass   |
-
-Notes:
-- wall_ms: +12.48% (warn >= 10.00%, fail > 15.00%)
+```bash
+cargo binstall perfgate-cli
 ```
 
-## Quick Start
+Or install from source:
 
-**1. Initialize** -- discover benchmarks and write the CI scaffold:
+```bash
+cargo install perfgate-cli
+```
+
+Prebuilt archives are published on
+[GitHub Releases](https://github.com/EffortlessMetrics/perfgate/releases) for
+Linux, macOS, and Windows. Verify the binary with:
+
+```bash
+perfgate --version
+perfgate doctor --help
+```
+
+## Start Here
+
+From a repository with benchmark commands:
 
 ```bash
 perfgate init --ci github --profile standard
+perfgate doctor --config perfgate.toml
+perfgate check --config perfgate.toml --all
+perfgate baseline promote --config perfgate.toml --all
+git add perfgate.toml .github/workflows/perfgate.yml baselines/ .perfgate/
 ```
 
-This creates:
+`perfgate init --ci github --profile standard` creates:
 
 ```text
 perfgate.toml
@@ -45,7 +55,8 @@ baselines/.gitkeep
 .perfgate/README.md
 ```
 
-**2. Review** -- the generated `perfgate.toml` is the local source of truth:
+The generated config defaults to local checked-in baselines and predictable
+artifacts:
 
 ```toml
 [defaults]
@@ -63,26 +74,7 @@ name = "my-service"
 command = ["./target/release/my-bench"]
 ```
 
-**3. Run** -- check locally or in CI:
-
-```bash
-perfgate check --config perfgate.toml --all
-```
-
-Optional diagnostics for regressing benches:
-
-```bash
-perfgate check --config perfgate.toml --bench my-service --profile-on-regression
-```
-
-**4. Promote** -- create the first trusted local baseline:
-
-```bash
-perfgate baseline status --config perfgate.toml
-perfgate baseline promote --config perfgate.toml --all
-```
-
-**5. Gate** -- the generated GitHub Actions workflow uses:
+The generated GitHub workflow uses the repository action:
 
 ```yaml
 - uses: EffortlessMetrics/perfgate@v0
@@ -90,176 +82,132 @@ perfgate baseline promote --config perfgate.toml --all
     config: perfgate.toml
     all: "true"
     require_baseline: "true"
+    upload_artifact: "true"
 ```
 
-Pin `@v0.15.1` for an exact patch release, or use `@v0.15` / `@v0` to follow
-the current compatible action tag.
+Use `@v0.15.1` for an exact patch pin, or `@v0.15` / `@v0` to follow the
+current compatible action tag.
 
-Exit code `2` = budget violated. That's it.
+## Daily Use
 
-## Install
-
-**Pre-built binaries** (fastest):
+Run the whole configured suite:
 
 ```bash
-# Download from GitHub Releases (Linux x86_64 example)
-curl -fsSL https://github.com/EffortlessMetrics/perfgate/releases/latest/download/perfgate-x86_64-unknown-linux-gnu.tar.gz \
-  | tar xz -C /usr/local/bin
+perfgate check --config perfgate.toml --all
 ```
 
-Available targets: `x86_64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`,
-`aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`,
-`x86_64-pc-windows-msvc`.
-
-**Via cargo-binstall** (auto-detects platform):
+Inspect local baseline state:
 
 ```bash
-cargo binstall perfgate-cli
+perfgate baseline status --config perfgate.toml
 ```
 
-**From source**:
+Promote a trusted current run into local baselines:
 
 ```bash
-cargo install perfgate-cli
+perfgate baseline promote --config perfgate.toml --all
 ```
 
-Verify the local install and project setup:
+Diagnose setup or path issues:
 
 ```bash
-perfgate doctor
+perfgate doctor --config perfgate.toml
 ```
+
+Exit codes are stable: `0` pass, `1` tool/runtime error, `2` budget fail, and
+`3` warn treated as failure with `--fail-on-warn`.
+
+## Artifacts
+
+`check --bench <name>` writes:
+
+```text
+artifacts/perfgate/
+  run.json
+  compare.json  # when a baseline exists
+  report.json
+  comment.md
+```
+
+`check --all` writes per-benchmark subdirectories, even when the config only has
+one benchmark:
+
+```text
+artifacts/perfgate/<bench>/
+  run.json
+  compare.json  # when a baseline exists
+  report.json
+  comment.md
+```
+
+`run.json`, `compare.json`, and `report.json` are versioned machine-readable
+receipts. `compare.json` is omitted while bootstrapping without a baseline. See
+[Artifact Layouts](docs/ARTIFACTS.md) and [Output Schemas](docs/SCHEMAS.md) for
+the contract details.
 
 ## What Gets Measured
 
-| Metric | Description | Unix | Windows |
-|--------|-------------|:----:|:-------:|
-| `wall_ms` | Wall-clock time (median) | yes | yes |
-| `cpu_ms` | User + system CPU time | yes | yes |
-| `max_rss_kb` | Peak resident set size | yes | yes |
-| `page_faults` | Major page faults | yes | -- |
-| `ctx_switches` | Context switches | yes | -- |
-| `binary_bytes` | Executable size | yes | yes |
-| `throughput_per_s` | Ops/sec (with `--work`) | yes | yes |
+| Metric | Description |
+| ------ | ----------- |
+| `wall_ms` | Wall-clock time |
+| `cpu_ms` | User + system CPU time |
+| `max_rss_kb` | Peak resident set size |
+| `page_faults` | Major page faults where available |
+| `ctx_switches` | Context switches where available |
+| `binary_bytes` | Executable size |
+| `throughput_per_s` | Ops/sec with `--work` |
 
-Comparisons use [Welch's t-test](https://en.wikipedia.org/wiki/Welch%27s_t-test)
-with configurable alpha. Add `--require-significance` to suppress verdicts when
-sample sizes are too small to be conclusive.
-
-## Features
-
-**Core Pipeline**
-- Three-stage **run -> compare -> verdict** pipeline with versioned JSON receipts
-- Config-driven `check` command runs the full pipeline from `perfgate.toml`
-- Baselines stored in-repo, cloud storage (`s3://`, `gs://`), or the optional baseline server
-- Bundled [presets](presets/) for standard, release, and fast-feedback workflows
-
-**Statistical Analysis**
-- Welch's t-test with configurable alpha and confidence intervals
-- Paired benchmarking for noisy CI environments with significance-based retries
-- Noise detection (CV-based) with configurable escalation policy
-- Per-metric statistic selection (median, p95, etc.)
-- Scaling validation with best-fit complexity classification via `perfgate scale`
-
-**Diagnostics**
-- `bisect` -- find the exact commit that introduced a regression
-- `blame` -- map regressions to `Cargo.lock` dependency changes
-- `explain` -- generate AI-ready regression diagnostics for PR comments
-- Optional flamegraph capture on warn/fail regressions via `--profile-on-regression`
-- Trend analysis and predictive budget alerts for drifting benchmarks
-
-## Advanced Workflows
-
-Validate computational complexity for a benchmark command:
-
-```bash
-perfgate scale --name parser --command "./target/release/parser-bench --size {n}" --sizes 100,1000,10000 --expected "O(n)"
-```
-
-Post or update a PR comment from a compare receipt:
-
-```bash
-perfgate comment --compare artifacts/perfgate/compare.json --repo owner/repo --pr 123
-```
-
-**CI Integration**
-- GitHub Actions, GitLab CI support with native annotations
-- Multi-format export: CSV, JSONL, HTML, Prometheus, JUnit
-- Cockpit mode for dashboard integration via `sensor.report.v1`
-- Fleet aggregation: merge results from distributed runners
-
-**Baseline Server**
-- REST API (Axum) with SQLite, PostgreSQL, or S3/GCS/Azure storage
-- Role-based access with API keys and GitHub Actions OIDC
-- Verdict history tracking and web dashboard (alpha)
-
-## Commands
-
-| Command | Description |
-|---------|-------------|
-| **`check`** | **Config-driven workflow (start here)** |
-| `doctor` | Diagnose config, benchmark commands, baselines, artifacts, CI, and server reachability |
-| `run` | Execute a benchmark, emit a run receipt |
-| `compare` | Compare a run against a baseline |
-| `diff` | Run a quick local regression check against discovered config/baselines |
-| `paired` | Interleaved A/B benchmarking for noisy environments |
-| `promote` | Promote a run to become the new baseline |
-| `md` | Render a comparison as Markdown |
-| `report` | Generate a cockpit-compatible report |
-| `export` | Export to CSV, JSONL, HTML, Prometheus, or JUnit |
-| `cargo-bench` | Wrap `cargo bench` and emit perfgate receipts |
-| `ingest` | Import external benchmark results into perfgate format |
-| `badge` | Generate SVG status, metric, or trend badges |
-| `discover` | Scan a repo for benchmarks and print detected targets |
-| `init` | Generate `perfgate.toml` and optional CI scaffolding |
-| `watch` | Re-run a benchmark on file changes with live deltas |
-| `serve` | Start the local dashboard/baseline server |
-| `scale` | Validate complexity scaling across input sizes |
-| `comment` | Post or update a GitHub PR performance comment |
-| `trend` | Analyze metric drift and predict threshold breaches |
-| `baseline` | Inspect local baselines and manage server baselines |
-| `fleet` | Analyze dependency regressions across projects |
-| `summary` | Summarize multiple comparisons in a table |
-| `aggregate` | Evaluate fleet/matrix receipts into `perfgate.aggregate.v1` |
-| `bisect` | Find the commit that introduced a regression |
-| `blame` | Map regressions to Cargo.lock dependency changes |
-| `explain` | Generate AI-ready regression diagnostics |
-
-Exit codes: `0` pass, `1` error, `2` fail, `3` warn (with `--fail-on-warn`).
+perfgate supports local baselines, cloud paths, and the optional baseline
+server, but local in-repo baselines are the default first setup.
 
 ## Documentation
 
-**Tutorials** -- get started step by step:
+Start with:
+
 - [GitHub Actions](docs/GETTING_STARTED_GITHUB_ACTIONS.md)
-- [GitLab CI](docs/GETTING_STARTED_GITLAB_CI.md)
-- [Bitbucket Pipelines](docs/GETTING_STARTED_BITBUCKET.md)
-- [CircleCI](docs/GETTING_STARTED_CIRCLECI.md)
+- [Configuration](docs/CONFIG.md)
+- [Artifact Layouts](docs/ARTIFACTS.md)
+- [Debugging the First CI Run](docs/DEBUGGING_FIRST_CI_RUN.md)
+- [Failure Playbook](docs/FAILURE_PLAYBOOK.md)
+
+For specific workflows:
+
+- [Step-by-Step Pipeline](docs/PIPELINE.md)
 - [Baseline Server](docs/GETTING_STARTED_BASELINE_SERVER.md)
-- [Step-by-Step Pipeline](docs/PIPELINE.md) -- manual run/compare/promote workflow
+- [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md)
+- [Flakiness History](docs/FLAKINESS.md)
+- [Fleet Aggregation](docs/FLEET_AGGREGATION.md)
+- [Cockpit Integration](docs/COCKPIT_MODE.md)
+- [Exporting Data](docs/EXPORT.md)
+- [Host Mismatch Detection](docs/HOST_MISMATCH.md)
 
-**How-To Guides** -- solve specific problems:
-- [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md) -- reduce noise in flaky CI
-- [Flakiness History](docs/FLAKINESS.md) -- interpret historical benchmark noise
-- [Fleet Aggregation](docs/FLEET_AGGREGATION.md) -- combine matrix or fleet receipts into one gate
-- [Cockpit Integration](docs/COCKPIT_MODE.md) -- dashboard integration via sensor.report.v1
-- [Exporting Data](docs/EXPORT.md) -- CSV, JSONL, HTML, Prometheus, JUnit
-- [Host Mismatch Detection](docs/HOST_MISMATCH.md) -- comparing across different hardware
-- [Baseline Server Admin](docs/BASELINE_SERVICE_DESIGN.md)
-- [Failure Playbook](docs/FAILURE_PLAYBOOK.md) -- diagnosing and fixing regressions
+For project contracts and internals:
 
-**Reference**:
-- [Configuration](docs/CONFIG.md) -- `perfgate.toml` options and per-metric budgets
-- [Output Schemas](docs/SCHEMAS.md) -- perfgate.run.v1, compare.v1, report.v1, sensor.report.v1
-- [Artifact Layouts](docs/ARTIFACTS.md) -- standard and cockpit mode output structure
-- [Architecture](docs/ARCHITECTURE.md) -- public crate surface and clean-architecture layers
-- [ADRs](docs/adrs/) -- architectural decision records
+- [Output Schemas](docs/SCHEMAS.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Public Crate Seams](docs/CRATE_SEAMS.md)
+- [Release Readiness](docs/RELEASE_READINESS.md)
 
-**Explanation**:
-- [Design Philosophy](docs/DESIGN.md) -- why perfgate works the way it does
-- [Self-Dogfooding](docs/SELF_DOGFOODING.md) -- how perfgate gates its own performance
+## Public Crates
+
+The intended public package surface is:
+
+```text
+perfgate
+perfgate-cli
+perfgate-types
+perfgate-client
+perfgate-server
+```
+
+Internal seams live behind modules and private compatibility wrappers. The
+workspace enforces this with `cargo run -p xtask -- public-surface --strict` and
+`cargo run -p xtask -- arch`.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and repo automation.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and repo
+automation.
 
 ## License
 

--- a/docs/DEBUGGING_FIRST_CI_RUN.md
+++ b/docs/DEBUGGING_FIRST_CI_RUN.md
@@ -1,0 +1,91 @@
+# Debugging the First CI Run
+
+This guide covers the first run after `perfgate init --ci github --profile standard`.
+
+## Start Locally
+
+Run the same config locally before reading CI logs:
+
+```bash
+perfgate check --config perfgate.toml --all
+perfgate baseline status --config perfgate.toml
+```
+
+If the check created a trusted first run, promote it into local baselines:
+
+```bash
+perfgate baseline promote --config perfgate.toml --all
+```
+
+Commit the generated baselines before expecting the generated GitHub workflow to
+pass with `require_baseline: "true"`.
+
+## Missing Baseline
+
+The generated workflow requires baselines by default. That is intentional: a CI
+gate should not silently pass without a comparison point.
+
+If CI reports a missing baseline:
+
+```bash
+perfgate check --config perfgate.toml --all
+perfgate baseline promote --config perfgate.toml --all
+```
+
+Then commit `baselines/` and rerun CI.
+
+## Artifact Paths
+
+The generated config writes artifacts under `artifacts/perfgate`.
+
+For `check --bench <name>`:
+
+```text
+artifacts/perfgate/
+  run.json
+  compare.json  # when a baseline exists
+  report.json
+  comment.md
+```
+
+For `check --all`, even when the config only has one benchmark:
+
+```text
+artifacts/perfgate/<bench>/
+  run.json
+  compare.json  # when a baseline exists
+  report.json
+  comment.md
+```
+
+If no baseline exists yet, inspect `run.json`, `report.json`, and `comment.md`.
+`compare.json` is written only when there is a baseline to compare against.
+
+## Exit Codes
+
+`perfgate` uses exit codes to separate tool failures from performance policy:
+
+- `1`: tool or runtime error, such as config, I/O, parse, or command failure
+- `2`: budget policy failed
+- `3`: warning was treated as failure with `--fail-on-warn`
+
+For setup failures, run:
+
+```bash
+perfgate doctor --config perfgate.toml
+```
+
+For budget failures, reproduce the specific benchmark locally:
+
+```bash
+perfgate check --config perfgate.toml --bench parser
+```
+
+Then inspect the matching artifact directory.
+
+## Next References
+
+- [GitHub Actions](GETTING_STARTED_GITHUB_ACTIONS.md)
+- [Artifact Layouts](ARTIFACTS.md)
+- [Configuration](CONFIG.md)
+- [Failure Playbook](FAILURE_PLAYBOOK.md)


### PR DESCRIPTION
## Summary
- compress the README around the install -> init -> doctor -> check -> baseline path
- clarify config-owned artifact defaults and `check --bench` vs `check --all` artifact layouts
- add a focused first-CI debugging guide for missing baselines, artifacts, and exit codes

## Validation
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test --files docs/DEBUGGING_FIRST_CI_RUN.md`
- `cargo run -p xtask -- action-check`
- `git diff --check`