### PR TITLE
xtask: include first-ci guide in doc-test

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2969,6 +2969,7 @@ fn default_doc_files() -> anyhow::Result<Vec<PathBuf>> {
     for name in [
         "README.md",
         "docs/CONFIG.md",
+        "docs/DEBUGGING_FIRST_CI_RUN.md",
         "docs/FLAKINESS.md",
         "docs/FLEET_AGGREGATION.md",
         "docs/PAIRED_BENCHMARKING.md",


### PR DESCRIPTION
## Summary
- add `docs/DEBUGGING_FIRST_CI_RUN.md` to the default `xtask doc-test` scan set
- ensures the new first-CI troubleshooting guide is validated without requiring an explicit `--files` argument

## Validation
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- doc-test`
- `git diff --check`