### PR TITLE
ci: build selfbench explicitly for dogfood lanes

### DIFF
--- a/.github/workflows/perfgate-nightly.yml
+++ b/.github/workflows/perfgate-nightly.yml
@@ -55,6 +55,7 @@ jobs:
           cat artifacts/trends/variance-summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Create or update baseline PR
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/perfgate-nightly.yml
+++ b/.github/workflows/perfgate-nightly.yml
@@ -20,7 +20,11 @@ jobs:
           toolchain: 1.93.0
 
       - name: Build release binaries
-        run: cargo build --release -p perfgate-cli --bin perfgate -p perfgate-selfbench
+        run: |
+          cargo build --release -p perfgate-cli --bin perfgate
+          cargo build --release -p perfgate-selfbench
+          ./target/release/perfgate --version
+          ./target/release/perfgate-selfbench noop
 
       - name: Make scripts executable
         run: chmod +x .ci/perf/*.sh

--- a/.github/workflows/perfgate-self.yml
+++ b/.github/workflows/perfgate-self.yml
@@ -43,7 +43,11 @@ jobs:
         with:
           toolchain: 1.93.0
       - name: Build release binaries
-        run: cargo build --release -p perfgate-cli --bin perfgate -p perfgate-selfbench
+        run: |
+          cargo build --release -p perfgate-cli --bin perfgate
+          cargo build --release -p perfgate-selfbench
+          ./target/release/perfgate --version
+          ./target/release/perfgate-selfbench noop
       - name: Make scripts executable
         run: chmod +x .ci/perf/*.sh
       - name: Run dogfooding


### PR DESCRIPTION
## Summary
- split the dogfood release build into separate `perfgate` and `perfgate-selfbench` builds
- smoke-test both release binaries before calibration starts
- apply the same build guard to the PR self-dogfood perf lane
- restrict the baseline-update step to `main` so branch-dispatched nightly validation cannot mutate the baseline bot branch

## Why
The scheduled nightly failed in `cargo run -p xtask -- dogfood promote` because the nested check receipt tried to run `./target/release/perfgate-selfbench` and captured `No such file or directory`. The combined build command used `--bin perfgate` while also selecting `perfgate-selfbench`, which can leave the selfbench binary unbuilt. This makes the dependency explicit and fails early if either binary is missing.

The `main` guard keeps manual branch dispatches useful for validation without letting them create or auto-merge baseline refresh PRs.

## Validation
- `CARGO_TARGET_DIR=E:\codex-target\perfgate-nightly-selfbench cargo build --release -p perfgate-selfbench`
- `E:\codex-target\perfgate-nightly-selfbench\release\perfgate-selfbench.exe noop`
- `git diff --check`

Hosted validation in progress:
- PR `perfgate-self` lane
- manual `perfgate-nightly` dispatch on this branch: https://github.com/EffortlessMetrics/perfgate/actions/runs/25537203924