### PR TITLE
cli: add audit event visibility

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -31,9 +31,9 @@ use perfgate_app::{
 use perfgate_client::types::auth::Role;
 use perfgate_client::types::{BaselineRecord, CreateKeyRequest, KeyEntry};
 use perfgate_client::{
-    AuthMethod, BaselineClient, ClientConfig, ListBaselinesQuery, ListVerdictsQuery,
-    ResolvedServerConfig, RetryConfig, SubmitVerdictRequest, UploadBaselineRequest,
-    resolve_server_config,
+    AuthMethod, BaselineClient, ClientConfig, ListAuditEventsQuery, ListAuditEventsResponse,
+    ListBaselinesQuery, ListVerdictsQuery, ResolvedServerConfig, RetryConfig, SubmitVerdictRequest,
+    UploadBaselineRequest, resolve_server_config,
 };
 use perfgate_domain::scaling::{
     ScalingReport, SizeMeasurement, classify_complexity, parse_complexity, render_ascii_chart,
@@ -268,6 +268,12 @@ enum Command {
     Admin {
         #[command(subcommand)]
         action: AdminAction,
+    },
+
+    /// List and export baseline service audit events.
+    Audit {
+        #[command(subcommand)]
+        action: AuditActionCli,
     },
 
     /// Summarize one or more compare receipts in a terminal table.
@@ -1375,6 +1381,96 @@ enum KeyAction {
     Rotate {
         /// Key ID to rotate.
         key_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum AuditActionFilter {
+    Create,
+    Update,
+    Delete,
+    Promote,
+}
+
+impl AuditActionFilter {
+    fn as_wire(self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Update => "update",
+            Self::Delete => "delete",
+            Self::Promote => "promote",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum AuditResourceFilter {
+    Baseline,
+    Key,
+    Verdict,
+}
+
+impl AuditResourceFilter {
+    fn as_wire(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline",
+            Self::Key => "key",
+            Self::Verdict => "verdict",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum AuditExportFormat {
+    Jsonl,
+    Json,
+}
+
+/// Common filters for baseline service audit queries.
+#[derive(Debug, Clone, Args)]
+struct AuditQueryArgs {
+    /// Filter by project. Defaults to --project or PERFGATE_PROJECT when set.
+    #[arg(long)]
+    project: Option<String>,
+
+    /// Filter by action.
+    #[arg(long)]
+    action: Option<AuditActionFilter>,
+
+    /// Filter by affected resource type.
+    #[arg(long)]
+    resource_type: Option<AuditResourceFilter>,
+
+    /// Filter by actor identity, such as an API key ID or OIDC subject.
+    #[arg(long)]
+    actor: Option<String>,
+
+    /// Maximum number of events to return.
+    #[arg(long, default_value_t = 50)]
+    limit: u32,
+
+    /// Pagination offset.
+    #[arg(long, default_value_t = 0)]
+    offset: u64,
+}
+
+/// Subcommands for baseline service audit visibility.
+#[derive(Debug, Subcommand)]
+enum AuditActionCli {
+    /// List audit events in a terminal table.
+    List {
+        #[command(flatten)]
+        query: AuditQueryArgs,
+    },
+
+    /// Export audit events as JSONL or JSON.
+    Export {
+        #[command(flatten)]
+        query: AuditQueryArgs,
+
+        /// Output format.
+        #[arg(long, default_value = "jsonl")]
+        format: AuditExportFormat,
     },
 }
 
@@ -2769,6 +2865,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
         Command::Admin { action } => execute_admin_action(action, &server_flags),
 
+        Command::Audit { action } => execute_audit_action(action, &server_flags),
+
         Command::Fleet { action } => execute_fleet_action(action, &server_flags),
 
         Command::Summary {
@@ -4030,6 +4128,95 @@ fn print_key_table(keys: &[KeyEntry]) {
             key.created_at.to_rfc3339(),
             expires_at,
             key.description
+        );
+    }
+}
+
+fn build_audit_query(
+    args: AuditQueryArgs,
+    server_config: &ResolvedServerConfig,
+) -> ListAuditEventsQuery {
+    ListAuditEventsQuery {
+        project: args.project.or_else(|| server_config.project.clone()),
+        action: args.action.map(|action| action.as_wire().to_string()),
+        resource_type: args
+            .resource_type
+            .map(|resource_type| resource_type.as_wire().to_string()),
+        actor: args.actor,
+        limit: args.limit,
+        offset: args.offset,
+        ..ListAuditEventsQuery::default()
+    }
+}
+
+fn execute_audit_action(action: AuditActionCli, server_flags: &ServerFlags) -> anyhow::Result<()> {
+    let (server_config, _config_file) = resolve_server_config_from_path(server_flags, None)?;
+    let client = server_config.require_fallback_client(None, BASELINE_SERVER_NOT_CONFIGURED)?;
+    let rt = tokio::runtime::Runtime::new()?;
+
+    match action {
+        AuditActionCli::List { query } => {
+            let query = build_audit_query(query, &server_config);
+
+            rt.block_on(async {
+                let response = client
+                    .list_audit_events(&query)
+                    .await
+                    .context("Failed to list audit events")?;
+                print_audit_table(&response);
+                Ok::<(), anyhow::Error>(())
+            })?
+        }
+        AuditActionCli::Export { query, format } => {
+            let query = build_audit_query(query, &server_config);
+
+            rt.block_on(async {
+                let response = client
+                    .list_audit_events(&query)
+                    .await
+                    .context("Failed to export audit events")?;
+
+                match format {
+                    AuditExportFormat::Jsonl => {
+                        for event in &response.events {
+                            println!("{}", serde_json::to_string(event)?);
+                        }
+                    }
+                    AuditExportFormat::Json => {
+                        println!("{}", serde_json::to_string_pretty(&response)?);
+                    }
+                }
+
+                Ok::<(), anyhow::Error>(())
+            })?
+        }
+    }
+
+    Ok(())
+}
+
+fn print_audit_table(response: &ListAuditEventsResponse) {
+    if response.events.is_empty() {
+        println!("No audit events found.");
+        return;
+    }
+
+    println!(
+        "Audit events ({} of {}):",
+        response.events.len(),
+        response.pagination.total
+    );
+    println!("id\ttimestamp\taction\tresource\tresource_id\tproject\tactor");
+    for event in &response.events {
+        println!(
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            event.id,
+            event.timestamp.to_rfc3339(),
+            event.action,
+            event.resource_type,
+            event.resource_id,
+            event.project,
+            event.actor
         );
     }
 }

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -23,6 +23,7 @@ fn cli_help_main() {
         .stdout(predicate::str::contains("check"))
         .stdout(predicate::str::contains("doctor"))
         .stdout(predicate::str::contains("paired"))
+        .stdout(predicate::str::contains("audit"))
         .stdout(predicate::str::contains("md"))
         .stdout(predicate::str::contains("export"))
         .stdout(predicate::str::contains("promote"))
@@ -140,6 +141,17 @@ fn cli_help_baseline() {
         .stdout(predicate::str::contains("promote"))
         .stdout(predicate::str::contains("list"))
         .stdout(predicate::str::contains("download"));
+}
+
+#[test]
+fn cli_help_audit() {
+    perfgate_cmd()
+        .args(["audit", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("List and export"))
+        .stdout(predicate::str::contains("list"))
+        .stdout(predicate::str::contains("export"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -4,7 +4,7 @@ use perfgate_types::{BASELINE_SCHEMA_V1, RUN_SCHEMA_V1};
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
-use wiremock::matchers::{header, method, path};
+use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
@@ -123,6 +123,25 @@ fn key_entry(id: &str, project: &str, revoked: bool) -> serde_json::Value {
         } else {
             serde_json::Value::Null
         }
+    })
+}
+
+fn audit_event(
+    id: &str,
+    project: &str,
+    action: &str,
+    resource_type: &str,
+    resource_id: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "timestamp": "2026-01-01T00:00:00Z",
+        "actor": "key-admin",
+        "action": action,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "project": project,
+        "metadata": {"benchmark": "parser"}
     })
 }
 
@@ -335,6 +354,125 @@ async fn test_admin_keys_rotate_with_mock_server() {
         .stderr(predicate::str::contains(
             "Rotated API key key-old -> key-new",
         ));
+}
+
+#[tokio::test]
+async fn test_audit_list_with_mock_server() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/audit"))
+        .and(header("Authorization", "Bearer admin-key"))
+        .and(query_param("project", "my-project"))
+        .and(query_param("action", "create"))
+        .and(query_param("resource_type", "baseline"))
+        .and(query_param("limit", "25"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "events": [
+                audit_event("audit-1", "my-project", "create", "baseline", "bl-1")
+            ],
+            "pagination": {
+                "limit": 25,
+                "offset": 0,
+                "total": 1,
+                "has_more": false
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("admin-key")
+        .arg("audit")
+        .arg("list")
+        .arg("--project")
+        .arg("my-project")
+        .arg("--action")
+        .arg("create")
+        .arg("--resource-type")
+        .arg("baseline")
+        .arg("--limit")
+        .arg("25");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Audit events (1 of 1):"))
+        .stdout(predicate::str::contains("audit-1"))
+        .stdout(predicate::str::contains("my-project"))
+        .stdout(predicate::str::contains("key-admin"));
+}
+
+#[tokio::test]
+async fn test_audit_export_jsonl_with_mock_server() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/audit"))
+        .and(header("Authorization", "Bearer admin-key"))
+        .and(query_param("project", "my-project"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "events": [
+                audit_event("audit-1", "my-project", "promote", "baseline", "bl-1"),
+                audit_event("audit-2", "my-project", "delete", "key", "key-1")
+            ],
+            "pagination": {
+                "limit": 50,
+                "offset": 0,
+                "total": 2,
+                "has_more": false
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("admin-key")
+        .arg("audit")
+        .arg("export")
+        .arg("--project")
+        .arg("my-project")
+        .arg("--format")
+        .arg("jsonl");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("\"id\":\"audit-1\""))
+        .stdout(predicate::str::contains("\"action\":\"promote\""))
+        .stdout(predicate::str::contains("\"id\":\"audit-2\""))
+        .stdout(predicate::str::contains("\"resource_type\":\"key\""));
+}
+
+#[tokio::test]
+async fn test_audit_list_reports_authorization_failure() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/audit"))
+        .and(header("Authorization", "Bearer viewer-key"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "error": "forbidden",
+            "message": "admin scope is required"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("viewer-key")
+        .arg("audit")
+        .arg("list");
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Failed to list audit events"));
 }
 
 #[tokio::test]

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 280
+assertion_line: 294
 expression: "help_output(&[\"--help\"])"
 ---
 Perf budgets and baseline diffs for CI / PR bots
@@ -21,6 +21,7 @@ Commands:
   paired Run paired benchmark: interleave baseline and current commands for reduced noise
   baseline Inspect local baselines and manage baselines on the baseline server
   admin Administer baseline service operations
+  audit List and export baseline service audit events
   summary Summarize one or more compare receipts in a terminal table
   aggregate Aggregate multiple run receipts (e.g. from a fleet) into a formal aggregate receipt
   bisect Automatically find the commit that introduced a performance regression

--- a/crates/perfgate-client/src/client.rs
+++ b/crates/perfgate-client/src/client.rs
@@ -349,6 +349,41 @@ impl BaselineClient {
         .await
     }
 
+    /// Lists audit events. Requires an admin API key on authenticated servers.
+    pub async fn list_audit_events(
+        &self,
+        query: &ListAuditEventsQuery,
+    ) -> Result<ListAuditEventsResponse, ClientError> {
+        self.execute_with_retry(|| {
+            let url = self.url("audit");
+            debug!(url = %url, "Listing audit events");
+
+            let client = self.inner.clone();
+            let query = query.clone();
+            async move {
+                let response = client
+                    .get(url)
+                    .query(&query)
+                    .send()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+
+                if !response.status().is_success() {
+                    let status = response.status().as_u16();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(ClientError::from_http(status, &body));
+                }
+
+                let body = response
+                    .json::<ListAuditEventsResponse>()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+                Ok(body)
+            }
+        })
+        .await
+    }
+
     /// Checks the health of the baseline service.
     pub async fn health_check(&self) -> Result<HealthResponse, ClientError> {
         let url = self.url("health");
@@ -633,7 +668,7 @@ impl BaselineClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn test_config(url: &str) -> ClientConfig {
@@ -714,5 +749,53 @@ mod tests {
 
         assert_eq!(response.version, "v2.0.0");
         assert_eq!(response.promoted_from, "v1.0.0");
+    }
+
+    #[tokio::test]
+    async fn test_list_audit_events() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/audit"))
+            .and(query_param("project", "my-project"))
+            .and(query_param("action", "create"))
+            .and(query_param("resource_type", "baseline"))
+            .and(query_param("limit", "25"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "events": [{
+                    "id": "audit_123",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "actor": "key-admin",
+                    "action": "create",
+                    "resource_type": "baseline",
+                    "resource_id": "bl_123",
+                    "project": "my-project",
+                    "metadata": {"benchmark": "parser"}
+                }],
+                "pagination": {
+                    "limit": 25,
+                    "offset": 0,
+                    "total": 1,
+                    "has_more": false
+                }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BaselineClient::new(test_config(&mock_server.uri())).unwrap();
+        let response = client
+            .list_audit_events(&ListAuditEventsQuery {
+                project: Some("my-project".to_string()),
+                action: Some("create".to_string()),
+                resource_type: Some("baseline".to_string()),
+                limit: 25,
+                ..ListAuditEventsQuery::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.events.len(), 1);
+        assert_eq!(response.events[0].id, "audit_123");
+        assert_eq!(response.events[0].project, "my-project");
     }
 }

--- a/crates/perfgate-client/src/fallback.rs
+++ b/crates/perfgate-client/src/fallback.rs
@@ -174,6 +174,14 @@ impl FallbackClient {
         self.client.list_verdicts(project, query).await
     }
 
+    /// Lists audit events (server only, no fallback).
+    pub async fn list_audit_events(
+        &self,
+        query: &ListAuditEventsQuery,
+    ) -> Result<ListAuditEventsResponse, ClientError> {
+        self.client.list_audit_events(query).await
+    }
+
     /// Checks server health.
     pub async fn health_check(&self) -> Result<HealthResponse, ClientError> {
         self.client.health_check().await

--- a/crates/perfgate-client/src/lib.rs
+++ b/crates/perfgate-client/src/lib.rs
@@ -6,6 +6,7 @@
 //! - Uploading and downloading baselines
 //! - Listing baselines with filtering
 //! - Promoting and deleting baselines
+//! - Listing admin audit events
 //! - Health checking
 //! - Automatic fallback to local storage when the server is unavailable
 //!
@@ -111,11 +112,12 @@ pub use config::{
 pub use error::ClientError;
 pub use fallback::FallbackClient;
 pub use types::{
-    AffectedProject, BaselineRecord, BaselineSource, BaselineSummary, DeleteBaselineResponse,
-    DependencyChange, DependencyEvent, DependencyImpactQuery, DependencyImpactResponse, FleetAlert,
-    HealthResponse, ListBaselinesQuery, ListBaselinesResponse, ListFleetAlertsQuery,
-    ListFleetAlertsResponse, ListVerdictsQuery, ListVerdictsResponse, PaginationInfo,
-    PromoteBaselineRequest, PromoteBaselineResponse, RecordDependencyEventRequest,
+    AffectedProject, AuditAction, AuditEvent, AuditResourceType, BaselineRecord, BaselineSource,
+    BaselineSummary, DeleteBaselineResponse, DependencyChange, DependencyEvent,
+    DependencyImpactQuery, DependencyImpactResponse, FleetAlert, HealthResponse,
+    ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse,
+    ListFleetAlertsQuery, ListFleetAlertsResponse, ListVerdictsQuery, ListVerdictsResponse,
+    PaginationInfo, PromoteBaselineRequest, PromoteBaselineResponse, RecordDependencyEventRequest,
     RecordDependencyEventResponse, StorageHealth, SubmitVerdictRequest, UploadBaselineRequest,
     UploadBaselineResponse, VerdictRecord,
 };

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -145,6 +145,8 @@ The main server-aware CLI workflows are:
 | `baseline flaky` | inspect benchmarks with elevated historical noise |
 | `baseline submit-verdict` | persist compare verdicts |
 | `baseline migrate` | upload local baseline JSON files recursively |
+| `audit list` | inspect append-only audit events |
+| `audit export --format jsonl` | export audit events for operators or compliance review |
 | `fleet alerts` | list fleet-wide dependency regression alerts |
 | `fleet impact` | inspect the project impact of a dependency |
 | `fleet record-event` | record a dependency change event with performance delta |

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -168,6 +168,15 @@ The current CLI surfaces that talk to the baseline service are:
 | `baseline verdicts` | Query pass/warn/fail verdict history |
 | `baseline submit-verdict` | Submit verdict data from a compare receipt |
 | `baseline migrate` | Upload local baseline JSON files to the server |
+| `audit list` | List admin audit events |
+| `audit export --format jsonl` | Export audit events for external review |
+
+Example audit queries:
+
+```bash
+perfgate audit list --project my-project
+perfgate audit export --project my-project --format jsonl
+```
 
 ## Server Endpoints
 


### PR DESCRIPTION
## Summary
- add `BaselineClient::list_audit_events` plus fallback-client server-only passthrough and re-exports
- add `perfgate audit list` and `perfgate audit export --format jsonl|json`
- document the CLI audit path and cover list/export/403 behavior with mock-server tests

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-client --all-features`
- `cargo test -p perfgate-cli --test cli_mock_server_tests --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features`
- `cargo clippy -p perfgate-client -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`

## Security
- audit listing remains server-authorized; CLI only calls the existing admin-only endpoint
- no API key material is printed by the new audit commands