### PR TITLE
cli: add serve doctor preflight

### DIFF
--- a/crates/perfgate-cli/README.md
+++ b/crates/perfgate-cli/README.md
@@ -79,6 +79,7 @@ Commands are organized by workflow stage.
 |-------------|---------|
 | `promote`   | Copy a run receipt into baseline storage |
 | `baseline`  | Manage baselines on a centralized server (list, upload, download, delete, history, verdicts, migrate) |
+| `serve`     | Start or preflight a local SQLite-backed dashboard server |
 | `aggregate` | Merge multiple run receipts (e.g. from a fleet) into one |
 | `fleet`     | Fleet-wide dependency regression alerts and impact analysis |
 

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -663,6 +663,10 @@ pub struct ServeArgs {
     #[arg(long)]
     pub db: Option<PathBuf>,
 
+    /// Check the local server database path and port, then exit
+    #[arg(long, default_value_t = false)]
+    pub doctor: bool,
+
     /// Do not open the browser automatically
     #[arg(long, default_value_t = false)]
     pub no_open: bool,
@@ -3635,12 +3639,24 @@ fn default_data_dir() -> anyhow::Result<PathBuf> {
     Ok(dir)
 }
 
+fn serve_db_path(db: Option<PathBuf>) -> anyhow::Result<PathBuf> {
+    match db {
+        Some(path) => Ok(path),
+        None => Ok(default_data_dir()?.join("data.db")),
+    }
+}
+
+fn serve_api_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/api/v1")
+}
+
 /// Start the local dashboard server.
 fn execute_serve(args: ServeArgs) -> anyhow::Result<()> {
-    let db_path = match args.db {
-        Some(p) => p,
-        None => default_data_dir()?.join("data.db"),
-    };
+    let db_path = serve_db_path(args.db)?;
+
+    if args.doctor {
+        return execute_serve_doctor(args.port, &db_path);
+    }
 
     // Ensure the parent directory exists for the database file.
     if let Some(parent) = db_path.parent() {
@@ -3650,11 +3666,16 @@ fn execute_serve(args: ServeArgs) -> anyhow::Result<()> {
 
     let bind_addr = format!("127.0.0.1:{}", args.port);
     let url = format!("http://127.0.0.1:{}", args.port);
+    let api_url = serve_api_url(args.port);
+    let health_url = format!("http://127.0.0.1:{}/health", args.port);
 
     eprintln!("perfgate serve");
     eprintln!("  database : {}", db_path.display());
     eprintln!("  dashboard: {url}");
+    eprintln!("  api      : {api_url}");
+    eprintln!("  health   : {health_url}");
     eprintln!("  auth     : disabled (local mode)");
+    eprintln!("  upload   : PERFGATE_LOCAL_DB={api_url} perfgate run --local-db ...");
     eprintln!();
     eprintln!("Press Ctrl+C to stop.");
 
@@ -3678,6 +3699,91 @@ fn execute_serve(args: ServeArgs) -> anyhow::Result<()> {
     })?;
 
     Ok(())
+}
+
+fn execute_serve_doctor(port: u16, db_path: &Path) -> anyhow::Result<()> {
+    let bind_addr = format!("127.0.0.1:{port}");
+    let url = format!("http://127.0.0.1:{port}");
+    let api_url = serve_api_url(port);
+    let health_url = format!("http://127.0.0.1:{port}/health");
+    let checks = vec![
+        serve_database_directory_check(db_path),
+        serve_sqlite_check(db_path),
+        serve_bind_check(&bind_addr),
+    ];
+
+    println!("perfgate serve doctor");
+    println!();
+    println!("{:<4} {:<18} {}", "INFO", "database", db_path.display());
+    println!("{:<4} {:<18} {}", "INFO", "dashboard", url);
+    println!("{:<4} {:<18} {}", "INFO", "api", api_url);
+    println!("{:<4} {:<18} {}", "INFO", "health", health_url);
+    for check in &checks {
+        println!(
+            "{:<4} {:<18} {}",
+            check.status.as_str(),
+            check.name,
+            check.detail
+        );
+    }
+
+    let failed = checks
+        .iter()
+        .filter(|check| check.status == DoctorStatus::Fail)
+        .count();
+    println!();
+    println!("Summary: {failed} failed check{}", plural(failed));
+
+    if failed > 0 {
+        anyhow::bail!("serve doctor found {failed} failed check{}", plural(failed));
+    }
+
+    Ok(())
+}
+
+fn serve_database_directory_check(db_path: &Path) -> DoctorCheck {
+    match ensure_database_directory_writable(db_path) {
+        Ok(parent) => DoctorCheck::ok("database dir", format!("{} writable", parent.display())),
+        Err(error) => DoctorCheck::fail("database dir", error.to_string()),
+    }
+}
+
+fn ensure_database_directory_writable(db_path: &Path) -> anyhow::Result<PathBuf> {
+    let parent = db_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create database directory {}", parent.display()))?;
+
+    let probe = parent.join(format!(".perfgate-serve-doctor-{}.tmp", std::process::id()));
+    fs::write(&probe, b"perfgate serve doctor\n")
+        .with_context(|| format!("write probe file {}", probe.display()))?;
+    fs::remove_file(&probe).with_context(|| format!("remove probe file {}", probe.display()))?;
+    Ok(parent.to_path_buf())
+}
+
+fn serve_sqlite_check(db_path: &Path) -> DoctorCheck {
+    match perfgate_server::SqliteStore::new(db_path, None) {
+        Ok(_) => DoctorCheck::ok("sqlite storage", "opened, initialized, and WAL configured"),
+        Err(error) => DoctorCheck::fail(
+            "sqlite storage",
+            format!("{} not usable: {error}", db_path.display()),
+        ),
+    }
+}
+
+fn serve_bind_check(bind_addr: &str) -> DoctorCheck {
+    match std::net::TcpListener::bind(bind_addr) {
+        Ok(listener) => {
+            drop(listener);
+            DoctorCheck::ok("dashboard bind", format!("{bind_addr} available"))
+        }
+        Err(error) => DoctorCheck::fail(
+            "dashboard bind",
+            format!("{bind_addr} unavailable: {error}"),
+        ),
+    }
 }
 
 /// Open a URL in the default browser.

--- a/crates/perfgate-cli/tests/cli_serve_tests.rs
+++ b/crates/perfgate-cli/tests/cli_serve_tests.rs
@@ -1,0 +1,63 @@
+//! CLI tests for the local `perfgate serve` sandbox.
+
+use predicates::prelude::*;
+use std::net::TcpListener;
+use tempfile::tempdir;
+
+mod common;
+use common::perfgate_cmd;
+
+#[test]
+fn serve_doctor_checks_local_database_and_port() {
+    let temp_dir = tempdir().expect("temp dir");
+    let db_path = temp_dir.path().join("nested").join("perfgate.db");
+
+    perfgate_cmd()
+        .args(["serve", "--doctor", "--port", "0", "--db"])
+        .arg(&db_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("perfgate serve doctor"))
+        .stdout(predicate::str::contains("INFO database"))
+        .stdout(predicate::str::contains("INFO api"))
+        .stdout(predicate::str::contains("INFO health"))
+        .stdout(predicate::str::contains("OK   database dir"))
+        .stdout(predicate::str::contains("OK   sqlite storage"))
+        .stdout(predicate::str::contains("OK   dashboard bind"))
+        .stdout(predicate::str::contains("Summary: 0 failed checks"));
+
+    assert!(
+        db_path.exists(),
+        "serve doctor should initialize the SQLite DB"
+    );
+}
+
+#[test]
+fn serve_doctor_fails_when_dashboard_port_is_unavailable() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test port");
+    let port = listener.local_addr().expect("local addr").port();
+    let temp_dir = tempdir().expect("temp dir");
+    let db_path = temp_dir.path().join("perfgate.db");
+
+    perfgate_cmd()
+        .args(["serve", "--doctor", "--port", &port.to_string(), "--db"])
+        .arg(&db_path)
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("FAIL dashboard bind"))
+        .stdout(predicate::str::contains("Summary: 1 failed check"))
+        .stderr(predicate::str::contains(
+            "serve doctor found 1 failed check",
+        ));
+}
+
+#[test]
+fn serve_help_shows_doctor_flag() {
+    perfgate_cmd()
+        .args(["serve", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Start a local dashboard server"))
+        .stdout(predicate::str::contains("--doctor"))
+        .stdout(predicate::str::contains("--db"));
+}

--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -20,6 +20,7 @@ perfgate-server --storage-type sqlite --database-url ./perfgate.db \
   --api-keys admin:pg_live_<32+alnum>:my-project
 
 # Local single-user sandbox
+cargo run -p perfgate-cli -- serve --doctor
 cargo run -p perfgate-cli -- serve --no-open
 ```
 

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -41,6 +41,9 @@ The current server binary supports:
 
 For local development, prefer `perfgate serve`. For a shared deployment,
 prefer `perfgate-server` directly.
+Run `perfgate serve --doctor` before starting the local sandbox when you want
+to verify the SQLite path, WAL setup, and dashboard port without keeping a
+server process running.
 
 The SQLite backend is intended for one server process. File-backed SQLite
 connections are configured with WAL mode and a 5 second busy timeout so normal
@@ -155,6 +158,7 @@ The main server-aware CLI workflows are:
 | `admin keys revoke` | revoke an API key |
 | `admin keys rotate` | create a replacement key and revoke the old key |
 | `serve` | run a local baseline server/dashboard in local mode |
+| `serve --doctor` | preflight the local SQLite path, WAL setup, and dashboard port |
 
 Cross-project compare is currently a CLI-side lookup override for baseline
 fetches. It does not change server-side auth or the project used by other

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -18,6 +18,16 @@ shared baseline service.
 
 ## Local Sandbox
 
+Preflight the local SQLite database path and dashboard port:
+
+```bash
+cargo run -p perfgate-cli -- serve --doctor --port 8484
+```
+
+The preflight opens and initializes the SQLite database, verifies WAL setup,
+checks that `127.0.0.1:8484` is available, and prints the dashboard, API, and
+health URLs it will use.
+
 Start a local server on `127.0.0.1:8484`:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `perfgate serve --doctor` to preflight the local SQLite sandbox without keeping the server running
- print API and health URLs, plus a `PERFGATE_LOCAL_DB` upload hint, when starting `perfgate serve`
- document the local sandbox preflight path and cover success, unavailable-port, and help output cases

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-cli --test cli_serve_tests --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features`
- `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`