### PR TITLE
server: add storage health detail

### DIFF
--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -128,7 +128,9 @@ skip WAL because SQLite reports `journal_mode=memory` for those connections.
 
 PostgreSQL storage uses a sqlx connection pool. The pool pings connections
 before reuse, applies `statement_timeout` on new connections, retries transient
-connection failures, and exposes pool occupancy from `/health`:
+connection failures, and exposes pool occupancy from `/health`. If storage is
+unhealthy, `/health` includes a coarse non-secret `storage.detail` code while
+the full storage error stays in server logs:
 
 ```bash
 perfgate-server \

--- a/crates/perfgate-server/src/handlers/health.rs
+++ b/crates/perfgate-server/src/handlers/health.rs
@@ -1,7 +1,10 @@
 //! Health check handlers.
 
 use axum::{Json, extract::State};
+use tracing::warn;
 
+use crate::error::StoreError;
+use crate::metrics;
 use crate::models::{HealthResponse, StorageHealth as ModelStorageHealth};
 use crate::server::AppState;
 use crate::storage::StorageHealth;
@@ -11,9 +14,19 @@ use crate::storage::StorageHealth;
 /// Returns server health status, storage backend health, and connection pool
 /// metrics (when using a pooled backend such as PostgreSQL).
 pub async fn health_check(State(state): State<AppState>) -> Json<HealthResponse> {
+    let mut storage_detail = None;
     let storage_health = match state.store.health_check().await {
         Ok(health) => health,
-        Err(_) => StorageHealth::Unhealthy,
+        Err(error) => {
+            warn!(
+                backend = state.store.backend_type(),
+                error = %error,
+                "Storage health check failed"
+            );
+            metrics::record_storage_error("health_check");
+            storage_detail = Some(storage_health_detail(&error).to_string());
+            StorageHealth::Unhealthy
+        }
     };
 
     let status_str = storage_health.as_str();
@@ -31,7 +44,188 @@ pub async fn health_check(State(state): State<AppState>) -> Json<HealthResponse>
         storage: ModelStorageHealth {
             backend: state.store.backend_type().to_string(),
             status: status_str.to_string(),
+            detail: storage_detail,
         },
         pool,
     })
+}
+
+fn storage_health_detail(error: &StoreError) -> &'static str {
+    match error {
+        StoreError::ConnectionError(_) => "connection_error",
+        StoreError::QueryError(_) => "query_error",
+        StoreError::IoError(_) => "io_error",
+        StoreError::SqliteError(_) => "sqlite_error",
+        StoreError::LockError(_) => "lock_error",
+        StoreError::SerializationError(_) => "serialization_error",
+        StoreError::AlreadyExists(_) | StoreError::NotFound(_) | StoreError::Other(_) => {
+            "storage_error"
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{
+        AuditEvent, BaselineRecord, BaselineVersion, ListAuditEventsQuery, ListAuditEventsResponse,
+        ListBaselinesQuery, ListBaselinesResponse, ListVerdictsQuery, ListVerdictsResponse,
+        PaginationInfo, VerdictRecord,
+    };
+    use crate::storage::{AuditStore, BaselineStore};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct FailingStore;
+
+    fn storage_failure() -> StoreError {
+        StoreError::QueryError(
+            "could not reach database at postgres://user:secret@example.invalid/perfgate"
+                .to_string(),
+        )
+    }
+
+    #[async_trait]
+    impl BaselineStore for FailingStore {
+        async fn create(&self, _record: &BaselineRecord) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn get(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+            _version: &str,
+        ) -> Result<Option<BaselineRecord>, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn get_latest(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+        ) -> Result<Option<BaselineRecord>, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list(
+            &self,
+            _project: &str,
+            _query: &ListBaselinesQuery,
+        ) -> Result<ListBaselinesResponse, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn update(&self, _record: &BaselineRecord) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn delete(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+            _version: &str,
+        ) -> Result<bool, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn hard_delete(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+            _version: &str,
+        ) -> Result<bool, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list_versions(
+            &self,
+            _project: &str,
+            _benchmark: &str,
+        ) -> Result<Vec<BaselineVersion>, StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn health_check(&self) -> Result<StorageHealth, StoreError> {
+            Err(storage_failure())
+        }
+
+        fn backend_type(&self) -> &'static str {
+            "failing"
+        }
+
+        async fn create_verdict(&self, _record: &VerdictRecord) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list_verdicts(
+            &self,
+            _project: &str,
+            _query: &ListVerdictsQuery,
+        ) -> Result<ListVerdictsResponse, StoreError> {
+            Err(storage_failure())
+        }
+    }
+
+    #[async_trait]
+    impl AuditStore for FailingStore {
+        async fn log_event(&self, _event: &AuditEvent) -> Result<(), StoreError> {
+            Err(storage_failure())
+        }
+
+        async fn list_events(
+            &self,
+            _query: &ListAuditEventsQuery,
+        ) -> Result<ListAuditEventsResponse, StoreError> {
+            Ok(ListAuditEventsResponse {
+                events: Vec::new(),
+                pagination: PaginationInfo {
+                    total: 0,
+                    offset: 0,
+                    limit: 100,
+                    has_more: false,
+                },
+            })
+        }
+    }
+
+    fn failing_state() -> AppState {
+        let store = Arc::new(FailingStore);
+        AppState {
+            store: store.clone(),
+            audit: store,
+        }
+    }
+
+    #[tokio::test]
+    async fn health_check_includes_sanitized_storage_detail_on_error() {
+        let Json(response) = health_check(State(failing_state())).await;
+
+        assert_eq!(response.status, "degraded");
+        assert_eq!(response.storage.backend, "failing");
+        assert_eq!(response.storage.status, "unhealthy");
+        assert_eq!(response.storage.detail.as_deref(), Some("query_error"));
+        let serialized = serde_json::to_string(&response).expect("serialize health response");
+        assert!(!serialized.contains("secret"));
+        assert!(!serialized.contains("example.invalid"));
+    }
+
+    #[test]
+    fn storage_health_detail_uses_stable_non_secret_codes() {
+        assert_eq!(
+            storage_health_detail(&StoreError::ConnectionError(
+                "postgres://user:secret@example.invalid/perfgate".to_string()
+            )),
+            "connection_error"
+        );
+        assert_eq!(
+            storage_health_detail(&StoreError::LockError("poisoned".to_string())),
+            "lock_error"
+        );
+        assert_eq!(
+            storage_health_detail(&StoreError::Other("anything".to_string())),
+            "storage_error"
+        );
+    }
 }

--- a/crates/perfgate-server/src/storage/postgres.rs
+++ b/crates/perfgate-server/src/storage/postgres.rs
@@ -649,13 +649,9 @@ impl BaselineStore for PostgresStore {
     }
 
     async fn health_check(&self) -> Result<StorageHealth, StoreError> {
-        match self
-            .with_retry(|pool| async move { sqlx::query("SELECT 1").execute(&pool).await })
-            .await
-        {
-            Ok(_) => Ok(StorageHealth::Healthy),
-            Err(_) => Ok(StorageHealth::Unhealthy),
-        }
+        self.with_retry(|pool| async move { sqlx::query("SELECT 1").execute(&pool).await })
+            .await?;
+        Ok(StorageHealth::Healthy)
     }
 
     fn backend_type(&self) -> &'static str {

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -532,7 +532,7 @@ impl BaselineStore for SqliteStore {
             .map_err(|e| StoreError::LockError(e.to_string()))?;
         match conn.query_row("SELECT 1", [], |_| Ok(())) {
             Ok(_) => Ok(StorageHealth::Healthy),
-            Err(_) => Ok(StorageHealth::Unhealthy),
+            Err(error) => Err(StoreError::QueryError(error.to_string())),
         }
     }
 

--- a/crates/perfgate-types/src/baseline_service.rs
+++ b/crates/perfgate-types/src/baseline_service.rs
@@ -659,6 +659,9 @@ pub struct ListAuditEventsResponse {
 pub struct StorageHealth {
     pub backend: String,
     pub status: String,
+    /// Coarse, sanitized failure detail when the backend is unhealthy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
 /// Connection pool metrics exposed via the health endpoint.
@@ -1149,6 +1152,32 @@ mod tests {
         let dependency = DependencyImpactQuery::default();
         assert_eq!(dependency.limit, default_limit());
         assert!(dependency.since.is_none());
+    }
+
+    #[test]
+    fn health_storage_detail_is_additive() {
+        let legacy = serde_json::json!({
+            "status": "healthy",
+            "version": "0.15.1",
+            "storage": {
+                "backend": "memory",
+                "status": "healthy"
+            }
+        });
+        let legacy: HealthResponse = serde_json::from_value(legacy).expect("legacy health");
+        assert_eq!(legacy.storage.detail, None);
+
+        let detailed = serde_json::json!({
+            "status": "degraded",
+            "version": "0.15.1",
+            "storage": {
+                "backend": "postgres",
+                "status": "unhealthy",
+                "detail": "query_error"
+            }
+        });
+        let detailed: HealthResponse = serde_json::from_value(detailed).expect("detailed health");
+        assert_eq!(detailed.storage.detail.as_deref(), Some("query_error"));
     }
 
     #[test]

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -221,9 +221,10 @@ perfgate-server \
 ```
 
 Use `/health` to verify storage readiness and PostgreSQL pool occupancy before
-making the server a required CI dependency. Use `/metrics` for Prometheus
-scraping once the service is shared by more than one workflow. The operational
-series include:
+making the server a required CI dependency. Unhealthy storage responses include
+a coarse non-secret `storage.detail` code; the raw storage error is kept in
+server logs. Use `/metrics` for Prometheus scraping once the service is shared
+by more than one workflow. The operational series include:
 
 ```text
 perfgate_server_requests_total

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -224,7 +224,9 @@ Point the CLI at the versioned API root, for example
 ## Operational Checks
 
 Use `/health` for liveness and storage readiness. PostgreSQL deployments also
-include current pool occupancy:
+include current pool occupancy. When storage is not healthy, `storage.detail`
+contains a coarse non-secret reason such as `query_error` or `connection_error`;
+inspect server logs for the full database error.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- add optional `storage.detail` to `/health` responses for unhealthy storage, using stable non-secret detail codes
- log raw storage health failures server-side and count them in storage-error metrics
- make SQLite/Postgres health probes return probe errors to the health handler instead of collapsing them inside storage

## Contract / Observability Notes
- Additive response change: legacy health JSON without `storage.detail` still deserializes.
- `/health` remains safe for unauthenticated liveness checks: the response exposes only coarse codes like `query_error`, while full storage errors stay in server logs.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-types --all-features`
- `cargo test -p perfgate-server --all-features`
- `cargo test -p perfgate-client --all-features`
- `cargo clippy -p perfgate-types -p perfgate-server -p perfgate-client --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- schema-compat`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`