### PR TITLE
api: add health schema compatibility fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `perfgate doctor` to diagnose local setup, config loading, benchmark
   command availability, baseline presence, artifact directory writability, CI
   detection, and baseline-server health.
-- Extended `xtask schema-compat` with baseline-service and fleet record
-  fixtures so the 0.16 server API contract is checked alongside receipt
-  compatibility.
+- Extended `xtask schema-compat` with baseline-service record, health-response,
+  and fleet fixtures so the 0.16 server API contract is checked alongside
+  receipt compatibility.
 
 ### Changed
 - Bumped Rust minimum supported version (MSRV) to 1.93.

--- a/crates/perfgate-types/src/baseline_service.rs
+++ b/crates/perfgate-types/src/baseline_service.rs
@@ -34,6 +34,9 @@ pub const VERDICT_SCHEMA_V1: &str = "perfgate.verdict.v1";
 /// Schema identifier for audit event records.
 pub const AUDIT_SCHEMA_V1: &str = "perfgate.audit.v1";
 
+/// Schema identifier for health response fixtures.
+pub const HEALTH_SCHEMA_V1: &str = "perfgate.health.v1";
+
 /// Source of baseline creation.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -13,6 +13,7 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 | `perfgate.baseline.v1` | baseline service | Stored baseline record returned by the server |
 | `perfgate.verdict.v1` | baseline service | Stored verdict history, including optional noise history fields |
 | `perfgate.audit.v1` | baseline service | Append-only audit event for baseline, verdict, and key mutations; inferred by fixture filename because current audit events do not include a `schema` field |
+| `perfgate.health.v1` | baseline service | Health response for liveness and storage readiness; inferred by fixture filename because `/health` responses do not include a `schema` field |
 | `perfgate.dependency_event.v1` | fleet API | Dependency-change event with performance impact |
 | `perfgate.fleet_alert.v1` | fleet API | Fleet-wide dependency regression alert |
 
@@ -61,10 +62,12 @@ with external consumers.
 
 Historical compatibility fixtures live under `fixtures/schema/<release>/`.
 `schema-compat` checks v0.15 examples for `perfgate.run.v1`,
-`perfgate.compare.v1`, `perfgate.report.v1`, and `sensor.report.v1`.
+`perfgate.compare.v1`, `perfgate.report.v1`, `sensor.report.v1`,
+and `perfgate.health.v1`.
 It also checks v0.16 baseline-service and fleet contract fixtures for
 `perfgate.baseline.v1`, `perfgate.verdict.v1`, `perfgate.audit.v1`,
-`perfgate.dependency_event.v1`, and `perfgate.fleet_alert.v1`.
+`perfgate.health.v1`, `perfgate.dependency_event.v1`, and
+`perfgate.fleet_alert.v1`.
 
 ## Versioning Policy
 

--- a/fixtures/schema/v0.15/perfgate.health.v1.json
+++ b/fixtures/schema/v0.15/perfgate.health.v1.json
@@ -1,0 +1,8 @@
+{
+  "status": "healthy",
+  "version": "0.15.1",
+  "storage": {
+    "backend": "memory",
+    "status": "healthy"
+  }
+}

--- a/fixtures/schema/v0.16/perfgate.health.v1.json
+++ b/fixtures/schema/v0.16/perfgate.health.v1.json
@@ -1,0 +1,14 @@
+{
+  "status": "degraded",
+  "version": "0.16.0",
+  "storage": {
+    "backend": "postgres",
+    "status": "unhealthy",
+    "detail": "query_error"
+  },
+  "pool": {
+    "idle": 0,
+    "active": 1,
+    "max": 20
+  }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2187,6 +2187,10 @@ fn cmd_schema_compat(fixtures_dir: &Path) -> anyhow::Result<()> {
                 serde_json::from_value::<perfgate_types::baseline_service::AuditEvent>(value)
                     .map(|_| ())
             }
+            "perfgate.health.v1" => {
+                serde_json::from_value::<perfgate_types::baseline_service::HealthResponse>(value)
+                    .map(|_| ())
+            }
             "perfgate.dependency_event.v1" => {
                 serde_json::from_value::<perfgate_types::baseline_service::DependencyEvent>(value)
                     .map(|_| ())
@@ -2253,7 +2257,11 @@ fn collect_schema_compat_json_files(dir: &Path, out: &mut Vec<PathBuf>) -> anyho
 
 fn infer_schema_from_fixture_path(path: &Path) -> Option<String> {
     let name = path.file_name()?.to_str()?;
-    (name == "perfgate.audit.v1.json").then(|| "perfgate.audit.v1".to_string())
+    match name {
+        "perfgate.audit.v1.json" => Some("perfgate.audit.v1".to_string()),
+        "perfgate.health.v1.json" => Some("perfgate.health.v1".to_string()),
+        _ => None,
+    }
 }
 
 fn check_schema_mirror_at(generated_dir: &Path, committed_dir: &Path) -> anyhow::Result<()> {
@@ -4658,6 +4666,48 @@ pkg-fmt = "zip"
         .expect("write fixture");
 
         cmd_schema_compat(&root).expect("schema-less audit fixture should deserialize");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn cmd_schema_compat_accepts_schema_less_health_fixtures_by_filename() {
+        let root = unique_temp_dir("perfgate_schema_compat_health");
+        let legacy_dir = root.join("v0.15");
+        let current_dir = root.join("v0.16");
+        fs::create_dir_all(&legacy_dir).expect("create legacy fixture dir");
+        fs::create_dir_all(&current_dir).expect("create current fixture dir");
+        fs::write(
+            legacy_dir.join("perfgate.health.v1.json"),
+            r#"{
+  "status": "healthy",
+  "version": "0.15.1",
+  "storage": {
+    "backend": "memory",
+    "status": "healthy"
+  }
+}"#,
+        )
+        .expect("write legacy fixture");
+        fs::write(
+            current_dir.join("perfgate.health.v1.json"),
+            r#"{
+  "status": "degraded",
+  "version": "0.16.0",
+  "storage": {
+    "backend": "postgres",
+    "status": "unhealthy",
+    "detail": "query_error"
+  },
+  "pool": {
+    "idle": 0,
+    "active": 1,
+    "max": 20
+  }
+}"#,
+        )
+        .expect("write current fixture");
+
+        cmd_schema_compat(&root).expect("schema-less health fixtures should deserialize");
         let _ = fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## Summary
- add `perfgate.health.v1` compatibility handling for schema-less `/health` response fixtures
- commit legacy and current health fixtures covering pre-detail and detailed storage health payloads
- document the health response contract in schema compatibility docs and changelog

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p xtask cmd_schema_compat_accepts_schema_less_health_fixtures_by_filename --all-features`
- `cargo run -p xtask -- schema-compat`
- `cargo test -p perfgate-types --all-features`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- schema-check`
- `cargo clippy -p xtask -p perfgate-types --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`