### PR TITLE
api: add structured evidence receipt schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `perfgate doctor` to diagnose local setup, config loading, benchmark
   command availability, baseline presence, artifact directory writability, CI
   detection, and baseline-server health.
+- Added schema-first structured performance evidence contracts for
+  `perfgate.probe.v1`, `perfgate.scenario.v1`, and `perfgate.tradeoff.v1`.
 - Extended `xtask schema-compat` with baseline-service record, health-response,
   and fleet fixtures so the 0.16 server API contract is checked alongside
   receipt compatibility.

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -30,6 +30,7 @@ pub mod fingerprint;
 mod io;
 mod paired;
 mod repair_context;
+mod structured_evidence;
 pub mod validation;
 
 pub use paired::{
@@ -40,6 +41,7 @@ pub use paired::{
 pub use defaults_config::*;
 pub use io::{ReadJsonError, read_json_file};
 pub use repair_context::*;
+pub use structured_evidence::*;
 
 pub use validation::{
     BENCH_NAME_MAX_LEN, BENCH_NAME_PATTERN, ValidationError as BenchNameValidationError,
@@ -56,6 +58,9 @@ pub const RUN_SCHEMA_V1: &str = "perfgate.run.v1";
 pub const AGGREGATE_SCHEMA_V1: &str = "perfgate.aggregate.v1";
 pub const BASELINE_SCHEMA_V1: &str = "perfgate.baseline.v1";
 pub const COMPARE_SCHEMA_V1: &str = "perfgate.compare.v1";
+pub const PROBE_SCHEMA_V1: &str = "perfgate.probe.v1";
+pub const SCENARIO_SCHEMA_V1: &str = "perfgate.scenario.v1";
+pub const TRADEOFF_SCHEMA_V1: &str = "perfgate.tradeoff.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
 pub const RATCHET_SCHEMA_V1: &str = "perfgate.ratchet.v1";

--- a/crates/perfgate-types/src/structured_evidence.rs
+++ b/crates/perfgate-types/src/structured_evidence.rs
@@ -1,0 +1,457 @@
+use crate::{
+    BenchMeta, CompareRef, Delta, MetricStatus, RunMeta, ToolInfo, TradeoffDowngrade, TradeoffRule,
+    Verdict,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Scope of a named performance probe inside a workload.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeScope {
+    Local,
+    Enclosing,
+    Dominant,
+    Total,
+}
+
+/// A numeric metric observed for a named probe.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ProbeMetricValue {
+    pub value: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub unit: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub statistic: Option<String>,
+}
+
+/// One named probe observation from external instrumentation.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ProbeObservation {
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub parent: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scope: Option<ProbeScope>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub iteration: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub started_at: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub ended_at: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub items: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metrics: BTreeMap<String, ProbeMetricValue>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attributes: BTreeMap<String, String>,
+}
+
+/// A versioned receipt for named probe observations (`perfgate.probe.v1`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ProbeReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub run: RunMeta,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub bench: Option<BenchMeta>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scenario: Option<String>,
+
+    pub probes: Vec<ProbeObservation>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// Scenario definition captured in a scenario evaluation receipt.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ScenarioMeta {
+    pub name: String,
+    pub weight: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub command: Option<Vec<String>>,
+}
+
+/// A scenario component such as one benchmark, phase, or probe group.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ScenarioComponent {
+    pub name: String,
+    pub weight: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub benchmark: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub compare_ref: Option<CompareRef>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub deltas: BTreeMap<String, Delta>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probes: Vec<String>,
+
+    pub status: MetricStatus,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub reasons: Vec<String>,
+}
+
+/// A versioned receipt for weighted workload scenarios (`perfgate.scenario.v1`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ScenarioReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub run: RunMeta,
+    pub scenario: ScenarioMeta,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub baseline_ref: Option<CompareRef>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub current_ref: Option<CompareRef>,
+
+    pub components: Vec<ScenarioComponent>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub weighted_deltas: BTreeMap<String, Delta>,
+
+    pub verdict: Verdict,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+/// Outcome of a tradeoff policy decision.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[serde(rename_all = "snake_case")]
+pub enum TradeoffDecisionStatus {
+    Accepted,
+    Rejected,
+    NotEvaluated,
+}
+
+/// Evaluation result for one tradeoff requirement.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffRequirementOutcome {
+    pub metric: String,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub probe: Option<String>,
+
+    pub required_change: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub observed_change: Option<f64>,
+
+    pub satisfied: bool,
+    pub status: MetricStatus,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<String>,
+}
+
+/// Evaluation result for one named tradeoff rule.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffRuleOutcome {
+    pub name: String,
+    pub status: TradeoffDecisionStatus,
+    pub accepted: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub downgrade_to: Option<TradeoffDowngrade>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requirements: Vec<TradeoffRequirementOutcome>,
+}
+
+/// Probe-level tradeoff evidence.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffProbeOutcome {
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scope: Option<ProbeScope>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub weight: Option<f64>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub deltas: BTreeMap<String, Delta>,
+
+    pub status: MetricStatus,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<String>,
+}
+
+/// Final structured tradeoff decision.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffDecision {
+    pub accepted_tradeoff: bool,
+    pub status: MetricStatus,
+    pub reason: String,
+}
+
+/// A versioned receipt explaining accepted or rejected tradeoffs (`perfgate.tradeoff.v1`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub run: RunMeta,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub scenario: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub baseline_ref: Option<CompareRef>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub current_ref: Option<CompareRef>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub configured_rules: Vec<TradeoffRule>,
+
+    pub rules: Vec<TradeoffRuleOutcome>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probes: Vec<TradeoffProbeOutcome>,
+
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub weighted_deltas: BTreeMap<String, Delta>,
+
+    pub decision: TradeoffDecision,
+    pub verdict: Verdict,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        PROBE_SCHEMA_V1, SCENARIO_SCHEMA_V1, TRADEOFF_SCHEMA_V1, U64Summary, VerdictCounts,
+        VerdictStatus,
+    };
+
+    fn tool() -> ToolInfo {
+        ToolInfo {
+            name: "perfgate".into(),
+            version: "0.16.0".into(),
+        }
+    }
+
+    fn run() -> RunMeta {
+        RunMeta {
+            id: "run-1".into(),
+            started_at: "2026-05-08T00:00:00Z".into(),
+            ended_at: "2026-05-08T00:00:01Z".into(),
+            host: crate::HostInfo {
+                os: "linux".into(),
+                arch: "x86_64".into(),
+                cpu_count: None,
+                memory_bytes: None,
+                hostname_hash: None,
+            },
+        }
+    }
+
+    fn verdict() -> Verdict {
+        Verdict {
+            status: VerdictStatus::Pass,
+            counts: VerdictCounts {
+                pass: 1,
+                warn: 0,
+                fail: 0,
+                skip: 0,
+            },
+            reasons: Vec::new(),
+        }
+    }
+
+    fn wall_delta() -> Delta {
+        Delta {
+            baseline: 100.0,
+            current: 92.0,
+            ratio: 0.92,
+            pct: -0.08,
+            regression: 0.0,
+            cv: None,
+            noise_threshold: None,
+            statistic: crate::MetricStatistic::Median,
+            significance: None,
+            status: MetricStatus::Pass,
+        }
+    }
+
+    #[test]
+    fn probe_receipt_round_trips() {
+        let mut metrics = BTreeMap::new();
+        metrics.insert(
+            "wall_ms".into(),
+            ProbeMetricValue {
+                value: 12.4,
+                unit: Some("ms".into()),
+                statistic: None,
+            },
+        );
+
+        let receipt = ProbeReceipt {
+            schema: PROBE_SCHEMA_V1.into(),
+            tool: tool(),
+            run: run(),
+            bench: None,
+            scenario: Some("large_file_parse".into()),
+            probes: vec![ProbeObservation {
+                name: "parser.tokenize".into(),
+                parent: Some("request.total".into()),
+                scope: Some(ProbeScope::Local),
+                iteration: Some(1),
+                started_at: None,
+                ended_at: None,
+                items: Some(10_000),
+                metrics,
+                attributes: BTreeMap::new(),
+            }],
+            metadata: BTreeMap::new(),
+        };
+
+        let json = serde_json::to_string(&receipt).expect("serialize probe receipt");
+        let parsed: ProbeReceipt = serde_json::from_str(&json).expect("parse probe receipt");
+        assert_eq!(parsed.schema, PROBE_SCHEMA_V1);
+        assert_eq!(parsed.probes[0].name, "parser.tokenize");
+    }
+
+    #[test]
+    fn scenario_receipt_round_trips() {
+        let mut weighted_deltas = BTreeMap::new();
+        weighted_deltas.insert("wall_ms".into(), wall_delta());
+
+        let receipt = ScenarioReceipt {
+            schema: SCENARIO_SCHEMA_V1.into(),
+            tool: tool(),
+            run: run(),
+            scenario: ScenarioMeta {
+                name: "large_file_parse".into(),
+                weight: 0.4,
+                description: None,
+                command: Some(vec!["cargo".into(), "bench".into()]),
+            },
+            baseline_ref: None,
+            current_ref: None,
+            components: vec![ScenarioComponent {
+                name: "parser.batch_loop".into(),
+                weight: 1.0,
+                benchmark: Some("large-file".into()),
+                compare_ref: None,
+                deltas: weighted_deltas.clone(),
+                probes: vec!["parser.tokenize".into()],
+                status: MetricStatus::Pass,
+                reasons: Vec::new(),
+            }],
+            weighted_deltas,
+            verdict: verdict(),
+            warnings: Vec::new(),
+        };
+
+        let json = serde_json::to_string(&receipt).expect("serialize scenario receipt");
+        let parsed: ScenarioReceipt = serde_json::from_str(&json).expect("parse scenario receipt");
+        assert_eq!(parsed.schema, SCENARIO_SCHEMA_V1);
+        assert_eq!(parsed.scenario.name, "large_file_parse");
+    }
+
+    #[test]
+    fn tradeoff_receipt_round_trips() {
+        let receipt = TradeoffReceipt {
+            schema: TRADEOFF_SCHEMA_V1.into(),
+            tool: tool(),
+            run: run(),
+            scenario: Some("large_file_parse".into()),
+            baseline_ref: None,
+            current_ref: None,
+            configured_rules: Vec::new(),
+            rules: vec![TradeoffRuleOutcome {
+                name: "tokenizer-slower-if-parser-faster".into(),
+                status: TradeoffDecisionStatus::Accepted,
+                accepted: true,
+                downgrade_to: Some(TradeoffDowngrade::Pass),
+                reason: Some("dominant parser loop improved".into()),
+                requirements: vec![TradeoffRequirementOutcome {
+                    metric: "wall_ms".into(),
+                    probe: Some("parser.batch_loop".into()),
+                    required_change: -0.08,
+                    observed_change: Some(-0.104),
+                    satisfied: true,
+                    status: MetricStatus::Pass,
+                    reason: None,
+                }],
+            }],
+            probes: vec![TradeoffProbeOutcome {
+                name: "parser.tokenize".into(),
+                scope: Some(ProbeScope::Local),
+                weight: Some(0.2),
+                deltas: BTreeMap::from([("wall_ms".into(), wall_delta())]),
+                status: MetricStatus::Warn,
+                reason: Some("local slowdown".into()),
+            }],
+            weighted_deltas: BTreeMap::from([("wall_ms".into(), wall_delta())]),
+            decision: TradeoffDecision {
+                accepted_tradeoff: true,
+                status: MetricStatus::Pass,
+                reason: "local slowdown offset by dominant-loop improvement".into(),
+            },
+            verdict: verdict(),
+            warnings: Vec::new(),
+        };
+
+        let json = serde_json::to_string(&receipt).expect("serialize tradeoff receipt");
+        let parsed: TradeoffReceipt = serde_json::from_str(&json).expect("parse tradeoff receipt");
+        assert_eq!(parsed.schema, TRADEOFF_SCHEMA_V1);
+        assert!(parsed.decision.accepted_tradeoff);
+    }
+
+    #[test]
+    fn minimal_probe_metric_can_represent_existing_summaries() {
+        let wall = U64Summary::new(12, 10, 14);
+        let value = ProbeMetricValue {
+            value: wall.median as f64,
+            unit: Some("ms".into()),
+            statistic: Some("median".into()),
+        };
+        assert_eq!(value.value, 12.0);
+    }
+}

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -8,6 +8,9 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 |--------|-------------|-------------|
 | `perfgate.run.v1` | `run`, `check` | Raw measurement data from a benchmark execution |
 | `perfgate.compare.v1` | `compare`, `check`, `paired` | Comparison of current run against baseline |
+| `perfgate.probe.v1` | schema-first contract | Named probe observations from internal phases or external instrumentation |
+| `perfgate.scenario.v1` | schema-first contract | Weighted workload-scenario evidence across benchmarks, phases, or probe groups |
+| `perfgate.tradeoff.v1` | schema-first contract | Structured decision evidence for accepted or rejected performance tradeoffs |
 | `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
 | `sensor.report.v1` | `check --mode cockpit` | Sensor integration envelope for dashboards |
 | `perfgate.baseline.v1` | baseline service | Stored baseline record returned by the server |
@@ -24,6 +27,9 @@ perfgate also commits generated schemas for tooling and editor integration:
 | File | Purpose |
 |------|---------|
 | `schemas/perfgate.config.v1.schema.json` | Validates `perfgate.toml` / JSON config shape, including optional per-benchmark scaling configuration |
+| `schemas/perfgate.probe.v1.schema.json` | Validates probe receipts for named phase/span metrics from external instrumentation |
+| `schemas/perfgate.scenario.v1.schema.json` | Validates weighted scenario receipts used to explain workload-level outcomes |
+| `schemas/perfgate.tradeoff.v1.schema.json` | Validates tradeoff receipts that explain why local regressions were accepted or rejected |
 | `schemas/perfgate.report.v1.schema.json` | Validates report receipts, including additive diagnostics such as `profile_path` |
 
 ## JSON Schema Generation
@@ -67,7 +73,8 @@ and `perfgate.health.v1`.
 It also checks v0.16 baseline-service and fleet contract fixtures for
 `perfgate.baseline.v1`, `perfgate.verdict.v1`, `perfgate.audit.v1`,
 `perfgate.health.v1`, `perfgate.dependency_event.v1`, and
-`perfgate.fleet_alert.v1`.
+`perfgate.fleet_alert.v1`, plus structured-evidence fixtures for
+`perfgate.probe.v1`, `perfgate.scenario.v1`, and `perfgate.tradeoff.v1`.
 
 ## Versioning Policy
 

--- a/fixtures/schema/v0.16/perfgate.probe.v1.json
+++ b/fixtures/schema/v0.16/perfgate.probe.v1.json
@@ -1,0 +1,39 @@
+{
+  "schema": "perfgate.probe.v1",
+  "tool": {
+    "name": "perfgate",
+    "version": "0.16.0"
+  },
+  "run": {
+    "id": "run-probe-1",
+    "started_at": "2026-05-08T00:00:00Z",
+    "ended_at": "2026-05-08T00:00:01Z",
+    "host": {
+      "os": "linux",
+      "arch": "x86_64"
+    }
+  },
+  "scenario": "large_file_parse",
+  "probes": [
+    {
+      "name": "parser.tokenize",
+      "parent": "request.total",
+      "scope": "local",
+      "items": 10000,
+      "metrics": {
+        "wall_ms": {
+          "value": 12.4,
+          "unit": "ms",
+          "statistic": "median"
+        },
+        "alloc_bytes": {
+          "value": 184320,
+          "unit": "bytes"
+        }
+      },
+      "attributes": {
+        "phase": "tokenize"
+      }
+    }
+  ]
+}

--- a/fixtures/schema/v0.16/perfgate.scenario.v1.json
+++ b/fixtures/schema/v0.16/perfgate.scenario.v1.json
@@ -1,0 +1,61 @@
+{
+  "schema": "perfgate.scenario.v1",
+  "tool": {
+    "name": "perfgate",
+    "version": "0.16.0"
+  },
+  "run": {
+    "id": "run-scenario-1",
+    "started_at": "2026-05-08T00:00:00Z",
+    "ended_at": "2026-05-08T00:00:01Z",
+    "host": {
+      "os": "linux",
+      "arch": "x86_64"
+    }
+  },
+  "scenario": {
+    "name": "large_file_parse",
+    "weight": 0.4,
+    "description": "Parse a large markdown file",
+    "command": ["cargo", "bench", "--bench", "large_file"]
+  },
+  "components": [
+    {
+      "name": "parser.batch_loop",
+      "weight": 1.0,
+      "benchmark": "large-file",
+      "deltas": {
+        "wall_ms": {
+          "baseline": 100.0,
+          "current": 92.2,
+          "ratio": 0.922,
+          "pct": -0.078,
+          "regression": 0.0,
+          "status": "pass"
+        }
+      },
+      "probes": ["parser.tokenize", "parser.ast_build"],
+      "status": "pass"
+    }
+  ],
+  "weighted_deltas": {
+    "wall_ms": {
+      "baseline": 100.0,
+      "current": 92.2,
+      "ratio": 0.922,
+      "pct": -0.078,
+      "regression": 0.0,
+      "status": "pass"
+    }
+  },
+  "verdict": {
+    "status": "pass",
+    "counts": {
+      "pass": 1,
+      "warn": 0,
+      "fail": 0,
+      "skip": 0
+    },
+    "reasons": []
+  }
+}

--- a/fixtures/schema/v0.16/perfgate.tradeoff.v1.json
+++ b/fixtures/schema/v0.16/perfgate.tradeoff.v1.json
@@ -1,0 +1,97 @@
+{
+  "schema": "perfgate.tradeoff.v1",
+  "tool": {
+    "name": "perfgate",
+    "version": "0.16.0"
+  },
+  "run": {
+    "id": "run-tradeoff-1",
+    "started_at": "2026-05-08T00:00:00Z",
+    "ended_at": "2026-05-08T00:00:01Z",
+    "host": {
+      "os": "linux",
+      "arch": "x86_64"
+    }
+  },
+  "scenario": "large_file_parse",
+  "rules": [
+    {
+      "name": "tokenizer-slower-if-parser-faster",
+      "status": "accepted",
+      "accepted": true,
+      "downgrade_to": "pass",
+      "reason": "dominant parser loop improved materially",
+      "requirements": [
+        {
+          "metric": "wall_ms",
+          "probe": "parser.batch_loop",
+          "required_change": -0.08,
+          "observed_change": -0.104,
+          "satisfied": true,
+          "status": "pass"
+        }
+      ]
+    }
+  ],
+  "probes": [
+    {
+      "name": "parser.tokenize",
+      "scope": "local",
+      "weight": 0.2,
+      "deltas": {
+        "wall_ms": {
+          "baseline": 12.1,
+          "current": 12.35,
+          "ratio": 1.021,
+          "pct": 0.021,
+          "regression": 0.021,
+          "status": "warn"
+        }
+      },
+      "status": "warn",
+      "reason": "local slowdown"
+    },
+    {
+      "name": "parser.batch_loop",
+      "scope": "dominant",
+      "weight": 0.8,
+      "deltas": {
+        "wall_ms": {
+          "baseline": 100.0,
+          "current": 89.6,
+          "ratio": 0.896,
+          "pct": -0.104,
+          "regression": 0.0,
+          "status": "pass"
+        }
+      },
+      "status": "pass",
+      "reason": "dominant loop improved"
+    }
+  ],
+  "weighted_deltas": {
+    "wall_ms": {
+      "baseline": 100.0,
+      "current": 94.0,
+      "ratio": 0.94,
+      "pct": -0.06,
+      "regression": 0.0,
+      "status": "pass"
+    }
+  },
+  "decision": {
+    "accepted_tradeoff": true,
+    "status": "pass",
+    "reason": "2.1% local slowdown is offset by a 10.4% dominant-loop improvement"
+  },
+  "verdict": {
+    "status": "pass",
+    "counts": {
+      "pass": 1,
+      "warn": 1,
+      "fail": 0,
+      "skip": 0
+    },
+    "reasons": ["tradeoff_tokenizer-slower-if-parser-faster_applied"]
+  }
+}

--- a/schemas/perfgate.probe.v1.schema.json
+++ b/schemas/perfgate.probe.v1.schema.json
@@ -1,0 +1,290 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ProbeReceipt",
+  "description": "A versioned receipt for named probe observations (`perfgate.probe.v1`).",
+  "type": "object",
+  "properties": {
+    "bench": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/BenchMeta"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "probes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ProbeObservation"
+      }
+    },
+    "run": {
+      "$ref": "#/$defs/RunMeta"
+    },
+    "scenario": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "schema": {
+      "type": "string"
+    },
+    "tool": {
+      "$ref": "#/$defs/ToolInfo"
+    }
+  },
+  "required": [
+    "schema",
+    "tool",
+    "run",
+    "probes"
+  ],
+  "$defs": {
+    "BenchMeta": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "argv vector (no shell parsing).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cwd": {
+          "description": "Optional working directory (stringified path).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "repeat": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "timeout_ms": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "warmup": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "work_units": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "name",
+        "command",
+        "repeat",
+        "warmup"
+      ]
+    },
+    "HostInfo": {
+      "type": "object",
+      "properties": {
+        "arch": {
+          "description": "CPU architecture (e.g., \"x86_64\", \"aarch64\")",
+          "type": "string"
+        },
+        "cpu_count": {
+          "description": "Number of logical CPUs (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "hostname_hash": {
+          "description": "Hashed hostname for fingerprinting (opt-in, privacy-preserving).\nWhen present, this is a SHA-256 hash of the actual hostname.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "memory_bytes": {
+          "description": "Total system memory in bytes (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "os": {
+          "description": "Operating system (e.g., \"linux\", \"macos\", \"windows\")",
+          "type": "string"
+        }
+      },
+      "required": [
+        "os",
+        "arch"
+      ]
+    },
+    "ProbeMetricValue": {
+      "description": "A numeric metric observed for a named probe.",
+      "type": "object",
+      "properties": {
+        "statistic": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "value": {
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ProbeObservation": {
+      "description": "One named probe observation from external instrumentation.",
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "ended_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "items": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "iteration": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "metrics": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ProbeMetricValue"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "parent": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProbeScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "started_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ProbeScope": {
+      "description": "Scope of a named performance probe inside a workload.",
+      "type": "string",
+      "enum": [
+        "local",
+        "enclosing",
+        "dominant",
+        "total"
+      ]
+    },
+    "RunMeta": {
+      "type": "object",
+      "properties": {
+        "ended_at": {
+          "type": "string"
+        },
+        "host": {
+          "$ref": "#/$defs/HostInfo"
+        },
+        "id": {
+          "type": "string"
+        },
+        "started_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "started_at",
+        "ended_at",
+        "host"
+      ]
+    },
+    "ToolInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    }
+  }
+}

--- a/schemas/perfgate.scenario.v1.schema.json
+++ b/schemas/perfgate.scenario.v1.schema.json
@@ -1,0 +1,461 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ScenarioReceipt",
+  "description": "A versioned receipt for weighted workload scenarios (`perfgate.scenario.v1`).",
+  "type": "object",
+  "properties": {
+    "baseline_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CompareRef"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ScenarioComponent"
+      }
+    },
+    "current_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CompareRef"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "run": {
+      "$ref": "#/$defs/RunMeta"
+    },
+    "scenario": {
+      "$ref": "#/$defs/ScenarioMeta"
+    },
+    "schema": {
+      "type": "string"
+    },
+    "tool": {
+      "$ref": "#/$defs/ToolInfo"
+    },
+    "verdict": {
+      "$ref": "#/$defs/Verdict"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "weighted_deltas": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/Delta"
+      }
+    }
+  },
+  "required": [
+    "schema",
+    "tool",
+    "run",
+    "scenario",
+    "components",
+    "verdict"
+  ],
+  "$defs": {
+    "CompareRef": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Delta": {
+      "type": "object",
+      "properties": {
+        "baseline": {
+          "type": "number",
+          "format": "double"
+        },
+        "current": {
+          "type": "number",
+          "format": "double"
+        },
+        "cv": {
+          "description": "Coefficient of variation for the current run.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "noise_threshold": {
+          "description": "Noise threshold used for this comparison.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "pct": {
+          "description": "(current - baseline) / baseline",
+          "type": "number",
+          "format": "double"
+        },
+        "ratio": {
+          "description": "current / baseline",
+          "type": "number",
+          "format": "double"
+        },
+        "regression": {
+          "description": "Positive regression amount, normalized as a fraction.",
+          "type": "number",
+          "format": "double"
+        },
+        "significance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Significance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "statistic": {
+          "$ref": "#/$defs/MetricStatistic"
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        }
+      },
+      "required": [
+        "baseline",
+        "current",
+        "ratio",
+        "pct",
+        "regression",
+        "status"
+      ]
+    },
+    "HostInfo": {
+      "type": "object",
+      "properties": {
+        "arch": {
+          "description": "CPU architecture (e.g., \"x86_64\", \"aarch64\")",
+          "type": "string"
+        },
+        "cpu_count": {
+          "description": "Number of logical CPUs (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "hostname_hash": {
+          "description": "Hashed hostname for fingerprinting (opt-in, privacy-preserving).\nWhen present, this is a SHA-256 hash of the actual hostname.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "memory_bytes": {
+          "description": "Total system memory in bytes (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "os": {
+          "description": "Operating system (e.g., \"linux\", \"macos\", \"windows\")",
+          "type": "string"
+        }
+      },
+      "required": [
+        "os",
+        "arch"
+      ]
+    },
+    "MetricStatistic": {
+      "type": "string",
+      "enum": [
+        "median",
+        "p95"
+      ]
+    },
+    "MetricStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "RunMeta": {
+      "type": "object",
+      "properties": {
+        "ended_at": {
+          "type": "string"
+        },
+        "host": {
+          "$ref": "#/$defs/HostInfo"
+        },
+        "id": {
+          "type": "string"
+        },
+        "started_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "started_at",
+        "ended_at",
+        "host"
+      ]
+    },
+    "ScenarioComponent": {
+      "description": "A scenario component such as one benchmark, phase, or probe group.",
+      "type": "object",
+      "properties": {
+        "benchmark": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "compare_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompareRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "deltas": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Delta"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "probes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        },
+        "weight": {
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "name",
+        "weight",
+        "status"
+      ]
+    },
+    "ScenarioMeta": {
+      "description": "Scenario definition captured in a scenario evaluation receipt.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "weight": {
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "name",
+        "weight"
+      ]
+    },
+    "Significance": {
+      "type": "object",
+      "properties": {
+        "alpha": {
+          "type": "number",
+          "format": "double"
+        },
+        "baseline_samples": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "ci_lower": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "ci_upper": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "current_samples": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "p_value": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "significant": {
+          "type": "boolean"
+        },
+        "test": {
+          "$ref": "#/$defs/SignificanceTest"
+        }
+      },
+      "required": [
+        "test",
+        "alpha",
+        "significant",
+        "baseline_samples",
+        "current_samples"
+      ]
+    },
+    "SignificanceTest": {
+      "type": "string",
+      "enum": [
+        "welch_t"
+      ]
+    },
+    "ToolInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "Verdict": {
+      "description": "Overall verdict for a comparison, with pass/warn/fail counts.\n\n# Examples\n\n```\nuse perfgate_types::{Verdict, VerdictStatus, VerdictCounts};\n\nlet verdict = Verdict {\n    status: VerdictStatus::Pass,\n    counts: VerdictCounts { pass: 2, warn: 0, fail: 0, skip: 0 },\n    reasons: vec![],\n};\nassert_eq!(verdict.status, VerdictStatus::Pass);\n\nlet failing = Verdict {\n    status: VerdictStatus::Fail,\n    counts: VerdictCounts { pass: 1, warn: 0, fail: 1, skip: 0 },\n    reasons: vec![\"wall_ms.fail\".into()],\n};\nassert_eq!(failing.status, VerdictStatus::Fail);\nassert!(!failing.reasons.is_empty());\n```",
+      "type": "object",
+      "properties": {
+        "counts": {
+          "$ref": "#/$defs/VerdictCounts"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/VerdictStatus"
+        }
+      },
+      "required": [
+        "status",
+        "counts",
+        "reasons"
+      ]
+    },
+    "VerdictCounts": {
+      "type": "object",
+      "properties": {
+        "fail": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "pass": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "skip": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "warn": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "VerdictStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    }
+  }
+}

--- a/schemas/perfgate.tradeoff.v1.schema.json
+++ b/schemas/perfgate.tradeoff.v1.schema.json
@@ -1,0 +1,637 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TradeoffReceipt",
+  "description": "A versioned receipt explaining accepted or rejected tradeoffs (`perfgate.tradeoff.v1`).",
+  "type": "object",
+  "properties": {
+    "baseline_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CompareRef"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "configured_rules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TradeoffRule"
+      }
+    },
+    "current_ref": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CompareRef"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "decision": {
+      "$ref": "#/$defs/TradeoffDecision"
+    },
+    "probes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TradeoffProbeOutcome"
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TradeoffRuleOutcome"
+      }
+    },
+    "run": {
+      "$ref": "#/$defs/RunMeta"
+    },
+    "scenario": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "schema": {
+      "type": "string"
+    },
+    "tool": {
+      "$ref": "#/$defs/ToolInfo"
+    },
+    "verdict": {
+      "$ref": "#/$defs/Verdict"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "weighted_deltas": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/Delta"
+      }
+    }
+  },
+  "required": [
+    "schema",
+    "tool",
+    "run",
+    "rules",
+    "decision",
+    "verdict"
+  ],
+  "$defs": {
+    "CompareRef": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Delta": {
+      "type": "object",
+      "properties": {
+        "baseline": {
+          "type": "number",
+          "format": "double"
+        },
+        "current": {
+          "type": "number",
+          "format": "double"
+        },
+        "cv": {
+          "description": "Coefficient of variation for the current run.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "noise_threshold": {
+          "description": "Noise threshold used for this comparison.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "pct": {
+          "description": "(current - baseline) / baseline",
+          "type": "number",
+          "format": "double"
+        },
+        "ratio": {
+          "description": "current / baseline",
+          "type": "number",
+          "format": "double"
+        },
+        "regression": {
+          "description": "Positive regression amount, normalized as a fraction.",
+          "type": "number",
+          "format": "double"
+        },
+        "significance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Significance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "statistic": {
+          "$ref": "#/$defs/MetricStatistic"
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        }
+      },
+      "required": [
+        "baseline",
+        "current",
+        "ratio",
+        "pct",
+        "regression",
+        "status"
+      ]
+    },
+    "HostInfo": {
+      "type": "object",
+      "properties": {
+        "arch": {
+          "description": "CPU architecture (e.g., \"x86_64\", \"aarch64\")",
+          "type": "string"
+        },
+        "cpu_count": {
+          "description": "Number of logical CPUs (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "hostname_hash": {
+          "description": "Hashed hostname for fingerprinting (opt-in, privacy-preserving).\nWhen present, this is a SHA-256 hash of the actual hostname.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "memory_bytes": {
+          "description": "Total system memory in bytes (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "os": {
+          "description": "Operating system (e.g., \"linux\", \"macos\", \"windows\")",
+          "type": "string"
+        }
+      },
+      "required": [
+        "os",
+        "arch"
+      ]
+    },
+    "Metric": {
+      "type": "string",
+      "enum": [
+        "binary_bytes",
+        "cpu_ms",
+        "ctx_switches",
+        "energy_uj",
+        "io_read_bytes",
+        "io_write_bytes",
+        "max_rss_kb",
+        "network_packets",
+        "page_faults",
+        "throughput_per_s",
+        "wall_ms"
+      ]
+    },
+    "MetricStatistic": {
+      "type": "string",
+      "enum": [
+        "median",
+        "p95"
+      ]
+    },
+    "MetricStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "ProbeScope": {
+      "description": "Scope of a named performance probe inside a workload.",
+      "type": "string",
+      "enum": [
+        "local",
+        "enclosing",
+        "dominant",
+        "total"
+      ]
+    },
+    "RunMeta": {
+      "type": "object",
+      "properties": {
+        "ended_at": {
+          "type": "string"
+        },
+        "host": {
+          "$ref": "#/$defs/HostInfo"
+        },
+        "id": {
+          "type": "string"
+        },
+        "started_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "started_at",
+        "ended_at",
+        "host"
+      ]
+    },
+    "Significance": {
+      "type": "object",
+      "properties": {
+        "alpha": {
+          "type": "number",
+          "format": "double"
+        },
+        "baseline_samples": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "ci_lower": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "ci_upper": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "current_samples": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "p_value": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "significant": {
+          "type": "boolean"
+        },
+        "test": {
+          "$ref": "#/$defs/SignificanceTest"
+        }
+      },
+      "required": [
+        "test",
+        "alpha",
+        "significant",
+        "baseline_samples",
+        "current_samples"
+      ]
+    },
+    "SignificanceTest": {
+      "type": "string",
+      "enum": [
+        "welch_t"
+      ]
+    },
+    "ToolInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    },
+    "TradeoffDecision": {
+      "description": "Final structured tradeoff decision.",
+      "type": "object",
+      "properties": {
+        "accepted_tradeoff": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        }
+      },
+      "required": [
+        "accepted_tradeoff",
+        "status",
+        "reason"
+      ]
+    },
+    "TradeoffDecisionStatus": {
+      "description": "Outcome of a tradeoff policy decision.",
+      "type": "string",
+      "enum": [
+        "accepted",
+        "rejected",
+        "not_evaluated"
+      ]
+    },
+    "TradeoffDowngrade": {
+      "description": "Target status when a tradeoff rule is satisfied.",
+      "type": "string",
+      "enum": [
+        "warn",
+        "pass"
+      ]
+    },
+    "TradeoffProbeOutcome": {
+      "description": "Probe-level tradeoff evidence.",
+      "type": "object",
+      "properties": {
+        "deltas": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/Delta"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProbeScope"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        },
+        "weight": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        }
+      },
+      "required": [
+        "name",
+        "status"
+      ]
+    },
+    "TradeoffRequirement": {
+      "description": "A required improvement used by a tradeoff rule.",
+      "type": "object",
+      "properties": {
+        "metric": {
+          "description": "Metric that must improve sufficiently for the tradeoff to apply.",
+          "$ref": "#/$defs/Metric"
+        },
+        "min_improvement_ratio": {
+          "description": "Minimum required improvement ratio.\n\nFor higher-is-better metrics, this is `current / baseline`.\nFor lower-is-better metrics, this is `baseline / current`.",
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "metric",
+        "min_improvement_ratio"
+      ]
+    },
+    "TradeoffRequirementOutcome": {
+      "description": "Evaluation result for one tradeoff requirement.",
+      "type": "object",
+      "properties": {
+        "metric": {
+          "type": "string"
+        },
+        "observed_change": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "probe": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "required_change": {
+          "type": "number",
+          "format": "double"
+        },
+        "satisfied": {
+          "type": "boolean"
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        }
+      },
+      "required": [
+        "metric",
+        "required_change",
+        "satisfied",
+        "status"
+      ]
+    },
+    "TradeoffRule": {
+      "description": "A structured tradeoff rule for explicit, auditable budget downgrades.",
+      "type": "object",
+      "properties": {
+        "downgrade_to": {
+          "description": "Downgrade target when all requirements are satisfied.",
+          "$ref": "#/$defs/TradeoffDowngrade",
+          "default": "warn"
+        },
+        "if_failed": {
+          "description": "The failed metric that this rule can downgrade.",
+          "$ref": "#/$defs/Metric"
+        },
+        "name": {
+          "description": "Unique rule name used in reason tokens.",
+          "type": "string"
+        },
+        "require": {
+          "description": "Required compensating improvements.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TradeoffRequirement"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "name",
+        "if_failed",
+        "require"
+      ]
+    },
+    "TradeoffRuleOutcome": {
+      "description": "Evaluation result for one named tradeoff rule.",
+      "type": "object",
+      "properties": {
+        "accepted": {
+          "type": "boolean"
+        },
+        "downgrade_to": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TradeoffDowngrade"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TradeoffRequirementOutcome"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/TradeoffDecisionStatus"
+        }
+      },
+      "required": [
+        "name",
+        "status",
+        "accepted"
+      ]
+    },
+    "Verdict": {
+      "description": "Overall verdict for a comparison, with pass/warn/fail counts.\n\n# Examples\n\n```\nuse perfgate_types::{Verdict, VerdictStatus, VerdictCounts};\n\nlet verdict = Verdict {\n    status: VerdictStatus::Pass,\n    counts: VerdictCounts { pass: 2, warn: 0, fail: 0, skip: 0 },\n    reasons: vec![],\n};\nassert_eq!(verdict.status, VerdictStatus::Pass);\n\nlet failing = Verdict {\n    status: VerdictStatus::Fail,\n    counts: VerdictCounts { pass: 1, warn: 0, fail: 1, skip: 0 },\n    reasons: vec![\"wall_ms.fail\".into()],\n};\nassert_eq!(failing.status, VerdictStatus::Fail);\nassert!(!failing.reasons.is_empty());\n```",
+      "type": "object",
+      "properties": {
+        "counts": {
+          "$ref": "#/$defs/VerdictCounts"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "status": {
+          "$ref": "#/$defs/VerdictStatus"
+        }
+      },
+      "required": [
+        "status",
+        "counts",
+        "reasons"
+      ]
+    },
+    "VerdictCounts": {
+      "type": "object",
+      "properties": {
+        "fail": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "pass": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "skip": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        },
+        "warn": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    },
+    "VerdictStatus": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "warn",
+        "fail",
+        "skip"
+      ]
+    }
+  }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,9 +16,12 @@ const TARGET_PUBLIC_PACKAGES: [&str; 5] = [
     "perfgate-cli",
 ];
 
-const SCHEMA_FILES: [&str; 8] = [
+const SCHEMA_FILES: [&str; 11] = [
     "perfgate.run.v1.schema.json",
     "perfgate.compare.v1.schema.json",
+    "perfgate.probe.v1.schema.json",
+    "perfgate.scenario.v1.schema.json",
+    "perfgate.tradeoff.v1.schema.json",
     "perfgate.config.v1.schema.json",
     "perfgate.report.v1.schema.json",
     "perfgate.aggregate.v1.schema.json",
@@ -2043,36 +2046,54 @@ fn cmd_schema(out_dir: &PathBuf) -> anyhow::Result<()> {
     write_schema(
         out_dir,
         SCHEMA_FILES[2],
-        schema_for!(perfgate_types::ConfigFile),
+        schema_for!(perfgate_types::ProbeReceipt),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[3],
-        schema_for!(perfgate_types::PerfgateReport),
+        schema_for!(perfgate_types::ScenarioReceipt),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[4],
-        schema_for!(perfgate_types::AggregateReceipt),
+        schema_for!(perfgate_types::TradeoffReceipt),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[5],
-        schema_for!(perfgate_types::RatchetReceipt),
+        schema_for!(perfgate_types::ConfigFile),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[6],
+        schema_for!(perfgate_types::PerfgateReport),
+    )?;
+
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[7],
+        schema_for!(perfgate_types::AggregateReceipt),
+    )?;
+
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[8],
+        schema_for!(perfgate_types::RatchetReceipt),
+    )?;
+
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[9],
         schema_for!(perfgate_types::RepairContextReceipt),
     )?;
 
     // Sensor report schema is vendored from contracts/, not generated.
     let vendored_schema = PathBuf::from("contracts/schemas/sensor.report.v1.schema.json");
-    let dest = out_dir.join(SCHEMA_FILES[7]);
+    let dest = out_dir.join(SCHEMA_FILES[10]);
     fs::copy(&vendored_schema, &dest).with_context(|| {
         format!(
             "copy vendored schema {} -> {}",
@@ -2168,6 +2189,15 @@ fn cmd_schema_compat(fixtures_dir: &Path) -> anyhow::Result<()> {
             }
             "perfgate.compare.v1" => {
                 serde_json::from_value::<perfgate_types::CompareReceipt>(value).map(|_| ())
+            }
+            "perfgate.probe.v1" => {
+                serde_json::from_value::<perfgate_types::ProbeReceipt>(value).map(|_| ())
+            }
+            "perfgate.scenario.v1" => {
+                serde_json::from_value::<perfgate_types::ScenarioReceipt>(value).map(|_| ())
+            }
+            "perfgate.tradeoff.v1" => {
+                serde_json::from_value::<perfgate_types::TradeoffReceipt>(value).map(|_| ())
             }
             "perfgate.report.v1" => {
                 serde_json::from_value::<perfgate_types::PerfgateReport>(value).map(|_| ())
@@ -3485,6 +3515,21 @@ fn validate_versioned_json_example(
             serde_json::from_value::<perfgate_types::CompareReceipt>(value)
                 .context("deserialize perfgate.compare.v1 example")?;
             Ok(Some(perfgate_types::COMPARE_SCHEMA_V1))
+        }
+        Some(perfgate_types::PROBE_SCHEMA_V1) => {
+            serde_json::from_value::<perfgate_types::ProbeReceipt>(value)
+                .context("deserialize perfgate.probe.v1 example")?;
+            Ok(Some(perfgate_types::PROBE_SCHEMA_V1))
+        }
+        Some(perfgate_types::SCENARIO_SCHEMA_V1) => {
+            serde_json::from_value::<perfgate_types::ScenarioReceipt>(value)
+                .context("deserialize perfgate.scenario.v1 example")?;
+            Ok(Some(perfgate_types::SCENARIO_SCHEMA_V1))
+        }
+        Some(perfgate_types::TRADEOFF_SCHEMA_V1) => {
+            serde_json::from_value::<perfgate_types::TradeoffReceipt>(value)
+                .context("deserialize perfgate.tradeoff.v1 example")?;
+            Ok(Some(perfgate_types::TRADEOFF_SCHEMA_V1))
         }
         Some(perfgate_types::AGGREGATE_SCHEMA_V1) => {
             serde_json::from_value::<perfgate_types::AggregateReceipt>(value)


### PR DESCRIPTION
## Summary
- add schema-first structured-evidence receipt contracts for `perfgate.probe.v1`, `perfgate.scenario.v1`, and `perfgate.tradeoff.v1`
- generate committed JSON schemas and add v0.16 compatibility fixtures for the three new receipt families
- wire schema generation, schema drift checks, schema compatibility, and doc JSON validation through `xtask`

## Notes
- this is contract-only: no probe macros, no ingestion command, and no scenario/tradeoff runtime evaluation behavior is introduced here

## Validation
- cargo fmt --all -- --check
- cargo test -p perfgate-types structured_evidence --all-features
- cargo test -p perfgate-types --all-features
- cargo run -p xtask -- schema
- cargo run -p xtask -- schema-check
- cargo run -p xtask -- schema-compat
- cargo test -p xtask schema --all-features
- cargo test -p xtask --all-features
- cargo run -p xtask -- docs-check
- cargo run -p xtask -- doc-test
- cargo clippy -p perfgate-types -p xtask --all-targets --all-features -- -D warnings
- cargo run -p xtask -- public-surface --strict
- cargo run -p xtask -- arch
- cargo run -p xtask -- ci
- git diff --check