### PR TITLE
ingest: add probe JSONL import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detection, and baseline-server health.
 - Added schema-first structured performance evidence contracts for
   `perfgate.probe.v1`, `perfgate.scenario.v1`, and `perfgate.tradeoff.v1`.
+- Added `perfgate ingest probes --file probes.jsonl` to convert
+  language-agnostic probe JSONL into `perfgate.probe.v1` receipts.
 - Extended `xtask schema-compat` with baseline-service record, health-response,
   and fleet fixtures so the 0.16 server API contract is checked alongside
   receipt compatibility.

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -378,9 +378,9 @@ enum Command {
 
     /// Import benchmark results from external frameworks into perfgate format.
     ///
-    /// Supports Criterion, hyperfine, Go bench, and pytest-benchmark.
-    /// Produces a standard perfgate.run.v1 receipt that can be used with
-    /// compare, report, check, and other perfgate commands.
+    /// Supports Criterion, hyperfine, Go bench, pytest-benchmark, OTel spans,
+    /// and probe JSONL. Produces standard perfgate.run.v1 or perfgate.probe.v1
+    /// receipts.
     Ingest(Box<IngestArgs>),
 
     /// Generate an embeddable SVG status badge from a report or compare receipt.
@@ -1207,13 +1207,16 @@ pub struct PairedArgs {
 
 #[derive(Debug, Args)]
 pub struct IngestArgs {
+    #[command(subcommand)]
+    pub command: Option<IngestCommand>,
+
     /// Input format: criterion, hyperfine, gobench, pytest, otel
     #[arg(long)]
-    pub format: String,
+    pub format: Option<String>,
 
     /// Path to the input file (or directory for criterion)
     #[arg(long)]
-    pub input: PathBuf,
+    pub input: Option<PathBuf>,
 
     /// Benchmark name (default: derived from input data)
     #[arg(long)]
@@ -1232,6 +1235,35 @@ pub struct IngestArgs {
     pub out: PathBuf,
 
     /// Pretty-print JSON
+    #[arg(long, default_value_t = false)]
+    pub pretty: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum IngestCommand {
+    /// Ingest language-agnostic probe JSONL into a perfgate.probe.v1 receipt.
+    Probes(IngestProbesArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct IngestProbesArgs {
+    /// Path to the probe JSONL file.
+    #[arg(long)]
+    pub file: PathBuf,
+
+    /// Optional benchmark name to attach to the probe receipt.
+    #[arg(long)]
+    pub bench: Option<String>,
+
+    /// Optional scenario name to attach to the probe receipt.
+    #[arg(long)]
+    pub scenario: Option<String>,
+
+    /// Output file path.
+    #[arg(long, default_value = "probe.json")]
+    pub out: PathBuf,
+
+    /// Pretty-print JSON.
     #[arg(long, default_value_t = false)]
     pub pretty: bool,
 }
@@ -2969,6 +3001,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
         Command::Ingest(args) => {
             let IngestArgs {
+                command,
                 format,
                 input,
                 name,
@@ -2977,6 +3010,19 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 out,
                 pretty,
             } = *args;
+
+            if let Some(command) = command {
+                return match command {
+                    IngestCommand::Probes(args) => execute_ingest_probes(args),
+                };
+            }
+
+            let format = format.ok_or_else(|| {
+                anyhow::anyhow!("ingest requires --format unless using a subcommand")
+            })?;
+            let input = input.ok_or_else(|| {
+                anyhow::anyhow!("ingest requires --input unless using a subcommand")
+            })?;
 
             let format = IngestFormat::parse(&format).ok_or_else(|| {
                 anyhow::anyhow!(
@@ -3071,6 +3117,24 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
         Command::Comment(args) => execute_comment(*args),
         Command::Trend(args) => execute_trend(*args),
     }
+}
+
+fn execute_ingest_probes(args: IngestProbesArgs) -> anyhow::Result<()> {
+    let content = fs::read_to_string(&args.file)
+        .with_context(|| format!("read probe JSONL file {}", args.file.display()))?;
+    let request = ingest::ProbeIngestRequest {
+        input: content,
+        bench: args.bench,
+        scenario: args.scenario,
+    };
+    let receipt = ingest::ingest_probes_jsonl(&request)?;
+    write_json(&args.out, &receipt, args.pretty)?;
+    eprintln!(
+        "Ingested probes {} -> {}",
+        args.file.display(),
+        args.out.display()
+    );
+    Ok(())
 }
 
 fn execute_badge(args: BadgeArgs) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_ingest_tests.rs
+++ b/crates/perfgate-cli/tests/cli_ingest_tests.rs
@@ -57,3 +57,54 @@ fn test_ingest_hyperfine_writes_run_receipt() {
     assert_eq!(receipt["tool"]["name"], "perfgate-ingest");
     assert_eq!(receipt["samples"].as_array().map(Vec::len), Some(3));
 }
+
+#[test]
+fn test_ingest_probes_writes_probe_receipt() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("probes.jsonl");
+    let output_path = temp_dir.path().join("probe.json");
+
+    fs::write(
+        &input_path,
+        r#"{"probe":"parser.tokenize","scope":"local","wall_ms":12.4,"alloc_bytes":184320,"items":10000}
+{"name":"parser.ast_build","parent":"parser.total","metrics":{"wall_ms":{"value":44.8,"unit":"ms"}}}
+"#,
+    )
+    .expect("failed to write probe input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("probes")
+        .arg("--file")
+        .arg(&input_path)
+        .arg("--bench")
+        .arg("parser")
+        .arg("--scenario")
+        .arg("large_file_parse")
+        .arg("--out")
+        .arg(&output_path);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Ingested probes"));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read probe output"),
+    )
+    .expect("probe output should be JSON");
+
+    assert_eq!(receipt["schema"], "perfgate.probe.v1");
+    assert_eq!(receipt["tool"]["name"], "perfgate-ingest");
+    assert_eq!(receipt["bench"]["name"], "parser");
+    assert_eq!(receipt["scenario"], "large_file_parse");
+    assert_eq!(receipt["probes"].as_array().map(Vec::len), Some(2));
+    assert_eq!(receipt["probes"][0]["name"], "parser.tokenize");
+    assert_eq!(receipt["probes"][0]["scope"], "local");
+    assert_eq!(receipt["probes"][0]["metrics"]["wall_ms"]["value"], 12.4);
+    assert_eq!(receipt["probes"][0]["metrics"]["wall_ms"]["unit"], "ms");
+    assert_eq!(
+        receipt["probes"][0]["metrics"]["alloc_bytes"]["value"],
+        184320.0
+    );
+    assert_eq!(receipt["probes"][1]["parent"], "parser.total");
+}

--- a/crates/perfgate/src/integrations/ingest/mod.rs
+++ b/crates/perfgate/src/integrations/ingest/mod.rs
@@ -10,10 +10,12 @@ mod criterion;
 mod gobench;
 mod hyperfine;
 mod otel;
+mod probes;
 mod pytest;
 
 use perfgate_types::{
-    BenchMeta, HostInfo, RUN_SCHEMA_V1, RunMeta, RunReceipt, Sample, Stats, ToolInfo, U64Summary,
+    BenchMeta, HostInfo, PROBE_SCHEMA_V1, ProbeReceipt, RUN_SCHEMA_V1, RunMeta, RunReceipt, Sample,
+    Stats, ToolInfo, U64Summary,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -22,6 +24,7 @@ pub use criterion::parse_criterion;
 pub use gobench::parse_gobench;
 pub use hyperfine::parse_hyperfine;
 pub use otel::parse_otel_json;
+pub use probes::{ProbeIngestRequest, ingest_probes_jsonl};
 pub use pytest::parse_pytest_benchmark;
 
 /// Supported ingest formats.
@@ -77,6 +80,50 @@ pub fn ingest(request: &IngestRequest) -> anyhow::Result<RunReceipt> {
             &request.include_spans,
             &request.exclude_spans,
         ),
+    }
+}
+
+/// Build scaffolding for a `ProbeReceipt` with sensible defaults.
+fn make_probe_receipt(
+    bench_name: Option<&str>,
+    scenario: Option<String>,
+    probes: Vec<perfgate_types::ProbeObservation>,
+) -> ProbeReceipt {
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    ProbeReceipt {
+        schema: PROBE_SCHEMA_V1.to_string(),
+        tool: ToolInfo {
+            name: "perfgate-ingest".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        run: RunMeta {
+            id: Uuid::new_v4().to_string(),
+            started_at: timestamp.clone(),
+            ended_at: timestamp,
+            host: HostInfo {
+                os: std::env::consts::OS.to_string(),
+                arch: std::env::consts::ARCH.to_string(),
+                cpu_count: None,
+                memory_bytes: None,
+                hostname_hash: None,
+            },
+        },
+        bench: bench_name.map(|name| BenchMeta {
+            name: name.to_string(),
+            cwd: None,
+            command: vec!["(ingested probes)".to_string()],
+            repeat: probes.len() as u32,
+            warmup: 0,
+            work_units: None,
+            timeout_ms: None,
+        }),
+        scenario,
+        probes,
+        metadata: Default::default(),
     }
 }
 

--- a/crates/perfgate/src/integrations/ingest/probes.rs
+++ b/crates/perfgate/src/integrations/ingest/probes.rs
@@ -1,0 +1,183 @@
+use anyhow::Context;
+use perfgate_types::{ProbeMetricValue, ProbeObservation, ProbeScope};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use super::make_probe_receipt;
+
+/// Request to ingest language-agnostic probe JSONL.
+pub struct ProbeIngestRequest {
+    /// Raw JSONL content.
+    pub input: String,
+    /// Optional benchmark name to attach as receipt metadata.
+    pub bench: Option<String>,
+    /// Optional scenario name to attach as receipt metadata.
+    pub scenario: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProbeEvent {
+    #[serde(alias = "probe")]
+    name: String,
+
+    #[serde(default)]
+    parent: Option<String>,
+
+    #[serde(default)]
+    scope: Option<ProbeScope>,
+
+    #[serde(default)]
+    iteration: Option<u32>,
+
+    #[serde(default)]
+    started_at: Option<String>,
+
+    #[serde(default)]
+    ended_at: Option<String>,
+
+    #[serde(default)]
+    items: Option<u64>,
+
+    #[serde(default)]
+    metrics: BTreeMap<String, ProbeMetricValue>,
+
+    #[serde(default)]
+    attributes: BTreeMap<String, String>,
+
+    #[serde(flatten)]
+    extra: BTreeMap<String, serde_json::Value>,
+}
+
+/// Ingest JSONL probe events into a `perfgate.probe.v1` receipt.
+pub fn ingest_probes_jsonl(
+    request: &ProbeIngestRequest,
+) -> anyhow::Result<perfgate_types::ProbeReceipt> {
+    let mut probes = Vec::new();
+
+    for (index, line) in request.input.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let raw: RawProbeEvent = serde_json::from_str(trimmed)
+            .with_context(|| format!("parse probe JSONL line {}", index + 1))?;
+        probes.push(raw.into_observation());
+    }
+
+    if probes.is_empty() {
+        anyhow::bail!("no probe events found in JSONL input");
+    }
+
+    Ok(make_probe_receipt(
+        request.bench.as_deref(),
+        request.scenario.clone(),
+        probes,
+    ))
+}
+
+impl RawProbeEvent {
+    fn into_observation(mut self) -> ProbeObservation {
+        let mut attributes = self.attributes;
+        let mut metrics = self.metrics;
+
+        for (key, value) in self.extra {
+            if let Some(number) = value.as_f64() {
+                metrics.insert(
+                    key.clone(),
+                    ProbeMetricValue {
+                        value: number,
+                        unit: infer_unit(&key).map(str::to_string),
+                        statistic: None,
+                    },
+                );
+            } else if let Some(text) = value.as_str() {
+                attributes.insert(key, text.to_string());
+            } else if value.is_boolean() || value.is_number() {
+                attributes.insert(key, value.to_string());
+            }
+        }
+
+        ProbeObservation {
+            name: self.name,
+            parent: self.parent.take(),
+            scope: self.scope,
+            iteration: self.iteration,
+            started_at: self.started_at.take(),
+            ended_at: self.ended_at.take(),
+            items: self.items,
+            metrics,
+            attributes,
+        }
+    }
+}
+
+fn infer_unit(metric: &str) -> Option<&'static str> {
+    match metric {
+        name if name.ends_with("_ms") => Some("ms"),
+        name if name.ends_with("_bytes") => Some("bytes"),
+        name if name.ends_with("_kb") => Some("KB"),
+        name if name.ends_with("_uj") => Some("uj"),
+        name if name.ends_with("_per_s") => Some("/s"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ingest_probe_jsonl_accepts_flat_metric_events() {
+        let receipt = ingest_probes_jsonl(&ProbeIngestRequest {
+            input: r#"{"probe":"parser.tokenize","wall_ms":12.4,"alloc_bytes":184320,"items":10000,"scope":"local"}"#.into(),
+            bench: Some("parser".into()),
+            scenario: Some("large_file_parse".into()),
+        })
+        .expect("ingest probe JSONL");
+
+        assert_eq!(receipt.schema, perfgate_types::PROBE_SCHEMA_V1);
+        assert_eq!(
+            receipt.bench.as_ref().map(|bench| bench.name.as_str()),
+            Some("parser")
+        );
+        assert_eq!(receipt.scenario.as_deref(), Some("large_file_parse"));
+        assert_eq!(receipt.probes.len(), 1);
+        assert_eq!(receipt.probes[0].name, "parser.tokenize");
+        assert_eq!(
+            receipt.probes[0].metrics["wall_ms"].unit.as_deref(),
+            Some("ms")
+        );
+        assert_eq!(
+            receipt.probes[0].metrics["alloc_bytes"].unit.as_deref(),
+            Some("bytes")
+        );
+    }
+
+    #[test]
+    fn ingest_probe_jsonl_accepts_nested_metrics() {
+        let receipt = ingest_probes_jsonl(&ProbeIngestRequest {
+            input:
+                r#"{"name":"parser.ast_build","metrics":{"wall_ms":{"value":44.8,"unit":"ms"}}}"#
+                    .into(),
+            bench: None,
+            scenario: None,
+        })
+        .expect("ingest probe JSONL");
+
+        assert_eq!(receipt.probes[0].metrics["wall_ms"].value, 44.8);
+        assert!(receipt.bench.is_none());
+    }
+
+    #[test]
+    fn ingest_probe_jsonl_rejects_empty_input() {
+        let err = ingest_probes_jsonl(&ProbeIngestRequest {
+            input: "\n\n".into(),
+            bench: None,
+            scenario: None,
+        })
+        .expect_err("empty JSONL should fail");
+
+        assert!(err.to_string().contains("no probe events"));
+    }
+}

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -8,7 +8,7 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 |--------|-------------|-------------|
 | `perfgate.run.v1` | `run`, `check` | Raw measurement data from a benchmark execution |
 | `perfgate.compare.v1` | `compare`, `check`, `paired` | Comparison of current run against baseline |
-| `perfgate.probe.v1` | schema-first contract | Named probe observations from internal phases or external instrumentation |
+| `perfgate.probe.v1` | `ingest probes` | Named probe observations from internal phases or external instrumentation |
 | `perfgate.scenario.v1` | schema-first contract | Weighted workload-scenario evidence across benchmarks, phases, or probe groups |
 | `perfgate.tradeoff.v1` | schema-first contract | Structured decision evidence for accepted or rejected performance tradeoffs |
 | `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
@@ -45,6 +45,23 @@ cargo run -p xtask -- schema-check
 
 # Verify old release fixtures still deserialize with current types
 cargo run -p xtask -- schema-compat
+```
+
+## Probe JSONL Ingestion
+
+`perfgate ingest probes` converts language-agnostic probe JSONL into a
+`perfgate.probe.v1` receipt:
+
+```bash
+perfgate ingest probes --file probes.jsonl --out probe.json
+```
+
+Each non-empty JSONL line is one probe observation. Lines may use the full
+`ProbeObservation` shape, or a compact flat shape where numeric top-level fields
+become metrics:
+
+```json
+{"probe":"parser.tokenize","scope":"local","wall_ms":12.4,"alloc_bytes":184320,"items":10000}
 ```
 
 ## Fixture Validation


### PR DESCRIPTION
## Summary
- add `perfgate ingest probes --file probes.jsonl` for language-agnostic probe JSONL ingestion
- convert compact flat events and full/nested probe metric events into `perfgate.probe.v1` receipts
- keep legacy `perfgate ingest --format ... --input ...` behavior intact and document the probe JSONL path

## Out of scope
- Rust probe macros
- scenario weighting/evaluation runtime
- tradeoff policy evaluation runtime

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate --all-features`
- `cargo test -p perfgate-cli --all-features`
- `cargo clippy -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`