### PR TITLE
scenario: evaluate weighted compare receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `perfgate.probe.v1`, `perfgate.scenario.v1`, and `perfgate.tradeoff.v1`.
 - Added `perfgate ingest probes --file probes.jsonl` to convert
   language-agnostic probe JSONL into `perfgate.probe.v1` receipts.
+- Added `perfgate scenario evaluate` to turn configured weighted scenarios and
+  benchmark compare receipts into `perfgate.scenario.v1` workload receipts.
 - Extended `xtask schema-compat` with baseline-service record, health-response,
   and fleet fixtures so the 0.16 server API contract is checked alongside
   receipt compatibility.

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -23,9 +23,10 @@ use perfgate_app::{
     CompareUseCase, DiffRequest, DiffUseCase, ExplainRequest, ExplainUseCase, ExportFormat,
     ExportUseCase, PairedRunRequest, PairedRunUseCase, PromoteRequest, PromoteUseCase,
     RatchetUseCase, ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase,
-    SensorReportBuilder, SystemClock, classify_error, github_annotations, is_host_mismatch_reason,
-    preview_lines, redact_command_for_diagnostics, render_json_diff, render_markdown,
-    render_markdown_template, render_terminal_diff,
+    ScenarioEvaluateInput, ScenarioEvaluateRequest, ScenarioUseCase, SensorReportBuilder,
+    SystemClock, classify_error, github_annotations, is_host_mismatch_reason, preview_lines,
+    redact_command_for_diagnostics, render_json_diff, render_markdown, render_markdown_template,
+    render_terminal_diff,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::types::auth::Role;
@@ -47,8 +48,8 @@ use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
     MetricStatus, OtelSpanIdentifiers, PerfgateReport, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
-    RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, SensorVerdictStatus,
-    ToolInfo, VerdictStatus,
+    RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
+    SensorVerdictStatus, ToolInfo, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
@@ -64,6 +65,7 @@ const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured;
 const DEFAULT_FALLBACK_BASELINE_DIR: &str = "baselines";
 const DEFAULT_ARTIFACT_DIR: &str = "artifacts/perfgate";
 const RUN_RECEIPT_FILE: &str = "run.json";
+const COMPARE_RECEIPT_FILE: &str = "compare.json";
 
 /// Output mode for the check command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum, Default)]
@@ -336,6 +338,12 @@ enum Command {
         /// Pretty-print JSON
         #[arg(long, default_value_t = false)]
         pretty: bool,
+    },
+
+    /// Evaluate configured workload scenarios from compare receipts.
+    Scenario {
+        #[command(subcommand)]
+        action: ScenarioAction,
     },
 
     /// Automatically find the commit that introduced a performance regression.
@@ -1243,6 +1251,39 @@ pub struct IngestArgs {
 pub enum IngestCommand {
     /// Ingest language-agnostic probe JSONL into a perfgate.probe.v1 receipt.
     Probes(IngestProbesArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ScenarioAction {
+    /// Evaluate configured scenarios into a perfgate.scenario.v1 receipt.
+    Evaluate(ScenarioEvaluateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ScenarioEvaluateArgs {
+    /// Path to perfgate.toml.
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Evaluate only one configured scenario by name.
+    #[arg(long)]
+    pub scenario: Option<String>,
+
+    /// Name to use for the combined weighted workload receipt.
+    #[arg(long)]
+    pub workload_name: Option<String>,
+
+    /// Override artifact directory used for default compare receipt lookup.
+    #[arg(long)]
+    pub out_dir: Option<PathBuf>,
+
+    /// Output scenario receipt path.
+    #[arg(long, default_value = "scenario.json")]
+    pub out: PathBuf,
+
+    /// Pretty-print JSON.
+    #[arg(long, default_value_t = false)]
+    pub pretty: bool,
 }
 
 #[derive(Debug, Args)]
@@ -2968,6 +3009,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
             }
         }
 
+        Command::Scenario { action } => execute_scenario_action(action),
+
         Command::Bisect(args) => {
             let usecase = BisectUseCase::default();
             usecase.execute(BisectRequest {
@@ -3135,6 +3178,91 @@ fn execute_ingest_probes(args: IngestProbesArgs) -> anyhow::Result<()> {
         args.out.display()
     );
     Ok(())
+}
+
+fn execute_scenario_action(action: ScenarioAction) -> anyhow::Result<()> {
+    match action {
+        ScenarioAction::Evaluate(args) => execute_scenario_evaluate(args),
+    }
+}
+
+fn execute_scenario_evaluate(args: ScenarioEvaluateArgs) -> anyhow::Result<()> {
+    let config = load_config_file(&args.config)
+        .with_context(|| format!("failed to load {}", args.config.display()))?;
+    config
+        .validate()
+        .map_err(|error| anyhow::anyhow!("{} is invalid: {error}", args.config.display()))?;
+
+    if config.scenarios.is_empty() {
+        anyhow::bail!(
+            "no [[scenario]] entries configured in {}",
+            args.config.display()
+        );
+    }
+
+    let selected = select_configured_scenarios(&config, args.scenario.as_deref())?;
+    let out_dir = args
+        .out_dir
+        .clone()
+        .unwrap_or_else(|| resolve_configured_out_dir(None, Some(&config)));
+
+    let mut inputs = Vec::new();
+    for scenario in selected {
+        let compare_path = scenario_compare_path(scenario, &out_dir);
+        let compare: CompareReceipt = read_json_from_location(&compare_path)
+            .with_context(|| format!("read scenario compare {}", compare_path.display()))?;
+        let run_id = compare.current_ref.run_id.clone();
+        inputs.push(ScenarioEvaluateInput {
+            config: scenario.clone(),
+            compare_ref: CompareRef {
+                path: Some(compare_path.display().to_string()),
+                run_id,
+            },
+            compare,
+        });
+    }
+
+    let outcome = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+        config,
+        inputs,
+        workload_name: args.workload_name,
+        tool: tool_info(),
+    })?;
+
+    write_json(&args.out, &outcome.receipt, args.pretty)?;
+    eprintln!("Scenario receipt written to {}", args.out.display());
+
+    match outcome.receipt.verdict.status {
+        VerdictStatus::Fail => exit_with_code(2),
+        VerdictStatus::Pass | VerdictStatus::Warn | VerdictStatus::Skip => Ok(()),
+    }
+}
+
+fn select_configured_scenarios<'a>(
+    config: &'a ConfigFile,
+    scenario: Option<&str>,
+) -> anyhow::Result<Vec<&'a ScenarioConfigFile>> {
+    if let Some(name) = scenario {
+        let selected: Vec<_> = config
+            .scenarios
+            .iter()
+            .filter(|candidate| candidate.name == name)
+            .collect();
+        if selected.is_empty() {
+            anyhow::bail!("scenario '{}' is not defined in the config file", name);
+        }
+        return Ok(selected);
+    }
+
+    Ok(config.scenarios.iter().collect())
+}
+
+fn scenario_compare_path(scenario: &ScenarioConfigFile, out_dir: &Path) -> PathBuf {
+    scenario
+        .compare
+        .as_deref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| out_dir.join(&scenario.bench).join(COMPARE_RECEIPT_FILE))
 }
 
 fn execute_badge(args: BadgeArgs) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -24,6 +24,7 @@ fn cli_help_main() {
         .stdout(predicate::str::contains("doctor"))
         .stdout(predicate::str::contains("paired"))
         .stdout(predicate::str::contains("audit"))
+        .stdout(predicate::str::contains("scenario"))
         .stdout(predicate::str::contains("md"))
         .stdout(predicate::str::contains("export"))
         .stdout(predicate::str::contains("promote"))
@@ -214,6 +215,33 @@ fn cli_help_cargo_bench() {
         .stdout(predicate::str::contains("--compare"));
 }
 
+#[test]
+fn cli_help_scenario() {
+    perfgate_cmd()
+        .args(["scenario", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Evaluate configured workload scenarios",
+        ))
+        .stdout(predicate::str::contains("evaluate"));
+}
+
+#[test]
+fn cli_help_scenario_evaluate() {
+    perfgate_cmd()
+        .args(["scenario", "evaluate", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Evaluate configured scenarios into a perfgate.scenario.v1 receipt",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--scenario"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--workload-name"));
+}
+
 // ── insta full-output snapshot tests ─────────────────────────────────
 
 fn help_output(args: &[&str]) -> String {
@@ -336,5 +364,18 @@ fn snapshot_help_ratchet_preview() {
     insta::assert_snapshot!(
         "help_ratchet_preview",
         help_output(&["ratchet", "preview", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_scenario() {
+    insta::assert_snapshot!("help_scenario", help_output(&["scenario", "--help"]));
+}
+
+#[test]
+fn snapshot_help_scenario_evaluate() {
+    insta::assert_snapshot!(
+        "help_scenario_evaluate",
+        help_output(&["scenario", "evaluate", "--help"])
     );
 }

--- a/crates/perfgate-cli/tests/cli_scenario_tests.rs
+++ b/crates/perfgate-cli/tests/cli_scenario_tests.rs
@@ -1,0 +1,192 @@
+//! Integration tests for `perfgate scenario`.
+
+mod common;
+
+use common::perfgate_cmd;
+use predicates::prelude::*;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[test]
+fn test_scenario_evaluate_writes_weighted_scenario_receipt() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    write_compare_receipt(
+        &out_dir.join("large-file").join("compare.json"),
+        "large-file",
+        100.0,
+        90.0,
+        "pass",
+    );
+    write_compare_receipt(
+        &out_dir.join("small-edit").join("compare.json"),
+        "small-edit",
+        100.0,
+        110.0,
+        "fail",
+    );
+
+    let config_path = temp_dir.path().join("perfgate.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"[defaults]
+threshold = 0.20
+warn_factor = 0.50
+out_dir = "{}"
+
+[[bench]]
+name = "large-file"
+command = ["echo", "large"]
+
+[[bench]]
+name = "small-edit"
+command = ["echo", "small"]
+
+[[scenario]]
+name = "large_file_parse"
+weight = 0.75
+bench = "large-file"
+
+[[scenario]]
+name = "small_edit"
+weight = 0.25
+bench = "small-edit"
+"#,
+            toml_path(&out_dir)
+        ),
+    )
+    .expect("failed to write config");
+
+    let output_path = temp_dir.path().join("scenario.json");
+    perfgate_cmd()
+        .arg("scenario")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Scenario receipt written"));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read scenario receipt"),
+    )
+    .expect("scenario receipt should be JSON");
+    let typed: perfgate_types::ScenarioReceipt =
+        serde_json::from_value(receipt.clone()).expect("scenario receipt should deserialize");
+
+    assert_eq!(typed.schema, "perfgate.scenario.v1");
+    assert_eq!(typed.scenario.name, "configured_workload");
+    assert_eq!(typed.components.len(), 2);
+    assert_eq!(typed.verdict.status, perfgate_types::VerdictStatus::Pass);
+    assert_eq!(receipt["weighted_deltas"]["wall_ms"]["baseline"], 100.0);
+    assert_eq!(receipt["weighted_deltas"]["wall_ms"]["current"], 95.0);
+    assert_eq!(receipt["weighted_deltas"]["wall_ms"]["status"], "pass");
+    let expected_compare_path = out_dir
+        .join("large-file")
+        .join("compare.json")
+        .display()
+        .to_string();
+    assert_eq!(
+        receipt["components"][0]["compare_ref"]["path"]
+            .as_str()
+            .map(|path| path.replace('\\', "/")),
+        Some(expected_compare_path.replace('\\', "/"))
+    );
+}
+
+#[test]
+fn test_scenario_evaluate_rejects_config_without_scenarios() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    fs::write(
+        &config_path,
+        r#"[[bench]]
+name = "large-file"
+command = ["echo", "large"]
+"#,
+    )
+    .expect("failed to write config");
+
+    perfgate_cmd()
+        .arg("scenario")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--out")
+        .arg(temp_dir.path().join("scenario.json"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no [[scenario]] entries configured",
+        ));
+}
+
+fn write_compare_receipt(path: &Path, bench: &str, baseline: f64, current: f64, status: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create compare fixture directory");
+    }
+
+    let fail = u32::from(status == "fail");
+    let warn = u32::from(status == "warn");
+    let pass = u32::from(status == "pass");
+    let skip = u32::from(status == "skip");
+    let regression = if current > baseline {
+        (current - baseline) / baseline
+    } else {
+        0.0
+    };
+    let receipt = json!({
+        "schema": "perfgate.compare.v1",
+        "tool": {"name": "perfgate", "version": "0.16.0"},
+        "bench": {
+            "name": bench,
+            "command": ["echo", bench],
+            "repeat": 1,
+            "warmup": 0
+        },
+        "baseline_ref": {
+            "path": format!("baselines/{bench}.json"),
+            "run_id": format!("{bench}-baseline")
+        },
+        "current_ref": {
+            "path": format!("artifacts/perfgate/{bench}/run.json"),
+            "run_id": format!("{bench}-current")
+        },
+        "budgets": {},
+        "deltas": {
+            "wall_ms": {
+                "baseline": baseline,
+                "current": current,
+                "ratio": current / baseline,
+                "pct": (current - baseline) / baseline,
+                "regression": regression,
+                "status": status
+            }
+        },
+        "verdict": {
+            "status": status,
+            "counts": {
+                "pass": pass,
+                "warn": warn,
+                "fail": fail,
+                "skip": skip
+            },
+            "reasons": []
+        }
+    });
+
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize compare fixture"),
+    )
+    .expect("failed to write compare fixture");
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 294
 expression: "help_output(&[\"--help\"])"
 ---
 Perf budgets and baseline diffs for CI / PR bots
@@ -24,6 +23,7 @@ Commands:
   audit List and export baseline service audit events
   summary Summarize one or more compare receipts in a terminal table
   aggregate Aggregate multiple run receipts (e.g. from a fleet) into a formal aggregate receipt
+  scenario Evaluate configured workload scenarios from compare receipts
   bisect Automatically find the commit that introduced a performance regression
   cargo-bench Wrap `cargo bench` and produce perfgate run receipts
   blame Analyze changes in Cargo.lock to identify dependency updates causing binary size regressions

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_scenario.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_scenario.snap
@@ -1,0 +1,19 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+expression: "help_output(&[\"scenario\", \"--help\"])"
+---
+Evaluate configured workload scenarios from compare receipts
+
+Usage: perfgate scenario [OPTIONS] <COMMAND>
+
+Commands:
+  evaluate Evaluate configured scenarios into a perfgate.scenario.v1 receipt
+  help Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_scenario_evaluate.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_scenario_evaluate.snap
@@ -1,0 +1,21 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+expression: "help_output(&[\"scenario\", \"evaluate\", \"--help\"])"
+---
+Evaluate configured scenarios into a perfgate.scenario.v1 receipt
+
+Usage: perfgate scenario evaluate [OPTIONS]
+
+Options:
+      --config <CONFIG> Path to perfgate.toml [default: perfgate.toml]
+      --scenario <SCENARIO> Evaluate only one configured scenario by name
+      --workload-name <WORKLOAD_NAME> Name to use for the combined weighted workload receipt
+      --out-dir <OUT_DIR> Override artifact directory used for default compare receipt lookup
+      --out <OUT> Output scenario receipt path [default: scenario.json]
+      --pretty Pretty-print JSON
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1373,6 +1373,10 @@ pub struct ConfigFile {
     #[serde(default, rename = "bench")]
     pub benches: Vec<BenchConfigFile>,
 
+    /// Optional weighted workload scenarios evaluated from compare receipts.
+    #[serde(default, rename = "scenario")]
+    pub scenarios: Vec<ScenarioConfigFile>,
+
     /// Optional tradeoff rules that can downgrade a failed metric when explicit
     /// compensating improvements are present.
     #[serde(default, rename = "tradeoff")]
@@ -1404,6 +1408,33 @@ impl ConfigFile {
     pub fn validate(&self) -> Result<(), String> {
         for bench in &self.benches {
             validate_bench_name(&bench.name).map_err(|e| e.to_string())?;
+        }
+        for scenario in &self.scenarios {
+            if scenario.name.trim().is_empty() {
+                return Err("scenario name must not be empty".to_string());
+            }
+            if !scenario.weight.is_finite() || scenario.weight <= 0.0 {
+                return Err(format!(
+                    "scenario '{}' weight must be a positive finite number",
+                    scenario.name
+                ));
+            }
+            if scenario.bench.trim().is_empty() {
+                return Err(format!(
+                    "scenario '{}' must reference a benchmark",
+                    scenario.name
+                ));
+            }
+            if !self
+                .benches
+                .iter()
+                .any(|bench| bench.name == scenario.bench)
+            {
+                return Err(format!(
+                    "scenario '{}' references unknown benchmark '{}'",
+                    scenario.name, scenario.bench
+                ));
+            }
         }
         for rule in &self.tradeoffs {
             if rule.require.is_empty() {
@@ -1518,6 +1549,32 @@ pub struct BenchConfigFile {
     /// Optional scaling validation configuration.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub scaling: Option<ScalingConfig>,
+}
+
+/// Weighted scenario definition for workload-level evaluation.
+///
+/// A scenario references an existing `[[bench]]` entry and, by default,
+/// `perfgate scenario evaluate` reads that benchmark's `compare.json` from the
+/// configured artifact directory.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct ScenarioConfigFile {
+    pub name: String,
+
+    /// Relative importance in the workload model.
+    pub weight: f64,
+
+    /// Configured benchmark that produces this scenario's compare receipt.
+    pub bench: String,
+
+    /// Optional human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<String>,
+
+    /// Optional explicit compare receipt path. When omitted, the CLI reads the
+    /// standard `out_dir/<bench>/compare.json` artifact.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub compare: Option<String>,
 }
 
 /// How ratcheting should update budgets.
@@ -1893,6 +1950,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![BenchConfigFile {
                 name: "bad|name".to_string(),
                 cwd: None,
@@ -1984,6 +2042,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
                 cwd: None,
@@ -2013,6 +2072,7 @@ mod tests {
                 downgrade_to: TradeoffDowngrade::Warn,
             }],
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".to_string(),
                 cwd: None,
@@ -2028,6 +2088,63 @@ mod tests {
         };
 
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn config_file_parses_weighted_scenarios() {
+        let config: ConfigFile = toml::from_str(
+            r#"
+[defaults]
+threshold = 0.20
+out_dir = "artifacts/perfgate"
+
+[[bench]]
+name = "large-file"
+command = ["cargo", "bench", "--bench", "large_file"]
+
+[[scenario]]
+name = "large_file_parse"
+weight = 0.35
+bench = "large-file"
+description = "Parse a large file"
+"#,
+        )
+        .expect("parse config");
+
+        assert_eq!(config.scenarios.len(), 1);
+        assert_eq!(config.scenarios[0].name, "large_file_parse");
+        assert_eq!(config.scenarios[0].bench, "large-file");
+        assert_eq!(config.scenarios[0].weight, 0.35);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn config_file_validate_rejects_invalid_scenarios() {
+        let mut config: ConfigFile = toml::from_str(
+            r#"
+[[bench]]
+name = "large-file"
+command = ["echo", "large"]
+"#,
+        )
+        .expect("parse config");
+
+        config.scenarios = vec![ScenarioConfigFile {
+            name: "unknown".to_string(),
+            weight: 1.0,
+            bench: "missing-bench".to_string(),
+            description: None,
+            compare: None,
+        }];
+        assert!(config.validate().unwrap_err().contains("unknown benchmark"));
+
+        config.scenarios[0].bench = "large-file".to_string();
+        config.scenarios[0].weight = 0.0;
+        assert!(config.validate().unwrap_err().contains("positive finite"));
+
+        config.scenarios[0].weight = 1.0;
+        config.scenarios[0].name = " ".to_string();
+        assert!(config.validate().unwrap_err().contains("must not be empty"));
     }
 
     // ---- Serde round-trip unit tests ----
@@ -2414,6 +2531,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![BenchConfigFile {
                 name: "my-bench".into(),
                 cwd: Some("/home/user/project".into()),
@@ -2453,6 +2571,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![],
         };
         let json = serde_json::to_string(&config).unwrap();
@@ -3541,6 +3660,7 @@ mod property_tests {
                 baseline_server,
                 tradeoffs: Vec::new(),
                 ratchet: None,
+                scenarios: Vec::new(),
                 benches,
             })
     }

--- a/crates/perfgate/src/app/baseline_resolve.rs
+++ b/crates/perfgate/src/app/baseline_resolve.rs
@@ -62,6 +62,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: Vec::new(),
         };
 

--- a/crates/perfgate/src/app/check.rs
+++ b/crates/perfgate/src/app/check.rs
@@ -1249,6 +1249,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench.clone()],
         };
 
@@ -1381,6 +1382,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench.clone()],
         };
 
@@ -1460,6 +1462,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 
@@ -1516,6 +1519,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 
@@ -1589,6 +1593,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 
@@ -1648,6 +1653,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 
@@ -1680,6 +1686,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![],
         };
 
@@ -1734,6 +1741,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 
@@ -1803,6 +1811,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 
@@ -1862,6 +1871,7 @@ mod tests {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![bench],
         };
 

--- a/crates/perfgate/src/app/mod.rs
+++ b/crates/perfgate/src/app/mod.rs
@@ -26,6 +26,7 @@ pub mod render;
 mod repair_context;
 mod report;
 pub mod runtime;
+mod scenario;
 pub mod sensor;
 mod sensor_report;
 mod trend;
@@ -48,6 +49,9 @@ pub use promote::{PromoteRequest, PromoteResult, PromoteUseCase};
 pub use ratchet::{RatchetPlan, RatchetUseCase, is_host_mismatch_reason, preview_lines};
 pub use repair_context::redact_command_for_diagnostics;
 pub use report::{ReportRequest, ReportResult, ReportUseCase};
+pub use scenario::{
+    ScenarioEvaluateInput, ScenarioEvaluateOutcome, ScenarioEvaluateRequest, ScenarioUseCase,
+};
 pub use sensor_report::{
     BenchOutcome, SensorCheckOptions, SensorReportBuilder, classify_error,
     default_engine_capability, run_sensor_check, sensor_fingerprint,

--- a/crates/perfgate/src/app/scenario.rs
+++ b/crates/perfgate/src/app/scenario.rs
@@ -1,0 +1,405 @@
+use crate::domain::budget::{aggregate_verdict, calculate_regression, determine_status};
+use perfgate_types::{
+    CompareReceipt, CompareRef, ConfigFile, Delta, HostInfo, Metric, MetricStatus, RunMeta,
+    SCENARIO_SCHEMA_V1, ScenarioComponent, ScenarioConfigFile, ScenarioMeta, ScenarioReceipt,
+    ToolInfo,
+};
+use std::collections::BTreeMap;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+const DEFAULT_SCENARIO_NAME: &str = "configured_workload";
+
+#[derive(Debug)]
+pub struct ScenarioEvaluateRequest {
+    pub config: ConfigFile,
+    pub inputs: Vec<ScenarioEvaluateInput>,
+    pub workload_name: Option<String>,
+    pub tool: ToolInfo,
+}
+
+#[derive(Debug)]
+pub struct ScenarioEvaluateInput {
+    pub config: ScenarioConfigFile,
+    pub compare_ref: CompareRef,
+    pub compare: CompareReceipt,
+}
+
+#[derive(Debug)]
+pub struct ScenarioEvaluateOutcome {
+    pub receipt: ScenarioReceipt,
+}
+
+pub struct ScenarioUseCase;
+
+impl ScenarioUseCase {
+    pub fn evaluate(req: ScenarioEvaluateRequest) -> anyhow::Result<ScenarioEvaluateOutcome> {
+        if req.inputs.is_empty() {
+            anyhow::bail!("no scenario inputs provided");
+        }
+
+        for input in &req.inputs {
+            if input.compare.bench.name != input.config.bench {
+                anyhow::bail!(
+                    "scenario '{}' expected compare receipt for benchmark '{}', got '{}'",
+                    input.config.name,
+                    input.config.bench,
+                    input.compare.bench.name
+                );
+            }
+        }
+
+        let components = build_components(&req.inputs);
+        let weighted_deltas = build_weighted_deltas(&req.inputs, &req.config)?;
+        let statuses: Vec<MetricStatus> =
+            weighted_deltas.values().map(|delta| delta.status).collect();
+        let mut verdict = aggregate_verdict(&statuses);
+        let warnings = build_warnings(&req.inputs, &weighted_deltas);
+        verdict.reasons = weighted_deltas
+            .iter()
+            .filter(|(_, delta)| !matches!(delta.status, MetricStatus::Pass))
+            .map(|(metric, delta)| {
+                format!("scenario_{}_{}", metric.as_str(), delta.status.as_str())
+            })
+            .collect();
+
+        let receipt = ScenarioReceipt {
+            schema: SCENARIO_SCHEMA_V1.to_string(),
+            tool: req.tool,
+            run: make_run_meta(),
+            scenario: scenario_meta(&req.inputs, req.workload_name.as_deref()),
+            baseline_ref: None,
+            current_ref: None,
+            components,
+            weighted_deltas,
+            verdict,
+            warnings,
+        };
+
+        Ok(ScenarioEvaluateOutcome { receipt })
+    }
+}
+
+fn build_components(inputs: &[ScenarioEvaluateInput]) -> Vec<ScenarioComponent> {
+    inputs
+        .iter()
+        .map(|input| ScenarioComponent {
+            name: input.config.name.clone(),
+            weight: input.config.weight,
+            benchmark: Some(input.config.bench.clone()),
+            compare_ref: Some(input.compare_ref.clone()),
+            deltas: stringify_deltas(&input.compare.deltas),
+            probes: Vec::new(),
+            status: metric_status_from_verdict(input.compare.verdict.status),
+            reasons: input.compare.verdict.reasons.clone(),
+        })
+        .collect()
+}
+
+fn stringify_deltas(deltas: &BTreeMap<Metric, Delta>) -> BTreeMap<String, Delta> {
+    deltas
+        .iter()
+        .map(|(metric, delta)| (metric.as_str().to_string(), delta.clone()))
+        .collect()
+}
+
+fn build_weighted_deltas(
+    inputs: &[ScenarioEvaluateInput],
+    config: &ConfigFile,
+) -> anyhow::Result<BTreeMap<String, Delta>> {
+    let mut totals: BTreeMap<Metric, WeightedMetricTotals> = BTreeMap::new();
+
+    for input in inputs {
+        for (metric, delta) in &input.compare.deltas {
+            let entry = totals.entry(*metric).or_default();
+            entry.weight += input.config.weight;
+            entry.baseline += delta.baseline * input.config.weight;
+            entry.current += delta.current * input.config.weight;
+            entry.statistic = Some(delta.statistic);
+        }
+    }
+
+    let threshold = config.defaults.threshold.unwrap_or(0.20);
+    let warn_threshold = threshold * config.defaults.warn_factor.unwrap_or(0.90);
+
+    let mut weighted = BTreeMap::new();
+    for (metric, total) in totals {
+        if total.weight <= 0.0 {
+            continue;
+        }
+        let baseline = total.baseline / total.weight;
+        let current = total.current / total.weight;
+        if baseline <= 0.0 {
+            anyhow::bail!(
+                "cannot evaluate weighted scenario metric '{}' with non-positive baseline {}",
+                metric.as_str(),
+                baseline
+            );
+        }
+
+        let ratio = current / baseline;
+        let pct = (current - baseline) / baseline;
+        let regression = calculate_regression(baseline, current, metric.default_direction());
+        let status = determine_status(regression, threshold, warn_threshold);
+        weighted.insert(
+            metric.as_str().to_string(),
+            Delta {
+                baseline,
+                current,
+                ratio,
+                pct,
+                regression,
+                cv: None,
+                noise_threshold: config.defaults.noise_threshold,
+                statistic: total.statistic.unwrap_or_default(),
+                significance: None,
+                status,
+            },
+        );
+    }
+
+    Ok(weighted)
+}
+
+#[derive(Default)]
+struct WeightedMetricTotals {
+    weight: f64,
+    baseline: f64,
+    current: f64,
+    statistic: Option<perfgate_types::MetricStatistic>,
+}
+
+fn build_warnings(
+    inputs: &[ScenarioEvaluateInput],
+    weighted_deltas: &BTreeMap<String, Delta>,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for metric in weighted_deltas.keys() {
+        let parsed_metric = Metric::parse_key(metric);
+        let missing: Vec<_> = inputs
+            .iter()
+            .filter(|input| {
+                parsed_metric
+                    .map(|metric| !input.compare.deltas.contains_key(&metric))
+                    .unwrap_or(false)
+            })
+            .map(|input| input.config.name.as_str())
+            .collect();
+        if !missing.is_empty() {
+            warnings.push(format!(
+                "metric '{}' was missing from scenario component(s): {}",
+                metric,
+                missing.join(", ")
+            ));
+        }
+    }
+    warnings
+}
+
+fn scenario_meta(inputs: &[ScenarioEvaluateInput], workload_name: Option<&str>) -> ScenarioMeta {
+    if inputs.len() == 1 {
+        let input = &inputs[0];
+        return ScenarioMeta {
+            name: input.config.name.clone(),
+            weight: input.config.weight,
+            description: input.config.description.clone(),
+            command: Some(input.compare.bench.command.clone()),
+        };
+    }
+
+    ScenarioMeta {
+        name: workload_name.unwrap_or(DEFAULT_SCENARIO_NAME).to_string(),
+        weight: 1.0,
+        description: Some("Weighted workload from configured scenarios".to_string()),
+        command: None,
+    }
+}
+
+fn metric_status_from_verdict(status: perfgate_types::VerdictStatus) -> MetricStatus {
+    match status {
+        perfgate_types::VerdictStatus::Pass => MetricStatus::Pass,
+        perfgate_types::VerdictStatus::Warn => MetricStatus::Warn,
+        perfgate_types::VerdictStatus::Fail => MetricStatus::Fail,
+        perfgate_types::VerdictStatus::Skip => MetricStatus::Skip,
+    }
+}
+
+fn make_run_meta() -> RunMeta {
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    RunMeta {
+        id: Uuid::new_v4().to_string(),
+        started_at: timestamp.clone(),
+        ended_at: timestamp,
+        host: HostInfo {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            cpu_count: None,
+            memory_bytes: None,
+            hostname_hash: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perfgate_types::{
+        BenchMeta, COMPARE_SCHEMA_V1, DefaultsConfig, MetricStatistic, Verdict, VerdictCounts,
+        VerdictStatus,
+    };
+
+    fn compare_receipt(
+        bench: &str,
+        baseline: f64,
+        current: f64,
+        status: MetricStatus,
+    ) -> CompareReceipt {
+        CompareReceipt {
+            schema: COMPARE_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            bench: BenchMeta {
+                name: bench.to_string(),
+                cwd: None,
+                command: vec!["echo".to_string(), bench.to_string()],
+                repeat: 1,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            baseline_ref: CompareRef {
+                path: Some(format!("baselines/{bench}.json")),
+                run_id: Some(format!("{bench}-base")),
+            },
+            current_ref: CompareRef {
+                path: Some(format!("artifacts/{bench}/run.json")),
+                run_id: Some(format!("{bench}-current")),
+            },
+            budgets: BTreeMap::new(),
+            deltas: BTreeMap::from([(
+                Metric::WallMs,
+                Delta {
+                    baseline,
+                    current,
+                    ratio: current / baseline,
+                    pct: (current - baseline) / baseline,
+                    regression: calculate_regression(
+                        baseline,
+                        current,
+                        Metric::WallMs.default_direction(),
+                    ),
+                    cv: None,
+                    noise_threshold: None,
+                    statistic: MetricStatistic::Median,
+                    significance: None,
+                    status,
+                },
+            )]),
+            verdict: Verdict {
+                status: match status {
+                    MetricStatus::Pass => VerdictStatus::Pass,
+                    MetricStatus::Warn => VerdictStatus::Warn,
+                    MetricStatus::Fail => VerdictStatus::Fail,
+                    MetricStatus::Skip => VerdictStatus::Skip,
+                },
+                counts: VerdictCounts {
+                    pass: u32::from(matches!(status, MetricStatus::Pass)),
+                    warn: u32::from(matches!(status, MetricStatus::Warn)),
+                    fail: u32::from(matches!(status, MetricStatus::Fail)),
+                    skip: u32::from(matches!(status, MetricStatus::Skip)),
+                },
+                reasons: Vec::new(),
+            },
+        }
+    }
+
+    fn scenario_input(
+        name: &str,
+        weight: f64,
+        bench: &str,
+        compare: CompareReceipt,
+    ) -> ScenarioEvaluateInput {
+        ScenarioEvaluateInput {
+            config: ScenarioConfigFile {
+                name: name.to_string(),
+                weight,
+                bench: bench.to_string(),
+                description: None,
+                compare: None,
+            },
+            compare_ref: CompareRef {
+                path: Some(format!("artifacts/{bench}/compare.json")),
+                run_id: compare.current_ref.run_id.clone(),
+            },
+            compare,
+        }
+    }
+
+    #[test]
+    fn scenario_evaluate_computes_weighted_deltas() {
+        let outcome = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+            config: ConfigFile {
+                defaults: DefaultsConfig {
+                    threshold: Some(0.20),
+                    warn_factor: Some(0.50),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            inputs: vec![
+                scenario_input(
+                    "large_file_parse",
+                    0.75,
+                    "large-file",
+                    compare_receipt("large-file", 100.0, 90.0, MetricStatus::Pass),
+                ),
+                scenario_input(
+                    "small_edit",
+                    0.25,
+                    "small-edit",
+                    compare_receipt("small-edit", 100.0, 110.0, MetricStatus::Fail),
+                ),
+            ],
+            workload_name: None,
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        })
+        .expect("evaluate scenario");
+
+        let delta = &outcome.receipt.weighted_deltas["wall_ms"];
+        assert_eq!(outcome.receipt.schema, SCENARIO_SCHEMA_V1);
+        assert_eq!(outcome.receipt.components.len(), 2);
+        assert!((delta.current - 95.0).abs() < f64::EPSILON);
+        assert_eq!(delta.status, MetricStatus::Pass);
+        assert_eq!(outcome.receipt.verdict.status, VerdictStatus::Pass);
+    }
+
+    #[test]
+    fn scenario_evaluate_rejects_mismatched_compare_benchmark() {
+        let err = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+            config: ConfigFile::default(),
+            inputs: vec![scenario_input(
+                "large_file_parse",
+                1.0,
+                "large-file",
+                compare_receipt("other-bench", 100.0, 90.0, MetricStatus::Pass),
+            )],
+            workload_name: None,
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        })
+        .expect_err("mismatched benchmark should fail");
+
+        assert!(err.to_string().contains("expected compare receipt"));
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -28,6 +28,17 @@ name = "api_latency"
 command = ["./target/release/api-bench"]
 repeat = 10                                   # override defaults per bench
 scaling = { sizes = [100, 1000, 10000], expected = "O(n)", repeat = 5, r_squared_threshold = 0.90 }
+
+[[scenario]]
+name = "api_latency_release"
+weight = 0.60
+bench = "api_latency"
+description = "Release-gate API latency workload"
+
+[[scenario]]
+name = "pst_extract_batch"
+weight = 0.40
+bench = "pst_extract"
 ```
 
 ## Budget Configuration
@@ -61,6 +72,42 @@ scaling = { sizes = [100, 1000, 10000], expected = "O(n)", repeat = 7, r_squared
 | `expected` | Optional expected complexity class such as `O(n)` or `O(n^2)` |
 | `repeat` | Optional repetitions per input size |
 | `r_squared_threshold` | Optional minimum fit quality threshold |
+
+## Scenario Configuration
+
+Scenarios define a weighted workload model over configured benchmarks. After
+`perfgate check --config perfgate.toml --all` has produced compare receipts,
+evaluate the workload into a `perfgate.scenario.v1` receipt:
+
+```bash
+perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scenario.json
+```
+
+Each `[[scenario]]` references one `[[bench]]`. By default, `scenario evaluate`
+reads `compare.json` from `[defaults].out_dir/<bench>/compare.json`. Use
+`compare = "path/to/compare.json"` when the compare receipt lives somewhere
+else.
+
+```toml
+[[bench]]
+name = "large-file"
+command = ["cargo", "bench", "--bench", "large_file"]
+
+[[bench]]
+name = "small-edit"
+command = ["cargo", "bench", "--bench", "small_edit"]
+
+[[scenario]]
+name = "large_file_parse"
+weight = 0.35
+bench = "large-file"
+
+[[scenario]]
+name = "small_incremental_edit"
+weight = 0.50
+bench = "small-edit"
+compare = "artifacts/perfgate/small-edit/compare.json"
+```
 
 ## Presets
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -9,7 +9,7 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 | `perfgate.run.v1` | `run`, `check` | Raw measurement data from a benchmark execution |
 | `perfgate.compare.v1` | `compare`, `check`, `paired` | Comparison of current run against baseline |
 | `perfgate.probe.v1` | `ingest probes` | Named probe observations from internal phases or external instrumentation |
-| `perfgate.scenario.v1` | schema-first contract | Weighted workload-scenario evidence across benchmarks, phases, or probe groups |
+| `perfgate.scenario.v1` | `scenario evaluate` | Weighted workload-scenario evidence across benchmarks, phases, or probe groups |
 | `perfgate.tradeoff.v1` | schema-first contract | Structured decision evidence for accepted or rejected performance tradeoffs |
 | `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
 | `sensor.report.v1` | `check --mode cockpit` | Sensor integration envelope for dashboards |
@@ -63,6 +63,19 @@ become metrics:
 ```json
 {"probe":"parser.tokenize","scope":"local","wall_ms":12.4,"alloc_bytes":184320,"items":10000}
 ```
+
+## Scenario Evaluation
+
+`perfgate scenario evaluate` reads configured `[[scenario]]` entries and their
+benchmark compare receipts, then writes a `perfgate.scenario.v1` weighted
+workload receipt:
+
+```bash
+perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scenario.json
+```
+
+By default, each scenario reads `[defaults].out_dir/<bench>/compare.json`.
+Set `compare = "path/to/compare.json"` on a scenario to override that lookup.
 
 ## Fixture Validation
 

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -33,6 +33,14 @@
         }
       ]
     },
+    "scenario": {
+      "description": "Optional weighted workload scenarios evaluated from compare receipts.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ScenarioConfigFile"
+      }
+    },
     "tradeoff": {
       "description": "Optional tradeoff rules that can downgrade a failed metric when explicit\ncompensating improvements are present.",
       "type": "array",
@@ -467,6 +475,43 @@
       },
       "required": [
         "sizes"
+      ]
+    },
+    "ScenarioConfigFile": {
+      "description": "Weighted scenario definition for workload-level evaluation.\n\nA scenario references an existing `[[bench]]` entry and, by default,\n`perfgate scenario evaluate` reads that benchmark's `compare.json` from the\nconfigured artifact directory.",
+      "type": "object",
+      "properties": {
+        "bench": {
+          "description": "Configured benchmark that produces this scenario's compare receipt.",
+          "type": "string"
+        },
+        "compare": {
+          "description": "Optional explicit compare receipt path. When omitted, the CLI reads the\nstandard `out_dir/<bench>/compare.json` artifact.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "description": "Optional human-readable description.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "weight": {
+          "description": "Relative importance in the workload model.",
+          "type": "number",
+          "format": "double"
+        }
+      },
+      "required": [
+        "name",
+        "weight",
+        "bench"
       ]
     },
     "TradeoffDowngrade": {

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -2917,6 +2917,7 @@ async fn given_config_file_with_bench(world: &mut PerfgateWorld, bench_name: Str
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: bench_name,
             cwd: None,
@@ -2973,6 +2974,7 @@ async fn given_config_file_with_bench_threshold(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: bench_name,
             cwd: None,
@@ -3030,6 +3032,7 @@ async fn given_config_file_with_bench_threshold_warn(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: bench_name,
             cwd: None,
@@ -3084,6 +3087,7 @@ async fn given_config_file_with_defaults_repeat_warmup(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![],
     };
 
@@ -3122,6 +3126,7 @@ async fn given_config_file_with_defaults_repeat(world: &mut PerfgateWorld, repea
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![],
     };
 
@@ -3214,6 +3219,7 @@ async fn given_config_file_with_bench_baseline_dir(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: bench_name,
             cwd: None,
@@ -3269,6 +3275,7 @@ async fn given_config_file_with_bench_baseline_pattern(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: bench_name,
             cwd: None,
@@ -3471,6 +3478,7 @@ async fn given_config_file_with_benches(world: &mut PerfgateWorld, bench_names_s
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches,
     };
 
@@ -3527,6 +3535,7 @@ async fn given_config_file_with_benches_tight(world: &mut PerfgateWorld, bench_n
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches,
     };
 
@@ -3587,6 +3596,7 @@ async fn given_config_file_with_benches_lenient(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches,
     };
 
@@ -3677,6 +3687,7 @@ async fn given_config_file_with_mixed_thresholds(
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches,
     };
 

--- a/tests/integration/validation_to_types.rs
+++ b/tests/integration/validation_to_types.rs
@@ -38,6 +38,7 @@ fn config_file_validates_bench_names() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: "valid-bench".to_string(),
             cwd: None,
@@ -63,6 +64,7 @@ fn config_file_rejects_invalid_bench_names() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: "../evil".to_string(),
             cwd: None,
@@ -88,6 +90,7 @@ fn multiple_benches_all_validated() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![
             BenchConfigFile {
                 name: "valid-bench".to_string(),
@@ -128,6 +131,7 @@ fn validation_fails_on_first_invalid_bench() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![
             BenchConfigFile {
                 name: "valid-bench".to_string(),
@@ -250,6 +254,7 @@ fn config_empty_benches_is_valid() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![],
     };
 
@@ -267,6 +272,7 @@ fn config_duplicate_bench_names_passes_validation() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![
             BenchConfigFile {
                 name: "same-name".to_string(),
@@ -416,6 +422,7 @@ fn config_empty_bench_name_rejected() {
         baseline_server: BaselineServerConfig::default(),
         tradeoffs: Vec::new(),
         ratchet: None,
+        scenarios: Vec::new(),
         benches: vec![BenchConfigFile {
             name: String::new(),
             cwd: None,
@@ -443,6 +450,7 @@ fn config_path_traversal_variants_rejected() {
             baseline_server: BaselineServerConfig::default(),
             tradeoffs: Vec::new(),
             ratchet: None,
+            scenarios: Vec::new(),
             benches: vec![BenchConfigFile {
                 name: name.to_string(),
                 cwd: None,


### PR DESCRIPTION
## Summary
- add `[[scenario]]` config entries and validation for weighted workload models
- add `perfgate scenario evaluate` to read compare receipts and emit `perfgate.scenario.v1`
- document scenario evaluation and cover CLI/help/schema behavior

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perfgate-types -p perfgate -p perfgate-cli --all-targets --all-features`
- `cargo test -p perfgate-types config_file --all-features`
- `cargo test -p perfgate scenario --all-features`
- `cargo test -p perfgate-cli --test cli_scenario_tests --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo clippy -p perfgate-types -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `cargo check --workspace --all-targets --all-features`
- `git diff --check`