### PR TITLE
tradeoff: evaluate scenario decision receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   language-agnostic probe JSONL into `perfgate.probe.v1` receipts.
 - Added `perfgate scenario evaluate` to turn configured weighted scenarios and
   benchmark compare receipts into `perfgate.scenario.v1` workload receipts.
+- Added `perfgate tradeoff evaluate` to turn configured tradeoff rules and
+  scenario receipts into `perfgate.tradeoff.v1` decision receipts.
 - Extended `xtask schema-compat` with baseline-service record, health-response,
   and fleet fixtures so the 0.16 server API contract is checked alongside
   receipt compatibility.

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -24,9 +24,9 @@ use perfgate_app::{
     ExportUseCase, PairedRunRequest, PairedRunUseCase, PromoteRequest, PromoteUseCase,
     RatchetUseCase, ReportRequest, ReportUseCase, RunBenchRequest, RunBenchUseCase,
     ScenarioEvaluateInput, ScenarioEvaluateRequest, ScenarioUseCase, SensorReportBuilder,
-    SystemClock, classify_error, github_annotations, is_host_mismatch_reason, preview_lines,
-    redact_command_for_diagnostics, render_json_diff, render_markdown, render_markdown_template,
-    render_terminal_diff,
+    SystemClock, TradeoffEvaluateRequest, TradeoffUseCase, classify_error, github_annotations,
+    is_host_mismatch_reason, preview_lines, redact_command_for_diagnostics, render_json_diff,
+    render_markdown, render_markdown_template, render_terminal_diff,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::types::auth::Role;
@@ -49,7 +49,7 @@ use perfgate_types::{
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
     MetricStatus, OtelSpanIdentifiers, PerfgateReport, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
     RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
-    SensorVerdictStatus, ToolInfo, VerdictStatus,
+    ScenarioReceipt, SensorVerdictStatus, ToolInfo, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
@@ -344,6 +344,12 @@ enum Command {
     Scenario {
         #[command(subcommand)]
         action: ScenarioAction,
+    },
+
+    /// Evaluate configured tradeoff rules against scenario evidence.
+    Tradeoff {
+        #[command(subcommand)]
+        action: TradeoffAction,
     },
 
     /// Automatically find the commit that introduced a performance regression.
@@ -1259,6 +1265,12 @@ pub enum ScenarioAction {
     Evaluate(ScenarioEvaluateArgs),
 }
 
+#[derive(Debug, Subcommand)]
+pub enum TradeoffAction {
+    /// Evaluate configured tradeoff rules into a perfgate.tradeoff.v1 receipt.
+    Evaluate(TradeoffEvaluateArgs),
+}
+
 #[derive(Debug, Args)]
 pub struct ScenarioEvaluateArgs {
     /// Path to perfgate.toml.
@@ -1279,6 +1291,25 @@ pub struct ScenarioEvaluateArgs {
 
     /// Output scenario receipt path.
     #[arg(long, default_value = "scenario.json")]
+    pub out: PathBuf,
+
+    /// Pretty-print JSON.
+    #[arg(long, default_value_t = false)]
+    pub pretty: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct TradeoffEvaluateArgs {
+    /// Path to perfgate.toml.
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Path to a perfgate.scenario.v1 receipt.
+    #[arg(long)]
+    pub scenario: PathBuf,
+
+    /// Output tradeoff receipt path.
+    #[arg(long, default_value = "tradeoff.json")]
     pub out: PathBuf,
 
     /// Pretty-print JSON.
@@ -3010,6 +3041,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
         }
 
         Command::Scenario { action } => execute_scenario_action(action),
+        Command::Tradeoff { action } => execute_tradeoff_action(action),
 
         Command::Bisect(args) => {
             let usecase = BisectUseCase::default();
@@ -3263,6 +3295,43 @@ fn scenario_compare_path(scenario: &ScenarioConfigFile, out_dir: &Path) -> PathB
         .as_deref()
         .map(PathBuf::from)
         .unwrap_or_else(|| out_dir.join(&scenario.bench).join(COMPARE_RECEIPT_FILE))
+}
+
+fn execute_tradeoff_action(action: TradeoffAction) -> anyhow::Result<()> {
+    match action {
+        TradeoffAction::Evaluate(args) => execute_tradeoff_evaluate(args),
+    }
+}
+
+fn execute_tradeoff_evaluate(args: TradeoffEvaluateArgs) -> anyhow::Result<()> {
+    let config = load_config_file(&args.config)
+        .with_context(|| format!("failed to load {}", args.config.display()))?;
+    config
+        .validate()
+        .map_err(|error| anyhow::anyhow!("{} is invalid: {error}", args.config.display()))?;
+
+    if config.tradeoffs.is_empty() {
+        anyhow::bail!(
+            "no [[tradeoff]] entries configured in {}",
+            args.config.display()
+        );
+    }
+
+    let scenario: ScenarioReceipt = read_json(&args.scenario)
+        .with_context(|| format!("read scenario receipt {}", args.scenario.display()))?;
+    let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+        scenario,
+        rules: config.tradeoffs,
+        tool: tool_info(),
+    })?;
+
+    write_json(&args.out, &outcome.receipt, args.pretty)?;
+    eprintln!("Tradeoff receipt written to {}", args.out.display());
+
+    match outcome.receipt.verdict.status {
+        VerdictStatus::Fail => exit_with_code(2),
+        VerdictStatus::Pass | VerdictStatus::Warn | VerdictStatus::Skip => Ok(()),
+    }
 }
 
 fn execute_badge(args: BadgeArgs) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -25,6 +25,7 @@ fn cli_help_main() {
         .stdout(predicate::str::contains("paired"))
         .stdout(predicate::str::contains("audit"))
         .stdout(predicate::str::contains("scenario"))
+        .stdout(predicate::str::contains("tradeoff"))
         .stdout(predicate::str::contains("md"))
         .stdout(predicate::str::contains("export"))
         .stdout(predicate::str::contains("promote"))
@@ -242,6 +243,32 @@ fn cli_help_scenario_evaluate() {
         .stdout(predicate::str::contains("--workload-name"));
 }
 
+#[test]
+fn cli_help_tradeoff() {
+    perfgate_cmd()
+        .args(["tradeoff", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Evaluate configured tradeoff rules",
+        ))
+        .stdout(predicate::str::contains("evaluate"));
+}
+
+#[test]
+fn cli_help_tradeoff_evaluate() {
+    perfgate_cmd()
+        .args(["tradeoff", "evaluate", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Evaluate configured tradeoff rules into a perfgate.tradeoff.v1 receipt",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--scenario"))
+        .stdout(predicate::str::contains("--out"));
+}
+
 // ── insta full-output snapshot tests ─────────────────────────────────
 
 fn help_output(args: &[&str]) -> String {
@@ -377,5 +404,18 @@ fn snapshot_help_scenario_evaluate() {
     insta::assert_snapshot!(
         "help_scenario_evaluate",
         help_output(&["scenario", "evaluate", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_tradeoff() {
+    insta::assert_snapshot!("help_tradeoff", help_output(&["tradeoff", "--help"]));
+}
+
+#[test]
+fn snapshot_help_tradeoff_evaluate() {
+    insta::assert_snapshot!(
+        "help_tradeoff_evaluate",
+        help_output(&["tradeoff", "evaluate", "--help"])
     );
 }

--- a/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
+++ b/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
@@ -1,0 +1,196 @@
+//! Integration tests for `perfgate tradeoff`.
+
+mod common;
+
+use common::perfgate_cmd;
+use predicates::prelude::*;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[test]
+fn test_tradeoff_evaluate_writes_tradeoff_receipt() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+    let output_path = temp_dir.path().join("tradeoff.json");
+
+    write_tradeoff_config(&config_path, 1.10, "warn");
+    write_scenario_receipt(&scenario_path, 80.0, "fail");
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Tradeoff receipt written"));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should be JSON");
+    let typed: perfgate_types::TradeoffReceipt =
+        serde_json::from_value(receipt.clone()).expect("tradeoff receipt should deserialize");
+
+    assert_eq!(typed.schema, "perfgate.tradeoff.v1");
+    assert_eq!(typed.scenario.as_deref(), Some("release_workload"));
+    assert!(typed.decision.accepted_tradeoff);
+    assert_eq!(typed.verdict.status, perfgate_types::VerdictStatus::Warn);
+    assert_eq!(
+        receipt["weighted_deltas"]["max_rss_kb"]["status"].as_str(),
+        Some("warn")
+    );
+    assert_eq!(receipt["rules"][0]["status"].as_str(), Some("accepted"));
+    assert_eq!(receipt["rules"][0]["requirements"][0]["satisfied"], true);
+}
+
+#[test]
+fn test_tradeoff_evaluate_fails_when_rule_not_satisfied() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+    let output_path = temp_dir.path().join("tradeoff.json");
+
+    write_tradeoff_config(&config_path, 1.20, "pass");
+    write_scenario_receipt(&scenario_path, 96.0, "fail");
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .code(2);
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should be JSON");
+
+    assert_eq!(receipt["schema"], "perfgate.tradeoff.v1");
+    assert_eq!(receipt["decision"]["accepted_tradeoff"], false);
+    assert_eq!(receipt["rules"][0]["status"], "rejected");
+    assert!(
+        receipt["verdict"]["reasons"]
+            .as_array()
+            .expect("reasons array")
+            .iter()
+            .any(|reason| reason == "tradeoff_rule_not_satisfied")
+    );
+}
+
+#[test]
+fn test_tradeoff_evaluate_rejects_config_without_tradeoffs() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+
+    fs::write(&config_path, "[defaults]\nthreshold = 0.20\n").expect("failed to write config");
+    write_scenario_receipt(&scenario_path, 80.0, "fail");
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(temp_dir.path().join("tradeoff.json"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no [[tradeoff]] entries configured",
+        ));
+}
+
+fn write_tradeoff_config(path: &Path, min_improvement_ratio: f64, downgrade_to: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"[[tradeoff]]
+name = "memory_for_speed"
+if_failed = "max_rss_kb"
+downgrade_to = "{downgrade_to}"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+min_improvement_ratio = {min_improvement_ratio}
+"#
+        ),
+    )
+    .expect("failed to write config");
+}
+
+fn write_scenario_receipt(path: &Path, wall_current: f64, memory_status: &str) {
+    let memory_fail = u32::from(memory_status == "fail");
+    let memory_warn = u32::from(memory_status == "warn");
+    let memory_pass = u32::from(memory_status == "pass");
+    let reasons: Vec<&str> = if memory_status == "fail" {
+        vec!["max_rss_kb_fail"]
+    } else if memory_status == "warn" {
+        vec!["max_rss_kb_warn"]
+    } else {
+        Vec::new()
+    };
+    let receipt = json!({
+        "schema": "perfgate.scenario.v1",
+        "tool": {"name": "perfgate", "version": "0.16.0"},
+        "run": {
+            "id": "scenario-run",
+            "started_at": "2026-05-08T00:00:00Z",
+            "ended_at": "2026-05-08T00:00:01Z",
+            "host": {"os": "linux", "arch": "x86_64"}
+        },
+        "scenario": {
+            "name": "release_workload",
+            "weight": 1.0
+        },
+        "components": [],
+        "weighted_deltas": {
+            "wall_ms": {
+                "baseline": 100.0,
+                "current": wall_current,
+                "ratio": wall_current / 100.0,
+                "pct": (wall_current - 100.0) / 100.0,
+                "regression": 0.0,
+                "status": "pass"
+            },
+            "max_rss_kb": {
+                "baseline": 100.0,
+                "current": 120.0,
+                "ratio": 1.20,
+                "pct": 0.20,
+                "regression": 0.20,
+                "status": memory_status
+            }
+        },
+        "verdict": {
+            "status": memory_status,
+            "counts": {
+                "pass": 1 + memory_pass,
+                "warn": memory_warn,
+                "fail": memory_fail,
+                "skip": 0
+            },
+            "reasons": reasons
+        }
+    });
+
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize scenario fixture"),
+    )
+    .expect("failed to write scenario fixture");
+}

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -24,6 +24,7 @@ Commands:
   summary Summarize one or more compare receipts in a terminal table
   aggregate Aggregate multiple run receipts (e.g. from a fleet) into a formal aggregate receipt
   scenario Evaluate configured workload scenarios from compare receipts
+  tradeoff Evaluate configured tradeoff rules against scenario evidence
   bisect Automatically find the commit that introduced a performance regression
   cargo-bench Wrap `cargo bench` and produce perfgate run receipts
   blame Analyze changes in Cargo.lock to identify dependency updates causing binary size regressions

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_tradeoff.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_tradeoff.snap
@@ -1,0 +1,19 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+expression: "help_output(&[\"tradeoff\", \"--help\"])"
+---
+Evaluate configured tradeoff rules against scenario evidence
+
+Usage: perfgate tradeoff [OPTIONS] <COMMAND>
+
+Commands:
+  evaluate Evaluate configured tradeoff rules into a perfgate.tradeoff.v1 receipt
+  help Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_tradeoff_evaluate.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_tradeoff_evaluate.snap
@@ -1,0 +1,19 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+expression: "help_output(&[\"tradeoff\", \"evaluate\", \"--help\"])"
+---
+Evaluate configured tradeoff rules into a perfgate.tradeoff.v1 receipt
+
+Usage: perfgate tradeoff evaluate [OPTIONS] --scenario <SCENARIO>
+
+Options:
+      --config <CONFIG> Path to perfgate.toml [default: perfgate.toml]
+      --scenario <SCENARIO> Path to a perfgate.scenario.v1 receipt
+      --out <OUT> Output tradeoff receipt path [default: tradeoff.json]
+      --pretty Pretty-print JSON
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1437,11 +1437,25 @@ impl ConfigFile {
             }
         }
         for rule in &self.tradeoffs {
+            if rule.name.trim().is_empty() {
+                return Err("tradeoff name must not be empty".to_string());
+            }
             if rule.require.is_empty() {
                 return Err(format!(
                     "tradeoff '{}' must require at least one compensating metric",
                     rule.name
                 ));
+            }
+            for requirement in &rule.require {
+                if !requirement.min_improvement_ratio.is_finite()
+                    || requirement.min_improvement_ratio <= 0.0
+                {
+                    return Err(format!(
+                        "tradeoff '{}' requirement for '{}' must use a positive finite improvement ratio",
+                        rule.name,
+                        requirement.metric.as_str()
+                    ));
+                }
             }
         }
         Ok(())
@@ -2088,6 +2102,48 @@ mod tests {
         };
 
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn config_file_validate_rejects_invalid_tradeoff_rules() {
+        let mut config = ConfigFile {
+            defaults: DefaultsConfig::default(),
+            baseline_server: BaselineServerConfig::default(),
+            tradeoffs: vec![TradeoffRule {
+                name: "memory_for_speed".to_string(),
+                if_failed: Metric::MaxRssKb,
+                require: vec![TradeoffRequirement {
+                    metric: Metric::WallMs,
+                    min_improvement_ratio: 1.10,
+                }],
+                downgrade_to: TradeoffDowngrade::Warn,
+            }],
+            ratchet: None,
+            scenarios: Vec::new(),
+            benches: vec![BenchConfigFile {
+                name: "my-bench".to_string(),
+                cwd: None,
+                work: None,
+                timeout: None,
+                command: vec!["echo".to_string()],
+                repeat: None,
+                warmup: None,
+                metrics: None,
+                budgets: None,
+                scaling: None,
+            }],
+        };
+        assert!(config.validate().is_ok());
+
+        config.tradeoffs[0].name = " ".to_string();
+        assert!(config.validate().unwrap_err().contains("must not be empty"));
+
+        config.tradeoffs[0].name = "memory_for_speed".to_string();
+        config.tradeoffs[0].require[0].min_improvement_ratio = 0.0;
+        assert!(config.validate().unwrap_err().contains("positive finite"));
+
+        config.tradeoffs[0].require[0].min_improvement_ratio = f64::NAN;
+        assert!(config.validate().unwrap_err().contains("positive finite"));
     }
 
     #[test]

--- a/crates/perfgate/src/app/mod.rs
+++ b/crates/perfgate/src/app/mod.rs
@@ -29,6 +29,7 @@ pub mod runtime;
 mod scenario;
 pub mod sensor;
 mod sensor_report;
+mod tradeoff;
 mod trend;
 pub mod watch;
 
@@ -56,6 +57,7 @@ pub use sensor_report::{
     BenchOutcome, SensorCheckOptions, SensorReportBuilder, classify_error,
     default_engine_capability, run_sensor_check, sensor_fingerprint,
 };
+pub use tradeoff::{TradeoffEvaluateOutcome, TradeoffEvaluateRequest, TradeoffUseCase};
 pub use trend::{
     TrendOutcome, TrendRequest, TrendUseCase, format_trend_chart, format_trend_output,
 };

--- a/crates/perfgate/src/app/tradeoff.rs
+++ b/crates/perfgate/src/app/tradeoff.rs
@@ -1,0 +1,415 @@
+use crate::domain::budget::{aggregate_verdict, reason_token};
+use perfgate_types::{
+    Delta, HostInfo, Metric, MetricStatus, RunMeta, ScenarioReceipt, TRADEOFF_SCHEMA_V1, ToolInfo,
+    TradeoffDecision, TradeoffDecisionStatus, TradeoffDowngrade, TradeoffReceipt,
+    TradeoffRequirement, TradeoffRequirementOutcome, TradeoffRule, TradeoffRuleOutcome,
+    VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC, VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED,
+    Verdict,
+};
+use std::collections::BTreeMap;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub struct TradeoffEvaluateRequest {
+    pub scenario: ScenarioReceipt,
+    pub rules: Vec<TradeoffRule>,
+    pub tool: ToolInfo,
+}
+
+#[derive(Debug)]
+pub struct TradeoffEvaluateOutcome {
+    pub receipt: TradeoffReceipt,
+}
+
+pub struct TradeoffUseCase;
+
+impl TradeoffUseCase {
+    pub fn evaluate(req: TradeoffEvaluateRequest) -> anyhow::Result<TradeoffEvaluateOutcome> {
+        if req.rules.is_empty() {
+            anyhow::bail!("no tradeoff rules provided");
+        }
+
+        let mut weighted_deltas = req.scenario.weighted_deltas.clone();
+        let mut rule_outcomes = Vec::new();
+        let mut accepted_reasons = Vec::new();
+        let mut rejected_reasons = Vec::new();
+
+        for rule in &req.rules {
+            let outcome = evaluate_rule(rule, &weighted_deltas);
+            if outcome.accepted {
+                if let Some(delta) = weighted_deltas.get_mut(rule.if_failed.as_str()) {
+                    delta.status = downgrade_status(rule.downgrade_to);
+                }
+                accepted_reasons.push(format!("tradeoff_{}_applied", rule.name));
+            } else if matches!(outcome.status, TradeoffDecisionStatus::Rejected) {
+                if outcome
+                    .requirements
+                    .iter()
+                    .any(|requirement| requirement.observed_change.is_none())
+                {
+                    rejected_reasons
+                        .push(VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC.to_string());
+                } else {
+                    rejected_reasons.push(VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED.to_string());
+                }
+            }
+            rule_outcomes.push(outcome);
+        }
+
+        let mut verdict = verdict_from_weighted_deltas(&weighted_deltas);
+        verdict
+            .reasons
+            .extend(non_pass_reason_tokens(&weighted_deltas));
+        for reason in accepted_reasons.iter().chain(rejected_reasons.iter()) {
+            push_unique(&mut verdict.reasons, reason.clone());
+        }
+
+        let accepted = rule_outcomes.iter().any(|outcome| outcome.accepted);
+        let decision = TradeoffDecision {
+            accepted_tradeoff: accepted,
+            status: metric_status_from_verdict(&verdict),
+            reason: decision_reason(accepted, &rule_outcomes, &verdict),
+        };
+
+        let receipt = TradeoffReceipt {
+            schema: TRADEOFF_SCHEMA_V1.to_string(),
+            tool: req.tool,
+            run: make_run_meta(),
+            scenario: Some(req.scenario.scenario.name),
+            baseline_ref: req.scenario.baseline_ref,
+            current_ref: req.scenario.current_ref,
+            configured_rules: req.rules,
+            rules: rule_outcomes,
+            probes: Vec::new(),
+            weighted_deltas,
+            decision,
+            verdict,
+            warnings: req.scenario.warnings,
+        };
+
+        Ok(TradeoffEvaluateOutcome { receipt })
+    }
+}
+
+fn evaluate_rule(
+    rule: &TradeoffRule,
+    weighted_deltas: &BTreeMap<String, Delta>,
+) -> TradeoffRuleOutcome {
+    let Some(target) = weighted_deltas.get(rule.if_failed.as_str()) else {
+        return TradeoffRuleOutcome {
+            name: rule.name.clone(),
+            status: TradeoffDecisionStatus::NotEvaluated,
+            accepted: false,
+            downgrade_to: None,
+            reason: Some(format!(
+                "failed metric '{}' is not present",
+                rule.if_failed.as_str()
+            )),
+            requirements: evaluate_requirements(&rule.require, weighted_deltas),
+        };
+    };
+
+    if target.status != MetricStatus::Fail {
+        return TradeoffRuleOutcome {
+            name: rule.name.clone(),
+            status: TradeoffDecisionStatus::NotEvaluated,
+            accepted: false,
+            downgrade_to: None,
+            reason: Some(format!(
+                "metric '{}' is not failing",
+                rule.if_failed.as_str()
+            )),
+            requirements: evaluate_requirements(&rule.require, weighted_deltas),
+        };
+    }
+
+    let requirements = evaluate_requirements(&rule.require, weighted_deltas);
+    let accepted =
+        !requirements.is_empty() && requirements.iter().all(|requirement| requirement.satisfied);
+
+    TradeoffRuleOutcome {
+        name: rule.name.clone(),
+        status: if accepted {
+            TradeoffDecisionStatus::Accepted
+        } else {
+            TradeoffDecisionStatus::Rejected
+        },
+        accepted,
+        downgrade_to: accepted.then_some(rule.downgrade_to),
+        reason: Some(if accepted {
+            "all required compensating improvements were satisfied".to_string()
+        } else {
+            "one or more required compensating improvements were not satisfied".to_string()
+        }),
+        requirements,
+    }
+}
+
+fn evaluate_requirements(
+    requirements: &[TradeoffRequirement],
+    weighted_deltas: &BTreeMap<String, Delta>,
+) -> Vec<TradeoffRequirementOutcome> {
+    requirements
+        .iter()
+        .map(|requirement| {
+            let metric_key = requirement.metric.as_str();
+            let Some(delta) = weighted_deltas.get(metric_key) else {
+                return TradeoffRequirementOutcome {
+                    metric: metric_key.to_string(),
+                    probe: None,
+                    required_change: required_change(requirement),
+                    observed_change: None,
+                    satisfied: false,
+                    status: MetricStatus::Fail,
+                    reason: Some("required metric missing".to_string()),
+                };
+            };
+
+            let observed_ratio = improvement_ratio(delta, requirement.metric);
+            let satisfied = observed_ratio
+                .map(|ratio| ratio >= requirement.min_improvement_ratio)
+                .unwrap_or(false);
+
+            TradeoffRequirementOutcome {
+                metric: metric_key.to_string(),
+                probe: None,
+                required_change: required_change(requirement),
+                observed_change: Some(delta.pct),
+                satisfied,
+                status: if satisfied {
+                    MetricStatus::Pass
+                } else {
+                    MetricStatus::Fail
+                },
+                reason: (!satisfied).then_some(format!(
+                    "requires improvement ratio >= {:.6}",
+                    requirement.min_improvement_ratio
+                )),
+            }
+        })
+        .collect()
+}
+
+fn required_change(requirement: &TradeoffRequirement) -> f64 {
+    match requirement.metric.default_direction() {
+        perfgate_types::Direction::Higher => requirement.min_improvement_ratio - 1.0,
+        perfgate_types::Direction::Lower => (1.0 / requirement.min_improvement_ratio) - 1.0,
+    }
+}
+
+fn improvement_ratio(delta: &Delta, metric: Metric) -> Option<f64> {
+    match metric.default_direction() {
+        perfgate_types::Direction::Higher => Some(delta.ratio),
+        perfgate_types::Direction::Lower => Some(if delta.current <= 0.0 {
+            f64::INFINITY
+        } else {
+            delta.baseline / delta.current
+        }),
+    }
+}
+
+fn downgrade_status(downgrade: TradeoffDowngrade) -> MetricStatus {
+    match downgrade {
+        TradeoffDowngrade::Warn => MetricStatus::Warn,
+        TradeoffDowngrade::Pass => MetricStatus::Pass,
+    }
+}
+
+fn verdict_from_weighted_deltas(weighted_deltas: &BTreeMap<String, Delta>) -> Verdict {
+    let statuses: Vec<_> = weighted_deltas.values().map(|delta| delta.status).collect();
+    aggregate_verdict(&statuses)
+}
+
+fn non_pass_reason_tokens(weighted_deltas: &BTreeMap<String, Delta>) -> Vec<String> {
+    weighted_deltas
+        .iter()
+        .filter_map(|(metric_key, delta)| {
+            if matches!(delta.status, MetricStatus::Pass) {
+                return None;
+            }
+            Metric::parse_key(metric_key).map(|metric| reason_token(metric, delta.status))
+        })
+        .collect()
+}
+
+fn metric_status_from_verdict(verdict: &Verdict) -> MetricStatus {
+    match verdict.status {
+        perfgate_types::VerdictStatus::Pass => MetricStatus::Pass,
+        perfgate_types::VerdictStatus::Warn => MetricStatus::Warn,
+        perfgate_types::VerdictStatus::Fail => MetricStatus::Fail,
+        perfgate_types::VerdictStatus::Skip => MetricStatus::Skip,
+    }
+}
+
+fn decision_reason(
+    accepted: bool,
+    rule_outcomes: &[TradeoffRuleOutcome],
+    verdict: &Verdict,
+) -> String {
+    if accepted && let Some(rule) = rule_outcomes.iter().find(|outcome| outcome.accepted) {
+        return format!("tradeoff '{}' accepted", rule.name);
+    }
+
+    if matches!(verdict.status, perfgate_types::VerdictStatus::Fail) {
+        "no configured tradeoff accepted the failing metric".to_string()
+    } else {
+        "no failing metric required a tradeoff decision".to_string()
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+fn make_run_meta() -> RunMeta {
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    RunMeta {
+        id: Uuid::new_v4().to_string(),
+        started_at: timestamp.clone(),
+        ended_at: timestamp,
+        host: HostInfo {
+            os: std::env::consts::OS.to_string(),
+            arch: std::env::consts::ARCH.to_string(),
+            cpu_count: None,
+            memory_bytes: None,
+            hostname_hash: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perfgate_types::{SCENARIO_SCHEMA_V1, ScenarioMeta, VerdictCounts, VerdictStatus};
+
+    fn scenario_receipt(wall_current: f64, memory_status: MetricStatus) -> ScenarioReceipt {
+        ScenarioReceipt {
+            schema: SCENARIO_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+            run: make_run_meta(),
+            scenario: ScenarioMeta {
+                name: "release_workload".to_string(),
+                weight: 1.0,
+                description: None,
+                command: None,
+            },
+            baseline_ref: None,
+            current_ref: None,
+            components: Vec::new(),
+            weighted_deltas: BTreeMap::from([
+                (
+                    "wall_ms".to_string(),
+                    delta(100.0, wall_current, MetricStatus::Pass),
+                ),
+                ("max_rss_kb".to_string(), delta(100.0, 120.0, memory_status)),
+            ]),
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    pass: 1,
+                    warn: 0,
+                    fail: 1,
+                    skip: 0,
+                },
+                reasons: vec!["max_rss_kb_fail".to_string()],
+            },
+            warnings: Vec::new(),
+        }
+    }
+
+    fn delta(baseline: f64, current: f64, status: MetricStatus) -> Delta {
+        Delta {
+            baseline,
+            current,
+            ratio: current / baseline,
+            pct: (current - baseline) / baseline,
+            regression: if current > baseline {
+                (current - baseline) / baseline
+            } else {
+                0.0
+            },
+            cv: None,
+            noise_threshold: None,
+            statistic: perfgate_types::MetricStatistic::Median,
+            significance: None,
+            status,
+        }
+    }
+
+    fn memory_for_speed_rule(downgrade_to: TradeoffDowngrade) -> TradeoffRule {
+        TradeoffRule {
+            name: "memory_for_speed".to_string(),
+            if_failed: Metric::MaxRssKb,
+            require: vec![TradeoffRequirement {
+                metric: Metric::WallMs,
+                min_improvement_ratio: 1.10,
+            }],
+            downgrade_to,
+        }
+    }
+
+    #[test]
+    fn tradeoff_evaluate_accepts_satisfied_rule() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(80.0, MetricStatus::Fail),
+            rules: vec![memory_for_speed_rule(TradeoffDowngrade::Warn)],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert_eq!(receipt.schema, TRADEOFF_SCHEMA_V1);
+        assert!(receipt.decision.accepted_tradeoff);
+        assert_eq!(
+            receipt.weighted_deltas["max_rss_kb"].status,
+            MetricStatus::Warn
+        );
+        assert_eq!(receipt.verdict.status, VerdictStatus::Warn);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Accepted);
+        assert_eq!(
+            receipt.rules[0].requirements[0].observed_change,
+            Some(-0.20)
+        );
+    }
+
+    #[test]
+    fn tradeoff_evaluate_rejects_unsatisfied_rule() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            rules: vec![memory_for_speed_rule(TradeoffDowngrade::Pass)],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(!receipt.decision.accepted_tradeoff);
+        assert_eq!(
+            receipt.weighted_deltas["max_rss_kb"].status,
+            MetricStatus::Fail
+        );
+        assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
+        assert!(
+            receipt
+                .verdict
+                .reasons
+                .contains(&VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED.to_string())
+        );
+    }
+}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -39,6 +39,15 @@ description = "Release-gate API latency workload"
 name = "pst_extract_batch"
 weight = 0.40
 bench = "pst_extract"
+
+[[tradeoff]]
+name = "memory-for-latency"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+min_improvement_ratio = 1.10
 ```
 
 ## Budget Configuration
@@ -108,6 +117,35 @@ weight = 0.50
 bench = "small-edit"
 compare = "artifacts/perfgate/small-edit/compare.json"
 ```
+
+## Tradeoff Configuration
+
+Tradeoff rules make accepted performance exchanges explicit. They only apply to
+metrics that are already failing, and every required compensating improvement
+must be present and satisfied.
+
+```toml
+[[tradeoff]]
+name = "memory-for-latency"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+min_improvement_ratio = 1.10
+```
+
+Evaluate the rules against a scenario receipt to produce
+`perfgate.tradeoff.v1` decision evidence:
+
+```bash
+perfgate tradeoff evaluate --config perfgate.toml --scenario artifacts/perfgate/scenario.json --out artifacts/perfgate/tradeoff.json
+```
+
+`min_improvement_ratio` follows metric direction. For lower-is-better metrics
+such as `wall_ms`, `1.10` means the baseline/current ratio must be at least
+1.10. For higher-is-better metrics such as `throughput_per_s`, the
+current/baseline ratio must be at least 1.10.
 
 ## Presets
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -10,7 +10,7 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 | `perfgate.compare.v1` | `compare`, `check`, `paired` | Comparison of current run against baseline |
 | `perfgate.probe.v1` | `ingest probes` | Named probe observations from internal phases or external instrumentation |
 | `perfgate.scenario.v1` | `scenario evaluate` | Weighted workload-scenario evidence across benchmarks, phases, or probe groups |
-| `perfgate.tradeoff.v1` | schema-first contract | Structured decision evidence for accepted or rejected performance tradeoffs |
+| `perfgate.tradeoff.v1` | `tradeoff evaluate` | Structured decision evidence for accepted or rejected performance tradeoffs |
 | `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
 | `sensor.report.v1` | `check --mode cockpit` | Sensor integration envelope for dashboards |
 | `perfgate.baseline.v1` | baseline service | Stored baseline record returned by the server |
@@ -76,6 +76,19 @@ perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scena
 
 By default, each scenario reads `[defaults].out_dir/<bench>/compare.json`.
 Set `compare = "path/to/compare.json"` on a scenario to override that lookup.
+
+## Tradeoff Evaluation
+
+`perfgate tradeoff evaluate` reads configured `[[tradeoff]]` rules and a
+`perfgate.scenario.v1` receipt, then writes a `perfgate.tradeoff.v1` decision
+receipt:
+
+```bash
+perfgate tradeoff evaluate --config perfgate.toml --scenario artifacts/perfgate/scenario.json --out artifacts/perfgate/tradeoff.json
+```
+
+The receipt records configured rules, requirement outcomes, the final decision,
+and the weighted deltas after any accepted downgrade.
 
 ## Fixture Validation
 


### PR DESCRIPTION
## Summary
- add `perfgate tradeoff evaluate` to produce `perfgate.tradeoff.v1` receipts from configured `[[tradeoff]]` rules and scenario receipts
- add app-level tradeoff evaluation, stricter tradeoff config validation, CLI integration tests, and help snapshots
- document the tradeoff config flow and mark `perfgate.tradeoff.v1` as produced by the new command

## Validation
- cargo fmt --all -- --check
- cargo check -p perfgate-types -p perfgate -p perfgate-cli --all-targets --all-features
- cargo clippy -p perfgate-types -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo test -p perfgate-types config_file_validate_rejects_invalid_tradeoff_rules --all-features
- cargo test -p perfgate tradeoff --all-features
- cargo test -p perfgate-cli --test cli_tradeoff_tests --all-features
- cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features
- cargo run -p xtask -- schema-check
- cargo run -p xtask -- docs-check
- cargo run -p xtask -- doc-test
- cargo run -p xtask -- public-surface --strict
- cargo run -p xtask -- arch
- cargo run -p xtask -- ci
- git diff --check