### PR TITLE
tradeoff: render decision receipts for review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   benchmark compare receipts into `perfgate.scenario.v1` workload receipts.
 - Added `perfgate tradeoff evaluate` to turn configured tradeoff rules and
   scenario receipts into `perfgate.tradeoff.v1` decision receipts.
+- Added Markdown and PR-comment rendering for `perfgate.tradeoff.v1` decision
+  receipts via `perfgate md --tradeoff` and `perfgate comment --tradeoff`.
 - Extended `xtask schema-compat` with baseline-service record, health-response,
   and fleet fixtures so the 0.16 server API contract is checked alongside
   receipt compatibility.

--- a/action.yml
+++ b/action.yml
@@ -366,7 +366,7 @@ runs:
 
           local listing
           listing="$(mktemp)"
-          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name comment.md -o -name 'perfgate.*.json' -o -name 'sensor.report.v1.json' \) | sort > "${listing}"
+          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name tradeoff.json -o -name comment.md -o -name 'perfgate.*.json' -o -name 'sensor.report.v1.json' \) | sort > "${listing}"
 
           local count
           count="$(wc -l < "${listing}" | tr -d ' ')"
@@ -434,7 +434,7 @@ runs:
       run: |
         set -euo pipefail
 
-        # Find a compare or report receipt to comment on.
+        # Find a tradeoff, compare, or report receipt to comment on.
         # In standard mode, report.json is a perfgate.report.v1.
         # In cockpit mode, report.json is a sensor.report.v1 (not
         # parseable as --report), so we look for extras/ receipts first.
@@ -442,26 +442,40 @@ runs:
         pr_num="${{ github.event.pull_request.number }}"
         posted=false
 
-        # 1. Cockpit single-bench extras
+        # 1. Tradeoff decision receipts, when workflows produced them explicitly.
+        if [[ "${posted}" == "false" && -f "${out}/tradeoff.json" ]]; then
+          perfgate comment --tradeoff "${out}/tradeoff.json" --pr "${pr_num}" || true
+          posted=true
+        fi
+        if [[ "${posted}" == "false" && -f "${out}/perfgate.tradeoff.v1.json" ]]; then
+          perfgate comment --tradeoff "${out}/perfgate.tradeoff.v1.json" --pr "${pr_num}" || true
+          posted=true
+        fi
+        if [[ "${posted}" == "false" && -f "${out}/extras/perfgate.tradeoff.v1.json" ]]; then
+          perfgate comment --tradeoff "${out}/extras/perfgate.tradeoff.v1.json" --pr "${pr_num}" || true
+          posted=true
+        fi
+
+        # 2. Cockpit single-bench extras
         if [[ "${posted}" == "false" && -f "${out}/extras/perfgate.report.v1.json" ]]; then
           perfgate comment --report "${out}/extras/perfgate.report.v1.json" --pr "${pr_num}" || true
           posted=true
         fi
 
-        # 2. Standard mode report.json (perfgate.report.v1)
+        # 3. Standard mode report.json (perfgate.report.v1)
         if [[ "${posted}" == "false" && -f "${out}/report.json" && "${{ inputs.mode }}" != "cockpit" ]]; then
           perfgate comment --report "${out}/report.json" --pr "${pr_num}" || true
           posted=true
         fi
 
-        # 3. Standard mode compare.json
+        # 4. Standard mode compare.json
         if [[ "${posted}" == "false" && -f "${out}/compare.json" ]]; then
           perfgate comment --compare "${out}/compare.json" --pr "${pr_num}" || true
           posted=true
         fi
 
         if [[ "${posted}" == "false" ]]; then
-          echo "No compare or report receipt found; skipping PR comment." >&2
+          echo "No tradeoff, compare, or report receipt found; skipping PR comment." >&2
         fi
 
     - name: Upload perfgate artifacts

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -26,7 +26,7 @@ use perfgate_app::{
     ScenarioEvaluateInput, ScenarioEvaluateRequest, ScenarioUseCase, SensorReportBuilder,
     SystemClock, TradeoffEvaluateRequest, TradeoffUseCase, classify_error, github_annotations,
     is_host_mismatch_reason, preview_lines, redact_command_for_diagnostics, render_json_diff,
-    render_markdown, render_markdown_template, render_terminal_diff,
+    render_markdown, render_markdown_template, render_terminal_diff, render_tradeoff_markdown,
     watch::{Debouncer, WatchRunRequest, WatchState, execute_watch_run, render_watch_display},
 };
 use perfgate_client::types::auth::Role;
@@ -49,7 +49,7 @@ use perfgate_types::{
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
     MetricStatus, OtelSpanIdentifiers, PerfgateReport, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
     RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
-    ScenarioReceipt, SensorVerdictStatus, ToolInfo, VerdictStatus,
+    ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
@@ -175,7 +175,11 @@ enum Command {
     /// Render a Markdown summary from a compare receipt.
     Md {
         #[arg(long)]
-        compare: PathBuf,
+        compare: Option<PathBuf>,
+
+        /// Path to a tradeoff receipt.
+        #[arg(long, conflicts_with = "compare")]
+        tradeoff: Option<PathBuf>,
 
         /// Output markdown path (default: stdout)
         #[arg(long)]
@@ -711,13 +715,17 @@ pub struct BisectArgs {
 
 #[derive(Debug, Args)]
 pub struct CommentArgs {
-    /// Path to a compare receipt (mutually exclusive with --report)
-    #[arg(long, conflicts_with = "report")]
+    /// Path to a compare receipt (mutually exclusive with --report and --tradeoff)
+    #[arg(long, conflicts_with_all = ["report", "tradeoff"])]
     pub compare: Option<PathBuf>,
 
-    /// Path to a report receipt (mutually exclusive with --compare)
-    #[arg(long, conflicts_with = "compare")]
+    /// Path to a report receipt (mutually exclusive with --compare and --tradeoff)
+    #[arg(long, conflicts_with_all = ["compare", "tradeoff"])]
     pub report: Option<PathBuf>,
+
+    /// Path to a tradeoff receipt (mutually exclusive with --compare and --report)
+    #[arg(long, conflicts_with_all = ["compare", "report"])]
+    pub tradeoff: Option<PathBuf>,
 
     /// GitHub token for API authentication.
     /// Can also be set via GITHUB_TOKEN environment variable.
@@ -2631,11 +2639,22 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
         Command::Md {
             compare,
+            tradeoff,
             out,
             template,
         } => {
-            let compare_receipt: perfgate_types::CompareReceipt = read_json(&compare)?;
-            let md = render_markdown_with_optional_template(&compare_receipt, template.as_deref())?;
+            let md = if let Some(compare) = compare {
+                let compare_receipt: CompareReceipt = read_json(&compare)?;
+                render_markdown_with_optional_template(&compare_receipt, template.as_deref())?
+            } else if let Some(tradeoff) = tradeoff {
+                if template.is_some() {
+                    anyhow::bail!("--template is only supported with --compare");
+                }
+                let tradeoff_receipt: TradeoffReceipt = read_json(&tradeoff)?;
+                render_tradeoff_markdown(&tradeoff_receipt)
+            } else {
+                anyhow::bail!("Either --compare or --tradeoff is required");
+            };
 
             match out {
                 Some(path) => {
@@ -4242,6 +4261,7 @@ fn execute_comment(args: CommentArgs) -> anyhow::Result<()> {
     let CommentArgs {
         compare,
         report,
+        tradeoff,
         github_token,
         repo,
         pr,
@@ -4265,8 +4285,11 @@ fn execute_comment(args: CommentArgs) -> anyhow::Result<()> {
             explain_text: None,
         };
         github::render_comment_from_report(&report_receipt, &options)
+    } else if let Some(tradeoff_path) = tradeoff {
+        let tradeoff_receipt: TradeoffReceipt = read_json(&tradeoff_path)?;
+        github::render_comment_from_tradeoff(&tradeoff_receipt)
     } else {
-        anyhow::bail!("Either --compare or --report is required");
+        anyhow::bail!("Either --compare, --report, or --tradeoff is required");
     };
 
     // Dry-run: print and exit

--- a/crates/perfgate-cli/tests/cli_comment_tests.rs
+++ b/crates/perfgate-cli/tests/cli_comment_tests.rs
@@ -7,6 +7,16 @@ use tempfile::tempdir;
 mod common;
 use common::{fixtures_dir, generate_compare_receipt, perfgate_cmd};
 
+fn tradeoff_fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("fixtures")
+        .join("schema")
+        .join("v0.16")
+        .join("perfgate.tradeoff.v1.json")
+}
+
 fn generate_warn_compare(dir: &Path) -> PathBuf {
     let compare_path = dir.join("compare.json");
     generate_compare_receipt(
@@ -62,4 +72,23 @@ fn comment_dry_run_renders_report_receipt() {
         .success()
         .stdout(predicate::str::contains("<!-- perfgate -->"))
         .stdout(predicate::str::contains("perfgate: **warn**"));
+}
+
+#[test]
+fn comment_dry_run_renders_tradeoff_receipt() {
+    let mut cmd = perfgate_cmd();
+    cmd.arg("comment")
+        .arg("--tradeoff")
+        .arg(tradeoff_fixture_path())
+        .arg("--dry-run");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("<!-- perfgate -->"))
+        .stdout(predicate::str::contains("perfgate tradeoff: pass"))
+        .stdout(predicate::str::contains("large_file_parse"))
+        .stdout(predicate::str::contains(
+            "tokenizer-slower-if-parser-faster",
+        ))
+        .stdout(predicate::str::contains("Raw tradeoff data"));
 }

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -106,7 +106,22 @@ fn cli_help_md() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Render a Markdown summary"))
-        .stdout(predicate::str::contains("--compare"));
+        .stdout(predicate::str::contains("--compare"))
+        .stdout(predicate::str::contains("--tradeoff"));
+}
+
+#[test]
+fn cli_help_comment() {
+    perfgate_cmd()
+        .args(["comment", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Post or update a performance report comment",
+        ))
+        .stdout(predicate::str::contains("--compare"))
+        .stdout(predicate::str::contains("--report"))
+        .stdout(predicate::str::contains("--tradeoff"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_md_tests.rs
+++ b/crates/perfgate-cli/tests/cli_md_tests.rs
@@ -4,10 +4,21 @@
 
 use predicates::prelude::*;
 use std::fs;
+use std::path::PathBuf;
 use tempfile::tempdir;
 
 mod common;
 use common::{fixtures_dir, generate_compare_receipt, perfgate_cmd};
+
+fn tradeoff_fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("fixtures")
+        .join("schema")
+        .join("v0.16")
+        .join("perfgate.tradeoff.v1.json")
+}
 
 /// Test markdown generation from compare receipt with pass verdict
 /// Verify output contains expected table structure and verdict emoji
@@ -227,9 +238,26 @@ fn test_md_missing_compare_argument() {
     let mut cmd = perfgate_cmd();
     cmd.arg("md");
 
+    cmd.assert().failure().stderr(predicate::str::contains(
+        "Either --compare or --tradeoff is required",
+    ));
+}
+
+#[test]
+fn test_md_tradeoff_receipt_stdout() {
+    let mut cmd = perfgate_cmd();
+    cmd.arg("md").arg("--tradeoff").arg(tradeoff_fixture_path());
+
     cmd.assert()
-        .failure()
-        .stderr(predicate::str::contains("--compare"));
+        .success()
+        .stdout(predicate::str::contains("perfgate tradeoff"))
+        .stdout(predicate::str::contains("large_file_parse"))
+        .stdout(predicate::str::contains("accepted"))
+        .stdout(predicate::str::contains(
+            "tokenizer-slower-if-parser-faster",
+        ))
+        .stdout(predicate::str::contains("Weighted Outcome"))
+        .stdout(predicate::str::contains("Probe Evidence"));
 }
 
 /// Test markdown output contains verdict reasons when present

--- a/crates/perfgate/src/app/mod.rs
+++ b/crates/perfgate/src/app/mod.rs
@@ -67,7 +67,7 @@ pub use render::{
     direction_str, format_metric, format_metric_with_statistic, format_pct, format_value,
     github_annotations, markdown_template_context, metric_status_icon, metric_status_str,
     parse_reason_token, render_complexity_section, render_markdown, render_markdown_template,
-    render_reason_line,
+    render_reason_line, render_tradeoff_markdown,
 };
 
 // Re-export export functionality from the app-owned presentation module for backward compatibility.

--- a/crates/perfgate/src/app/render.rs
+++ b/crates/perfgate/src/app/render.rs
@@ -10,7 +10,7 @@ pub mod summary;
 use anyhow::Context;
 use perfgate_types::{
     CompareReceipt, ComplexityGateResult, ComplexityGateStatus, Direction, Metric, MetricStatistic,
-    MetricStatus,
+    MetricStatus, TradeoffDecisionStatus, TradeoffReceipt,
 };
 use serde_json::json;
 
@@ -71,6 +71,132 @@ pub fn render_markdown(compare: &CompareReceipt) -> String {
         for r in &compare.verdict.reasons {
             out.push_str(&render_reason_line(compare, r));
         }
+    }
+
+    out
+}
+
+/// Render a [`TradeoffReceipt`] as Markdown for review comments and local diagnostics.
+pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
+    let mut out = String::new();
+
+    let header = match tradeoff.verdict.status {
+        perfgate_types::VerdictStatus::Pass => "✅ perfgate tradeoff: pass",
+        perfgate_types::VerdictStatus::Warn => "⚠️ perfgate tradeoff: warn",
+        perfgate_types::VerdictStatus::Fail => "❌ perfgate tradeoff: fail",
+        perfgate_types::VerdictStatus::Skip => "⏭️ perfgate tradeoff: skip",
+    };
+
+    out.push_str(header);
+    out.push_str("\n\n");
+
+    if let Some(scenario) = &tradeoff.scenario {
+        out.push_str(&format!("**Scenario:** `{scenario}`\n\n"));
+    }
+
+    out.push_str(&format!(
+        "**Decision:** {} - {}\n\n",
+        metric_status_icon(tradeoff.decision.status),
+        tradeoff.decision.reason
+    ));
+
+    if !tradeoff.weighted_deltas.is_empty() {
+        out.push_str("### Weighted Outcome\n\n");
+        out.push_str("| metric | baseline | current | delta | status |\n");
+        out.push_str("|---|---:|---:|---:|---|\n");
+        for (metric_key, delta) in &tradeoff.weighted_deltas {
+            let (baseline, current, unit) = Metric::parse_key(metric_key)
+                .map(|metric| {
+                    (
+                        format_value(metric, delta.baseline),
+                        format_value(metric, delta.current),
+                        metric.display_unit(),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    (
+                        format!("{:.3}", delta.baseline),
+                        format!("{:.3}", delta.current),
+                        "",
+                    )
+                });
+            out.push_str(&format!(
+                "| `{metric_key}` | {baseline} {unit} | {current} {unit} | {delta_pct} | {status} |\n",
+                delta_pct = format_pct(delta.pct),
+                status = metric_status_icon(delta.status),
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !tradeoff.rules.is_empty() {
+        out.push_str("### Tradeoff Rules\n\n");
+        out.push_str("| rule | decision | downgrade | requirements |\n");
+        out.push_str("|---|---|---|---|\n");
+        for rule in &tradeoff.rules {
+            let requirements = if rule.requirements.is_empty() {
+                "none".to_string()
+            } else {
+                rule.requirements
+                    .iter()
+                    .map(|requirement| {
+                        let observed = requirement
+                            .observed_change
+                            .map(format_pct)
+                            .unwrap_or_else(|| "missing".to_string());
+                        format!(
+                            "`{}` observed {} / required {} {}",
+                            requirement.metric,
+                            observed,
+                            format_pct(requirement.required_change),
+                            metric_status_icon(requirement.status)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join("<br>")
+            };
+            let downgrade = rule
+                .downgrade_to
+                .map(tradeoff_downgrade_label)
+                .unwrap_or("-");
+            out.push_str(&format!(
+                "| `{}` | {} | `{}` | {} |\n",
+                rule.name,
+                tradeoff_decision_label(rule.status),
+                downgrade,
+                requirements
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !tradeoff.probes.is_empty() {
+        out.push_str("### Probe Evidence\n\n");
+        out.push_str("| probe | scope | status | reason |\n");
+        out.push_str("|---|---|---|---|\n");
+        for probe in &tradeoff.probes {
+            let scope = probe
+                .scope
+                .map(|scope| format!("{:?}", scope).to_lowercase())
+                .unwrap_or_else(|| "-".to_string());
+            let reason = probe.reason.as_deref().unwrap_or("-");
+            out.push_str(&format!(
+                "| `{}` | `{}` | {} | {} |\n",
+                probe.name,
+                scope,
+                metric_status_icon(probe.status),
+                reason
+            ));
+        }
+        out.push('\n');
+    }
+
+    if !tradeoff.warnings.is_empty() {
+        out.push_str("### Warnings\n\n");
+        for warning in &tradeoff.warnings {
+            out.push_str(&format!("- {warning}\n"));
+        }
+        out.push('\n');
     }
 
     out
@@ -349,11 +475,27 @@ pub fn metric_status_str(status: MetricStatus) -> &'static str {
     }
 }
 
+fn tradeoff_decision_label(status: TradeoffDecisionStatus) -> &'static str {
+    match status {
+        TradeoffDecisionStatus::Accepted => "accepted",
+        TradeoffDecisionStatus::Rejected => "rejected",
+        TradeoffDecisionStatus::NotEvaluated => "not evaluated",
+    }
+}
+
+fn tradeoff_downgrade_label(downgrade: perfgate_types::TradeoffDowngrade) -> &'static str {
+    match downgrade {
+        perfgate_types::TradeoffDowngrade::Warn => "warn",
+        perfgate_types::TradeoffDowngrade::Pass => "pass",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use perfgate_types::{
-        BenchMeta, Budget, CompareRef, Delta, ToolInfo, Verdict, VerdictCounts, VerdictStatus,
+        BenchMeta, Budget, CompareRef, Delta, RunMeta, ToolInfo, TradeoffDecision,
+        TradeoffRuleOutcome, Verdict, VerdictCounts, VerdictStatus,
     };
     use std::collections::BTreeMap;
 
@@ -416,12 +558,117 @@ mod tests {
         }
     }
 
+    fn make_tradeoff_receipt(status: MetricStatus) -> TradeoffReceipt {
+        let mut weighted_deltas = BTreeMap::new();
+        weighted_deltas.insert(
+            "wall_ms".to_string(),
+            Delta {
+                baseline: 100.0,
+                current: 88.0,
+                ratio: 0.88,
+                pct: -0.12,
+                regression: 0.0,
+                cv: None,
+                noise_threshold: None,
+                statistic: MetricStatistic::Median,
+                significance: None,
+                status: MetricStatus::Pass,
+            },
+        );
+        weighted_deltas.insert(
+            "max_rss_kb".to_string(),
+            Delta {
+                baseline: 100.0,
+                current: 115.0,
+                ratio: 1.15,
+                pct: 0.15,
+                regression: 0.15,
+                cv: None,
+                noise_threshold: None,
+                statistic: MetricStatistic::Median,
+                significance: None,
+                status,
+            },
+        );
+
+        TradeoffReceipt {
+            schema: perfgate_types::TRADEOFF_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+            run: RunMeta {
+                id: "tradeoff-run".to_string(),
+                started_at: "2026-05-08T00:00:00Z".to_string(),
+                ended_at: "2026-05-08T00:00:01Z".to_string(),
+                host: perfgate_types::HostInfo {
+                    os: "linux".to_string(),
+                    arch: "x86_64".to_string(),
+                    cpu_count: None,
+                    memory_bytes: None,
+                    hostname_hash: None,
+                },
+            },
+            scenario: Some("release_workload".to_string()),
+            baseline_ref: None,
+            current_ref: None,
+            configured_rules: Vec::new(),
+            rules: vec![TradeoffRuleOutcome {
+                name: "memory_for_speed".to_string(),
+                status: TradeoffDecisionStatus::Accepted,
+                accepted: true,
+                downgrade_to: Some(perfgate_types::TradeoffDowngrade::Warn),
+                reason: Some("all required compensating improvements were satisfied".to_string()),
+                requirements: vec![perfgate_types::TradeoffRequirementOutcome {
+                    metric: "wall_ms".to_string(),
+                    probe: None,
+                    required_change: -0.10,
+                    observed_change: Some(-0.12),
+                    satisfied: true,
+                    status: MetricStatus::Pass,
+                    reason: None,
+                }],
+            }],
+            probes: Vec::new(),
+            weighted_deltas,
+            decision: TradeoffDecision {
+                accepted_tradeoff: true,
+                status,
+                reason: "tradeoff 'memory_for_speed' accepted".to_string(),
+            },
+            verdict: Verdict {
+                status: VerdictStatus::Warn,
+                counts: VerdictCounts {
+                    pass: 1,
+                    warn: 1,
+                    fail: 0,
+                    skip: 0,
+                },
+                reasons: vec!["tradeoff_memory_for_speed_applied".to_string()],
+            },
+            warnings: Vec::new(),
+        }
+    }
+
     #[test]
     fn markdown_renders_table() {
         let receipt = make_compare_receipt(MetricStatus::Pass);
         let md = render_markdown(&receipt);
         assert!(md.contains("| metric | baseline"));
         assert!(md.contains("wall_ms"));
+    }
+
+    #[test]
+    fn tradeoff_markdown_renders_decision_and_rules() {
+        let receipt = make_tradeoff_receipt(MetricStatus::Warn);
+        let md = render_tradeoff_markdown(&receipt);
+
+        assert!(md.contains("perfgate tradeoff: warn"));
+        assert!(md.contains("**Scenario:** `release_workload`"));
+        assert!(md.contains("tradeoff 'memory_for_speed' accepted"));
+        assert!(md.contains("| `max_rss_kb` |"));
+        assert!(md.contains("| `memory_for_speed` | accepted | `warn` |"));
+        assert!(md.contains("`wall_ms` observed -12.00% / required -10.00%"));
     }
 
     #[test]

--- a/crates/perfgate/src/integrations/github/comment.rs
+++ b/crates/perfgate/src/integrations/github/comment.rs
@@ -6,9 +6,9 @@
 use super::client::COMMENT_MARKER;
 use crate::app::render::{
     direction_str, format_metric_with_statistic, format_pct, format_value, metric_status_icon,
-    render_reason_line,
+    render_reason_line, render_tradeoff_markdown,
 };
-use perfgate_types::{CompareReceipt, PerfgateReport, VerdictStatus};
+use perfgate_types::{CompareReceipt, PerfgateReport, TradeoffReceipt, VerdictStatus};
 
 /// Options for customizing the rendered comment.
 #[derive(Debug, Clone, Default)]
@@ -146,6 +146,27 @@ pub fn render_comment_from_report(report: &PerfgateReport, options: &CommentOpti
             ));
         }
     }
+
+    out.push_str("\n---\n");
+    out.push_str("*Posted by [perfgate](https://github.com/EffortlessMetrics/perfgate)*\n");
+
+    out
+}
+
+/// Render a full PR comment body from a `TradeoffReceipt`.
+pub fn render_comment_from_tradeoff(tradeoff: &TradeoffReceipt) -> String {
+    let mut out = String::new();
+
+    out.push_str(COMMENT_MARKER);
+    out.push('\n');
+    out.push_str(&render_tradeoff_markdown(tradeoff));
+
+    out.push_str("\n<details>\n<summary>Raw tradeoff data</summary>\n\n");
+    out.push_str("```json\n");
+    if let Ok(json) = serde_json::to_string_pretty(tradeoff) {
+        out.push_str(&json);
+    }
+    out.push_str("\n```\n\n</details>\n");
 
     out.push_str("\n---\n");
     out.push_str("*Posted by [perfgate](https://github.com/EffortlessMetrics/perfgate)*\n");

--- a/crates/perfgate/src/integrations/github/mod.rs
+++ b/crates/perfgate/src/integrations/github/mod.rs
@@ -16,7 +16,7 @@ pub mod types;
 pub use client::{COMMENT_MARKER, GitHubClient};
 pub use comment::{
     CommentOptions, parse_github_repository, parse_pr_number_from_ref, render_comment,
-    render_comment_from_report,
+    render_comment_from_report, render_comment_from_tradeoff,
 };
 pub use error::GitHubError;
 pub use types::GitHubComment;

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -142,6 +142,13 @@ Evaluate the rules against a scenario receipt to produce
 perfgate tradeoff evaluate --config perfgate.toml --scenario artifacts/perfgate/scenario.json --out artifacts/perfgate/tradeoff.json
 ```
 
+Render the decision for local review or PR comments:
+
+```bash
+perfgate md --tradeoff artifacts/perfgate/tradeoff.json --out artifacts/perfgate/tradeoff.md
+perfgate comment --tradeoff artifacts/perfgate/tradeoff.json --dry-run
+```
+
 `min_improvement_ratio` follows metric direction. For lower-is-better metrics
 such as `wall_ms`, `1.10` means the baseline/current ratio must be at least
 1.10. For higher-is-better metrics such as `throughput_per_s`, the

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -90,6 +90,13 @@ perfgate tradeoff evaluate --config perfgate.toml --scenario artifacts/perfgate/
 The receipt records configured rules, requirement outcomes, the final decision,
 and the weighted deltas after any accepted downgrade.
 
+Render the decision evidence for review:
+
+```bash
+perfgate md --tradeoff artifacts/perfgate/tradeoff.json
+perfgate comment --tradeoff artifacts/perfgate/tradeoff.json --dry-run
+```
+
 ## Fixture Validation
 
 Validate JSON files against the vendored `sensor.report.v1` schema:


### PR DESCRIPTION
## Summary
- render `perfgate.tradeoff.v1` receipts as review-ready Markdown
- add `perfgate md --tradeoff` and `perfgate comment --tradeoff`
- teach the composite action to list `tradeoff.json` artifacts and prefer tradeoff decision receipts for PR comments when present
- document the tradeoff receipt review path

## Validation
- cargo test -p perfgate tradeoff_markdown_renders_decision_and_rules --all-features
- cargo test -p perfgate-cli --test cli_md_tests --all-features
- cargo test -p perfgate-cli --test cli_comment_tests --all-features
- cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features
- cargo check -p perfgate -p perfgate-cli --all-targets --all-features
- cargo clippy -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo run -p xtask -- action-check
- cargo run -p xtask -- docs-check
- cargo run -p xtask -- doc-test
- cargo run -p xtask -- public-surface --strict
- cargo run -p xtask -- arch
- cargo run -p xtask -- ci
- git diff --check

## Notes
- Restored free space by deleting the repo-local `target/` directory; validation used `E:\codex-target\perfgate-tradeoff-review`.