### PR TITLE
feat: add decision evaluate workflow

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -344,6 +344,12 @@ enum Command {
         pretty: bool,
     },
 
+    /// Evaluate scenario and tradeoff evidence into a review-ready decision summary.
+    Decision {
+        #[command(subcommand)]
+        action: DecisionAction,
+    },
+
     /// Evaluate configured workload scenarios from compare receipts.
     Scenario {
         #[command(subcommand)]
@@ -1279,6 +1285,12 @@ pub enum TradeoffAction {
     Evaluate(TradeoffEvaluateArgs),
 }
 
+#[derive(Debug, Subcommand)]
+pub enum DecisionAction {
+    /// Evaluate configured scenarios and tradeoffs, then render decision markdown.
+    Evaluate(DecisionEvaluateArgs),
+}
+
 #[derive(Debug, Args)]
 pub struct ScenarioEvaluateArgs {
     /// Path to perfgate.toml.
@@ -1321,6 +1333,41 @@ pub struct TradeoffEvaluateArgs {
     pub out: PathBuf,
 
     /// Pretty-print JSON.
+    #[arg(long, default_value_t = false)]
+    pub pretty: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DecisionEvaluateArgs {
+    /// Path to perfgate.toml.
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Evaluate only one configured scenario by name.
+    #[arg(long)]
+    pub scenario: Option<String>,
+
+    /// Name to use for the combined weighted workload receipt.
+    #[arg(long)]
+    pub workload_name: Option<String>,
+
+    /// Override artifact directory used for compare lookup and default outputs.
+    #[arg(long)]
+    pub out_dir: Option<PathBuf>,
+
+    /// Output scenario receipt path.
+    #[arg(long)]
+    pub scenario_out: Option<PathBuf>,
+
+    /// Output tradeoff receipt path.
+    #[arg(long)]
+    pub tradeoff_out: Option<PathBuf>,
+
+    /// Output decision markdown path.
+    #[arg(long)]
+    pub decision_out: Option<PathBuf>,
+
+    /// Pretty-print JSON receipts.
     #[arg(long, default_value_t = false)]
     pub pretty: bool,
 }
@@ -3059,6 +3106,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
             }
         }
 
+        Command::Decision { action } => execute_decision_action(action),
         Command::Scenario { action } => execute_scenario_action(action),
         Command::Tradeoff { action } => execute_tradeoff_action(action),
 
@@ -3238,47 +3286,18 @@ fn execute_scenario_action(action: ScenarioAction) -> anyhow::Result<()> {
 }
 
 fn execute_scenario_evaluate(args: ScenarioEvaluateArgs) -> anyhow::Result<()> {
-    let config = load_config_file(&args.config)
-        .with_context(|| format!("failed to load {}", args.config.display()))?;
-    config
-        .validate()
-        .map_err(|error| anyhow::anyhow!("{} is invalid: {error}", args.config.display()))?;
-
-    if config.scenarios.is_empty() {
-        anyhow::bail!(
-            "no [[scenario]] entries configured in {}",
-            args.config.display()
-        );
-    }
-
-    let selected = select_configured_scenarios(&config, args.scenario.as_deref())?;
+    let config = load_validated_config(&args.config)?;
     let out_dir = args
         .out_dir
         .clone()
         .unwrap_or_else(|| resolve_configured_out_dir(None, Some(&config)));
-
-    let mut inputs = Vec::new();
-    for scenario in selected {
-        let compare_path = scenario_compare_path(scenario, &out_dir);
-        let compare: CompareReceipt = read_json_from_location(&compare_path)
-            .with_context(|| format!("read scenario compare {}", compare_path.display()))?;
-        let run_id = compare.current_ref.run_id.clone();
-        inputs.push(ScenarioEvaluateInput {
-            config: scenario.clone(),
-            compare_ref: CompareRef {
-                path: Some(compare_path.display().to_string()),
-                run_id,
-            },
-            compare,
-        });
-    }
-
-    let outcome = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+    let outcome = evaluate_configured_scenarios(
         config,
-        inputs,
-        workload_name: args.workload_name,
-        tool: tool_info(),
-    })?;
+        &args.config,
+        args.scenario.as_deref(),
+        args.workload_name,
+        &out_dir,
+    )?;
 
     write_json(&args.out, &outcome.receipt, args.pretty)?;
     eprintln!("Scenario receipt written to {}", args.out.display());
@@ -3287,6 +3306,58 @@ fn execute_scenario_evaluate(args: ScenarioEvaluateArgs) -> anyhow::Result<()> {
         VerdictStatus::Fail => exit_with_code(2),
         VerdictStatus::Pass | VerdictStatus::Warn | VerdictStatus::Skip => Ok(()),
     }
+}
+
+fn load_validated_config(config_path: &Path) -> anyhow::Result<ConfigFile> {
+    let config = load_config_file(config_path)
+        .with_context(|| format!("failed to load {}", config_path.display()))?;
+    config
+        .validate()
+        .map_err(|error| anyhow::anyhow!("{} is invalid: {error}", config_path.display()))?;
+    Ok(config)
+}
+
+fn evaluate_configured_scenarios(
+    config: ConfigFile,
+    config_path: &Path,
+    scenario: Option<&str>,
+    workload_name: Option<String>,
+    out_dir: &Path,
+) -> anyhow::Result<perfgate_app::ScenarioEvaluateOutcome> {
+    if config.scenarios.is_empty() {
+        anyhow::bail!(
+            "no [[scenario]] entries configured in {}",
+            config_path.display()
+        );
+    }
+
+    let selected: Vec<_> = select_configured_scenarios(&config, scenario)?
+        .into_iter()
+        .cloned()
+        .collect();
+
+    let mut inputs = Vec::new();
+    for scenario in selected {
+        let compare_path = scenario_compare_path(&scenario, out_dir);
+        let compare: CompareReceipt = read_json_from_location(&compare_path)
+            .with_context(|| format!("read scenario compare {}", compare_path.display()))?;
+        let run_id = compare.current_ref.run_id.clone();
+        inputs.push(ScenarioEvaluateInput {
+            config: scenario,
+            compare_ref: CompareRef {
+                path: Some(compare_path.display().to_string()),
+                run_id,
+            },
+            compare,
+        });
+    }
+
+    ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+        config,
+        inputs,
+        workload_name,
+        tool: tool_info(),
+    })
 }
 
 fn select_configured_scenarios<'a>(
@@ -3323,31 +3394,87 @@ fn execute_tradeoff_action(action: TradeoffAction) -> anyhow::Result<()> {
 }
 
 fn execute_tradeoff_evaluate(args: TradeoffEvaluateArgs) -> anyhow::Result<()> {
-    let config = load_config_file(&args.config)
-        .with_context(|| format!("failed to load {}", args.config.display()))?;
-    config
-        .validate()
-        .map_err(|error| anyhow::anyhow!("{} is invalid: {error}", args.config.display()))?;
-
-    if config.tradeoffs.is_empty() {
-        anyhow::bail!(
-            "no [[tradeoff]] entries configured in {}",
-            args.config.display()
-        );
-    }
-
+    let config = load_validated_config(&args.config)?;
     let scenario: ScenarioReceipt = read_json(&args.scenario)
         .with_context(|| format!("read scenario receipt {}", args.scenario.display()))?;
-    let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
-        scenario,
-        rules: config.tradeoffs,
-        tool: tool_info(),
-    })?;
+    let outcome = evaluate_configured_tradeoffs(&config, &args.config, scenario)?;
 
     write_json(&args.out, &outcome.receipt, args.pretty)?;
     eprintln!("Tradeoff receipt written to {}", args.out.display());
 
     match outcome.receipt.verdict.status {
+        VerdictStatus::Fail => exit_with_code(2),
+        VerdictStatus::Pass | VerdictStatus::Warn | VerdictStatus::Skip => Ok(()),
+    }
+}
+
+fn evaluate_configured_tradeoffs(
+    config: &ConfigFile,
+    config_path: &Path,
+    scenario: ScenarioReceipt,
+) -> anyhow::Result<perfgate_app::TradeoffEvaluateOutcome> {
+    if config.tradeoffs.is_empty() {
+        anyhow::bail!(
+            "no [[tradeoff]] entries configured in {}",
+            config_path.display()
+        );
+    }
+
+    TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+        scenario,
+        rules: config.tradeoffs.clone(),
+        tool: tool_info(),
+    })
+}
+
+fn execute_decision_action(action: DecisionAction) -> anyhow::Result<()> {
+    match action {
+        DecisionAction::Evaluate(args) => execute_decision_evaluate(args),
+    }
+}
+
+fn execute_decision_evaluate(args: DecisionEvaluateArgs) -> anyhow::Result<()> {
+    let config = load_validated_config(&args.config)?;
+    let out_dir = resolve_configured_out_dir(args.out_dir.as_ref(), Some(&config));
+    let scenario_out = args
+        .scenario_out
+        .clone()
+        .unwrap_or_else(|| out_dir.join("scenario.json"));
+    let tradeoff_out = args
+        .tradeoff_out
+        .clone()
+        .unwrap_or_else(|| out_dir.join("tradeoff.json"));
+    let decision_out = args
+        .decision_out
+        .clone()
+        .unwrap_or_else(|| out_dir.join("decision.md"));
+
+    let scenario_outcome = evaluate_configured_scenarios(
+        config.clone(),
+        &args.config,
+        args.scenario.as_deref(),
+        args.workload_name,
+        &out_dir,
+    )?;
+    write_json(&scenario_out, &scenario_outcome.receipt, args.pretty)?;
+    eprintln!("Scenario receipt written to {}", scenario_out.display());
+
+    let tradeoff_outcome =
+        evaluate_configured_tradeoffs(&config, &args.config, scenario_outcome.receipt)?;
+    write_json(&tradeoff_out, &tradeoff_outcome.receipt, args.pretty)?;
+    eprintln!("Tradeoff receipt written to {}", tradeoff_out.display());
+
+    let markdown = render_tradeoff_markdown(&tradeoff_outcome.receipt);
+    if let Some(parent) = decision_out
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+    atomic_write(&decision_out, markdown.as_bytes())?;
+    eprintln!("Decision markdown written to {}", decision_out.display());
+
+    match tradeoff_outcome.receipt.verdict.status {
         VerdictStatus::Fail => exit_with_code(2),
         VerdictStatus::Pass | VerdictStatus::Warn | VerdictStatus::Skip => Ok(()),
     }

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -284,6 +284,33 @@ fn cli_help_tradeoff_evaluate() {
         .stdout(predicate::str::contains("--out"));
 }
 
+#[test]
+fn cli_help_decision() {
+    perfgate_cmd()
+        .args(["decision", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Evaluate scenario and tradeoff evidence",
+        ))
+        .stdout(predicate::str::contains("evaluate"));
+}
+
+#[test]
+fn cli_help_decision_evaluate() {
+    perfgate_cmd()
+        .args(["decision", "evaluate", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Evaluate configured scenarios and tradeoffs",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--scenario-out"))
+        .stdout(predicate::str::contains("--tradeoff-out"))
+        .stdout(predicate::str::contains("--decision-out"));
+}
+
 // ── insta full-output snapshot tests ─────────────────────────────────
 
 fn help_output(args: &[&str]) -> String {
@@ -432,5 +459,18 @@ fn snapshot_help_tradeoff_evaluate() {
     insta::assert_snapshot!(
         "help_tradeoff_evaluate",
         help_output(&["tradeoff", "evaluate", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_decision() {
+    insta::assert_snapshot!("help_decision", help_output(&["decision", "--help"]));
+}
+
+#[test]
+fn snapshot_help_decision_evaluate() {
+    insta::assert_snapshot!(
+        "help_decision_evaluate",
+        help_output(&["decision", "evaluate", "--help"])
     );
 }

--- a/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
+++ b/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
@@ -194,6 +194,71 @@ fn structured_decision_path_produces_scenario_and_tradeoff_receipts() {
     assert!(decision.contains("memory_for_speed"));
 }
 
+#[test]
+fn decision_evaluate_runs_structured_decision_workflow() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let root = temp_dir.path();
+    let config_path = root.join("perfgate.toml");
+    write_config(&config_path);
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args(["check", "--config", "perfgate.toml", "--all"])
+        .assert()
+        .success();
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args(["baseline", "promote", "--config", "perfgate.toml", "--all"])
+        .assert()
+        .success();
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "check",
+            "--config",
+            "perfgate.toml",
+            "--all",
+            "--require-baseline",
+        ])
+        .assert()
+        .success();
+
+    let compare_path = root.join("artifacts/perfgate/parser/compare.json");
+    assert!(compare_path.exists(), "check should write compare receipt");
+    write_controlled_compare_receipt(&compare_path);
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args(["decision", "evaluate", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Scenario receipt written"))
+        .stderr(predicate::str::contains("Tradeoff receipt written"))
+        .stderr(predicate::str::contains("Decision markdown written"));
+
+    let scenario_path = root.join("artifacts/perfgate/scenario.json");
+    let tradeoff_path = root.join("artifacts/perfgate/tradeoff.json");
+    let decision_path = root.join("artifacts/perfgate/decision.md");
+
+    let scenario: perfgate_types::ScenarioReceipt =
+        serde_json::from_str(&fs::read_to_string(scenario_path).expect("read scenario receipt"))
+            .expect("scenario receipt should deserialize");
+    assert_eq!(scenario.schema, "perfgate.scenario.v1");
+
+    let tradeoff: perfgate_types::TradeoffReceipt =
+        serde_json::from_str(&fs::read_to_string(tradeoff_path).expect("read tradeoff receipt"))
+            .expect("tradeoff receipt should deserialize");
+    assert_eq!(tradeoff.schema, "perfgate.tradeoff.v1");
+    assert!(tradeoff.decision.accepted_tradeoff);
+    assert_eq!(tradeoff.decision.status, perfgate_types::MetricStatus::Warn);
+
+    let decision = fs::read_to_string(decision_path).expect("read decision md");
+    assert!(decision.contains("perfgate tradeoff: warn"));
+    assert!(decision.contains("tradeoff 'memory_for_speed' accepted"));
+}
+
 fn write_controlled_compare_receipt(path: &Path) {
     let receipt = json!({
         "schema": "perfgate.compare.v1",

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
@@ -1,0 +1,19 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+expression: "help_output(&[\"decision\", \"--help\"])"
+---
+Evaluate scenario and tradeoff evidence into a review-ready decision summary
+
+Usage: perfgate decision [OPTIONS] <COMMAND>
+
+Commands:
+  evaluate Evaluate configured scenarios and tradeoffs, then render decision markdown
+  help Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision_evaluate.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision_evaluate.snap
@@ -1,0 +1,23 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+expression: "help_output(&[\"decision\", \"evaluate\", \"--help\"])"
+---
+Evaluate configured scenarios and tradeoffs, then render decision markdown
+
+Usage: perfgate decision evaluate [OPTIONS]
+
+Options:
+      --config <CONFIG> Path to perfgate.toml [default: perfgate.toml]
+      --scenario <SCENARIO> Evaluate only one configured scenario by name
+      --workload-name <WORKLOAD_NAME> Name to use for the combined weighted workload receipt
+      --out-dir <OUT_DIR> Override artifact directory used for compare lookup and default outputs
+      --scenario-out <SCENARIO_OUT> Output scenario receipt path
+      --tradeoff-out <TRADEOFF_OUT> Output tradeoff receipt path
+      --decision-out <DECISION_OUT> Output decision markdown path
+      --pretty Pretty-print JSON receipts
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -23,6 +23,7 @@ Commands:
   audit List and export baseline service audit events
   summary Summarize one or more compare receipts in a terminal table
   aggregate Aggregate multiple run receipts (e.g. from a fleet) into a formal aggregate receipt
+  decision Evaluate scenario and tradeoff evidence into a review-ready decision summary
   scenario Evaluate configured workload scenarios from compare receipts
   tradeoff Evaluate configured tradeoff rules against scenario evidence
   bisect Automatically find the commit that introduced a performance regression

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -149,6 +149,15 @@ perfgate md --tradeoff artifacts/perfgate/tradeoff.json --out artifacts/perfgate
 perfgate comment --tradeoff artifacts/perfgate/tradeoff.json --dry-run
 ```
 
+To run the structured decision path as one local workflow, use:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+It uses the configured artifact directory for compare lookups and writes
+`scenario.json`, `tradeoff.json`, and `decision.md` there by default.
+
 `min_improvement_ratio` follows metric direction. For lower-is-better metrics
 such as `wall_ms`, `1.10` means the baseline/current ratio must be at least
 1.10. For higher-is-better metrics such as `throughput_per_s`, the

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -97,6 +97,21 @@ perfgate md --tradeoff artifacts/perfgate/tradeoff.json
 perfgate comment --tradeoff artifacts/perfgate/tradeoff.json --dry-run
 ```
 
+For the paved local workflow, `decision evaluate` runs the scenario evaluation,
+tradeoff evaluation, and markdown rendering steps together:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+By default it writes:
+
+```text
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+```
+
 ## Fixture Validation
 
 Validate JSON files against the vendored `sensor.report.v1` schema:


### PR DESCRIPTION
## Summary
- add `perfgate decision evaluate` as a one-command wrapper for scenario evaluation, tradeoff evaluation, and tradeoff markdown rendering
- write default outputs to the configured artifact directory: `scenario.json`, `tradeoff.json`, and `decision.md`
- reuse existing scenario/tradeoff app use cases, add e2e/help coverage, and document the paved workflow

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-cli --test cli_structured_decision_e2e_tests --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features`
- `cargo test -p perfgate-cli --test cli_scenario_tests --test cli_tradeoff_tests --all-features`
- `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`