### PR TITLE
action: add decision evaluation mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,10 @@ inputs:
     description: "Post or update a PR comment with perfgate results (requires GITHUB_TOKEN)"
     required: false
     default: "false"
+  decision:
+    description: "Run perfgate decision evaluate after check and publish scenario/tradeoff/decision artifacts"
+    required: false
+    default: "false"
   github_token:
     description: "GitHub token for posting PR comments (defaults to github.token)"
     required: false
@@ -87,6 +91,9 @@ outputs:
   exit_code:
     description: "perfgate process exit code (0=pass, 1=error, 2=fail, 3=warn-as-fail); always available"
     value: ${{ steps.run_check.outputs.exit_code }}
+  decision_exit_code:
+    description: "perfgate decision evaluate exit code when decision=true"
+    value: ${{ steps.run_decision.outputs.exit_code }}
 
 runs:
   using: "composite"
@@ -296,16 +303,66 @@ runs:
 
         echo "exit_code=${status}" >> "${GITHUB_OUTPUT}"
 
+        if [[ "${{ inputs.decision }}" == "true" && "${status}" == "2" ]]; then
+          echo "policy_failure_deferred=true" >> "${GITHUB_OUTPUT}"
+          echo "perfgate check reported a policy failure; deferring final verdict to decision evaluate."
+          exit 0
+        fi
+
+        echo "policy_failure_deferred=false" >> "${GITHUB_OUTPUT}"
         exit "${status}"
 
+    - id: run_decision
+      name: Run perfgate decision
+      if: always() && inputs.decision == 'true' && (steps.run_check.outputs.exit_code == '0' || steps.run_check.outputs.exit_code == '2')
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        args=(decision evaluate --config "${{ inputs.config }}")
+
+        if [[ -n "${{ inputs.out_dir }}" ]]; then
+          args+=(--out-dir "${{ inputs.out_dir }}")
+        fi
+
+        set +e
+        perfgate "${args[@]}"
+        status=$?
+        set -e
+
+        echo "exit_code=${status}" >> "${GITHUB_OUTPUT}"
+
+        exit "${status}"
+
+    - name: Append perfgate decision summary
+      if: always() && inputs.decision == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        out="${{ steps.resolve_out_dir.outputs.out_dir }}"
+        if [[ -f "${out}/decision.md" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+          {
+            echo "### perfgate decision"
+            echo
+            cat "${out}/decision.md"
+          } >> "${GITHUB_STEP_SUMMARY}"
+        fi
+
     - name: Print perfgate failure summary
-      if: always() && steps.run_check.outputs.exit_code != '0'
+      if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0'))
       shell: bash
       run: |
         set -euo pipefail
 
         out="${{ steps.resolve_out_dir.outputs.out_dir }}"
         exit_code="${{ steps.run_check.outputs.exit_code }}"
+        decision_exit_code="${{ steps.run_decision.outputs.exit_code }}"
+        exit_source="check"
+        if [[ "${{ inputs.decision }}" == "true" && -n "${decision_exit_code}" && "${decision_exit_code}" != "0" ]]; then
+          exit_code="${decision_exit_code}"
+          exit_source="decision"
+        fi
         if [[ -z "${exit_code}" ]]; then
           exit_code="unknown"
         fi
@@ -366,7 +423,7 @@ runs:
 
           local listing
           listing="$(mktemp)"
-          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name tradeoff.json -o -name comment.md -o -name 'perfgate.*.json' -o -name 'sensor.report.v1.json' \) | sort > "${listing}"
+          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name comment.md -o -name 'perfgate.*.json' -o -name 'sensor.report.v1.json' \) | sort > "${listing}"
 
           local count
           count="$(wc -l < "${listing}" | tr -d ' ')"
@@ -383,11 +440,22 @@ runs:
         }
 
         repro_line="$(format_command "${repro[@]}")"
+        decision_repro=()
+        if [[ "${{ inputs.decision }}" == "true" ]]; then
+          decision_repro=(perfgate decision evaluate --config "${{ inputs.config }}")
+          if [[ -n "${{ inputs.out_dir }}" ]]; then
+            decision_repro+=(--out-dir "${{ inputs.out_dir }}")
+          fi
+        fi
 
-        echo "perfgate exited with code ${exit_code}"
+        echo "perfgate ${exit_source} exited with code ${exit_code}"
         echo
         echo "Reproduce locally:"
         echo "  ${repro_line}"
+        if [[ "${{ inputs.decision }}" == "true" ]]; then
+          decision_repro_line="$(format_command "${decision_repro[@]}")"
+          echo "  ${decision_repro_line}"
+        fi
         echo
         echo "Artifacts:"
         print_artifacts
@@ -404,10 +472,13 @@ runs:
           {
             echo "### perfgate local reproduction"
             echo
-            echo "perfgate exited with code \`${exit_code}\`."
+            echo "perfgate ${exit_source} exited with code \`${exit_code}\`."
             echo
             echo "```bash"
             echo "${repro_line}"
+            if [[ "${{ inputs.decision }}" == "true" ]]; then
+              echo "${decision_repro_line}"
+            fi
             echo "```"
             echo
             echo "Artifacts:"

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -103,6 +103,29 @@ command and the resolved artifact paths to the job log and step summary. With
 `artifacts/perfgate/<bench>/` unless `out_dir` or `[defaults].out_dir`
 overrides the location.
 
+To surface structured scenario/tradeoff decisions in the job summary and PR
+comment, opt in to decision mode:
+
+```yaml
+      - name: Run perfgate
+        id: perfgate
+        uses: EffortlessMetrics/perfgate@v0.15.1
+        with:
+          config: perfgate.toml
+          all: "true"
+          require_baseline: "true"
+          decision: "true"
+          comment: "true"
+```
+
+Decision mode runs `perfgate decision evaluate --config perfgate.toml` after
+`check`, writes `scenario.json`, `tradeoff.json`, and `decision.md` under the
+resolved artifact directory, and appends `decision.md` to the GitHub step
+summary. If `check` reports a policy failure with exit code `2`, the action
+defers the final policy result to the decision receipt so an accepted tradeoff
+can downgrade the result according to configured policy. Runtime errors and
+`--fail-on-warn` failures still stop the action.
+
 ## 4) Manual PR performance gate workflow
 
 Create `.github/workflows/perfgate.yml`:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -430,6 +430,17 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
                 .to_string(),
         );
     }
+    if action
+        .inputs
+        .get("decision")
+        .and_then(|input| input.default.as_deref())
+        != Some("false")
+    {
+        errors.push(
+            "action.yml decision input must exist and default to false for opt-in structured decisions"
+                .to_string(),
+        );
+    }
 
     let Some(binary_install_run) = action.step_run("Install perfgate (pre-built binary)") else {
         errors.push("action.yml must include the pre-built binary install step".to_string());
@@ -540,6 +551,80 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
     {
         errors.push("action.yml must not unconditionally pass the out_dir input".to_string());
     }
+    if !run_check_lines
+        .iter()
+        .any(|line| line == "echo \"policy_failure_deferred=true\" >> \"${GITHUB_OUTPUT}\"")
+        || !run_check_lines.iter().any(|line| {
+            line == "if [[ \"${{ inputs.decision }}\" == \"true\" && \"${status}\" == \"2\" ]]; then"
+        })
+    {
+        errors.push(
+            "action.yml must defer check policy failures to decision evaluate when decision=true"
+                .to_string(),
+        );
+    }
+
+    let Some(run_decision_run) = action.step_run("Run perfgate decision") else {
+        errors.push("action.yml must include the perfgate decision evaluation step".to_string());
+        return errors;
+    };
+    let run_decision_lines = active_shell_lines(run_decision_run);
+    if !raw_action.contains(
+        "if: always() && inputs.decision == 'true' && (steps.run_check.outputs.exit_code == '0' || steps.run_check.outputs.exit_code == '2')",
+    ) {
+        errors.push(
+            "action.yml decision step must run only after pass or policy-fail check results"
+                .to_string(),
+        );
+    }
+    if !run_decision_lines
+        .iter()
+        .any(|line| line == "args=(decision evaluate --config \"${{ inputs.config }}\")")
+    {
+        errors.push(
+            "action.yml decision step must run `perfgate decision evaluate` with the configured file"
+                .to_string(),
+        );
+    }
+    if !run_decision_lines
+        .iter()
+        .any(|line| line == "if [[ -n \"${{ inputs.out_dir }}\" ]]; then")
+        || !run_decision_lines
+            .iter()
+            .any(|line| line == "args+=(--out-dir \"${{ inputs.out_dir }}\")")
+    {
+        errors.push(
+            "action.yml decision step must pass --out-dir only when the input explicitly overrides config"
+                .to_string(),
+        );
+    }
+    if !run_decision_lines
+        .iter()
+        .any(|line| line == "echo \"exit_code=${status}\" >> \"${GITHUB_OUTPUT}\"")
+    {
+        errors.push("action.yml decision step must expose its exit code".to_string());
+    }
+
+    let Some(decision_summary_run) = action.step_run("Append perfgate decision summary") else {
+        errors.push("action.yml must append decision.md to GITHUB_STEP_SUMMARY".to_string());
+        return errors;
+    };
+    let decision_summary_lines = active_shell_lines(decision_summary_run);
+    if !raw_action.contains("if: always() && inputs.decision == 'true'")
+        || !decision_summary_lines
+            .iter()
+            .any(|line| line == "out=\"${{ steps.resolve_out_dir.outputs.out_dir }}\"")
+        || !decision_summary_lines.iter().any(|line| {
+            line == "if [[ -f \"${out}/decision.md\" && -n \"${GITHUB_STEP_SUMMARY:-}\" ]]; then"
+        })
+        || !decision_summary_lines
+            .iter()
+            .any(|line| line == "cat \"${out}/decision.md\"")
+    {
+        errors.push(
+            "action.yml must publish generated decision.md to the GitHub step summary".to_string(),
+        );
+    }
 
     let Some(failure_summary_run) = action.step_run("Print perfgate failure summary") else {
         errors.push(
@@ -548,8 +633,12 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
         return errors;
     };
     let failure_summary_lines = active_shell_lines(failure_summary_run);
-    if !raw_action.contains("if: always() && steps.run_check.outputs.exit_code != '0'") {
-        errors.push("action.yml failure summary must run after failed perfgate checks".to_string());
+    if !raw_action.contains("steps.run_check.outputs.policy_failure_deferred != 'true'")
+        || !raw_action.contains("steps.run_decision.outputs.exit_code != '0'")
+    {
+        errors.push(
+            "action.yml failure summary must respect decision-mode final verdicts".to_string(),
+        );
     }
     if !failure_summary_lines
         .iter()
@@ -590,6 +679,9 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
         line.contains("-name run.json")
             && line.contains("-name compare.json")
             && line.contains("-name report.json")
+            && line.contains("-name scenario.json")
+            && line.contains("-name tradeoff.json")
+            && line.contains("-name decision.md")
             && line.contains("-name comment.md")
             && line.contains("-name 'perfgate.*.json'")
     }) {
@@ -3987,6 +4079,9 @@ inputs:
   out_dir:
     description: "Artifact output directory"
     default: ""
+  decision:
+    description: "Run structured decision evaluation"
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -4014,8 +4109,26 @@ runs:
         if [[ -n "${{ inputs.out_dir }}" ]]; then
           args+=(--out-dir "${{ inputs.out_dir }}")
         fi
+        if [[ "${{ inputs.decision }}" == "true" && "${status}" == "2" ]]; then
+          echo "policy_failure_deferred=true" >> "${GITHUB_OUTPUT}"
+        fi
+    - name: Run perfgate decision
+      if: always() && inputs.decision == 'true' && (steps.run_check.outputs.exit_code == '0' || steps.run_check.outputs.exit_code == '2')
+      run: |
+        args=(decision evaluate --config "${{ inputs.config }}")
+        if [[ -n "${{ inputs.out_dir }}" ]]; then
+          args+=(--out-dir "${{ inputs.out_dir }}")
+        fi
+        echo "exit_code=${status}" >> "${GITHUB_OUTPUT}"
+    - name: Append perfgate decision summary
+      if: always() && inputs.decision == 'true'
+      run: |
+        out="${{ steps.resolve_out_dir.outputs.out_dir }}"
+        if [[ -f "${out}/decision.md" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+          cat "${out}/decision.md"
+        fi
     - name: Print perfgate failure summary
-      if: always() && steps.run_check.outputs.exit_code != '0'
+      if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0'))
       run: |
         out="${{ steps.resolve_out_dir.outputs.out_dir }}"
         exit_code="${{ steps.run_check.outputs.exit_code }}"
@@ -4023,7 +4136,7 @@ runs:
         {
           echo "Reproduce locally:"
           echo "### perfgate local reproduction"
-          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name comment.md -o -name 'perfgate.*.json' \) | sort
+          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name comment.md -o -name 'perfgate.*.json' \) | sort
         } >> "${GITHUB_STEP_SUMMARY}"
     - name: Post PR comment
       run: |
@@ -4055,6 +4168,53 @@ pkg-fmt = "zip"
         );
 
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn action_check_rejects_missing_decision_input() {
+        let action = valid_action_install_surface().replace(
+            "  decision:\n    description: \"Run structured decision evaluation\"\n    default: \"false\"\n",
+            "",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors.iter().any(|error| error.contains("decision input")),
+            "errors should mention missing decision input: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn action_check_rejects_missing_decision_step() {
+        let action = valid_action_install_surface().replace(
+            "    - name: Run perfgate decision",
+            "    - name: Run decision",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("decision evaluation step")),
+            "errors should mention missing decision step: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn action_check_rejects_missing_decision_summary_step() {
+        let action = valid_action_install_surface().replace(
+            "    - name: Append perfgate decision summary",
+            "    - name: Append generic summary",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors.iter().any(|error| error.contains("decision.md")),
+            "errors should mention missing decision summary: {:?}",
+            errors
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add opt-in `decision: "true"` mode to the composite action
- run `perfgate decision evaluate` after successful checks or policy-fail checks, publishing `scenario.json`, `tradeoff.json`, and `decision.md`
- defer check exit code 2 to the decision receipt so accepted tradeoffs can own the final policy result
- extend `xtask action-check` coverage for the new action contract

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p xtask action --all-features`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- ci`
- `git diff --check`