### PR TITLE
scenario: attach probe compare evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named probe deltas between baseline and current structured evidence.
 - Added `perfgate scenario evaluate` to turn configured weighted scenarios and
   benchmark compare receipts into `perfgate.scenario.v1` workload receipts.
+- Added optional scenario `probe_compare` references so workload receipts can
+  carry advisory probe names and probe-compare receipt references.
 - Added `perfgate tradeoff evaluate` to turn configured tradeoff rules and
   scenario receipts into `perfgate.tradeoff.v1` decision receipts.
 - Added Markdown and PR-comment rendering for `perfgate.tradeoff.v1` decision

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -48,10 +48,10 @@ use perfgate_types::error::{ConfigValidationError, IoError, PerfgateError};
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
-    MetricStatus, OtelSpanIdentifiers, PerfgateReport, ProbeReceipt, REPAIR_CONTEXT_SCHEMA_V1,
-    RatchetConfig, RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt,
-    ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt,
-    VerdictStatus,
+    MetricStatus, OtelSpanIdentifiers, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
+    REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairGitMetadata,
+    RepairMetricBreach, RunReceipt, ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus,
+    ToolInfo, TradeoffReceipt, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
@@ -3407,6 +3407,8 @@ fn evaluate_configured_scenarios(
         let compare: CompareReceipt = read_json_from_location(&compare_path)
             .with_context(|| format!("read scenario compare {}", compare_path.display()))?;
         let run_id = compare.current_ref.run_id.clone();
+        let (probe_compare_ref, probe_compare, probe_compare_warning) =
+            load_scenario_probe_compare(&scenario)?;
         inputs.push(ScenarioEvaluateInput {
             config: scenario,
             compare_ref: CompareRef {
@@ -3414,6 +3416,9 @@ fn evaluate_configured_scenarios(
                 run_id,
             },
             compare,
+            probe_compare_ref,
+            probe_compare,
+            probe_compare_warning,
         });
     }
 
@@ -3450,6 +3455,42 @@ fn scenario_compare_path(scenario: &ScenarioConfigFile, out_dir: &Path) -> PathB
         .as_deref()
         .map(PathBuf::from)
         .unwrap_or_else(|| out_dir.join(&scenario.bench).join(COMPARE_RECEIPT_FILE))
+}
+
+fn load_scenario_probe_compare(
+    scenario: &ScenarioConfigFile,
+) -> anyhow::Result<(
+    Option<CompareRef>,
+    Option<ProbeCompareReceipt>,
+    Option<String>,
+)> {
+    let Some(path) = scenario.probe_compare.as_deref().map(PathBuf::from) else {
+        return Ok((None, None, None));
+    };
+
+    let compare_ref = CompareRef {
+        path: Some(path.display().to_string()),
+        run_id: None,
+    };
+    if !location_exists(&path)? {
+        return Ok((
+            Some(compare_ref),
+            None,
+            Some(format!(
+                "probe evidence missing for scenario '{}' at {}",
+                scenario.name,
+                path.display()
+            )),
+        ));
+    }
+
+    let receipt: ProbeCompareReceipt = read_json_from_location(&path)
+        .with_context(|| format!("read scenario probe compare {}", path.display()))?;
+    let compare_ref = CompareRef {
+        path: Some(path.display().to_string()),
+        run_id: Some(receipt.run.id.clone()),
+    };
+    Ok((Some(compare_ref), Some(receipt), None))
 }
 
 fn execute_tradeoff_action(action: TradeoffAction) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_scenario_tests.rs
+++ b/crates/perfgate-cli/tests/cli_scenario_tests.rs
@@ -20,6 +20,7 @@ fn test_scenario_evaluate_writes_weighted_scenario_receipt() {
         90.0,
         "pass",
     );
+    write_probe_compare_receipt(&out_dir.join("large-file").join("probe-compare.json"));
     write_compare_receipt(
         &out_dir.join("small-edit").join("compare.json"),
         "small-edit",
@@ -49,13 +50,15 @@ command = ["echo", "small"]
 name = "large_file_parse"
 weight = 0.75
 bench = "large-file"
+probe_compare = "{}"
 
 [[scenario]]
 name = "small_edit"
 weight = 0.25
 bench = "small-edit"
 "#,
-            toml_path(&out_dir)
+            toml_path(&out_dir),
+            toml_path(&out_dir.join("large-file").join("probe-compare.json"))
         ),
     )
     .expect("failed to write config");
@@ -97,6 +100,20 @@ bench = "small-edit"
             .map(|path| path.replace('\\', "/")),
         Some(expected_compare_path.replace('\\', "/"))
     );
+    assert_eq!(receipt["components"][0]["probes"][0], "parser.tokenize");
+    assert_eq!(
+        receipt["components"][0]["probe_compare_ref"]["path"]
+            .as_str()
+            .map(|path| path.replace('\\', "/")),
+        Some(
+            out_dir
+                .join("large-file")
+                .join("probe-compare.json")
+                .display()
+                .to_string()
+                .replace('\\', "/")
+        )
+    );
 }
 
 #[test]
@@ -124,6 +141,70 @@ command = ["echo", "large"]
         .stderr(predicate::str::contains(
             "no [[scenario]] entries configured",
         ));
+}
+
+#[test]
+fn test_scenario_evaluate_records_missing_probe_compare_warning() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    write_compare_receipt(
+        &out_dir.join("large-file").join("compare.json"),
+        "large-file",
+        100.0,
+        90.0,
+        "pass",
+    );
+
+    let missing_probe_compare = out_dir
+        .join("large-file")
+        .join("missing-probe-compare.json");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    fs::write(
+        &config_path,
+        format!(
+            r#"[defaults]
+out_dir = "{}"
+
+[[bench]]
+name = "large-file"
+command = ["echo", "large"]
+
+[[scenario]]
+name = "large_file_parse"
+weight = 1.0
+bench = "large-file"
+probe_compare = "{}"
+"#,
+            toml_path(&out_dir),
+            toml_path(&missing_probe_compare)
+        ),
+    )
+    .expect("failed to write config");
+
+    let output_path = temp_dir.path().join("scenario.json");
+    perfgate_cmd()
+        .arg("scenario")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .success();
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read scenario receipt"),
+    )
+    .expect("scenario receipt should be JSON");
+    assert!(
+        receipt["warnings"]
+            .as_array()
+            .expect("scenario warnings should be array")
+            .iter()
+            .any(|warning| warning
+                .as_str()
+                .is_some_and(|warning| warning.contains("probe evidence missing")))
+    );
 }
 
 fn write_compare_receipt(path: &Path, bench: &str, baseline: f64, current: f64, status: &str) {
@@ -185,6 +266,43 @@ fn write_compare_receipt(path: &Path, bench: &str, baseline: f64, current: f64, 
         serde_json::to_string_pretty(&receipt).expect("serialize compare fixture"),
     )
     .expect("failed to write compare fixture");
+}
+
+fn write_probe_compare_receipt(path: &Path) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create probe compare fixture directory");
+    }
+
+    let receipt = json!({
+        "schema": "perfgate.probe_compare.v1",
+        "tool": {"name": "perfgate", "version": "0.16.0"},
+        "run": {
+            "id": "probe-compare-run",
+            "started_at": "2026-05-08T00:00:00Z",
+            "ended_at": "2026-05-08T00:00:01Z",
+            "host": {"os": "linux", "arch": "x86_64"}
+        },
+        "scenario": "large_file_parse",
+        "probes": [{
+            "name": "parser.tokenize",
+            "scope": "local",
+            "baseline_count": 1,
+            "current_count": 1,
+            "deltas": {},
+            "status": "pass"
+        }],
+        "verdict": {
+            "status": "pass",
+            "counts": {"pass": 1, "warn": 0, "fail": 0, "skip": 0},
+            "reasons": []
+        }
+    });
+
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize probe compare fixture"),
+    )
+    .expect("failed to write probe compare fixture");
 }
 
 fn toml_path(path: &Path) -> String {

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1590,6 +1590,12 @@ pub struct ScenarioConfigFile {
     /// standard `out_dir/<bench>/compare.json` artifact.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub compare: Option<String>,
+
+    /// Optional probe comparison receipt path. When present, scenario
+    /// evaluation attaches probe names and a receipt reference without making
+    /// probes part of the scenario verdict.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub probe_compare: Option<String>,
 }
 
 /// How ratcheting should update budgets.
@@ -2164,6 +2170,7 @@ name = "large_file_parse"
 weight = 0.35
 bench = "large-file"
 description = "Parse a large file"
+probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
 "#,
         )
         .expect("parse config");
@@ -2172,6 +2179,10 @@ description = "Parse a large file"
         assert_eq!(config.scenarios[0].name, "large_file_parse");
         assert_eq!(config.scenarios[0].bench, "large-file");
         assert_eq!(config.scenarios[0].weight, 0.35);
+        assert_eq!(
+            config.scenarios[0].probe_compare.as_deref(),
+            Some("artifacts/perfgate/large-file/probe-compare.json")
+        );
         assert!(config.validate().is_ok());
     }
 
@@ -2192,6 +2203,7 @@ command = ["echo", "large"]
             bench: "missing-bench".to_string(),
             description: None,
             compare: None,
+            probe_compare: None,
         }];
         assert!(config.validate().unwrap_err().contains("unknown benchmark"));
 

--- a/crates/perfgate-types/src/structured_evidence.rs
+++ b/crates/perfgate-types/src/structured_evidence.rs
@@ -159,6 +159,9 @@ pub struct ScenarioComponent {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub compare_ref: Option<CompareRef>,
 
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub probe_compare_ref: Option<CompareRef>,
+
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub deltas: BTreeMap<String, Delta>,
 
@@ -429,6 +432,10 @@ mod tests {
                 weight: 1.0,
                 benchmark: Some("large-file".into()),
                 compare_ref: None,
+                probe_compare_ref: Some(CompareRef {
+                    path: Some("artifacts/perfgate/large-file/probe-compare.json".into()),
+                    run_id: Some("probe-current".into()),
+                }),
                 deltas: weighted_deltas.clone(),
                 probes: vec!["parser.tokenize".into()],
                 status: MetricStatus::Pass,

--- a/crates/perfgate/src/app/scenario.rs
+++ b/crates/perfgate/src/app/scenario.rs
@@ -1,8 +1,8 @@
 use crate::domain::budget::{aggregate_verdict, calculate_regression, determine_status};
 use perfgate_types::{
-    CompareReceipt, CompareRef, ConfigFile, Delta, HostInfo, Metric, MetricStatus, RunMeta,
-    SCENARIO_SCHEMA_V1, ScenarioComponent, ScenarioConfigFile, ScenarioMeta, ScenarioReceipt,
-    ToolInfo,
+    CompareReceipt, CompareRef, ConfigFile, Delta, HostInfo, Metric, MetricStatus,
+    PROBE_COMPARE_SCHEMA_V1, ProbeCompareReceipt, RunMeta, SCENARIO_SCHEMA_V1, ScenarioComponent,
+    ScenarioConfigFile, ScenarioMeta, ScenarioReceipt, ToolInfo,
 };
 use std::collections::BTreeMap;
 use time::OffsetDateTime;
@@ -23,6 +23,9 @@ pub struct ScenarioEvaluateInput {
     pub config: ScenarioConfigFile,
     pub compare_ref: CompareRef,
     pub compare: CompareReceipt,
+    pub probe_compare_ref: Option<CompareRef>,
+    pub probe_compare: Option<ProbeCompareReceipt>,
+    pub probe_compare_warning: Option<String>,
 }
 
 #[derive(Debug)]
@@ -45,6 +48,16 @@ impl ScenarioUseCase {
                     input.config.name,
                     input.config.bench,
                     input.compare.bench.name
+                );
+            }
+            if let Some(probe_compare) = &input.probe_compare
+                && probe_compare.schema != PROBE_COMPARE_SCHEMA_V1
+            {
+                anyhow::bail!(
+                    "scenario '{}' probe compare receipt must use schema '{}', got '{}'",
+                    input.config.name,
+                    PROBE_COMPARE_SCHEMA_V1,
+                    probe_compare.schema
                 );
             }
         }
@@ -88,8 +101,19 @@ fn build_components(inputs: &[ScenarioEvaluateInput]) -> Vec<ScenarioComponent> 
             weight: input.config.weight,
             benchmark: Some(input.config.bench.clone()),
             compare_ref: Some(input.compare_ref.clone()),
+            probe_compare_ref: input.probe_compare_ref.clone(),
             deltas: stringify_deltas(&input.compare.deltas),
-            probes: Vec::new(),
+            probes: input
+                .probe_compare
+                .as_ref()
+                .map(|receipt| {
+                    receipt
+                        .probes
+                        .iter()
+                        .map(|probe| probe.name.clone())
+                        .collect()
+                })
+                .unwrap_or_default(),
             status: metric_status_from_verdict(input.compare.verdict.status),
             reasons: input.compare.verdict.reasons.clone(),
         })
@@ -193,6 +217,27 @@ fn build_warnings(
             ));
         }
     }
+    for input in inputs {
+        if let Some(warning) = &input.probe_compare_warning {
+            warnings.push(warning.clone());
+        }
+        if let Some(probe_compare) = &input.probe_compare {
+            if let Some(scenario) = &probe_compare.scenario
+                && scenario != &input.config.name
+            {
+                warnings.push(format!(
+                    "scenario '{}' attached probe compare receipt for scenario '{}'",
+                    input.config.name, scenario
+                ));
+            }
+            warnings.extend(probe_compare.warnings.iter().map(|warning| {
+                format!(
+                    "scenario '{}' probe compare warning: {}",
+                    input.config.name, warning
+                )
+            }));
+        }
+    }
     warnings
 }
 
@@ -248,8 +293,8 @@ fn make_run_meta() -> RunMeta {
 mod tests {
     use super::*;
     use perfgate_types::{
-        BenchMeta, COMPARE_SCHEMA_V1, DefaultsConfig, MetricStatistic, Verdict, VerdictCounts,
-        VerdictStatus,
+        BenchMeta, COMPARE_SCHEMA_V1, DefaultsConfig, MetricStatistic, PROBE_COMPARE_SCHEMA_V1,
+        ProbeCompareObservation, ProbeScope, Verdict, VerdictCounts, VerdictStatus,
     };
 
     fn compare_receipt(
@@ -319,6 +364,56 @@ mod tests {
         }
     }
 
+    fn probe_compare_receipt(probes: &[&str]) -> ProbeCompareReceipt {
+        ProbeCompareReceipt {
+            schema: PROBE_COMPARE_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            run: RunMeta {
+                id: "probe-compare-run".to_string(),
+                started_at: "2026-05-08T00:00:00Z".to_string(),
+                ended_at: "2026-05-08T00:00:01Z".to_string(),
+                host: HostInfo {
+                    os: "linux".to_string(),
+                    arch: "x86_64".to_string(),
+                    cpu_count: None,
+                    memory_bytes: None,
+                    hostname_hash: None,
+                },
+            },
+            bench: None,
+            scenario: Some("large_file_parse".to_string()),
+            baseline_ref: None,
+            current_ref: None,
+            probes: probes
+                .iter()
+                .map(|name| ProbeCompareObservation {
+                    name: (*name).to_string(),
+                    parent: None,
+                    scope: Some(ProbeScope::Local),
+                    baseline_count: 1,
+                    current_count: 1,
+                    deltas: BTreeMap::new(),
+                    status: MetricStatus::Pass,
+                    reasons: Vec::new(),
+                })
+                .collect(),
+            verdict: Verdict {
+                status: VerdictStatus::Pass,
+                counts: VerdictCounts {
+                    pass: probes.len() as u32,
+                    warn: 0,
+                    fail: 0,
+                    skip: 0,
+                },
+                reasons: Vec::new(),
+            },
+            warnings: vec!["probe warning".to_string()],
+        }
+    }
+
     fn scenario_input(
         name: &str,
         weight: f64,
@@ -332,12 +427,16 @@ mod tests {
                 bench: bench.to_string(),
                 description: None,
                 compare: None,
+                probe_compare: None,
             },
             compare_ref: CompareRef {
                 path: Some(format!("artifacts/{bench}/compare.json")),
                 run_id: compare.current_ref.run_id.clone(),
             },
             compare,
+            probe_compare_ref: None,
+            probe_compare: None,
+            probe_compare_warning: None,
         }
     }
 
@@ -401,5 +500,127 @@ mod tests {
         .expect_err("mismatched benchmark should fail");
 
         assert!(err.to_string().contains("expected compare receipt"));
+    }
+
+    #[test]
+    fn scenario_evaluate_attaches_probe_compare_names_and_reference() {
+        let mut input = scenario_input(
+            "large_file_parse",
+            1.0,
+            "large-file",
+            compare_receipt("large-file", 100.0, 90.0, MetricStatus::Pass),
+        );
+        input.config.probe_compare =
+            Some("artifacts/perfgate/large-file/probe-compare.json".into());
+        input.probe_compare_ref = Some(CompareRef {
+            path: Some("artifacts/perfgate/large-file/probe-compare.json".into()),
+            run_id: Some("probe-compare-run".into()),
+        });
+        input.probe_compare = Some(probe_compare_receipt(&[
+            "parser.tokenize",
+            "parser.batch_loop",
+        ]));
+
+        let outcome = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+            config: ConfigFile::default(),
+            inputs: vec![input],
+            workload_name: None,
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        })
+        .expect("evaluate scenario");
+
+        let component = &outcome.receipt.components[0];
+        assert_eq!(
+            component.probes,
+            vec![
+                "parser.tokenize".to_string(),
+                "parser.batch_loop".to_string()
+            ]
+        );
+        assert_eq!(
+            component
+                .probe_compare_ref
+                .as_ref()
+                .and_then(|reference| reference.run_id.as_deref()),
+            Some("probe-compare-run")
+        );
+        assert!(
+            outcome
+                .receipt
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("probe warning"))
+        );
+        assert_eq!(outcome.receipt.verdict.status, VerdictStatus::Pass);
+    }
+
+    #[test]
+    fn scenario_evaluate_rejects_wrong_probe_compare_schema() {
+        let mut input = scenario_input(
+            "large_file_parse",
+            1.0,
+            "large-file",
+            compare_receipt("large-file", 100.0, 90.0, MetricStatus::Pass),
+        );
+        let mut probe_compare = probe_compare_receipt(&["parser.tokenize"]);
+        probe_compare.schema = "perfgate.probe_compare.v0".to_string();
+        input.probe_compare = Some(probe_compare);
+
+        let err = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+            config: ConfigFile::default(),
+            inputs: vec![input],
+            workload_name: None,
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        })
+        .expect_err("wrong probe compare schema should fail");
+
+        assert!(
+            err.to_string()
+                .contains("probe compare receipt must use schema")
+        );
+    }
+
+    #[test]
+    fn scenario_evaluate_records_advisory_probe_warnings() {
+        let mut input = scenario_input(
+            "large_file_parse",
+            1.0,
+            "large-file",
+            compare_receipt("large-file", 100.0, 90.0, MetricStatus::Pass),
+        );
+        let mut probe_compare = probe_compare_receipt(&["parser.tokenize"]);
+        probe_compare.scenario = Some("other_scenario".to_string());
+        input.probe_compare = Some(probe_compare);
+        input.probe_compare_warning =
+            Some("probe evidence missing for scenario 'large_file_parse'".to_string());
+
+        let outcome = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+            config: ConfigFile::default(),
+            inputs: vec![input],
+            workload_name: None,
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        })
+        .expect("evaluate scenario with advisory probe warnings");
+
+        assert_eq!(outcome.receipt.verdict.status, VerdictStatus::Pass);
+        assert!(
+            outcome
+                .receipt
+                .warnings
+                .iter()
+                .any(|warning| warning.contains("probe evidence missing"))
+        );
+        assert!(outcome.receipt.warnings.iter().any(|warning| {
+            warning.contains("attached probe compare receipt for scenario 'other_scenario'")
+        }));
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -95,7 +95,9 @@ perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scena
 Each `[[scenario]]` references one `[[bench]]`. By default, `scenario evaluate`
 reads `compare.json` from `[defaults].out_dir/<bench>/compare.json`. Use
 `compare = "path/to/compare.json"` when the compare receipt lives somewhere
-else.
+else. Use `probe_compare = "path/to/probe-compare.json"` to attach advisory
+probe-level evidence from `perfgate probe compare`; scenario verdicts still come
+from benchmark compare receipts and weighted deltas.
 
 ```toml
 [[bench]]
@@ -110,6 +112,7 @@ command = ["cargo", "bench", "--bench", "small_edit"]
 name = "large_file_parse"
 weight = 0.35
 bench = "large-file"
+probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
 
 [[scenario]]
 name = "small_incremental_edit"
@@ -117,6 +120,10 @@ weight = 0.50
 bench = "small-edit"
 compare = "artifacts/perfgate/small-edit/compare.json"
 ```
+
+When a configured `probe_compare` file is missing, `scenario evaluate` records a
+warning in the scenario receipt instead of failing. This keeps probe evidence
+explicit and advisory until tradeoff policy opts into using it.
 
 ## Tradeoff Configuration
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -92,6 +92,10 @@ perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scena
 
 By default, each scenario reads `[defaults].out_dir/<bench>/compare.json`.
 Set `compare = "path/to/compare.json"` on a scenario to override that lookup.
+Set `probe_compare = "path/to/probe-compare.json"` to attach advisory probe
+delta evidence. Scenario receipts record the probe names and a
+`probe_compare_ref`; consumers follow that reference for full probe deltas, and
+probe evidence does not change the scenario verdict yet.
 
 ## Tradeoff Evaluation
 

--- a/fixtures/schema/v0.16/perfgate.scenario.v1.json
+++ b/fixtures/schema/v0.16/perfgate.scenario.v1.json
@@ -24,6 +24,10 @@
       "name": "parser.batch_loop",
       "weight": 1.0,
       "benchmark": "large-file",
+      "probe_compare_ref": {
+        "path": "artifacts/perfgate/large-file/probe-compare.json",
+        "run_id": "probe-compare-run"
+      },
       "deltas": {
         "wall_ms": {
           "baseline": 100.0,

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -502,6 +502,13 @@
         "name": {
           "type": "string"
         },
+        "probe_compare": {
+          "description": "Optional probe comparison receipt path. When present, scenario\nevaluation attaches probe names and a receipt reference without making\nprobes part of the scenario verdict.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "weight": {
           "description": "Relative importance in the workload model.",
           "type": "number",

--- a/schemas/perfgate.scenario.v1.schema.json
+++ b/schemas/perfgate.scenario.v1.schema.json
@@ -262,6 +262,16 @@
         "name": {
           "type": "string"
         },
+        "probe_compare_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CompareRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "probes": {
           "type": "array",
           "items": {


### PR DESCRIPTION
## Summary
- add optional `probe_compare` paths to configured scenarios
- attach probe-compare receipt refs and probe names to `perfgate.scenario.v1` components
- keep missing/mismatched probe evidence advisory while rejecting wrong probe-compare schema versions
- update schemas, schema fixture, config/schema docs, and changelog

## Validation
- `cargo test -p perfgate scenario --all-features`
- `cargo test -p perfgate-cli --test cli_scenario_tests --all-features`
- `cargo test -p perfgate-types scenario --all-features`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- schema-compat`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo fmt --all -- --check`
- `cargo clippy -p perfgate -p perfgate-types -p perfgate-cli -p xtask --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`