### PR TITLE
tradeoff: support probe requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carry advisory probe names and probe-compare receipt references.
 - Added `perfgate tradeoff evaluate` to turn configured tradeoff rules and
   scenario receipts into `perfgate.tradeoff.v1` decision receipts.
+- Added probe-backed tradeoff requirements with `probe = "name"` so accepted
+  tradeoffs can depend on named probe improvements from attached probe-compare
+  evidence.
 - Added Markdown and PR-comment rendering for `perfgate.tradeoff.v1` decision
   receipts via `perfgate md --tradeoff` and `perfgate comment --tradeoff`.
 - Extended `xtask schema-compat` with baseline-service record, health-response,

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -3517,7 +3517,7 @@ fn execute_tradeoff_evaluate(args: TradeoffEvaluateArgs) -> anyhow::Result<()> {
 fn evaluate_configured_tradeoffs(
     config: &ConfigFile,
     config_path: &Path,
-    scenario: ScenarioReceipt,
+    mut scenario: ScenarioReceipt,
 ) -> anyhow::Result<perfgate_app::TradeoffEvaluateOutcome> {
     if config.tradeoffs.is_empty() {
         anyhow::bail!(
@@ -3525,12 +3525,54 @@ fn evaluate_configured_tradeoffs(
             config_path.display()
         );
     }
+    let (probe_compares, probe_warnings) = load_tradeoff_probe_compares(&scenario)?;
+    scenario.warnings.extend(probe_warnings);
 
     TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
         scenario,
+        probe_compares,
         rules: config.tradeoffs.clone(),
         tool: tool_info(),
     })
+}
+
+fn load_tradeoff_probe_compares(
+    scenario: &ScenarioReceipt,
+) -> anyhow::Result<(Vec<ProbeCompareReceipt>, Vec<String>)> {
+    let mut paths = BTreeSet::new();
+    let mut receipts = Vec::new();
+    let mut warnings = Vec::new();
+
+    for component in &scenario.components {
+        let Some(reference) = &component.probe_compare_ref else {
+            continue;
+        };
+        let Some(path) = reference.path.as_ref() else {
+            warnings.push(format!(
+                "scenario component '{}' probe compare reference has no path",
+                component.name
+            ));
+            continue;
+        };
+        if !paths.insert(path.clone()) {
+            continue;
+        }
+
+        let path = PathBuf::from(path);
+        if !location_exists(&path)? {
+            warnings.push(format!(
+                "probe compare evidence missing at {}",
+                path.display()
+            ));
+            continue;
+        }
+
+        let receipt: ProbeCompareReceipt = read_json_from_location(&path)
+            .with_context(|| format!("read tradeoff probe compare {}", path.display()))?;
+        receipts.push(receipt);
+    }
+
+    Ok((receipts, warnings))
 }
 
 fn execute_decision_action(action: DecisionAction) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
+++ b/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
@@ -65,6 +65,47 @@ min_improvement_ratio = 1.10
     .expect("write config");
 }
 
+fn write_probe_config(path: &Path, probe_compare_path: &Path) {
+    fs::write(
+        path,
+        format!(
+            r#"[defaults]
+repeat = 1
+warmup = 0
+threshold = 10.0
+warn_factor = 0.50
+noise_threshold = 1.0
+noise_policy = "warn"
+baseline_dir = "baselines"
+out_dir = "artifacts/perfgate"
+
+[[bench]]
+name = "parser"
+command = [{}]
+
+[[scenario]]
+name = "release_workload"
+weight = 1.0
+bench = "parser"
+probe_compare = "{}"
+
+[[tradeoff]]
+name = "memory_for_probe_speed"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = 1.10
+"#,
+            command_toml_array(&success_command()),
+            toml_path(probe_compare_path)
+        ),
+    )
+    .expect("write probe config");
+}
+
 #[test]
 fn structured_decision_path_produces_scenario_and_tradeoff_receipts() {
     let temp_dir = tempdir().expect("create temp dir");
@@ -201,7 +242,8 @@ fn decision_evaluate_runs_structured_decision_workflow() {
     let temp_dir = tempdir().expect("create temp dir");
     let root = temp_dir.path();
     let config_path = root.join("perfgate.toml");
-    write_config(&config_path);
+    let probe_compare_path = root.join("artifacts/perfgate/parser/probe-compare.json");
+    write_probe_config(&config_path, &probe_compare_path);
 
     perfgate_cmd()
         .current_dir(root)
@@ -231,7 +273,8 @@ fn decision_evaluate_runs_structured_decision_workflow() {
 
     let compare_path = root.join("artifacts/perfgate/parser/compare.json");
     assert!(compare_path.exists(), "check should write compare receipt");
-    write_controlled_compare_receipt(&compare_path);
+    write_controlled_compare_receipt_with_wall(&compare_path, 96.0);
+    write_probe_compare_receipt(&probe_compare_path, 80.0);
 
     perfgate_cmd()
         .current_dir(root)
@@ -257,13 +300,23 @@ fn decision_evaluate_runs_structured_decision_workflow() {
     assert_eq!(tradeoff.schema, "perfgate.tradeoff.v1");
     assert!(tradeoff.decision.accepted_tradeoff);
     assert_eq!(tradeoff.decision.status, perfgate_types::MetricStatus::Warn);
+    assert_eq!(
+        tradeoff.rules[0].requirements[0].probe.as_deref(),
+        Some("parser.batch_loop")
+    );
+    assert_eq!(tradeoff.probes[0].name, "parser.batch_loop");
 
     let decision = fs::read_to_string(decision_path).expect("read decision md");
     assert!(decision.contains("perfgate tradeoff: warn"));
-    assert!(decision.contains("tradeoff 'memory_for_speed' accepted"));
+    assert!(decision.contains("tradeoff 'memory_for_probe_speed' accepted"));
+    assert!(decision.contains("Probe Evidence"));
 }
 
 fn write_controlled_compare_receipt(path: &Path) {
+    write_controlled_compare_receipt_with_wall(path, 80.0);
+}
+
+fn write_controlled_compare_receipt_with_wall(path: &Path, wall_current: f64) {
     let receipt = json!({
         "schema": "perfgate.compare.v1",
         "tool": {"name": "perfgate", "version": "0.16.0"},
@@ -285,9 +338,9 @@ fn write_controlled_compare_receipt(path: &Path) {
         "deltas": {
             "wall_ms": {
                 "baseline": 100.0,
-                "current": 80.0,
-                "ratio": 0.80,
-                "pct": -0.20,
+                "current": wall_current,
+                "ratio": wall_current / 100.0,
+                "pct": (wall_current - 100.0) / 100.0,
                 "regression": 0.0,
                 "status": "pass"
             },
@@ -317,4 +370,50 @@ fn write_controlled_compare_receipt(path: &Path) {
         serde_json::to_string_pretty(&receipt).expect("serialize controlled compare receipt"),
     )
     .expect("write controlled compare receipt");
+}
+
+fn write_probe_compare_receipt(path: &Path, wall_current: f64) {
+    let receipt = json!({
+        "schema": "perfgate.probe_compare.v1",
+        "tool": {"name": "perfgate", "version": "0.16.0"},
+        "run": {
+            "id": "probe-compare-run",
+            "started_at": "2026-05-08T00:00:00Z",
+            "ended_at": "2026-05-08T00:00:01Z",
+            "host": {"os": "linux", "arch": "x86_64"}
+        },
+        "scenario": "release_workload",
+        "probes": [{
+            "name": "parser.batch_loop",
+            "scope": "dominant",
+            "baseline_count": 1,
+            "current_count": 1,
+            "deltas": {
+                "wall_ms": {
+                    "baseline": 100.0,
+                    "current": wall_current,
+                    "ratio": wall_current / 100.0,
+                    "pct": (wall_current - 100.0) / 100.0,
+                    "regression": 0.0,
+                    "status": "pass"
+                }
+            },
+            "status": "pass"
+        }],
+        "verdict": {
+            "status": "pass",
+            "counts": {"pass": 1, "warn": 0, "fail": 0, "skip": 0},
+            "reasons": []
+        }
+    });
+
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize probe compare receipt"),
+    )
+    .expect("write probe compare receipt");
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
 }

--- a/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
+++ b/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
@@ -91,6 +91,48 @@ fn test_tradeoff_evaluate_fails_when_rule_not_satisfied() {
 }
 
 #[test]
+fn test_tradeoff_evaluate_uses_probe_requirement() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+    let probe_compare_path = temp_dir.path().join("probe-compare.json");
+    let output_path = temp_dir.path().join("tradeoff.json");
+
+    write_probe_tradeoff_config(&config_path, 1.10, "warn");
+    write_probe_compare_receipt(&probe_compare_path, "parser.batch_loop", 80.0);
+    write_scenario_receipt_with_probe_ref(&scenario_path, 96.0, "fail", &probe_compare_path);
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Tradeoff receipt written"));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should be JSON");
+    let typed: perfgate_types::TradeoffReceipt =
+        serde_json::from_value(receipt.clone()).expect("tradeoff receipt should deserialize");
+
+    assert!(typed.decision.accepted_tradeoff);
+    assert_eq!(typed.verdict.status, perfgate_types::VerdictStatus::Warn);
+    assert_eq!(
+        typed.rules[0].requirements[0].probe.as_deref(),
+        Some("parser.batch_loop")
+    );
+    assert_eq!(typed.rules[0].requirements[0].observed_change, Some(-0.20));
+    assert_eq!(typed.probes[0].name, "parser.batch_loop");
+}
+
+#[test]
 fn test_tradeoff_evaluate_rejects_config_without_tradeoffs() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let config_path = temp_dir.path().join("perfgate.toml");
@@ -133,7 +175,44 @@ min_improvement_ratio = {min_improvement_ratio}
     .expect("failed to write config");
 }
 
+fn write_probe_tradeoff_config(path: &Path, min_improvement_ratio: f64, downgrade_to: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"[[tradeoff]]
+name = "memory_for_probe_speed"
+if_failed = "max_rss_kb"
+downgrade_to = "{downgrade_to}"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = {min_improvement_ratio}
+"#
+        ),
+    )
+    .expect("failed to write config");
+}
+
 fn write_scenario_receipt(path: &Path, wall_current: f64, memory_status: &str) {
+    write_scenario_receipt_inner(path, wall_current, memory_status, None);
+}
+
+fn write_scenario_receipt_with_probe_ref(
+    path: &Path,
+    wall_current: f64,
+    memory_status: &str,
+    probe_compare_path: &Path,
+) {
+    write_scenario_receipt_inner(path, wall_current, memory_status, Some(probe_compare_path));
+}
+
+fn write_scenario_receipt_inner(
+    path: &Path,
+    wall_current: f64,
+    memory_status: &str,
+    probe_compare_path: Option<&Path>,
+) {
     let memory_fail = u32::from(memory_status == "fail");
     let memory_warn = u32::from(memory_status == "warn");
     let memory_pass = u32::from(memory_status == "pass");
@@ -144,6 +223,31 @@ fn write_scenario_receipt(path: &Path, wall_current: f64, memory_status: &str) {
     } else {
         Vec::new()
     };
+    let components = probe_compare_path
+        .map(|path| {
+            json!([{
+                "name": "large_file_parse",
+                "weight": 1.0,
+                "benchmark": "large-file",
+                "probe_compare_ref": {
+                    "path": path.display().to_string(),
+                    "run_id": "probe-compare-run"
+                },
+                "deltas": {
+                    "wall_ms": {
+                        "baseline": 100.0,
+                        "current": wall_current,
+                        "ratio": wall_current / 100.0,
+                        "pct": (wall_current - 100.0) / 100.0,
+                        "regression": 0.0,
+                        "status": "pass"
+                    }
+                },
+                "probes": ["parser.batch_loop"],
+                "status": "pass"
+            }])
+        })
+        .unwrap_or_else(|| json!([]));
     let receipt = json!({
         "schema": "perfgate.scenario.v1",
         "tool": {"name": "perfgate", "version": "0.16.0"},
@@ -157,7 +261,7 @@ fn write_scenario_receipt(path: &Path, wall_current: f64, memory_status: &str) {
             "name": "release_workload",
             "weight": 1.0
         },
-        "components": [],
+        "components": components,
         "weighted_deltas": {
             "wall_ms": {
                 "baseline": 100.0,
@@ -193,4 +297,46 @@ fn write_scenario_receipt(path: &Path, wall_current: f64, memory_status: &str) {
         serde_json::to_string_pretty(&receipt).expect("serialize scenario fixture"),
     )
     .expect("failed to write scenario fixture");
+}
+
+fn write_probe_compare_receipt(path: &Path, probe: &str, wall_current: f64) {
+    let receipt = json!({
+        "schema": "perfgate.probe_compare.v1",
+        "tool": {"name": "perfgate", "version": "0.16.0"},
+        "run": {
+            "id": "probe-compare-run",
+            "started_at": "2026-05-08T00:00:00Z",
+            "ended_at": "2026-05-08T00:00:01Z",
+            "host": {"os": "linux", "arch": "x86_64"}
+        },
+        "scenario": "release_workload",
+        "probes": [{
+            "name": probe,
+            "scope": "dominant",
+            "baseline_count": 1,
+            "current_count": 1,
+            "deltas": {
+                "wall_ms": {
+                    "baseline": 100.0,
+                    "current": wall_current,
+                    "ratio": wall_current / 100.0,
+                    "pct": (wall_current - 100.0) / 100.0,
+                    "regression": 0.0,
+                    "status": "pass"
+                }
+            },
+            "status": "pass"
+        }],
+        "verdict": {
+            "status": "pass",
+            "counts": {"pass": 1, "warn": 0, "fail": 0, "skip": 0},
+            "reasons": []
+        }
+    });
+
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize probe compare fixture"),
+    )
+    .expect("failed to write probe compare fixture");
 }

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1448,6 +1448,16 @@ impl ConfigFile {
                 ));
             }
             for requirement in &rule.require {
+                if requirement
+                    .probe
+                    .as_ref()
+                    .is_some_and(|probe| probe.trim().is_empty())
+                {
+                    return Err(format!(
+                        "tradeoff '{}' requirement probe must not be empty",
+                        rule.name
+                    ));
+                }
                 if !requirement.min_improvement_ratio.is_finite()
                     || requirement.min_improvement_ratio <= 0.0
                 {
@@ -1726,6 +1736,11 @@ pub struct BudgetOverride {
 pub struct TradeoffRequirement {
     /// Metric that must improve sufficiently for the tradeoff to apply.
     pub metric: Metric,
+
+    /// Optional probe name. When set, the requirement is evaluated against
+    /// attached probe comparison evidence instead of weighted scenario deltas.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub probe: Option<String>,
 
     /// Minimum required improvement ratio.
     ///
@@ -2121,6 +2136,7 @@ mod tests {
                 if_failed: Metric::MaxRssKb,
                 require: vec![TradeoffRequirement {
                     metric: Metric::WallMs,
+                    probe: None,
                     min_improvement_ratio: 1.10,
                 }],
                 downgrade_to: TradeoffDowngrade::Warn,
@@ -2146,6 +2162,12 @@ mod tests {
         assert!(config.validate().unwrap_err().contains("must not be empty"));
 
         config.tradeoffs[0].name = "memory_for_speed".to_string();
+        config.tradeoffs[0].require[0].probe = Some(" ".to_string());
+        assert!(config.validate().unwrap_err().contains("must not be empty"));
+
+        config.tradeoffs[0].require[0].probe = Some("parser.batch_loop".to_string());
+        assert!(config.validate().is_ok());
+
         config.tradeoffs[0].require[0].min_improvement_ratio = 0.0;
         assert!(config.validate().unwrap_err().contains("positive finite"));
 

--- a/crates/perfgate/src/app/tradeoff.rs
+++ b/crates/perfgate/src/app/tradeoff.rs
@@ -1,18 +1,20 @@
 use crate::domain::budget::{aggregate_verdict, reason_token};
 use perfgate_types::{
-    Delta, HostInfo, Metric, MetricStatus, RunMeta, ScenarioReceipt, TRADEOFF_SCHEMA_V1, ToolInfo,
-    TradeoffDecision, TradeoffDecisionStatus, TradeoffDowngrade, TradeoffReceipt,
+    Delta, HostInfo, Metric, MetricStatus, PROBE_COMPARE_SCHEMA_V1, ProbeCompareObservation,
+    ProbeCompareReceipt, RunMeta, ScenarioReceipt, TRADEOFF_SCHEMA_V1, ToolInfo, TradeoffDecision,
+    TradeoffDecisionStatus, TradeoffDowngrade, TradeoffProbeOutcome, TradeoffReceipt,
     TradeoffRequirement, TradeoffRequirementOutcome, TradeoffRule, TradeoffRuleOutcome,
     VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC, VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED,
     Verdict,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct TradeoffEvaluateRequest {
     pub scenario: ScenarioReceipt,
+    pub probe_compares: Vec<ProbeCompareReceipt>,
     pub rules: Vec<TradeoffRule>,
     pub tool: ToolInfo,
 }
@@ -29,14 +31,24 @@ impl TradeoffUseCase {
         if req.rules.is_empty() {
             anyhow::bail!("no tradeoff rules provided");
         }
+        for probe_compare in &req.probe_compares {
+            if probe_compare.schema != PROBE_COMPARE_SCHEMA_V1 {
+                anyhow::bail!(
+                    "probe compare receipt must use schema '{}', got '{}'",
+                    PROBE_COMPARE_SCHEMA_V1,
+                    probe_compare.schema
+                );
+            }
+        }
 
         let mut weighted_deltas = req.scenario.weighted_deltas.clone();
+        let (probe_index, probe_warnings) = index_probe_compares(&req.probe_compares);
         let mut rule_outcomes = Vec::new();
         let mut accepted_reasons = Vec::new();
         let mut rejected_reasons = Vec::new();
 
         for rule in &req.rules {
-            let outcome = evaluate_rule(rule, &weighted_deltas);
+            let outcome = evaluate_rule(rule, &weighted_deltas, &probe_index);
             if outcome.accepted {
                 if let Some(delta) = weighted_deltas.get_mut(rule.if_failed.as_str()) {
                     delta.status = downgrade_status(rule.downgrade_to);
@@ -56,6 +68,7 @@ impl TradeoffUseCase {
             }
             rule_outcomes.push(outcome);
         }
+        let probes = tradeoff_probe_outcomes(&rule_outcomes, &probe_index);
 
         let mut verdict = verdict_from_weighted_deltas(&weighted_deltas);
         verdict
@@ -72,6 +85,11 @@ impl TradeoffUseCase {
             reason: decision_reason(accepted, &rule_outcomes, &verdict),
         };
 
+        let mut warnings = req.scenario.warnings;
+        for warning in probe_warnings {
+            push_unique(&mut warnings, warning);
+        }
+
         let receipt = TradeoffReceipt {
             schema: TRADEOFF_SCHEMA_V1.to_string(),
             tool: req.tool,
@@ -81,11 +99,11 @@ impl TradeoffUseCase {
             current_ref: req.scenario.current_ref,
             configured_rules: req.rules,
             rules: rule_outcomes,
-            probes: Vec::new(),
+            probes,
             weighted_deltas,
             decision,
             verdict,
-            warnings: req.scenario.warnings,
+            warnings,
         };
 
         Ok(TradeoffEvaluateOutcome { receipt })
@@ -95,6 +113,7 @@ impl TradeoffUseCase {
 fn evaluate_rule(
     rule: &TradeoffRule,
     weighted_deltas: &BTreeMap<String, Delta>,
+    probe_index: &BTreeMap<String, ProbeCompareObservation>,
 ) -> TradeoffRuleOutcome {
     let Some(target) = weighted_deltas.get(rule.if_failed.as_str()) else {
         return TradeoffRuleOutcome {
@@ -106,7 +125,7 @@ fn evaluate_rule(
                 "failed metric '{}' is not present",
                 rule.if_failed.as_str()
             )),
-            requirements: evaluate_requirements(&rule.require, weighted_deltas),
+            requirements: evaluate_requirements(&rule.require, weighted_deltas, probe_index),
         };
     };
 
@@ -120,11 +139,11 @@ fn evaluate_rule(
                 "metric '{}' is not failing",
                 rule.if_failed.as_str()
             )),
-            requirements: evaluate_requirements(&rule.require, weighted_deltas),
+            requirements: evaluate_requirements(&rule.require, weighted_deltas, probe_index),
         };
     }
 
-    let requirements = evaluate_requirements(&rule.require, weighted_deltas);
+    let requirements = evaluate_requirements(&rule.require, weighted_deltas, probe_index);
     let accepted =
         !requirements.is_empty() && requirements.iter().all(|requirement| requirement.satisfied);
 
@@ -149,15 +168,20 @@ fn evaluate_rule(
 fn evaluate_requirements(
     requirements: &[TradeoffRequirement],
     weighted_deltas: &BTreeMap<String, Delta>,
+    probe_index: &BTreeMap<String, ProbeCompareObservation>,
 ) -> Vec<TradeoffRequirementOutcome> {
     requirements
         .iter()
         .map(|requirement| {
+            if requirement.probe.is_some() {
+                return evaluate_probe_requirement(requirement, probe_index);
+            }
+
             let metric_key = requirement.metric.as_str();
             let Some(delta) = weighted_deltas.get(metric_key) else {
                 return TradeoffRequirementOutcome {
                     metric: metric_key.to_string(),
-                    probe: None,
+                    probe: requirement.probe.clone(),
                     required_change: required_change(requirement),
                     observed_change: None,
                     satisfied: false,
@@ -173,7 +197,7 @@ fn evaluate_requirements(
 
             TradeoffRequirementOutcome {
                 metric: metric_key.to_string(),
-                probe: None,
+                probe: requirement.probe.clone(),
                 required_change: required_change(requirement),
                 observed_change: Some(delta.pct),
                 satisfied,
@@ -187,6 +211,122 @@ fn evaluate_requirements(
                     requirement.min_improvement_ratio
                 )),
             }
+        })
+        .collect()
+}
+
+fn evaluate_probe_requirement(
+    requirement: &TradeoffRequirement,
+    probe_index: &BTreeMap<String, ProbeCompareObservation>,
+) -> TradeoffRequirementOutcome {
+    let metric_key = requirement.metric.as_str();
+    let Some(probe_name) = requirement.probe.as_deref() else {
+        return TradeoffRequirementOutcome {
+            metric: metric_key.to_string(),
+            probe: None,
+            required_change: required_change(requirement),
+            observed_change: None,
+            satisfied: false,
+            status: MetricStatus::Fail,
+            reason: Some("required probe missing".to_string()),
+        };
+    };
+
+    let Some(probe) = probe_index.get(probe_name) else {
+        return TradeoffRequirementOutcome {
+            metric: metric_key.to_string(),
+            probe: Some(probe_name.to_string()),
+            required_change: required_change(requirement),
+            observed_change: None,
+            satisfied: false,
+            status: MetricStatus::Fail,
+            reason: Some(format!("required probe '{probe_name}' missing")),
+        };
+    };
+
+    let Some(delta) = probe.deltas.get(metric_key) else {
+        return TradeoffRequirementOutcome {
+            metric: metric_key.to_string(),
+            probe: Some(probe_name.to_string()),
+            required_change: required_change(requirement),
+            observed_change: None,
+            satisfied: false,
+            status: MetricStatus::Fail,
+            reason: Some(format!(
+                "required probe '{probe_name}' metric '{metric_key}' missing"
+            )),
+        };
+    };
+
+    let observed_ratio = improvement_ratio(delta, requirement.metric);
+    let satisfied = observed_ratio
+        .map(|ratio| ratio >= requirement.min_improvement_ratio)
+        .unwrap_or(false);
+
+    TradeoffRequirementOutcome {
+        metric: metric_key.to_string(),
+        probe: Some(probe_name.to_string()),
+        required_change: required_change(requirement),
+        observed_change: Some(delta.pct),
+        satisfied,
+        status: if satisfied {
+            MetricStatus::Pass
+        } else {
+            MetricStatus::Fail
+        },
+        reason: (!satisfied).then_some(format!(
+            "requires improvement ratio >= {:.6}",
+            requirement.min_improvement_ratio
+        )),
+    }
+}
+
+fn index_probe_compares(
+    probe_compares: &[ProbeCompareReceipt],
+) -> (BTreeMap<String, ProbeCompareObservation>, Vec<String>) {
+    let mut index = BTreeMap::new();
+    let mut warnings = Vec::new();
+    for receipt in probe_compares {
+        warnings.extend(
+            receipt
+                .warnings
+                .iter()
+                .map(|warning| format!("probe compare warning: {warning}")),
+        );
+        for probe in &receipt.probes {
+            if index.insert(probe.name.clone(), probe.clone()).is_some() {
+                warnings.push(format!(
+                    "probe '{}' appeared in more than one probe compare receipt; last value used",
+                    probe.name
+                ));
+            }
+        }
+    }
+    (index, warnings)
+}
+
+fn tradeoff_probe_outcomes(
+    rule_outcomes: &[TradeoffRuleOutcome],
+    probe_index: &BTreeMap<String, ProbeCompareObservation>,
+) -> Vec<TradeoffProbeOutcome> {
+    let probe_names: BTreeSet<String> = rule_outcomes
+        .iter()
+        .flat_map(|rule| rule.requirements.iter())
+        .filter_map(|requirement| requirement.probe.clone())
+        .collect();
+
+    probe_names
+        .iter()
+        .filter_map(|name| {
+            let probe = probe_index.get(name)?;
+            Some(TradeoffProbeOutcome {
+                name: probe.name.clone(),
+                scope: probe.scope,
+                weight: None,
+                deltas: probe.deltas.clone(),
+                status: probe.status,
+                reason: probe.reasons.first().cloned(),
+            })
         })
         .collect()
 }
@@ -287,7 +427,10 @@ fn make_run_meta() -> RunMeta {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use perfgate_types::{SCENARIO_SCHEMA_V1, ScenarioMeta, VerdictCounts, VerdictStatus};
+    use perfgate_types::{
+        PROBE_COMPARE_SCHEMA_V1, ProbeCompareObservation, ProbeCompareReceipt, ProbeScope,
+        SCENARIO_SCHEMA_V1, ScenarioMeta, VerdictCounts, VerdictStatus,
+    };
 
     fn scenario_receipt(wall_current: f64, memory_status: MetricStatus) -> ScenarioReceipt {
         ScenarioReceipt {
@@ -352,9 +495,62 @@ mod tests {
             if_failed: Metric::MaxRssKb,
             require: vec![TradeoffRequirement {
                 metric: Metric::WallMs,
+                probe: None,
                 min_improvement_ratio: 1.10,
             }],
             downgrade_to,
+        }
+    }
+
+    fn memory_for_probe_speed_rule(downgrade_to: TradeoffDowngrade) -> TradeoffRule {
+        TradeoffRule {
+            name: "memory_for_probe_speed".to_string(),
+            if_failed: Metric::MaxRssKb,
+            require: vec![TradeoffRequirement {
+                metric: Metric::WallMs,
+                probe: Some("parser.batch_loop".to_string()),
+                min_improvement_ratio: 1.10,
+            }],
+            downgrade_to,
+        }
+    }
+
+    fn probe_compare_receipt(probe_name: &str, wall_current: f64) -> ProbeCompareReceipt {
+        ProbeCompareReceipt {
+            schema: PROBE_COMPARE_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+            run: make_run_meta(),
+            bench: None,
+            scenario: Some("release_workload".to_string()),
+            baseline_ref: None,
+            current_ref: None,
+            probes: vec![ProbeCompareObservation {
+                name: probe_name.to_string(),
+                parent: None,
+                scope: Some(ProbeScope::Dominant),
+                baseline_count: 1,
+                current_count: 1,
+                deltas: BTreeMap::from([(
+                    "wall_ms".to_string(),
+                    delta(100.0, wall_current, MetricStatus::Pass),
+                )]),
+                status: MetricStatus::Pass,
+                reasons: Vec::new(),
+            }],
+            verdict: Verdict {
+                status: VerdictStatus::Pass,
+                counts: VerdictCounts {
+                    pass: 1,
+                    warn: 0,
+                    fail: 0,
+                    skip: 0,
+                },
+                reasons: Vec::new(),
+            },
+            warnings: Vec::new(),
         }
     }
 
@@ -362,6 +558,7 @@ mod tests {
     fn tradeoff_evaluate_accepts_satisfied_rule() {
         let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
             scenario: scenario_receipt(80.0, MetricStatus::Fail),
+            probe_compares: Vec::new(),
             rules: vec![memory_for_speed_rule(TradeoffDowngrade::Warn)],
             tool: ToolInfo {
                 name: "perfgate".to_string(),
@@ -389,6 +586,7 @@ mod tests {
     fn tradeoff_evaluate_rejects_unsatisfied_rule() {
         let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
             scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: Vec::new(),
             rules: vec![memory_for_speed_rule(TradeoffDowngrade::Pass)],
             tool: ToolInfo {
                 name: "perfgate".to_string(),
@@ -411,5 +609,61 @@ mod tests {
                 .reasons
                 .contains(&VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED.to_string())
         );
+    }
+
+    #[test]
+    fn tradeoff_evaluate_accepts_satisfied_probe_requirement() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: vec![probe_compare_receipt("parser.batch_loop", 80.0)],
+            rules: vec![memory_for_probe_speed_rule(TradeoffDowngrade::Warn)],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(receipt.decision.accepted_tradeoff);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Accepted);
+        assert_eq!(
+            receipt.rules[0].requirements[0].probe.as_deref(),
+            Some("parser.batch_loop")
+        );
+        assert_eq!(
+            receipt.rules[0].requirements[0].observed_change,
+            Some(-0.20)
+        );
+        assert_eq!(receipt.probes.len(), 1);
+        assert_eq!(receipt.probes[0].name, "parser.batch_loop");
+        assert_eq!(receipt.verdict.status, VerdictStatus::Warn);
+    }
+
+    #[test]
+    fn tradeoff_evaluate_rejects_missing_probe_requirement() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: vec![probe_compare_receipt("parser.tokenize", 80.0)],
+            rules: vec![memory_for_probe_speed_rule(TradeoffDowngrade::Pass)],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(!receipt.decision.accepted_tradeoff);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
+        assert_eq!(receipt.rules[0].requirements[0].observed_change, None);
+        assert!(
+            receipt.rules[0].requirements[0]
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("required probe"))
+        );
+        assert_eq!(receipt.probes.len(), 0);
+        assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
     }
 }

--- a/crates/perfgate/src/domain/mod.rs
+++ b/crates/perfgate/src/domain/mod.rs
@@ -242,6 +242,7 @@ mod tradeoff_tests {
             if_failed: Metric::MaxRssKb,
             require: vec![TradeoffRequirement {
                 metric: Metric::ThroughputPerS,
+                probe: None,
                 min_improvement_ratio,
             }],
             downgrade_to: TradeoffDowngrade::Warn,
@@ -302,6 +303,7 @@ mod tradeoff_tests {
                 if_failed: Metric::MaxRssKb,
                 require: vec![TradeoffRequirement {
                     metric: Metric::ThroughputPerS,
+                    probe: None,
                     min_improvement_ratio: 1.5,
                 }],
                 downgrade_to: TradeoffDowngrade::Pass,
@@ -472,6 +474,7 @@ mod tradeoff_tests {
             if_failed: Metric::MaxRssKb,
             require: vec![TradeoffRequirement {
                 metric: Metric::WallMs,
+                probe: None,
                 min_improvement_ratio: 1.1,
             }],
             downgrade_to: TradeoffDowngrade::Warn,
@@ -490,6 +493,41 @@ mod tradeoff_tests {
                 .verdict
                 .reasons
                 .contains(&"tradeoff_memory_for_latency_applied".to_string())
+        );
+    }
+
+    #[test]
+    fn probe_requirement_does_not_apply_without_probe_context() {
+        let baseline = base_stats(100, 1000, 1000);
+        let current = base_stats(80, 1300, 1000);
+        let budgets = BTreeMap::from([
+            (Metric::WallMs, Budget::new(0.20, 0.1, Direction::Lower)),
+            (Metric::MaxRssKb, Budget::new(0.15, 0.1, Direction::Lower)),
+        ]);
+        let rule = TradeoffRule {
+            name: "memory_for_probe_latency".to_string(),
+            if_failed: Metric::MaxRssKb,
+            require: vec![TradeoffRequirement {
+                metric: Metric::WallMs,
+                probe: Some("parser.batch_loop".to_string()),
+                min_improvement_ratio: 1.1,
+            }],
+            downgrade_to: TradeoffDowngrade::Warn,
+        };
+
+        let comparison =
+            compare_stats_with_tradeoffs(&baseline, &current, &budgets, &[rule]).unwrap();
+
+        assert_eq!(comparison.verdict.status, VerdictStatus::Fail);
+        assert_eq!(
+            comparison.deltas.get(&Metric::MaxRssKb).unwrap().status,
+            MetricStatus::Fail
+        );
+        assert!(
+            comparison
+                .verdict
+                .reasons
+                .contains(&VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC.to_string())
         );
     }
 }
@@ -1004,6 +1042,12 @@ fn apply_tradeoffs(
             let mut satisfied = !rule.require.is_empty();
 
             for requirement in &rule.require {
+                if requirement.probe.is_some() {
+                    missing_required_metric = true;
+                    satisfied = false;
+                    break;
+                }
+
                 let Some(required_delta) = deltas.get(&requirement.metric) else {
                     missing_required_metric = true;
                     satisfied = false;

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -142,6 +142,21 @@ metric = "wall_ms"
 min_improvement_ratio = 1.10
 ```
 
+Requirements can also target a named probe from scenario-attached
+`perfgate.probe_compare.v1` evidence:
+
+```toml
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = 1.10
+```
+
+When `probe` is set, `tradeoff evaluate` follows the scenario component's
+`probe_compare_ref` and evaluates the requirement against that probe's metric
+delta. Missing probe evidence leaves the requirement unsatisfied; it does not
+silently fall back to weighted scenario deltas.
+
 Evaluate the rules against a scenario receipt to produce
 `perfgate.tradeoff.v1` decision evidence:
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -110,6 +110,11 @@ perfgate tradeoff evaluate --config perfgate.toml --scenario artifacts/perfgate/
 The receipt records configured rules, requirement outcomes, the final decision,
 and the weighted deltas after any accepted downgrade.
 
+When a tradeoff requirement includes `probe = "name"`, evaluation uses
+scenario-attached `probe_compare_ref` receipts to find that probe's metric
+delta. Probe-backed requirement outcomes record the probe name, and matching
+probe deltas are copied into the tradeoff receipt's `probes` section for review.
+
 Render the decision evidence for review:
 
 ```bash

--- a/fixtures/schema/v0.16/perfgate.tradeoff.v1.json
+++ b/fixtures/schema/v0.16/perfgate.tradeoff.v1.json
@@ -14,6 +14,20 @@
     }
   },
   "scenario": "large_file_parse",
+  "configured_rules": [
+    {
+      "name": "tokenizer-slower-if-parser-faster",
+      "if_failed": "wall_ms",
+      "require": [
+        {
+          "metric": "wall_ms",
+          "probe": "parser.batch_loop",
+          "min_improvement_ratio": 1.1
+        }
+      ],
+      "downgrade_to": "pass"
+    }
+  ],
   "rules": [
     {
       "name": "tokenizer-slower-if-parser-faster",

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -541,6 +541,13 @@
           "description": "Minimum required improvement ratio.\n\nFor higher-is-better metrics, this is `current / baseline`.\nFor lower-is-better metrics, this is `baseline / current`.",
           "type": "number",
           "format": "double"
+        },
+        "probe": {
+          "description": "Optional probe name. When set, the requirement is evaluated against\nattached probe comparison evidence instead of weighted scenario deltas.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [

--- a/schemas/perfgate.tradeoff.v1.schema.json
+++ b/schemas/perfgate.tradeoff.v1.schema.json
@@ -445,6 +445,13 @@
           "description": "Minimum required improvement ratio.\n\nFor higher-is-better metrics, this is `current / baseline`.\nFor lower-is-better metrics, this is `baseline / current`.",
           "type": "number",
           "format": "double"
+        },
+        "probe": {
+          "description": "Optional probe name. When set, the requirement is evaluated against\nattached probe comparison evidence instead of weighted scenario deltas.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [


### PR DESCRIPTION
## Summary
- add optional `probe = "name"` on tradeoff requirements
- load scenario-attached probe compare receipts during `tradeoff evaluate` / `decision evaluate`
- evaluate probe-backed requirements against named probe deltas and copy matching probe evidence into tradeoff receipts
- prevent raw compare/check tradeoffs from silently falling back when a requirement needs probe context
- update schemas, schema fixture, docs, and changelog

## Validation
- `cargo test -p perfgate tradeoff --all-features`
- `cargo test -p perfgate-cli --test cli_tradeoff_tests --all-features`
- `cargo test -p perfgate-cli --test cli_structured_decision_e2e_tests --all-features`
- `cargo test -p perfgate-types tradeoff --all-features`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- schema-compat`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo fmt --all -- --check`
- `cargo clippy -p perfgate -p perfgate-types -p perfgate-cli -p xtask --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`