### PR TITLE
examples: add performance decision fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ For specific workflows:
 - [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md)
 - [Flakiness History](docs/FLAKINESS.md)
 - [Fleet Aggregation](docs/FLEET_AGGREGATION.md)
+- [Performance Decision Example](examples/performance-decision/README.md)
 - [Cockpit Integration](docs/COCKPIT_MODE.md)
 - [Exporting Data](docs/EXPORT.md)
 - [Host Mismatch Detection](docs/HOST_MISMATCH.md)

--- a/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
+++ b/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
@@ -1,0 +1,145 @@
+//! Integration test for the runnable performance decision example.
+
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+use common::perfgate_cmd;
+
+#[test]
+fn performance_decision_example_runs_end_to_end() {
+    let temp_dir = tempdir().expect("create temp dir");
+    let root = temp_dir.path();
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crate should live under crates/perfgate-cli");
+    let source = repo_root.join("examples/performance-decision");
+    let destination = root.join("examples/performance-decision");
+    copy_dir_all(&source, &destination);
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "ingest",
+            "probes",
+            "--file",
+            "examples/performance-decision/probes-baseline.jsonl",
+            "--out",
+            "artifacts/perfgate/large-file/probes-baseline.json",
+        ])
+        .assert()
+        .success();
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "ingest",
+            "probes",
+            "--file",
+            "examples/performance-decision/probes-current.jsonl",
+            "--out",
+            "artifacts/perfgate/large-file/probes-current.json",
+        ])
+        .assert()
+        .success();
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "probe",
+            "compare",
+            "--baseline",
+            "artifacts/perfgate/large-file/probes-baseline.json",
+            "--current",
+            "artifacts/perfgate/large-file/probes-current.json",
+            "--out",
+            "artifacts/perfgate/large-file/probe-compare.json",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Probe compare receipt written"));
+
+    let probe_compare: perfgate_types::ProbeCompareReceipt = serde_json::from_str(
+        &fs::read_to_string(root.join("artifacts/perfgate/large-file/probe-compare.json"))
+            .expect("read probe compare receipt"),
+    )
+    .expect("probe compare receipt should deserialize");
+    assert!(
+        probe_compare
+            .probes
+            .iter()
+            .any(|probe| probe.name == "parser.tokenize")
+    );
+    assert!(
+        probe_compare
+            .probes
+            .iter()
+            .any(|probe| probe.name == "parser.batch_loop")
+    );
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "decision",
+            "evaluate",
+            "--config",
+            "examples/performance-decision/perfgate.toml",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Scenario receipt written"))
+        .stderr(predicate::str::contains("Tradeoff receipt written"))
+        .stderr(predicate::str::contains("Decision markdown written"));
+
+    let scenario: perfgate_types::ScenarioReceipt = serde_json::from_str(
+        &fs::read_to_string(root.join("artifacts/perfgate/scenario.json"))
+            .expect("read scenario receipt"),
+    )
+    .expect("scenario receipt should deserialize");
+    assert_eq!(scenario.schema, "perfgate.scenario.v1");
+    assert!(
+        scenario.components[0]
+            .probes
+            .iter()
+            .any(|probe| probe == "parser.batch_loop")
+    );
+
+    let tradeoff: perfgate_types::TradeoffReceipt = serde_json::from_str(
+        &fs::read_to_string(root.join("artifacts/perfgate/tradeoff.json"))
+            .expect("read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should deserialize");
+    assert_eq!(tradeoff.schema, "perfgate.tradeoff.v1");
+    assert!(tradeoff.decision.accepted_tradeoff);
+    assert_eq!(tradeoff.decision.status, perfgate_types::MetricStatus::Warn);
+    assert_eq!(tradeoff.rules[0].name, "memory_for_probe_speed");
+    assert!(tradeoff.rules[0].accepted);
+    assert_eq!(
+        tradeoff.rules[0].requirements[0].probe.as_deref(),
+        Some("parser.batch_loop")
+    );
+    assert_eq!(tradeoff.probes[0].name, "parser.batch_loop");
+
+    let decision =
+        fs::read_to_string(root.join("artifacts/perfgate/decision.md")).expect("read decision md");
+    assert!(decision.contains("perfgate tradeoff: warn"));
+    assert!(decision.contains("tradeoff 'memory_for_probe_speed' accepted"));
+    assert!(decision.contains("Probe Evidence"));
+}
+
+fn copy_dir_all(source: &Path, destination: &Path) {
+    fs::create_dir_all(destination).expect("create destination directory");
+    for entry in fs::read_dir(source).expect("read source directory") {
+        let entry = entry.expect("read source directory entry");
+        let entry_source = entry.path();
+        let entry_destination = destination.join(entry.file_name());
+        if entry.file_type().expect("read source entry type").is_dir() {
+            copy_dir_all(&entry_source, &entry_destination);
+        } else {
+            fs::copy(&entry_source, &entry_destination).expect("copy source file");
+        }
+    }
+}

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -78,7 +78,7 @@ perfgate probe compare --baseline baselines/probes.json --current artifacts/perf
 
 Missing probes or missing metrics are recorded as warnings instead of policy
 failures. This keeps early probe evidence advisory while still producing
-durable deltas that scenario and tradeoff workflows can attach later.
+durable deltas that scenario and tradeoff workflows can attach.
 
 ## Scenario Evaluation
 
@@ -136,6 +136,9 @@ artifacts/perfgate/scenario.json
 artifacts/perfgate/tradeoff.json
 artifacts/perfgate/decision.md
 ```
+
+For a runnable probe/scenario/tradeoff fixture, see
+[`examples/performance-decision`](../examples/performance-decision/README.md).
 
 ## Fixture Validation
 

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -1,0 +1,36 @@
+# Performance Decision Example
+
+This fixture demonstrates the structured decision path without requiring a
+benchmark harness. It uses committed compare receipts plus language-agnostic
+probe JSONL so the decision is deterministic.
+
+Run from the repository root:
+
+```bash
+perfgate ingest probes --file examples/performance-decision/probes-baseline.jsonl --out artifacts/perfgate/large-file/probes-baseline.json
+perfgate ingest probes --file examples/performance-decision/probes-current.jsonl --out artifacts/perfgate/large-file/probes-current.json
+perfgate probe compare --baseline artifacts/perfgate/large-file/probes-baseline.json --current artifacts/perfgate/large-file/probes-current.json --out artifacts/perfgate/large-file/probe-compare.json
+perfgate decision evaluate --config examples/performance-decision/perfgate.toml
+```
+
+Expected shape:
+
+```text
+artifacts/perfgate/
+  large-file/probe-compare.json
+  scenario.json
+  tradeoff.json
+  decision.md
+```
+
+The fixture models a memory-for-speed decision:
+
+- the weighted workload improves on `wall_ms`;
+- `max_rss_kb` fails before tradeoff policy is applied;
+- `parser.batch_loop` improves enough to satisfy the probe-backed requirement;
+- the final decision is `warn` with an accepted tradeoff.
+
+`parser.tokenize` is also present in the probe comparison and regresses
+slightly. That evidence remains visible in `probe-compare.json`; the tradeoff
+rule accepts the memory regression only because the dominant batch-loop probe
+improves.

--- a/examples/performance-decision/perfgate.toml
+++ b/examples/performance-decision/perfgate.toml
@@ -1,0 +1,36 @@
+[defaults]
+threshold = 0.20
+warn_factor = 0.50
+out_dir = "artifacts/perfgate"
+baseline_dir = "baselines"
+
+[[bench]]
+name = "large-file"
+command = ["echo", "large-file fixture"]
+
+[[bench]]
+name = "small-edit"
+command = ["echo", "small-edit fixture"]
+
+[[scenario]]
+name = "large_file_parse"
+weight = 0.75
+bench = "large-file"
+compare = "examples/performance-decision/receipts/large-file.compare.json"
+probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
+
+[[scenario]]
+name = "small_edit"
+weight = 0.25
+bench = "small-edit"
+compare = "examples/performance-decision/receipts/small-edit.compare.json"
+
+[[tradeoff]]
+name = "memory_for_probe_speed"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = 1.10

--- a/examples/performance-decision/probes-baseline.jsonl
+++ b/examples/performance-decision/probes-baseline.jsonl
@@ -1,0 +1,2 @@
+{"probe":"parser.tokenize","scope":"local","wall_ms":12.10,"alloc_bytes":184320,"items":10000}
+{"probe":"parser.batch_loop","scope":"dominant","wall_ms":100.00,"alloc_bytes":1048576,"items":10000}

--- a/examples/performance-decision/probes-current.jsonl
+++ b/examples/performance-decision/probes-current.jsonl
@@ -1,0 +1,2 @@
+{"probe":"parser.tokenize","scope":"local","wall_ms":12.35,"alloc_bytes":184960,"items":10000}
+{"probe":"parser.batch_loop","scope":"dominant","wall_ms":89.60,"alloc_bytes":1000000,"items":10000}

--- a/examples/performance-decision/receipts/large-file.compare.json
+++ b/examples/performance-decision/receipts/large-file.compare.json
@@ -1,0 +1,50 @@
+{
+  "schema": "perfgate.compare.v1",
+  "tool": {
+    "name": "perfgate",
+    "version": "0.16.0"
+  },
+  "bench": {
+    "name": "large-file",
+    "command": ["echo", "large-file fixture"],
+    "repeat": 1,
+    "warmup": 0
+  },
+  "baseline_ref": {
+    "path": "baselines/large-file.json",
+    "run_id": "large-file-baseline"
+  },
+  "current_ref": {
+    "path": "artifacts/perfgate/large-file/run.json",
+    "run_id": "large-file-current"
+  },
+  "budgets": {},
+  "deltas": {
+    "wall_ms": {
+      "baseline": 100.0,
+      "current": 90.0,
+      "ratio": 0.9,
+      "pct": -0.1,
+      "regression": 0.0,
+      "status": "pass"
+    },
+    "max_rss_kb": {
+      "baseline": 100.0,
+      "current": 130.0,
+      "ratio": 1.3,
+      "pct": 0.3,
+      "regression": 0.3,
+      "status": "fail"
+    }
+  },
+  "verdict": {
+    "status": "fail",
+    "counts": {
+      "pass": 1,
+      "warn": 0,
+      "fail": 1,
+      "skip": 0
+    },
+    "reasons": ["max_rss_kb_fail"]
+  }
+}

--- a/examples/performance-decision/receipts/small-edit.compare.json
+++ b/examples/performance-decision/receipts/small-edit.compare.json
@@ -1,0 +1,50 @@
+{
+  "schema": "perfgate.compare.v1",
+  "tool": {
+    "name": "perfgate",
+    "version": "0.16.0"
+  },
+  "bench": {
+    "name": "small-edit",
+    "command": ["echo", "small-edit fixture"],
+    "repeat": 1,
+    "warmup": 0
+  },
+  "baseline_ref": {
+    "path": "baselines/small-edit.json",
+    "run_id": "small-edit-baseline"
+  },
+  "current_ref": {
+    "path": "artifacts/perfgate/small-edit/run.json",
+    "run_id": "small-edit-current"
+  },
+  "budgets": {},
+  "deltas": {
+    "wall_ms": {
+      "baseline": 100.0,
+      "current": 102.0,
+      "ratio": 1.02,
+      "pct": 0.02,
+      "regression": 0.02,
+      "status": "pass"
+    },
+    "max_rss_kb": {
+      "baseline": 100.0,
+      "current": 101.0,
+      "ratio": 1.01,
+      "pct": 0.01,
+      "regression": 0.01,
+      "status": "pass"
+    }
+  },
+  "verdict": {
+    "status": "pass",
+    "counts": {
+      "pass": 2,
+      "warn": 0,
+      "fail": 0,
+      "skip": 0
+    },
+    "reasons": []
+  }
+}


### PR DESCRIPTION
## Summary
- add a runnable `examples/performance-decision` fixture for the probe -> probe compare -> scenario -> tradeoff -> decision workflow
- include deterministic compare receipts and probe JSONL that model a memory-for-speed accepted tradeoff
- add an integration test that copies the example into a temp workspace and runs the documented commands end to end
- link the example from README and schema docs

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-cli --test cli_performance_decision_example_tests --all-features`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `git diff --check`
- `cargo run -p xtask -- ci`