### PR TITLE
decision: improve tradeoff report readability

### DIFF
--- a/crates/perfgate-cli/tests/cli_md_tests.rs
+++ b/crates/perfgate-cli/tests/cli_md_tests.rs
@@ -256,8 +256,11 @@ fn test_md_tradeoff_receipt_stdout() {
         .stdout(predicate::str::contains(
             "tokenizer-slower-if-parser-faster",
         ))
-        .stdout(predicate::str::contains("Weighted Outcome"))
-        .stdout(predicate::str::contains("Probe Evidence"));
+        .stdout(predicate::str::contains("Summary"))
+        .stdout(predicate::str::contains("Weighted Workload"))
+        .stdout(predicate::str::contains("Probe Evidence"))
+        .stdout(predicate::str::contains("Accepted / Rejected Tradeoffs"))
+        .stdout(predicate::str::contains("Local Reproduction"));
 }
 
 /// Test markdown output contains verdict reasons when present

--- a/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
+++ b/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
@@ -121,13 +121,32 @@ fn performance_decision_example_runs_end_to_end() {
         tradeoff.rules[0].requirements[0].probe.as_deref(),
         Some("parser.batch_loop")
     );
-    assert_eq!(tradeoff.probes[0].name, "parser.batch_loop");
+    assert!(
+        tradeoff
+            .probes
+            .iter()
+            .any(|probe| probe.name == "parser.batch_loop")
+    );
+    assert!(
+        tradeoff
+            .probes
+            .iter()
+            .any(|probe| probe.name == "parser.tokenize")
+    );
 
     let decision =
         fs::read_to_string(root.join("artifacts/perfgate/decision.md")).expect("read decision md");
     assert!(decision.contains("perfgate tradeoff: warn"));
     assert!(decision.contains("tradeoff 'memory_for_probe_speed' accepted"));
+    assert!(decision.contains("Weighted Workload"));
     assert!(decision.contains("Probe Evidence"));
+    assert!(decision.contains("parser.tokenize"));
+    assert!(decision.contains("+2.07%"));
+    assert!(decision.contains("parser.batch_loop"));
+    assert!(decision.contains("-10.40%"));
+    assert!(decision.contains("Accepted / Rejected Tradeoffs"));
+    assert!(decision.contains("Evidence Files"));
+    assert!(decision.contains("Local Reproduction"));
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) {

--- a/crates/perfgate/src/app/render.rs
+++ b/crates/perfgate/src/app/render.rs
@@ -9,8 +9,9 @@ pub mod summary;
 
 use anyhow::Context;
 use perfgate_types::{
-    CompareReceipt, ComplexityGateResult, ComplexityGateStatus, Direction, Metric, MetricStatistic,
-    MetricStatus, TradeoffDecisionStatus, TradeoffReceipt,
+    CompareReceipt, ComplexityGateResult, ComplexityGateStatus, Delta, Direction, Metric,
+    MetricStatistic, MetricStatus, TradeoffDecisionStatus, TradeoffReceipt,
+    TradeoffRequirementOutcome,
 };
 use serde_json::json;
 
@@ -90,38 +91,38 @@ pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
     out.push_str(header);
     out.push_str("\n\n");
 
-    if let Some(scenario) = &tradeoff.scenario {
-        out.push_str(&format!("**Scenario:** `{scenario}`\n\n"));
-    }
-
+    out.push_str("### Summary\n\n");
+    out.push_str("| field | value |\n");
+    out.push_str("|---|---|\n");
     out.push_str(&format!(
-        "**Decision:** {} - {}\n\n",
+        "| final verdict | {} {} |\n",
         metric_status_icon(tradeoff.decision.status),
-        tradeoff.decision.reason
+        metric_status_str(tradeoff.decision.status)
     ));
+    if let Some(scenario) = &tradeoff.scenario {
+        out.push_str(&format!("| scenario | `{scenario}` |\n"));
+    }
+    out.push_str(&format!("| decision | {} |\n", tradeoff.decision.reason));
+    out.push_str(&format!(
+        "| accepted tradeoff | {} |\n",
+        if tradeoff.decision.accepted_tradeoff {
+            "yes"
+        } else {
+            "no"
+        }
+    ));
+    out.push('\n');
 
-    if !tradeoff.weighted_deltas.is_empty() {
-        out.push_str("### Weighted Outcome\n\n");
+    out.push_str("### Weighted Workload\n\n");
+    if tradeoff.weighted_deltas.is_empty() {
+        out.push_str("No weighted workload deltas recorded.\n\n");
+    } else {
         out.push_str("| metric | baseline | current | delta | status |\n");
         out.push_str("|---|---:|---:|---:|---|\n");
         for (metric_key, delta) in &tradeoff.weighted_deltas {
-            let (baseline, current, unit) = Metric::parse_key(metric_key)
-                .map(|metric| {
-                    (
-                        format_value(metric, delta.baseline),
-                        format_value(metric, delta.current),
-                        metric.display_unit(),
-                    )
-                })
-                .unwrap_or_else(|| {
-                    (
-                        format!("{:.3}", delta.baseline),
-                        format!("{:.3}", delta.current),
-                        "",
-                    )
-                });
+            let (baseline, current) = format_delta_values(metric_key, delta);
             out.push_str(&format!(
-                "| `{metric_key}` | {baseline} {unit} | {current} {unit} | {delta_pct} | {status} |\n",
+                "| `{metric_key}` | {baseline} | {current} | {delta_pct} | {status} |\n",
                 delta_pct = format_pct(delta.pct),
                 status = metric_status_icon(delta.status),
             ));
@@ -129,29 +130,59 @@ pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
         out.push('\n');
     }
 
-    if !tradeoff.rules.is_empty() {
-        out.push_str("### Tradeoff Rules\n\n");
-        out.push_str("| rule | decision | downgrade | requirements |\n");
-        out.push_str("|---|---|---|---|\n");
+    out.push_str("### Probe Evidence\n\n");
+    if tradeoff.probes.is_empty() {
+        out.push_str("No probe evidence attached.\n\n");
+    } else {
+        out.push_str("| probe | scope | metric | baseline | current | delta | status | reason |\n");
+        out.push_str("|---|---|---|---:|---:|---:|---|---|\n");
+        for probe in &tradeoff.probes {
+            let scope = probe
+                .scope
+                .map(|scope| format!("{:?}", scope).to_lowercase())
+                .unwrap_or_else(|| "-".to_string());
+            let reason = probe.reason.as_deref().unwrap_or("-");
+            if probe.deltas.is_empty() {
+                out.push_str(&format!(
+                    "| `{}` | `{}` | `-` | - | - | - | {} | {} |\n",
+                    probe.name,
+                    scope,
+                    metric_status_icon(probe.status),
+                    reason
+                ));
+                continue;
+            }
+            for (metric_key, delta) in &probe.deltas {
+                let (baseline, current) = format_delta_values(metric_key, delta);
+                out.push_str(&format!(
+                    "| `{}` | `{}` | `{}` | {} | {} | {} | {} | {} |\n",
+                    probe.name,
+                    scope,
+                    metric_key,
+                    baseline,
+                    current,
+                    format_pct(delta.pct),
+                    metric_status_icon(delta.status),
+                    reason
+                ));
+            }
+        }
+        out.push('\n');
+    }
+
+    out.push_str("### Accepted / Rejected Tradeoffs\n\n");
+    if tradeoff.rules.is_empty() {
+        out.push_str("No tradeoff rules evaluated.\n\n");
+    } else {
+        out.push_str("| rule | decision | downgrade | requirements | reason |\n");
+        out.push_str("|---|---|---|---|---|\n");
         for rule in &tradeoff.rules {
             let requirements = if rule.requirements.is_empty() {
                 "none".to_string()
             } else {
                 rule.requirements
                     .iter()
-                    .map(|requirement| {
-                        let observed = requirement
-                            .observed_change
-                            .map(format_pct)
-                            .unwrap_or_else(|| "missing".to_string());
-                        format!(
-                            "`{}` observed {} / required {} {}",
-                            requirement.metric,
-                            observed,
-                            format_pct(requirement.required_change),
-                            metric_status_icon(requirement.status)
-                        )
-                    })
+                    .map(render_tradeoff_requirement)
                     .collect::<Vec<_>>()
                     .join("<br>")
             };
@@ -159,47 +190,108 @@ pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
                 .downgrade_to
                 .map(tradeoff_downgrade_label)
                 .unwrap_or("-");
+            let reason = rule.reason.as_deref().unwrap_or("-");
             out.push_str(&format!(
-                "| `{}` | {} | `{}` | {} |\n",
+                "| `{}` | {} | `{}` | {} | {} |\n",
                 rule.name,
                 tradeoff_decision_label(rule.status),
                 downgrade,
-                requirements
-            ));
-        }
-        out.push('\n');
-    }
-
-    if !tradeoff.probes.is_empty() {
-        out.push_str("### Probe Evidence\n\n");
-        out.push_str("| probe | scope | status | reason |\n");
-        out.push_str("|---|---|---|---|\n");
-        for probe in &tradeoff.probes {
-            let scope = probe
-                .scope
-                .map(|scope| format!("{:?}", scope).to_lowercase())
-                .unwrap_or_else(|| "-".to_string());
-            let reason = probe.reason.as_deref().unwrap_or("-");
-            out.push_str(&format!(
-                "| `{}` | `{}` | {} | {} |\n",
-                probe.name,
-                scope,
-                metric_status_icon(probe.status),
+                requirements,
                 reason
             ));
         }
         out.push('\n');
     }
 
-    if !tradeoff.warnings.is_empty() {
-        out.push_str("### Warnings\n\n");
+    out.push_str("### Policy Reasons\n\n");
+    if tradeoff.verdict.reasons.is_empty() && tradeoff.warnings.is_empty() {
+        out.push_str("- none\n");
+    } else {
+        for reason in &tradeoff.verdict.reasons {
+            out.push_str(&format!("- `{reason}`\n"));
+        }
         for warning in &tradeoff.warnings {
             out.push_str(&format!("- {warning}\n"));
         }
-        out.push('\n');
     }
+    out.push('\n');
+
+    out.push_str("### Evidence Files\n\n");
+    out.push_str("- `scenario.json`: weighted workload evidence\n");
+    out.push_str("- `tradeoff.json`: structured tradeoff decision receipt\n");
+    out.push_str("- `decision.md`: this review summary\n");
+    if let Some(reference) = &tradeoff.baseline_ref {
+        if let Some(path) = &reference.path {
+            out.push_str(&format!("- baseline: `{path}`\n"));
+        }
+        if let Some(run_id) = &reference.run_id {
+            out.push_str(&format!("- baseline run: `{run_id}`\n"));
+        }
+    }
+    if let Some(reference) = &tradeoff.current_ref {
+        if let Some(path) = &reference.path {
+            out.push_str(&format!("- current: `{path}`\n"));
+        }
+        if let Some(run_id) = &reference.run_id {
+            out.push_str(&format!("- current run: `{run_id}`\n"));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("### Local Reproduction\n\n");
+    out.push_str("```bash\n");
+    out.push_str("perfgate decision evaluate --config perfgate.toml\n");
+    out.push_str("```\n\n");
 
     out
+}
+
+fn render_tradeoff_requirement(requirement: &TradeoffRequirementOutcome) -> String {
+    let observed = requirement
+        .observed_change
+        .map(format_pct)
+        .unwrap_or_else(|| "missing".to_string());
+    let target = requirement
+        .probe
+        .as_deref()
+        .map(|probe| format!("probe `{probe}` `{}`", requirement.metric))
+        .unwrap_or_else(|| format!("`{}`", requirement.metric));
+    let reason = requirement
+        .reason
+        .as_deref()
+        .map(|reason| format!(" ({reason})"))
+        .unwrap_or_default();
+    format!(
+        "{target} observed {observed} / required {required} {status}{reason}",
+        required = format_pct(requirement.required_change),
+        status = metric_status_icon(requirement.status)
+    )
+}
+
+fn format_delta_values(metric_key: &str, delta: &Delta) -> (String, String) {
+    Metric::parse_key(metric_key)
+        .map(|metric| {
+            (
+                format_value_with_unit(metric, delta.baseline),
+                format_value_with_unit(metric, delta.current),
+            )
+        })
+        .unwrap_or_else(|| {
+            (
+                format!("{:.3}", delta.baseline),
+                format!("{:.3}", delta.current),
+            )
+        })
+}
+
+fn format_value_with_unit(metric: Metric, value: f64) -> String {
+    let value = format_value(metric, value);
+    let unit = metric.display_unit();
+    if unit.is_empty() {
+        value
+    } else {
+        format!("{value} {unit}")
+    }
 }
 
 /// Render a complexity-gate section for markdown reports.
@@ -494,8 +586,8 @@ fn tradeoff_downgrade_label(downgrade: perfgate_types::TradeoffDowngrade) -> &'s
 mod tests {
     use super::*;
     use perfgate_types::{
-        BenchMeta, Budget, CompareRef, Delta, RunMeta, ToolInfo, TradeoffDecision,
-        TradeoffRuleOutcome, Verdict, VerdictCounts, VerdictStatus,
+        BenchMeta, Budget, CompareRef, Delta, ProbeScope, RunMeta, ToolInfo, TradeoffDecision,
+        TradeoffProbeOutcome, TradeoffRuleOutcome, Verdict, VerdictCounts, VerdictStatus,
     };
     use std::collections::BTreeMap;
 
@@ -629,7 +721,52 @@ mod tests {
                     reason: None,
                 }],
             }],
-            probes: Vec::new(),
+            probes: vec![
+                TradeoffProbeOutcome {
+                    name: "parser.tokenize".to_string(),
+                    scope: Some(ProbeScope::Local),
+                    weight: None,
+                    deltas: BTreeMap::from([(
+                        "wall_ms".to_string(),
+                        Delta {
+                            baseline: 100.0,
+                            current: 102.1,
+                            ratio: 1.021,
+                            pct: 0.021,
+                            regression: 0.021,
+                            cv: None,
+                            noise_threshold: None,
+                            statistic: MetricStatistic::Median,
+                            significance: None,
+                            status: MetricStatus::Warn,
+                        },
+                    )]),
+                    status: MetricStatus::Warn,
+                    reason: Some("local phase regressed".to_string()),
+                },
+                TradeoffProbeOutcome {
+                    name: "parser.batch_loop".to_string(),
+                    scope: Some(ProbeScope::Dominant),
+                    weight: None,
+                    deltas: BTreeMap::from([(
+                        "wall_ms".to_string(),
+                        Delta {
+                            baseline: 100.0,
+                            current: 89.6,
+                            ratio: 0.896,
+                            pct: -0.104,
+                            regression: 0.0,
+                            cv: None,
+                            noise_threshold: None,
+                            statistic: MetricStatistic::Median,
+                            significance: None,
+                            status: MetricStatus::Pass,
+                        },
+                    )]),
+                    status: MetricStatus::Pass,
+                    reason: None,
+                },
+            ],
             weighted_deltas,
             decision: TradeoffDecision {
                 accepted_tradeoff: true,
@@ -664,11 +801,22 @@ mod tests {
         let md = render_tradeoff_markdown(&receipt);
 
         assert!(md.contains("perfgate tradeoff: warn"));
-        assert!(md.contains("**Scenario:** `release_workload`"));
+        assert!(md.contains("### Summary"));
+        assert!(md.contains("| scenario | `release_workload` |"));
         assert!(md.contains("tradeoff 'memory_for_speed' accepted"));
+        assert!(md.contains("### Weighted Workload"));
         assert!(md.contains("| `max_rss_kb` |"));
+        assert!(md.contains("### Probe Evidence"));
+        assert!(md.contains("| `parser.tokenize` | `local` | `wall_ms`"));
+        assert!(md.contains("+2.10%"));
+        assert!(md.contains("| `parser.batch_loop` | `dominant` | `wall_ms`"));
+        assert!(md.contains("-10.40%"));
+        assert!(md.contains("### Accepted / Rejected Tradeoffs"));
         assert!(md.contains("| `memory_for_speed` | accepted | `warn` |"));
         assert!(md.contains("`wall_ms` observed -12.00% / required -10.00%"));
+        assert!(md.contains("### Policy Reasons"));
+        assert!(md.contains("### Evidence Files"));
+        assert!(md.contains("### Local Reproduction"));
     }
 
     #[test]

--- a/crates/perfgate/src/app/tradeoff.rs
+++ b/crates/perfgate/src/app/tradeoff.rs
@@ -7,7 +7,7 @@ use perfgate_types::{
     VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC, VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED,
     Verdict,
 };
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -68,7 +68,7 @@ impl TradeoffUseCase {
             }
             rule_outcomes.push(outcome);
         }
-        let probes = tradeoff_probe_outcomes(&rule_outcomes, &probe_index);
+        let probes = tradeoff_probe_outcomes(&probe_index);
 
         let mut verdict = verdict_from_weighted_deltas(&weighted_deltas);
         verdict
@@ -306,27 +306,17 @@ fn index_probe_compares(
 }
 
 fn tradeoff_probe_outcomes(
-    rule_outcomes: &[TradeoffRuleOutcome],
     probe_index: &BTreeMap<String, ProbeCompareObservation>,
 ) -> Vec<TradeoffProbeOutcome> {
-    let probe_names: BTreeSet<String> = rule_outcomes
-        .iter()
-        .flat_map(|rule| rule.requirements.iter())
-        .filter_map(|requirement| requirement.probe.clone())
-        .collect();
-
-    probe_names
-        .iter()
-        .filter_map(|name| {
-            let probe = probe_index.get(name)?;
-            Some(TradeoffProbeOutcome {
-                name: probe.name.clone(),
-                scope: probe.scope,
-                weight: None,
-                deltas: probe.deltas.clone(),
-                status: probe.status,
-                reason: probe.reasons.first().cloned(),
-            })
+    probe_index
+        .values()
+        .map(|probe| TradeoffProbeOutcome {
+            name: probe.name.clone(),
+            scope: probe.scope,
+            weight: None,
+            deltas: probe.deltas.clone(),
+            status: probe.status,
+            reason: probe.reasons.first().cloned(),
         })
         .collect()
 }
@@ -663,7 +653,8 @@ mod tests {
                 .as_deref()
                 .is_some_and(|reason| reason.contains("required probe"))
         );
-        assert_eq!(receipt.probes.len(), 0);
+        assert_eq!(receipt.probes.len(), 1);
+        assert_eq!(receipt.probes[0].name, "parser.tokenize");
         assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
     }
 }


### PR DESCRIPTION
## Summary
- restructure tradeoff/decision markdown into review-oriented sections: summary, weighted workload, probe evidence, accepted/rejected tradeoffs, policy reasons, evidence files, and local reproduction
- render probe-level metric deltas so local regressions and compensating improvements are visible in `decision.md`, `md --tradeoff`, comments, and action summaries
- carry scenario-attached probe compare observations into the tradeoff receipt for review while leaving tradeoff policy evaluation unchanged
- strengthen CLI/example assertions around the improved decision report

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate --all-features`
- `cargo test -p perfgate-cli --all-features`
- `cargo clippy -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- action-check`
- `git diff --check`
- `cargo run -p xtask -- ci`