### PR TITLE
docs: document performance decision workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,32 @@ The generated GitHub workflow uses the repository action:
 Use `@v0.15.1` for an exact patch pin, or `@v0.15` / `@v0` to follow the
 current compatible action tag.
 
+## Performance Decisions
+
+The normal gate is still `perfgate check`. When a repo has workload scenarios,
+probe evidence, or accepted tradeoff policy, use the one-command decision
+workflow after `check`:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+It writes `scenario.json`, `tradeoff.json`, and `decision.md` under the
+configured artifact directory. `decision.md` is the review surface: it explains
+the weighted workload result, probe movement, accepted or rejected tradeoff
+rules, policy reasons, evidence files, and the local reproduction command.
+
+In GitHub Actions, opt in with:
+
+```yaml
+- uses: EffortlessMetrics/perfgate@v0
+  with:
+    config: perfgate.toml
+    all: "true"
+    require_baseline: "true"
+    decision: "true"
+```
+
 ## Daily Use
 
 Run the whole configured suite:
@@ -172,6 +198,7 @@ Start with:
 
 For specific workflows:
 
+- [Performance Decisions](docs/PERFORMANCE_DECISIONS.md)
 - [Step-by-Step Pipeline](docs/PIPELINE.md)
 - [Baseline Server](docs/GETTING_STARTED_BASELINE_SERVER.md)
 - [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -84,13 +84,19 @@ scaling = { sizes = [100, 1000, 10000], expected = "O(n)", repeat = 7, r_squared
 
 ## Scenario Configuration
 
-Scenarios define a weighted workload model over configured benchmarks. After
-`perfgate check --config perfgate.toml --all` has produced compare receipts,
-evaluate the workload into a `perfgate.scenario.v1` receipt:
+Scenarios define a weighted workload model over configured benchmarks. The
+taught path is to run the whole structured decision workflow after `check` has
+produced compare receipts:
 
 ```bash
-perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scenario.json
+perfgate check --config perfgate.toml --all
+perfgate decision evaluate --config perfgate.toml
 ```
+
+`decision evaluate` writes `scenario.json`, `tradeoff.json`, and `decision.md`
+under `[defaults].out_dir` unless output paths are overridden. Use
+`perfgate scenario evaluate` directly only when debugging or composing a custom
+pipeline.
 
 Each `[[scenario]]` references one `[[bench]]`. By default, `scenario evaluate`
 reads `compare.json` from `[defaults].out_dir/<bench>/compare.json`. Use
@@ -157,7 +163,18 @@ When `probe` is set, `tradeoff evaluate` follows the scenario component's
 delta. Missing probe evidence leaves the requirement unsatisfied; it does not
 silently fall back to weighted scenario deltas.
 
-Evaluate the rules against a scenario receipt to produce
+For the normal local workflow, run scenario evaluation, tradeoff evaluation, and
+decision Markdown rendering together:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+It uses the configured artifact directory for compare lookups and writes
+`scenario.json`, `tradeoff.json`, and `decision.md` there by default.
+
+The primitive commands remain available when you need to inspect an intermediate
+receipt. Evaluate the rules against a scenario receipt to produce
 `perfgate.tradeoff.v1` decision evidence:
 
 ```bash
@@ -170,15 +187,6 @@ Render the decision for local review or PR comments:
 perfgate md --tradeoff artifacts/perfgate/tradeoff.json --out artifacts/perfgate/tradeoff.md
 perfgate comment --tradeoff artifacts/perfgate/tradeoff.json --dry-run
 ```
-
-To run the structured decision path as one local workflow, use:
-
-```bash
-perfgate decision evaluate --config perfgate.toml
-```
-
-It uses the configured artifact directory for compare lookups and writes
-`scenario.json`, `tradeoff.json`, and `decision.md` there by default.
 
 `min_improvement_ratio` follows metric direction. For lower-is-better metrics
 such as `wall_ms`, `1.10` means the baseline/current ratio must be at least

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -126,6 +126,12 @@ defers the final policy result to the decision receipt so an accepted tradeoff
 can downgrade the result according to configured policy. Runtime errors and
 `--fail-on-warn` failures still stop the action.
 
+Use decision mode when `perfgate.toml` contains `[[scenario]]` weights,
+`[[tradeoff]]` policy, or probe comparison evidence. The lower-level
+`scenario evaluate`, `tradeoff evaluate`, and `md --tradeoff` commands remain
+available for custom pipelines, but the action path should usually be the
+single `decision: "true"` input.
+
 ## 4) Manual PR performance gate workflow
 
 Create `.github/workflows/perfgate.yml`:

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -1,0 +1,164 @@
+# Performance Decisions
+
+perfgate's normal gate answers whether configured benchmarks stayed inside
+their budgets:
+
+```bash
+perfgate check --config perfgate.toml --all
+```
+
+The decision workflow answers a richer review question:
+
+```text
+What moved, where did it move, and is the tradeoff acceptable under policy?
+```
+
+Use it after `check` has produced compare receipts:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+By default this writes:
+
+```text
+artifacts/perfgate/
+  scenario.json
+  tradeoff.json
+  decision.md
+```
+
+`decision.md` is the human review surface. It summarizes the weighted workload,
+probe evidence, accepted or rejected tradeoff rules, policy reasons, evidence
+files, and the local reproduction command.
+
+## Workflow Levels
+
+### Normal Gate
+
+Use `check` for the first CI gate:
+
+```bash
+perfgate check --config perfgate.toml --all
+perfgate baseline promote --config perfgate.toml --all
+```
+
+This is still the default path. It is conservative, explicit, and works with
+local checked-in baselines.
+
+### Decision Workflow
+
+Use `decision evaluate` when the repo has scenario weights or tradeoff rules:
+
+```bash
+perfgate check --config perfgate.toml --all
+perfgate decision evaluate --config perfgate.toml
+```
+
+This command runs the structured evidence chain in one step:
+
+```text
+scenario evaluate
+tradeoff evaluate
+markdown rendering
+```
+
+It does not run benchmarks. It consumes the receipts already produced by
+`check`.
+
+### Probe Evidence
+
+Named probes explain internal phase movement. Ingest probe observations from any
+language or harness:
+
+```bash
+perfgate ingest probes --file probes.jsonl --out artifacts/perfgate/probes.json
+```
+
+Compare probe receipts when you want deltas such as `parser.tokenize +2.1%`:
+
+```bash
+perfgate probe compare --baseline baselines/probes.json --current artifacts/perfgate/probes.json --out artifacts/perfgate/probe-compare.json
+```
+
+Attach that receipt to a scenario with `probe_compare`:
+
+```toml
+[[scenario]]
+name = "large_file_parse"
+bench = "large-file"
+weight = 0.75
+probe_compare = "artifacts/perfgate/probe-compare.json"
+```
+
+Probe evidence is advisory until a tradeoff rule explicitly requires it.
+
+## Config Shape
+
+Scenarios model workload importance:
+
+```toml
+[[scenario]]
+name = "large_file_parse"
+bench = "large-file"
+weight = 0.75
+
+[[scenario]]
+name = "small_edit"
+bench = "small-edit"
+weight = 0.25
+```
+
+Tradeoff rules make accepted exchanges explicit:
+
+```toml
+[[tradeoff]]
+name = "tokenizer-cost-for-batch-loop-win"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = 1.10
+```
+
+When `probe` is present, the requirement is satisfied only by that named probe's
+delta from scenario-attached probe comparison evidence.
+
+## GitHub Actions
+
+Enable decision mode in the repository action:
+
+```yaml
+- uses: EffortlessMetrics/perfgate@v0
+  with:
+    config: perfgate.toml
+    all: "true"
+    require_baseline: "true"
+    decision: "true"
+```
+
+Decision mode runs `perfgate decision evaluate --config perfgate.toml` after
+`check`, uploads the decision artifacts, and appends `decision.md` to the job
+summary. If `check` exits `2` for a policy failure, the action can defer the
+final result to the decision receipt so an accepted tradeoff owns the final
+policy outcome.
+
+## Primitive Commands
+
+The lower-level commands are still useful for debugging and custom pipelines:
+
+```bash
+perfgate scenario evaluate --config perfgate.toml --out artifacts/perfgate/scenario.json
+perfgate tradeoff evaluate --config perfgate.toml --scenario artifacts/perfgate/scenario.json --out artifacts/perfgate/tradeoff.json
+perfgate md --tradeoff artifacts/perfgate/tradeoff.json --out artifacts/perfgate/decision.md
+```
+
+Prefer `perfgate decision evaluate` for the normal local and CI workflow.
+
+## Example
+
+For a deterministic runnable fixture that shows a memory warning accepted by a
+probe-backed speed improvement, see
+[`examples/performance-decision`](../examples/performance-decision/README.md).

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -21,6 +21,17 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 | `perfgate.dependency_event.v1` | fleet API | Dependency-change event with performance impact |
 | `perfgate.fleet_alert.v1` | fleet API | Fleet-wide dependency regression alert |
 
+For the normal structured-decision workflow, users should not run these receipt
+producers one by one. Run:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+That command reads the configured compare receipts, evaluates scenarios,
+evaluates tradeoff rules, and renders `decision.md` alongside
+`scenario.json` and `tradeoff.json`.
+
 ## Additional Generated Schemas
 
 perfgate also commits generated schemas for tooling and editor integration:
@@ -82,7 +93,8 @@ durable deltas that scenario and tradeoff workflows can attach.
 
 ## Scenario Evaluation
 
-`perfgate scenario evaluate` reads configured `[[scenario]]` entries and their
+`perfgate scenario evaluate` is the primitive command behind
+`decision evaluate`. It reads configured `[[scenario]]` entries and their
 benchmark compare receipts, then writes a `perfgate.scenario.v1` weighted
 workload receipt:
 
@@ -99,7 +111,8 @@ probe evidence does not change the scenario verdict yet.
 
 ## Tradeoff Evaluation
 
-`perfgate tradeoff evaluate` reads configured `[[tradeoff]]` rules and a
+`perfgate tradeoff evaluate` is the primitive command behind
+`decision evaluate`. It reads configured `[[tradeoff]]` rules and a
 `perfgate.scenario.v1` receipt, then writes a `perfgate.tradeoff.v1` decision
 receipt:
 
@@ -122,8 +135,8 @@ perfgate md --tradeoff artifacts/perfgate/tradeoff.json
 perfgate comment --tradeoff artifacts/perfgate/tradeoff.json --dry-run
 ```
 
-For the paved local workflow, `decision evaluate` runs the scenario evaluation,
-tradeoff evaluation, and markdown rendering steps together:
+For the paved local workflow, use `decision evaluate` instead of manually
+chaining the primitive commands:
 
 ```bash
 perfgate decision evaluate --config perfgate.toml

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -13,6 +13,10 @@ perfgate probe compare --baseline artifacts/perfgate/large-file/probes-baseline.
 perfgate decision evaluate --config examples/performance-decision/perfgate.toml
 ```
 
+`decision evaluate` is the command to teach users. It consumes the configured
+compare and probe-compare receipts, evaluates scenario weights and tradeoff
+policy, then writes the review-ready Markdown.
+
 Expected shape:
 
 ```text


### PR DESCRIPTION
## Summary
- add a dedicated Performance Decisions guide that teaches `perfgate decision evaluate` as the advanced workflow
- update README, config, schema, GitHub Actions, and example docs to present the wrapper before lower-level primitives
- keep `scenario evaluate`, `tradeoff evaluate`, `probe compare`, and `md --tradeoff` documented as debugging/custom-pipeline commands

## Validation
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test --files docs/PERFORMANCE_DECISIONS.md`
- `cargo run -p xtask -- action-check`
- `git diff --check`