### PR TITLE
decision: run configured probe comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ It writes `scenario.json`, `tradeoff.json`, and `decision.md` under the
 configured artifact directory. `decision.md` is the review surface: it explains
 the weighted workload result, probe movement, accepted or rejected tradeoff
 rules, policy reasons, evidence files, and the local reproduction command.
+When scenarios configure probe baseline/current paths, `decision evaluate` also
+writes the configured `probe-compare.json` before evaluating the decision.
 
 In GitHub Actions, opt in with:
 

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -3430,6 +3430,89 @@ fn evaluate_configured_scenarios(
     })
 }
 
+fn run_configured_probe_compares(
+    config: &ConfigFile,
+    scenario: Option<&str>,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    for scenario in select_configured_scenarios(config, scenario)? {
+        let Some((baseline_path, current_path, out_path)) =
+            configured_probe_compare_paths(scenario)?
+        else {
+            continue;
+        };
+
+        let baseline: ProbeReceipt =
+            read_json_from_location(&baseline_path).with_context(|| {
+                format!(
+                    "read scenario '{}' baseline probe receipt {}",
+                    scenario.name,
+                    baseline_path.display()
+                )
+            })?;
+        let current: ProbeReceipt = read_json_from_location(&current_path).with_context(|| {
+            format!(
+                "read scenario '{}' current probe receipt {}",
+                scenario.name,
+                current_path.display()
+            )
+        })?;
+
+        let outcome = ProbeCompareUseCase::compare(ProbeCompareRequest {
+            baseline_ref: CompareRef {
+                path: Some(baseline_path.display().to_string()),
+                run_id: Some(baseline.run.id.clone()),
+            },
+            current_ref: CompareRef {
+                path: Some(current_path.display().to_string()),
+                run_id: Some(current.run.id.clone()),
+            },
+            baseline,
+            current,
+            tool: tool_info(),
+        })?;
+
+        write_json_to_location(&out_path, &outcome.receipt, pretty)?;
+        eprintln!("Probe compare receipt written to {}", out_path.display());
+    }
+
+    Ok(())
+}
+
+fn configured_probe_compare_paths(
+    scenario: &ScenarioConfigFile,
+) -> anyhow::Result<Option<(PathBuf, PathBuf, PathBuf)>> {
+    let has_probe_inputs = scenario.probe_baseline.is_some() || scenario.probe_current.is_some();
+    if !has_probe_inputs {
+        return Ok(None);
+    }
+
+    let Some(baseline) = scenario.probe_baseline.as_deref() else {
+        anyhow::bail!(
+            "scenario '{}' probe comparison requires probe_baseline, probe_current, and probe_compare",
+            scenario.name
+        );
+    };
+    let Some(current) = scenario.probe_current.as_deref() else {
+        anyhow::bail!(
+            "scenario '{}' probe comparison requires probe_baseline, probe_current, and probe_compare",
+            scenario.name
+        );
+    };
+    let Some(out) = scenario.probe_compare.as_deref() else {
+        anyhow::bail!(
+            "scenario '{}' probe comparison requires probe_baseline, probe_current, and probe_compare",
+            scenario.name
+        );
+    };
+
+    Ok(Some((
+        PathBuf::from(baseline),
+        PathBuf::from(current),
+        PathBuf::from(out),
+    )))
+}
+
 fn select_configured_scenarios<'a>(
     config: &'a ConfigFile,
     scenario: Option<&str>,
@@ -3596,6 +3679,8 @@ fn execute_decision_evaluate(args: DecisionEvaluateArgs) -> anyhow::Result<()> {
         .decision_out
         .clone()
         .unwrap_or_else(|| out_dir.join("decision.md"));
+
+    run_configured_probe_compares(&config, args.scenario.as_deref(), args.pretty)?;
 
     let scenario_outcome = evaluate_configured_scenarios(
         config.clone(),

--- a/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
+++ b/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
@@ -49,18 +49,17 @@ fn performance_decision_example_runs_end_to_end() {
     perfgate_cmd()
         .current_dir(root)
         .args([
-            "probe",
-            "compare",
-            "--baseline",
-            "artifacts/perfgate/large-file/probes-baseline.json",
-            "--current",
-            "artifacts/perfgate/large-file/probes-current.json",
-            "--out",
-            "artifacts/perfgate/large-file/probe-compare.json",
+            "decision",
+            "evaluate",
+            "--config",
+            "examples/performance-decision/perfgate.toml",
         ])
         .assert()
         .success()
-        .stderr(predicate::str::contains("Probe compare receipt written"));
+        .stderr(predicate::str::contains("Probe compare receipt written"))
+        .stderr(predicate::str::contains("Scenario receipt written"))
+        .stderr(predicate::str::contains("Tradeoff receipt written"))
+        .stderr(predicate::str::contains("Decision markdown written"));
 
     let probe_compare: perfgate_types::ProbeCompareReceipt = serde_json::from_str(
         &fs::read_to_string(root.join("artifacts/perfgate/large-file/probe-compare.json"))
@@ -79,20 +78,6 @@ fn performance_decision_example_runs_end_to_end() {
             .iter()
             .any(|probe| probe.name == "parser.batch_loop")
     );
-
-    perfgate_cmd()
-        .current_dir(root)
-        .args([
-            "decision",
-            "evaluate",
-            "--config",
-            "examples/performance-decision/perfgate.toml",
-        ])
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("Scenario receipt written"))
-        .stderr(predicate::str::contains("Tradeoff receipt written"))
-        .stderr(predicate::str::contains("Decision markdown written"));
 
     let scenario: perfgate_types::ScenarioReceipt = serde_json::from_str(
         &fs::read_to_string(root.join("artifacts/perfgate/scenario.json"))

--- a/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
+++ b/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
@@ -65,7 +65,12 @@ min_improvement_ratio = 1.10
     .expect("write config");
 }
 
-fn write_probe_config(path: &Path, probe_compare_path: &Path) {
+fn write_probe_config(
+    path: &Path,
+    probe_baseline_path: &Path,
+    probe_current_path: &Path,
+    probe_compare_path: &Path,
+) {
     fs::write(
         path,
         format!(
@@ -87,6 +92,8 @@ command = [{}]
 name = "release_workload"
 weight = 1.0
 bench = "parser"
+probe_baseline = "{}"
+probe_current = "{}"
 probe_compare = "{}"
 
 [[tradeoff]]
@@ -100,6 +107,8 @@ probe = "parser.batch_loop"
 min_improvement_ratio = 1.10
 "#,
             command_toml_array(&success_command()),
+            toml_path(probe_baseline_path),
+            toml_path(probe_current_path),
             toml_path(probe_compare_path)
         ),
     )
@@ -242,8 +251,15 @@ fn decision_evaluate_runs_structured_decision_workflow() {
     let temp_dir = tempdir().expect("create temp dir");
     let root = temp_dir.path();
     let config_path = root.join("perfgate.toml");
+    let probe_baseline_path = root.join("artifacts/perfgate/parser/probes-baseline.json");
+    let probe_current_path = root.join("artifacts/perfgate/parser/probes-current.json");
     let probe_compare_path = root.join("artifacts/perfgate/parser/probe-compare.json");
-    write_probe_config(&config_path, &probe_compare_path);
+    write_probe_config(
+        &config_path,
+        &probe_baseline_path,
+        &probe_current_path,
+        &probe_compare_path,
+    );
 
     perfgate_cmd()
         .current_dir(root)
@@ -274,13 +290,15 @@ fn decision_evaluate_runs_structured_decision_workflow() {
     let compare_path = root.join("artifacts/perfgate/parser/compare.json");
     assert!(compare_path.exists(), "check should write compare receipt");
     write_controlled_compare_receipt_with_wall(&compare_path, 96.0);
-    write_probe_compare_receipt(&probe_compare_path, 80.0);
+    write_probe_receipt(&probe_baseline_path, 100.0);
+    write_probe_receipt(&probe_current_path, 80.0);
 
     perfgate_cmd()
         .current_dir(root)
         .args(["decision", "evaluate", "--config", "perfgate.toml"])
         .assert()
         .success()
+        .stderr(predicate::str::contains("Probe compare receipt written"))
         .stderr(predicate::str::contains("Scenario receipt written"))
         .stderr(predicate::str::contains("Tradeoff receipt written"))
         .stderr(predicate::str::contains("Decision markdown written"));
@@ -288,6 +306,32 @@ fn decision_evaluate_runs_structured_decision_workflow() {
     let scenario_path = root.join("artifacts/perfgate/scenario.json");
     let tradeoff_path = root.join("artifacts/perfgate/tradeoff.json");
     let decision_path = root.join("artifacts/perfgate/decision.md");
+    assert!(
+        probe_compare_path.exists(),
+        "decision evaluate should write configured probe compare receipt"
+    );
+
+    let probe_compare: perfgate_types::ProbeCompareReceipt = serde_json::from_str(
+        &fs::read_to_string(&probe_compare_path).expect("read probe compare receipt"),
+    )
+    .expect("probe compare receipt should deserialize");
+    assert_eq!(probe_compare.schema, "perfgate.probe_compare.v1");
+    let expected_probe_baseline = toml_path(&probe_baseline_path);
+    let expected_probe_current = toml_path(&probe_current_path);
+    assert_eq!(
+        probe_compare
+            .baseline_ref
+            .as_ref()
+            .and_then(|r| r.path.as_deref()),
+        Some(expected_probe_baseline.as_str())
+    );
+    assert_eq!(
+        probe_compare
+            .current_ref
+            .as_ref()
+            .and_then(|r| r.path.as_deref()),
+        Some(expected_probe_current.as_str())
+    );
 
     let scenario: perfgate_types::ScenarioReceipt =
         serde_json::from_str(&fs::read_to_string(scenario_path).expect("read scenario receipt"))
@@ -372,12 +416,12 @@ fn write_controlled_compare_receipt_with_wall(path: &Path, wall_current: f64) {
     .expect("write controlled compare receipt");
 }
 
-fn write_probe_compare_receipt(path: &Path, wall_current: f64) {
+fn write_probe_receipt(path: &Path, wall_ms: f64) {
     let receipt = json!({
-        "schema": "perfgate.probe_compare.v1",
+        "schema": "perfgate.probe.v1",
         "tool": {"name": "perfgate", "version": "0.16.0"},
         "run": {
-            "id": "probe-compare-run",
+            "id": format!("probe-run-{wall_ms}"),
             "started_at": "2026-05-08T00:00:00Z",
             "ended_at": "2026-05-08T00:00:01Z",
             "host": {"os": "linux", "arch": "x86_64"}
@@ -386,32 +430,20 @@ fn write_probe_compare_receipt(path: &Path, wall_current: f64) {
         "probes": [{
             "name": "parser.batch_loop",
             "scope": "dominant",
-            "baseline_count": 1,
-            "current_count": 1,
-            "deltas": {
+            "metrics": {
                 "wall_ms": {
-                    "baseline": 100.0,
-                    "current": wall_current,
-                    "ratio": wall_current / 100.0,
-                    "pct": (wall_current - 100.0) / 100.0,
-                    "regression": 0.0,
-                    "status": "pass"
+                    "value": wall_ms,
+                    "unit": "ms"
                 }
-            },
-            "status": "pass"
-        }],
-        "verdict": {
-            "status": "pass",
-            "counts": {"pass": 1, "warn": 0, "fail": 0, "skip": 0},
-            "reasons": []
-        }
+            }
+        }]
     });
 
     fs::write(
         path,
-        serde_json::to_string_pretty(&receipt).expect("serialize probe compare receipt"),
+        serde_json::to_string_pretty(&receipt).expect("serialize probe receipt"),
     )
-    .expect("write probe compare receipt");
+    .expect("write probe receipt");
 }
 
 fn toml_path(path: &Path) -> String {

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1436,6 +1436,27 @@ impl ConfigFile {
                     scenario.name, scenario.bench
                 ));
             }
+            let has_probe_inputs =
+                scenario.probe_baseline.is_some() || scenario.probe_current.is_some();
+            if has_probe_inputs
+                && (scenario
+                    .probe_baseline
+                    .as_ref()
+                    .is_none_or(|path| path.trim().is_empty())
+                    || scenario
+                        .probe_current
+                        .as_ref()
+                        .is_none_or(|path| path.trim().is_empty())
+                    || scenario
+                        .probe_compare
+                        .as_ref()
+                        .is_none_or(|path| path.trim().is_empty()))
+            {
+                return Err(format!(
+                    "scenario '{}' probe comparison requires probe_baseline, probe_current, and probe_compare",
+                    scenario.name
+                ));
+            }
         }
         for rule in &self.tradeoffs {
             if rule.name.trim().is_empty() {
@@ -1606,6 +1627,18 @@ pub struct ScenarioConfigFile {
     /// probes part of the scenario verdict.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub probe_compare: Option<String>,
+
+    /// Optional baseline probe receipt path. When paired with `probe_current`
+    /// and `probe_compare`, `perfgate decision evaluate` creates the probe
+    /// comparison receipt before scenario evaluation.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub probe_baseline: Option<String>,
+
+    /// Optional current probe receipt path. When paired with `probe_baseline`
+    /// and `probe_compare`, `perfgate decision evaluate` creates the probe
+    /// comparison receipt before scenario evaluation.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub probe_current: Option<String>,
 }
 
 /// How ratcheting should update budgets.
@@ -2193,6 +2226,8 @@ weight = 0.35
 bench = "large-file"
 description = "Parse a large file"
 probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
+probe_baseline = "baselines/large-file-probes.json"
+probe_current = "artifacts/perfgate/large-file/probes.json"
 "#,
         )
         .expect("parse config");
@@ -2204,6 +2239,14 @@ probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
         assert_eq!(
             config.scenarios[0].probe_compare.as_deref(),
             Some("artifacts/perfgate/large-file/probe-compare.json")
+        );
+        assert_eq!(
+            config.scenarios[0].probe_baseline.as_deref(),
+            Some("baselines/large-file-probes.json")
+        );
+        assert_eq!(
+            config.scenarios[0].probe_current.as_deref(),
+            Some("artifacts/perfgate/large-file/probes.json")
         );
         assert!(config.validate().is_ok());
     }
@@ -2226,6 +2269,8 @@ command = ["echo", "large"]
             description: None,
             compare: None,
             probe_compare: None,
+            probe_baseline: None,
+            probe_current: None,
         }];
         assert!(config.validate().unwrap_err().contains("unknown benchmark"));
 
@@ -2236,6 +2281,20 @@ command = ["echo", "large"]
         config.scenarios[0].weight = 1.0;
         config.scenarios[0].name = " ".to_string();
         assert!(config.validate().unwrap_err().contains("must not be empty"));
+
+        config.scenarios[0].name = "large-file-workload".to_string();
+        config.scenarios[0].probe_baseline = Some("baselines/probes.json".to_string());
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .contains("probe comparison requires")
+        );
+
+        config.scenarios[0].probe_current = Some("artifacts/perfgate/probes.json".to_string());
+        config.scenarios[0].probe_compare =
+            Some("artifacts/perfgate/probe-compare.json".to_string());
+        assert!(config.validate().is_ok());
     }
 
     // ---- Serde round-trip unit tests ----

--- a/crates/perfgate/src/app/scenario.rs
+++ b/crates/perfgate/src/app/scenario.rs
@@ -428,6 +428,8 @@ mod tests {
                 description: None,
                 compare: None,
                 probe_compare: None,
+                probe_baseline: None,
+                probe_current: None,
             },
             compare_ref: CompareRef {
                 path: Some(format!("artifacts/{bench}/compare.json")),

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -105,6 +105,12 @@ else. Use `probe_compare = "path/to/probe-compare.json"` to attach advisory
 probe-level evidence from `perfgate probe compare`; scenario verdicts still come
 from benchmark compare receipts and weighted deltas.
 
+When a scenario has `probe_baseline`, `probe_current`, and `probe_compare`,
+`perfgate decision evaluate` runs the probe comparison first and writes the
+configured `probe_compare` receipt before scenario evaluation. Existing
+`probe_compare`-only configs still work when another tool or command already
+wrote the receipt.
+
 ```toml
 [[bench]]
 name = "large-file"
@@ -118,6 +124,8 @@ command = ["cargo", "bench", "--bench", "small_edit"]
 name = "large_file_parse"
 weight = 0.35
 bench = "large-file"
+probe_baseline = "baselines/large-file-probes.json"
+probe_current = "artifacts/perfgate/large-file/probes.json"
 probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
 
 [[scenario]]

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -132,6 +132,10 @@ Use decision mode when `perfgate.toml` contains `[[scenario]]` weights,
 available for custom pipelines, but the action path should usually be the
 single `decision: "true"` input.
 
+If scenarios configure `probe_baseline`, `probe_current`, and `probe_compare`,
+decision mode also creates the probe comparison receipt before evaluating the
+scenario and tradeoff receipts.
+
 ## 4) Manual PR performance gate workflow
 
 Create `.github/workflows/perfgate.yml`:

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -91,6 +91,19 @@ weight = 0.75
 probe_compare = "artifacts/perfgate/probe-compare.json"
 ```
 
+Or let `decision evaluate` create it when baseline and current probe receipts
+are configured:
+
+```toml
+[[scenario]]
+name = "large_file_parse"
+bench = "large-file"
+weight = 0.75
+probe_baseline = "baselines/large-file-probes.json"
+probe_current = "artifacts/perfgate/large-file-probes.json"
+probe_compare = "artifacts/perfgate/large-file-probe-compare.json"
+```
+
 Probe evidence is advisory until a tradeoff rule explicitly requires it.
 
 ## Config Shape

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -109,6 +109,10 @@ delta evidence. Scenario receipts record the probe names and a
 `probe_compare_ref`; consumers follow that reference for full probe deltas, and
 probe evidence does not change the scenario verdict yet.
 
+When `probe_baseline`, `probe_current`, and `probe_compare` are configured on a
+scenario, `perfgate decision evaluate` writes the `perfgate.probe_compare.v1`
+receipt before it invokes this primitive scenario evaluation step.
+
 ## Tradeoff Evaluation
 
 `perfgate tradeoff evaluate` is the primitive command behind

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -9,13 +9,12 @@ Run from the repository root:
 ```bash
 perfgate ingest probes --file examples/performance-decision/probes-baseline.jsonl --out artifacts/perfgate/large-file/probes-baseline.json
 perfgate ingest probes --file examples/performance-decision/probes-current.jsonl --out artifacts/perfgate/large-file/probes-current.json
-perfgate probe compare --baseline artifacts/perfgate/large-file/probes-baseline.json --current artifacts/perfgate/large-file/probes-current.json --out artifacts/perfgate/large-file/probe-compare.json
 perfgate decision evaluate --config examples/performance-decision/perfgate.toml
 ```
 
 `decision evaluate` is the command to teach users. It consumes the configured
-compare and probe-compare receipts, evaluates scenario weights and tradeoff
-policy, then writes the review-ready Markdown.
+compare receipts, runs the configured probe comparison, evaluates scenario
+weights and tradeoff policy, then writes the review-ready Markdown.
 
 Expected shape:
 
@@ -35,6 +34,6 @@ The fixture models a memory-for-speed decision:
 - the final decision is `warn` with an accepted tradeoff.
 
 `parser.tokenize` is also present in the probe comparison and regresses
-slightly. That evidence remains visible in `probe-compare.json`; the tradeoff
-rule accepts the memory regression only because the dominant batch-loop probe
-improves.
+slightly. That evidence remains visible in the generated `probe-compare.json`;
+the tradeoff rule accepts the memory regression only because the dominant
+batch-loop probe improves.

--- a/examples/performance-decision/perfgate.toml
+++ b/examples/performance-decision/perfgate.toml
@@ -17,6 +17,8 @@ name = "large_file_parse"
 weight = 0.75
 bench = "large-file"
 compare = "examples/performance-decision/receipts/large-file.compare.json"
+probe_baseline = "artifacts/perfgate/large-file/probes-baseline.json"
+probe_current = "artifacts/perfgate/large-file/probes-current.json"
 probe_compare = "artifacts/perfgate/large-file/probe-compare.json"
 
 [[scenario]]

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -502,8 +502,22 @@
         "name": {
           "type": "string"
         },
+        "probe_baseline": {
+          "description": "Optional baseline probe receipt path. When paired with `probe_current`\nand `probe_compare`, `perfgate decision evaluate` creates the probe\ncomparison receipt before scenario evaluation.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "probe_compare": {
           "description": "Optional probe comparison receipt path. When present, scenario\nevaluation attaches probe names and a receipt reference without making\nprobes part of the scenario verdict.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "probe_current": {
+          "description": "Optional current probe receipt path. When paired with `probe_baseline`\nand `probe_compare`, `perfgate decision evaluate` creates the probe\ncomparison receipt before scenario evaluation.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
## Summary
- add scenario-level `probe_baseline` and `probe_current` config so `decision evaluate` can create the configured `probe_compare` receipt before scenario evaluation
- update the structured-decision e2e and performance-decision example so the taught path is `ingest probes -> decision evaluate`, without a manual `probe compare` step
- document the generated probe-compare flow and regenerate the config schema

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-types config_file_parses_weighted_scenarios --all-features`
- `cargo test -p perfgate-types config_file_validate_rejects_invalid_scenarios --all-features`
- `cargo test -p perfgate-cli --test cli_structured_decision_e2e_tests decision_evaluate_runs_structured_decision_workflow --all-features`
- `cargo test -p perfgate-cli --test cli_performance_decision_example_tests --all-features`
- `cargo run -p xtask -- schema`
- `cargo run -p xtask -- schema-check`
- `cargo test -p perfgate --all-features`
- `cargo test -p perfgate-types --all-features`
- `cargo test -p perfgate-cli --all-features`
- `cargo clippy -p perfgate -p perfgate-types -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- doc-test --files docs/PERFORMANCE_DECISIONS.md`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`