### PR TITLE
tradeoff: constrain accepted local regressions

### DIFF
--- a/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
+++ b/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
@@ -133,6 +133,59 @@ fn test_tradeoff_evaluate_uses_probe_requirement() {
 }
 
 #[test]
+fn test_tradeoff_evaluate_enforces_local_regression_cap() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+    let probe_compare_path = temp_dir.path().join("probe-compare.json");
+    let output_path = temp_dir.path().join("tradeoff.json");
+
+    write_probe_tradeoff_config_with_allow(&config_path, 1.10, "warn", 0.03);
+    write_probe_compare_receipt_many(
+        &probe_compare_path,
+        &[
+            ("parser.batch_loop", 80.0, "dominant"),
+            ("parser.tokenize", 105.0, "local"),
+        ],
+    );
+    write_scenario_receipt_with_probe_ref(&scenario_path, 96.0, "fail", &probe_compare_path);
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .code(2);
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should be JSON");
+
+    assert_eq!(receipt["decision"]["accepted_tradeoff"], false);
+    assert_eq!(receipt["rules"][0]["status"], "rejected");
+    assert_eq!(
+        receipt["rules"][0]["allowances"][0]["probe"],
+        "parser.tokenize"
+    );
+    assert_eq!(
+        receipt["rules"][0]["allowances"][0]["satisfied"].as_bool(),
+        Some(false)
+    );
+    assert!(
+        receipt["rules"][0]["allowances"][0]["reason"]
+            .as_str()
+            .expect("allowance reason")
+            .contains("exceeds cap")
+    );
+}
+
+#[test]
 fn test_tradeoff_evaluate_rejects_config_without_tradeoffs() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let config_path = temp_dir.path().join("perfgate.toml");
@@ -188,6 +241,35 @@ downgrade_to = "{downgrade_to}"
 metric = "wall_ms"
 probe = "parser.batch_loop"
 min_improvement_ratio = {min_improvement_ratio}
+"#
+        ),
+    )
+    .expect("failed to write config");
+}
+
+fn write_probe_tradeoff_config_with_allow(
+    path: &Path,
+    min_improvement_ratio: f64,
+    downgrade_to: &str,
+    max_regression: f64,
+) {
+    fs::write(
+        path,
+        format!(
+            r#"[[tradeoff]]
+name = "memory_for_probe_speed"
+if_failed = "max_rss_kb"
+downgrade_to = "{downgrade_to}"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = {min_improvement_ratio}
+
+[[tradeoff.allow]]
+metric = "wall_ms"
+probe = "parser.tokenize"
+max_regression = {max_regression}
 "#
         ),
     )
@@ -300,6 +382,10 @@ fn write_scenario_receipt_inner(
 }
 
 fn write_probe_compare_receipt(path: &Path, probe: &str, wall_current: f64) {
+    write_probe_compare_receipt_many(path, &[(probe, wall_current, "dominant")]);
+}
+
+fn write_probe_compare_receipt_many(path: &Path, probes: &[(&str, f64, &str)]) {
     let receipt = json!({
         "schema": "perfgate.probe_compare.v1",
         "tool": {"name": "perfgate", "version": "0.16.0"},
@@ -310,23 +396,30 @@ fn write_probe_compare_receipt(path: &Path, probe: &str, wall_current: f64) {
             "host": {"os": "linux", "arch": "x86_64"}
         },
         "scenario": "release_workload",
-        "probes": [{
-            "name": probe,
-            "scope": "dominant",
-            "baseline_count": 1,
-            "current_count": 1,
-            "deltas": {
-                "wall_ms": {
-                    "baseline": 100.0,
-                    "current": wall_current,
-                    "ratio": wall_current / 100.0,
-                    "pct": (wall_current - 100.0) / 100.0,
-                    "regression": 0.0,
-                    "status": "pass"
-                }
-            },
-            "status": "pass"
-        }],
+        "probes": probes.iter().map(|(probe, wall_current, scope)| {
+            let regression = if *wall_current > 100.0 {
+                (*wall_current - 100.0) / 100.0
+            } else {
+                0.0
+            };
+            json!({
+                "name": probe,
+                "scope": scope,
+                "baseline_count": 1,
+                "current_count": 1,
+                "deltas": {
+                    "wall_ms": {
+                        "baseline": 100.0,
+                        "current": wall_current,
+                        "ratio": wall_current / 100.0,
+                        "pct": (wall_current - 100.0) / 100.0,
+                        "regression": regression,
+                        "status": if regression > 0.0 { "warn" } else { "pass" }
+                    }
+                },
+                "status": if regression > 0.0 { "warn" } else { "pass" }
+            })
+        }).collect::<Vec<_>>(),
         "verdict": {
             "status": "pass",
             "counts": {"pass": 1, "warn": 0, "fail": 0, "skip": 0},

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -1489,6 +1489,21 @@ impl ConfigFile {
                     ));
                 }
             }
+            for allowance in &rule.allow {
+                if allowance.probe.trim().is_empty() {
+                    return Err(format!(
+                        "tradeoff '{}' allowance probe must not be empty",
+                        rule.name
+                    ));
+                }
+                if !allowance.max_regression.is_finite() || allowance.max_regression < 0.0 {
+                    return Err(format!(
+                        "tradeoff '{}' allowance for '{}' must use a non-negative finite max regression",
+                        rule.name,
+                        allowance.metric.as_str()
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -1782,6 +1797,22 @@ pub struct TradeoffRequirement {
     pub min_improvement_ratio: f64,
 }
 
+/// A local regression allowance used by a tradeoff rule.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffAllowance {
+    /// Metric whose local regression is capped.
+    pub metric: Metric,
+
+    /// Probe name that is allowed to regress within the configured cap.
+    pub probe: String,
+
+    /// Maximum accepted regression as a ratio.
+    ///
+    /// For example, `0.03` allows up to a 3% local regression.
+    pub max_regression: f64,
+}
+
 /// Target status when a tradeoff rule is satisfied.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -1805,6 +1836,10 @@ pub struct TradeoffRule {
     /// Required compensating improvements.
     #[schemars(length(min = 1))]
     pub require: Vec<TradeoffRequirement>,
+
+    /// Optional local regression caps that must remain satisfied.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow: Vec<TradeoffAllowance>,
 
     /// Downgrade target when all requirements are satisfied.
     #[serde(default)]
@@ -2138,6 +2173,7 @@ mod tests {
                 name: "empty".to_string(),
                 if_failed: Metric::WallMs,
                 require: Vec::new(),
+                allow: Vec::new(),
                 downgrade_to: TradeoffDowngrade::Warn,
             }],
             ratchet: None,
@@ -2172,6 +2208,7 @@ mod tests {
                     probe: None,
                     min_improvement_ratio: 1.10,
                 }],
+                allow: Vec::new(),
                 downgrade_to: TradeoffDowngrade::Warn,
             }],
             ratchet: None,
@@ -2206,6 +2243,31 @@ mod tests {
 
         config.tradeoffs[0].require[0].min_improvement_ratio = f64::NAN;
         assert!(config.validate().unwrap_err().contains("positive finite"));
+
+        config.tradeoffs[0].require[0].min_improvement_ratio = 1.10;
+        config.tradeoffs[0].allow = vec![TradeoffAllowance {
+            metric: Metric::WallMs,
+            probe: " ".to_string(),
+            max_regression: 0.03,
+        }];
+        assert!(config.validate().unwrap_err().contains("must not be empty"));
+
+        config.tradeoffs[0].allow[0].probe = "parser.tokenize".to_string();
+        config.tradeoffs[0].allow[0].max_regression = -0.01;
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .contains("non-negative finite")
+        );
+
+        config.tradeoffs[0].allow[0].max_regression = f64::NAN;
+        assert!(
+            config
+                .validate()
+                .unwrap_err()
+                .contains("non-negative finite")
+        );
     }
 
     #[test]

--- a/crates/perfgate-types/src/structured_evidence.rs
+++ b/crates/perfgate-types/src/structured_evidence.rs
@@ -231,6 +231,24 @@ pub struct TradeoffRequirementOutcome {
     pub reason: Option<String>,
 }
 
+/// Evaluation result for one local regression allowance.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct TradeoffAllowanceOutcome {
+    pub metric: String,
+    pub probe: String,
+    pub max_regression: f64,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub observed_regression: Option<f64>,
+
+    pub satisfied: bool,
+    pub status: MetricStatus,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<String>,
+}
+
 /// Evaluation result for one named tradeoff rule.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -247,6 +265,9 @@ pub struct TradeoffRuleOutcome {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub requirements: Vec<TradeoffRequirementOutcome>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowances: Vec<TradeoffAllowanceOutcome>,
 }
 
 /// Probe-level tradeoff evidence.
@@ -518,6 +539,15 @@ mod tests {
                     probe: Some("parser.batch_loop".into()),
                     required_change: -0.08,
                     observed_change: Some(-0.104),
+                    satisfied: true,
+                    status: MetricStatus::Pass,
+                    reason: None,
+                }],
+                allowances: vec![TradeoffAllowanceOutcome {
+                    metric: "wall_ms".into(),
+                    probe: "parser.tokenize".into(),
+                    max_regression: 0.03,
+                    observed_regression: Some(0.021),
                     satisfied: true,
                     status: MetricStatus::Pass,
                     reason: None,

--- a/crates/perfgate/src/app/render.rs
+++ b/crates/perfgate/src/app/render.rs
@@ -10,8 +10,8 @@ pub mod summary;
 use anyhow::Context;
 use perfgate_types::{
     CompareReceipt, ComplexityGateResult, ComplexityGateStatus, Delta, Direction, Metric,
-    MetricStatistic, MetricStatus, TradeoffDecisionStatus, TradeoffReceipt,
-    TradeoffRequirementOutcome,
+    MetricStatistic, MetricStatus, TradeoffAllowanceOutcome, TradeoffDecisionStatus,
+    TradeoffReceipt, TradeoffRequirementOutcome,
 };
 use serde_json::json;
 
@@ -174,8 +174,8 @@ pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
     if tradeoff.rules.is_empty() {
         out.push_str("No tradeoff rules evaluated.\n\n");
     } else {
-        out.push_str("| rule | decision | downgrade | requirements | reason |\n");
-        out.push_str("|---|---|---|---|---|\n");
+        out.push_str("| rule | decision | downgrade | requirements | local caps | reason |\n");
+        out.push_str("|---|---|---|---|---|---|\n");
         for rule in &tradeoff.rules {
             let requirements = if rule.requirements.is_empty() {
                 "none".to_string()
@@ -186,17 +186,27 @@ pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
                     .collect::<Vec<_>>()
                     .join("<br>")
             };
+            let allowances = if rule.allowances.is_empty() {
+                "none".to_string()
+            } else {
+                rule.allowances
+                    .iter()
+                    .map(render_tradeoff_allowance)
+                    .collect::<Vec<_>>()
+                    .join("<br>")
+            };
             let downgrade = rule
                 .downgrade_to
                 .map(tradeoff_downgrade_label)
                 .unwrap_or("-");
             let reason = rule.reason.as_deref().unwrap_or("-");
             out.push_str(&format!(
-                "| `{}` | {} | `{}` | {} | {} |\n",
+                "| `{}` | {} | `{}` | {} | {} | {} |\n",
                 rule.name,
                 tradeoff_decision_label(rule.status),
                 downgrade,
                 requirements,
+                allowances,
                 reason
             ));
         }
@@ -265,6 +275,25 @@ fn render_tradeoff_requirement(requirement: &TradeoffRequirementOutcome) -> Stri
         "{target} observed {observed} / required {required} {status}{reason}",
         required = format_pct(requirement.required_change),
         status = metric_status_icon(requirement.status)
+    )
+}
+
+fn render_tradeoff_allowance(allowance: &TradeoffAllowanceOutcome) -> String {
+    let observed = allowance
+        .observed_regression
+        .map(format_pct)
+        .unwrap_or_else(|| "missing".to_string());
+    let reason = allowance
+        .reason
+        .as_deref()
+        .map(|reason| format!(" ({reason})"))
+        .unwrap_or_default();
+    format!(
+        "probe `{probe}` `{metric}` regression {observed} / cap {cap} {status}{reason}",
+        probe = allowance.probe,
+        metric = allowance.metric,
+        cap = format_pct(allowance.max_regression),
+        status = metric_status_icon(allowance.status)
     )
 }
 
@@ -716,6 +745,15 @@ mod tests {
                     probe: None,
                     required_change: -0.10,
                     observed_change: Some(-0.12),
+                    satisfied: true,
+                    status: MetricStatus::Pass,
+                    reason: None,
+                }],
+                allowances: vec![perfgate_types::TradeoffAllowanceOutcome {
+                    metric: "wall_ms".to_string(),
+                    probe: "parser.tokenize".to_string(),
+                    max_regression: 0.03,
+                    observed_regression: Some(0.021),
                     satisfied: true,
                     status: MetricStatus::Pass,
                     reason: None,

--- a/crates/perfgate/src/app/tradeoff.rs
+++ b/crates/perfgate/src/app/tradeoff.rs
@@ -1,11 +1,11 @@
 use crate::domain::budget::{aggregate_verdict, reason_token};
 use perfgate_types::{
     Delta, HostInfo, Metric, MetricStatus, PROBE_COMPARE_SCHEMA_V1, ProbeCompareObservation,
-    ProbeCompareReceipt, RunMeta, ScenarioReceipt, TRADEOFF_SCHEMA_V1, ToolInfo, TradeoffDecision,
-    TradeoffDecisionStatus, TradeoffDowngrade, TradeoffProbeOutcome, TradeoffReceipt,
-    TradeoffRequirement, TradeoffRequirementOutcome, TradeoffRule, TradeoffRuleOutcome,
-    VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC, VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED,
-    Verdict,
+    ProbeCompareReceipt, RunMeta, ScenarioReceipt, TRADEOFF_SCHEMA_V1, ToolInfo, TradeoffAllowance,
+    TradeoffAllowanceOutcome, TradeoffDecision, TradeoffDecisionStatus, TradeoffDowngrade,
+    TradeoffProbeOutcome, TradeoffReceipt, TradeoffRequirement, TradeoffRequirementOutcome,
+    TradeoffRule, TradeoffRuleOutcome, VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC,
+    VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED, Verdict,
 };
 use std::collections::BTreeMap;
 use time::OffsetDateTime;
@@ -59,6 +59,10 @@ impl TradeoffUseCase {
                     .requirements
                     .iter()
                     .any(|requirement| requirement.observed_change.is_none())
+                    || outcome
+                        .allowances
+                        .iter()
+                        .any(|allowance| allowance.observed_regression.is_none())
                 {
                     rejected_reasons
                         .push(VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC.to_string());
@@ -126,6 +130,7 @@ fn evaluate_rule(
                 rule.if_failed.as_str()
             )),
             requirements: evaluate_requirements(&rule.require, weighted_deltas, probe_index),
+            allowances: evaluate_allowances(&rule.allow, probe_index),
         };
     };
 
@@ -140,12 +145,15 @@ fn evaluate_rule(
                 rule.if_failed.as_str()
             )),
             requirements: evaluate_requirements(&rule.require, weighted_deltas, probe_index),
+            allowances: evaluate_allowances(&rule.allow, probe_index),
         };
     }
 
     let requirements = evaluate_requirements(&rule.require, weighted_deltas, probe_index);
-    let accepted =
-        !requirements.is_empty() && requirements.iter().all(|requirement| requirement.satisfied);
+    let allowances = evaluate_allowances(&rule.allow, probe_index);
+    let accepted = !requirements.is_empty()
+        && requirements.iter().all(|requirement| requirement.satisfied)
+        && allowances.iter().all(|allowance| allowance.satisfied);
 
     TradeoffRuleOutcome {
         name: rule.name.clone(),
@@ -157,11 +165,17 @@ fn evaluate_rule(
         accepted,
         downgrade_to: accepted.then_some(rule.downgrade_to),
         reason: Some(if accepted {
-            "all required compensating improvements were satisfied".to_string()
+            if allowances.is_empty() {
+                "all required compensating improvements were satisfied".to_string()
+            } else {
+                "all required compensating improvements and local regression caps were satisfied"
+                    .to_string()
+            }
         } else {
-            "one or more required compensating improvements were not satisfied".to_string()
+            "one or more required compensating improvements or local regression caps were not satisfied".to_string()
         }),
         requirements,
+        allowances,
     }
 }
 
@@ -209,6 +223,64 @@ fn evaluate_requirements(
                 reason: (!satisfied).then_some(format!(
                     "requires improvement ratio >= {:.6}",
                     requirement.min_improvement_ratio
+                )),
+            }
+        })
+        .collect()
+}
+
+fn evaluate_allowances(
+    allowances: &[TradeoffAllowance],
+    probe_index: &BTreeMap<String, ProbeCompareObservation>,
+) -> Vec<TradeoffAllowanceOutcome> {
+    allowances
+        .iter()
+        .map(|allowance| {
+            let metric_key = allowance.metric.as_str();
+            let Some(probe) = probe_index.get(&allowance.probe) else {
+                return TradeoffAllowanceOutcome {
+                    metric: metric_key.to_string(),
+                    probe: allowance.probe.clone(),
+                    max_regression: allowance.max_regression,
+                    observed_regression: None,
+                    satisfied: false,
+                    status: MetricStatus::Fail,
+                    reason: Some(format!("allowed probe '{}' missing", allowance.probe)),
+                };
+            };
+
+            let Some(delta) = probe.deltas.get(metric_key) else {
+                return TradeoffAllowanceOutcome {
+                    metric: metric_key.to_string(),
+                    probe: allowance.probe.clone(),
+                    max_regression: allowance.max_regression,
+                    observed_regression: None,
+                    satisfied: false,
+                    status: MetricStatus::Fail,
+                    reason: Some(format!(
+                        "allowed probe '{}' metric '{metric_key}' missing",
+                        allowance.probe
+                    )),
+                };
+            };
+
+            let observed_regression = delta.regression;
+            let satisfied = observed_regression <= allowance.max_regression + f64::EPSILON;
+
+            TradeoffAllowanceOutcome {
+                metric: metric_key.to_string(),
+                probe: allowance.probe.clone(),
+                max_regression: allowance.max_regression,
+                observed_regression: Some(observed_regression),
+                satisfied,
+                status: if satisfied {
+                    MetricStatus::Pass
+                } else {
+                    MetricStatus::Fail
+                },
+                reason: (!satisfied).then_some(format!(
+                    "regression {:.6} exceeds cap {:.6}",
+                    observed_regression, allowance.max_regression
                 )),
             }
         })
@@ -488,6 +560,7 @@ mod tests {
                 probe: None,
                 min_improvement_ratio: 1.10,
             }],
+            allow: Vec::new(),
             downgrade_to,
         }
     }
@@ -501,11 +574,37 @@ mod tests {
                 probe: Some("parser.batch_loop".to_string()),
                 min_improvement_ratio: 1.10,
             }],
+            allow: Vec::new(),
+            downgrade_to,
+        }
+    }
+
+    fn memory_for_probe_speed_rule_with_allow(
+        downgrade_to: TradeoffDowngrade,
+        max_regression: f64,
+    ) -> TradeoffRule {
+        TradeoffRule {
+            name: "memory_for_probe_speed".to_string(),
+            if_failed: Metric::MaxRssKb,
+            require: vec![TradeoffRequirement {
+                metric: Metric::WallMs,
+                probe: Some("parser.batch_loop".to_string()),
+                min_improvement_ratio: 1.10,
+            }],
+            allow: vec![TradeoffAllowance {
+                metric: Metric::WallMs,
+                probe: "parser.tokenize".to_string(),
+                max_regression,
+            }],
             downgrade_to,
         }
     }
 
     fn probe_compare_receipt(probe_name: &str, wall_current: f64) -> ProbeCompareReceipt {
+        probe_compare_receipt_many(&[(probe_name, wall_current, ProbeScope::Dominant)])
+    }
+
+    fn probe_compare_receipt_many(probes: &[(&str, f64, ProbeScope)]) -> ProbeCompareReceipt {
         ProbeCompareReceipt {
             schema: PROBE_COMPARE_SCHEMA_V1.to_string(),
             tool: ToolInfo {
@@ -517,19 +616,24 @@ mod tests {
             scenario: Some("release_workload".to_string()),
             baseline_ref: None,
             current_ref: None,
-            probes: vec![ProbeCompareObservation {
-                name: probe_name.to_string(),
-                parent: None,
-                scope: Some(ProbeScope::Dominant),
-                baseline_count: 1,
-                current_count: 1,
-                deltas: BTreeMap::from([(
-                    "wall_ms".to_string(),
-                    delta(100.0, wall_current, MetricStatus::Pass),
-                )]),
-                status: MetricStatus::Pass,
-                reasons: Vec::new(),
-            }],
+            probes: probes
+                .iter()
+                .map(
+                    |(probe_name, wall_current, scope)| ProbeCompareObservation {
+                        name: (*probe_name).to_string(),
+                        parent: None,
+                        scope: Some(*scope),
+                        baseline_count: 1,
+                        current_count: 1,
+                        deltas: BTreeMap::from([(
+                            "wall_ms".to_string(),
+                            delta(100.0, *wall_current, MetricStatus::Pass),
+                        )]),
+                        status: MetricStatus::Pass,
+                        reasons: Vec::new(),
+                    },
+                )
+                .collect(),
             verdict: Verdict {
                 status: VerdictStatus::Pass,
                 counts: VerdictCounts {
@@ -628,6 +732,102 @@ mod tests {
         assert_eq!(receipt.probes.len(), 1);
         assert_eq!(receipt.probes[0].name, "parser.batch_loop");
         assert_eq!(receipt.verdict.status, VerdictStatus::Warn);
+    }
+
+    #[test]
+    fn tradeoff_evaluate_accepts_allowed_local_regression_cap() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: vec![probe_compare_receipt_many(&[
+                ("parser.batch_loop", 80.0, ProbeScope::Dominant),
+                ("parser.tokenize", 102.1, ProbeScope::Local),
+            ])],
+            rules: vec![memory_for_probe_speed_rule_with_allow(
+                TradeoffDowngrade::Warn,
+                0.03,
+            )],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(receipt.decision.accepted_tradeoff);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Accepted);
+        assert_eq!(receipt.rules[0].allowances[0].probe, "parser.tokenize");
+        assert_eq!(
+            receipt.rules[0].allowances[0].observed_regression,
+            Some(0.020999999999999943)
+        );
+        assert!(receipt.rules[0].allowances[0].satisfied);
+        assert_eq!(receipt.verdict.status, VerdictStatus::Warn);
+    }
+
+    #[test]
+    fn tradeoff_evaluate_rejects_local_regression_over_cap() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: vec![probe_compare_receipt_many(&[
+                ("parser.batch_loop", 80.0, ProbeScope::Dominant),
+                ("parser.tokenize", 105.0, ProbeScope::Local),
+            ])],
+            rules: vec![memory_for_probe_speed_rule_with_allow(
+                TradeoffDowngrade::Warn,
+                0.03,
+            )],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(!receipt.decision.accepted_tradeoff);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
+        assert_eq!(
+            receipt.rules[0].allowances[0].observed_regression,
+            Some(0.05)
+        );
+        assert!(!receipt.rules[0].allowances[0].satisfied);
+        assert!(
+            receipt.rules[0].allowances[0]
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("exceeds cap"))
+        );
+        assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
+    }
+
+    #[test]
+    fn tradeoff_evaluate_rejects_missing_allowed_local_probe() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: vec![probe_compare_receipt("parser.batch_loop", 80.0)],
+            rules: vec![memory_for_probe_speed_rule_with_allow(
+                TradeoffDowngrade::Warn,
+                0.03,
+            )],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(!receipt.decision.accepted_tradeoff);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
+        assert_eq!(receipt.rules[0].allowances[0].observed_regression, None);
+        assert!(
+            receipt.rules[0].allowances[0]
+                .reason
+                .as_deref()
+                .is_some_and(|reason| reason.contains("allowed probe"))
+        );
+        assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
     }
 
     #[test]

--- a/crates/perfgate/src/domain/mod.rs
+++ b/crates/perfgate/src/domain/mod.rs
@@ -245,6 +245,7 @@ mod tradeoff_tests {
                 probe: None,
                 min_improvement_ratio,
             }],
+            allow: Vec::new(),
             downgrade_to: TradeoffDowngrade::Warn,
         }
     }
@@ -306,6 +307,7 @@ mod tradeoff_tests {
                     probe: None,
                     min_improvement_ratio: 1.5,
                 }],
+                allow: Vec::new(),
                 downgrade_to: TradeoffDowngrade::Pass,
             }],
         )
@@ -416,6 +418,7 @@ mod tradeoff_tests {
             name: "empty".to_string(),
             if_failed: Metric::MaxRssKb,
             require: Vec::new(),
+            allow: Vec::new(),
             downgrade_to: TradeoffDowngrade::Warn,
         };
 
@@ -477,6 +480,7 @@ mod tradeoff_tests {
                 probe: None,
                 min_improvement_ratio: 1.1,
             }],
+            allow: Vec::new(),
             downgrade_to: TradeoffDowngrade::Warn,
         };
 
@@ -511,6 +515,47 @@ mod tradeoff_tests {
                 metric: Metric::WallMs,
                 probe: Some("parser.batch_loop".to_string()),
                 min_improvement_ratio: 1.1,
+            }],
+            allow: Vec::new(),
+            downgrade_to: TradeoffDowngrade::Warn,
+        };
+
+        let comparison =
+            compare_stats_with_tradeoffs(&baseline, &current, &budgets, &[rule]).unwrap();
+
+        assert_eq!(comparison.verdict.status, VerdictStatus::Fail);
+        assert_eq!(
+            comparison.deltas.get(&Metric::MaxRssKb).unwrap().status,
+            MetricStatus::Fail
+        );
+        assert!(
+            comparison
+                .verdict
+                .reasons
+                .contains(&VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC.to_string())
+        );
+    }
+
+    #[test]
+    fn local_regression_allowance_does_not_apply_without_probe_context() {
+        let baseline = base_stats(100, 1000, 1000);
+        let current = base_stats(80, 1300, 1000);
+        let budgets = BTreeMap::from([
+            (Metric::WallMs, Budget::new(0.20, 0.1, Direction::Lower)),
+            (Metric::MaxRssKb, Budget::new(0.15, 0.1, Direction::Lower)),
+        ]);
+        let rule = TradeoffRule {
+            name: "memory_for_probe_latency".to_string(),
+            if_failed: Metric::MaxRssKb,
+            require: vec![TradeoffRequirement {
+                metric: Metric::WallMs,
+                probe: None,
+                min_improvement_ratio: 1.1,
+            }],
+            allow: vec![perfgate_types::TradeoffAllowance {
+                metric: Metric::WallMs,
+                probe: "parser.tokenize".to_string(),
+                max_regression: 0.03,
             }],
             downgrade_to: TradeoffDowngrade::Warn,
         };
@@ -1062,6 +1107,11 @@ fn apply_tradeoffs(
                 if ratio < requirement.min_improvement_ratio {
                     satisfied = false;
                 }
+            }
+
+            if !rule.allow.is_empty() {
+                missing_required_metric = true;
+                satisfied = false;
             }
 
             if !satisfied {

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -171,6 +171,19 @@ When `probe` is set, `tradeoff evaluate` follows the scenario component's
 delta. Missing probe evidence leaves the requirement unsatisfied; it does not
 silently fall back to weighted scenario deltas.
 
+Use `[[tradeoff.allow]]` to cap the local regression that a tradeoff may accept:
+
+```toml
+[[tradeoff.allow]]
+metric = "wall_ms"
+probe = "parser.tokenize"
+max_regression = 0.03
+```
+
+`max_regression = 0.03` allows at most a 3% regression for the named probe.
+Missing probe evidence or a regression above the cap rejects the tradeoff even
+when the compensating improvement requirement passes.
+
 For the normal local workflow, run scenario evaluation, tradeoff evaluation, and
 decision Markdown rendering together:
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -134,10 +134,17 @@ downgrade_to = "warn"
 metric = "wall_ms"
 probe = "parser.batch_loop"
 min_improvement_ratio = 1.10
+
+[[tradeoff.allow]]
+metric = "wall_ms"
+probe = "parser.tokenize"
+max_regression = 0.03
 ```
 
 When `probe` is present, the requirement is satisfied only by that named probe's
-delta from scenario-attached probe comparison evidence.
+delta from scenario-attached probe comparison evidence. `[[tradeoff.allow]]`
+keeps the local regression bounded; if `parser.tokenize` regresses by more than
+3%, the tradeoff is rejected even if `parser.batch_loop` improves enough.
 
 ## GitHub Actions
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -131,6 +131,9 @@ When a tradeoff requirement includes `probe = "name"`, evaluation uses
 scenario-attached `probe_compare_ref` receipts to find that probe's metric
 delta. Probe-backed requirement outcomes record the probe name, and matching
 probe deltas are copied into the tradeoff receipt's `probes` section for review.
+When a rule includes `[[tradeoff.allow]]`, the receipt also records local
+regression cap outcomes so reviewers can see whether a probe stayed within the
+accepted bound.
 
 Render the decision evidence for review:
 

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -31,9 +31,10 @@ The fixture models a memory-for-speed decision:
 - the weighted workload improves on `wall_ms`;
 - `max_rss_kb` fails before tradeoff policy is applied;
 - `parser.batch_loop` improves enough to satisfy the probe-backed requirement;
+- `parser.tokenize` regresses, but stays under the configured 3% local cap;
 - the final decision is `warn` with an accepted tradeoff.
 
 `parser.tokenize` is also present in the probe comparison and regresses
 slightly. That evidence remains visible in the generated `probe-compare.json`;
-the tradeoff rule accepts the memory regression only because the dominant
-batch-loop probe improves.
+the tradeoff rule accepts the memory regression only because the local
+tokenizer regression stays bounded and the dominant batch-loop probe improves.

--- a/examples/performance-decision/perfgate.toml
+++ b/examples/performance-decision/perfgate.toml
@@ -36,3 +36,8 @@ downgrade_to = "warn"
 metric = "wall_ms"
 probe = "parser.batch_loop"
 min_improvement_ratio = 1.10
+
+[[tradeoff.allow]]
+metric = "wall_ms"
+probe = "parser.tokenize"
+max_regression = 0.03

--- a/schemas/perfgate.config.v1.schema.json
+++ b/schemas/perfgate.config.v1.schema.json
@@ -535,6 +535,30 @@
         "bench"
       ]
     },
+    "TradeoffAllowance": {
+      "description": "A local regression allowance used by a tradeoff rule.",
+      "type": "object",
+      "properties": {
+        "max_regression": {
+          "description": "Maximum accepted regression as a ratio.\n\nFor example, `0.03` allows up to a 3% local regression.",
+          "type": "number",
+          "format": "double"
+        },
+        "metric": {
+          "description": "Metric whose local regression is capped.",
+          "$ref": "#/$defs/Metric"
+        },
+        "probe": {
+          "description": "Probe name that is allowed to regress within the configured cap.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "metric",
+        "probe",
+        "max_regression"
+      ]
+    },
     "TradeoffDowngrade": {
       "description": "Target status when a tradeoff rule is satisfied.",
       "type": "string",
@@ -573,6 +597,13 @@
       "description": "A structured tradeoff rule for explicit, auditable budget downgrades.",
       "type": "object",
       "properties": {
+        "allow": {
+          "description": "Optional local regression caps that must remain satisfied.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TradeoffAllowance"
+          }
+        },
         "downgrade_to": {
           "description": "Downgrade target when all requirements are satisfied.",
           "$ref": "#/$defs/TradeoffDowngrade",

--- a/schemas/perfgate.tradeoff.v1.schema.json
+++ b/schemas/perfgate.tradeoff.v1.schema.json
@@ -351,6 +351,72 @@
         "version"
       ]
     },
+    "TradeoffAllowance": {
+      "description": "A local regression allowance used by a tradeoff rule.",
+      "type": "object",
+      "properties": {
+        "max_regression": {
+          "description": "Maximum accepted regression as a ratio.\n\nFor example, `0.03` allows up to a 3% local regression.",
+          "type": "number",
+          "format": "double"
+        },
+        "metric": {
+          "description": "Metric whose local regression is capped.",
+          "$ref": "#/$defs/Metric"
+        },
+        "probe": {
+          "description": "Probe name that is allowed to regress within the configured cap.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "metric",
+        "probe",
+        "max_regression"
+      ]
+    },
+    "TradeoffAllowanceOutcome": {
+      "description": "Evaluation result for one local regression allowance.",
+      "type": "object",
+      "properties": {
+        "max_regression": {
+          "type": "number",
+          "format": "double"
+        },
+        "metric": {
+          "type": "string"
+        },
+        "observed_regression": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "probe": {
+          "type": "string"
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "satisfied": {
+          "type": "boolean"
+        },
+        "status": {
+          "$ref": "#/$defs/MetricStatus"
+        }
+      },
+      "required": [
+        "metric",
+        "probe",
+        "max_regression",
+        "satisfied",
+        "status"
+      ]
+    },
     "TradeoffDecision": {
       "description": "Final structured tradeoff decision.",
       "type": "object",
@@ -507,6 +573,13 @@
       "description": "A structured tradeoff rule for explicit, auditable budget downgrades.",
       "type": "object",
       "properties": {
+        "allow": {
+          "description": "Optional local regression caps that must remain satisfied.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TradeoffAllowance"
+          }
+        },
         "downgrade_to": {
           "description": "Downgrade target when all requirements are satisfied.",
           "$ref": "#/$defs/TradeoffDowngrade",
@@ -541,6 +614,12 @@
       "properties": {
         "accepted": {
           "type": "boolean"
+        },
+        "allowances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TradeoffAllowanceOutcome"
+          }
         },
         "downgrade_to": {
           "anyOf": [


### PR DESCRIPTION
## Summary
- add additive `[[tradeoff.allow]]` config for named-probe local regression caps
- require configured caps to pass before an otherwise satisfied tradeoff can downgrade a failing metric
- record allowance outcomes in `perfgate.tradeoff.v1`, render them in `decision.md`, refresh schemas/docs, and update the performance-decision example

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-types tradeoff --all-features`
- `cargo test -p perfgate app::tradeoff --all-features`
- `cargo test -p perfgate domain::tradeoff_tests --all-features`
- `cargo test -p perfgate app::render --all-features`
- `cargo test -p perfgate-cli --test cli_tradeoff_tests --all-features`
- `cargo test -p perfgate-cli --test cli_performance_decision_example_tests --all-features`
- `cargo run -p xtask -- schema`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo clippy -p perfgate -p perfgate-types -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- ci`
- `git diff --check`