### PR TITLE
tradeoff: mark incomplete evidence for review

### DIFF
--- a/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
+++ b/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
@@ -186,6 +186,54 @@ fn test_tradeoff_evaluate_enforces_local_regression_cap() {
 }
 
 #[test]
+fn test_tradeoff_evaluate_marks_missing_local_cap_evidence_needs_review() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+    let probe_compare_path = temp_dir.path().join("probe-compare.json");
+    let output_path = temp_dir.path().join("tradeoff.json");
+
+    write_probe_tradeoff_config_with_allow(&config_path, 1.10, "warn", 0.03);
+    write_probe_compare_receipt_many(
+        &probe_compare_path,
+        &[("parser.batch_loop", 80.0, "dominant")],
+    );
+    write_scenario_receipt_with_probe_ref(&scenario_path, 96.0, "fail", &probe_compare_path);
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .success();
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should be JSON");
+
+    assert_eq!(receipt["decision"]["accepted_tradeoff"], false);
+    assert_eq!(receipt["decision"]["review_required"], true);
+    assert_eq!(receipt["rules"][0]["status"], "needs_review");
+    assert_eq!(
+        receipt["weighted_deltas"]["max_rss_kb"]["status"].as_str(),
+        Some("warn")
+    );
+    assert!(
+        receipt["verdict"]["reasons"]
+            .as_array()
+            .expect("reasons array")
+            .iter()
+            .any(|reason| reason == "tradeoff_review_required")
+    );
+}
+
+#[test]
 fn test_tradeoff_evaluate_rejects_config_without_tradeoffs() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let config_path = temp_dir.path().join("perfgate.toml");

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -87,6 +87,7 @@ pub const VERDICT_REASON_TRUNCATED: &str = "truncated";
 pub const VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED: &str = "tradeoff_rule_not_satisfied";
 pub const VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC: &str =
     "tradeoff_missing_required_metric";
+pub const VERDICT_REASON_TRADEOFF_REVIEW_REQUIRED: &str = "tradeoff_review_required";
 pub const VERDICT_REASON_COMPLEXITY_EXPECTED_EXCEEDED: &str = "complexity_expected_exceeded";
 pub const VERDICT_REASON_COMPLEXITY_FIT_LOW_CONFIDENCE: &str = "complexity_fit_low_confidence";
 pub const VERDICT_REASON_COMPLEXITY_MEASUREMENT_INCOMPLETE: &str =

--- a/crates/perfgate-types/src/structured_evidence.rs
+++ b/crates/perfgate-types/src/structured_evidence.rs
@@ -207,6 +207,7 @@ pub struct ScenarioReceipt {
 pub enum TradeoffDecisionStatus {
     Accepted,
     Rejected,
+    NeedsReview,
     NotEvaluated,
 }
 
@@ -296,6 +297,12 @@ pub struct TradeoffProbeOutcome {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TradeoffDecision {
     pub accepted_tradeoff: bool,
+    #[serde(default)]
+    pub review_required: bool,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub review_reasons: Vec<String>,
+
     pub status: MetricStatus,
     pub reason: String,
 }
@@ -564,6 +571,8 @@ mod tests {
             weighted_deltas: BTreeMap::from([("wall_ms".into(), wall_delta())]),
             decision: TradeoffDecision {
                 accepted_tradeoff: true,
+                review_required: false,
+                review_reasons: Vec::new(),
                 status: MetricStatus::Pass,
                 reason: "local slowdown offset by dominant-loop improvement".into(),
             },

--- a/crates/perfgate/src/app/render.rs
+++ b/crates/perfgate/src/app/render.rs
@@ -111,7 +111,27 @@ pub fn render_tradeoff_markdown(tradeoff: &TradeoffReceipt) -> String {
             "no"
         }
     ));
+    out.push_str(&format!(
+        "| review required | {} |\n",
+        if tradeoff.decision.review_required {
+            "yes"
+        } else {
+            "no"
+        }
+    ));
     out.push('\n');
+
+    if tradeoff.decision.review_required {
+        out.push_str("### Review Required\n\n");
+        if tradeoff.decision.review_reasons.is_empty() {
+            out.push_str("- evidence is incomplete; review required\n");
+        } else {
+            for reason in &tradeoff.decision.review_reasons {
+                out.push_str(&format!("- {reason}\n"));
+            }
+        }
+        out.push('\n');
+    }
 
     out.push_str("### Weighted Workload\n\n");
     if tradeoff.weighted_deltas.is_empty() {
@@ -491,6 +511,9 @@ pub fn render_reason_line(compare: &CompareReceipt, token: &str) -> String {
     if token == "tradeoff_missing_required_metric" {
         return "- tradeoff could not be evaluated: required metric missing\n".to_string();
     }
+    if token == "tradeoff_review_required" {
+        return "- tradeoff requires review: evidence is incomplete\n".to_string();
+    }
 
     let context = parse_reason_token(token).and_then(|(metric, status)| {
         compare
@@ -600,6 +623,7 @@ fn tradeoff_decision_label(status: TradeoffDecisionStatus) -> &'static str {
     match status {
         TradeoffDecisionStatus::Accepted => "accepted",
         TradeoffDecisionStatus::Rejected => "rejected",
+        TradeoffDecisionStatus::NeedsReview => "needs review",
         TradeoffDecisionStatus::NotEvaluated => "not evaluated",
     }
 }
@@ -808,6 +832,8 @@ mod tests {
             weighted_deltas,
             decision: TradeoffDecision {
                 accepted_tradeoff: true,
+                review_required: false,
+                review_reasons: Vec::new(),
                 status,
                 reason: "tradeoff 'memory_for_speed' accepted".to_string(),
             },
@@ -855,6 +881,25 @@ mod tests {
         assert!(md.contains("### Policy Reasons"));
         assert!(md.contains("### Evidence Files"));
         assert!(md.contains("### Local Reproduction"));
+    }
+
+    #[test]
+    fn tradeoff_markdown_renders_review_required() {
+        let mut receipt = make_tradeoff_receipt(MetricStatus::Warn);
+        receipt.decision.accepted_tradeoff = false;
+        receipt.decision.review_required = true;
+        receipt.decision.review_reasons =
+            vec!["tradeoff 'memory_for_speed' requires review: evidence is incomplete".to_string()];
+        receipt.decision.reason = "tradeoff 'memory_for_speed' requires review".to_string();
+        receipt.rules[0].status = TradeoffDecisionStatus::NeedsReview;
+        receipt.rules[0].accepted = false;
+
+        let md = render_tradeoff_markdown(&receipt);
+
+        assert!(md.contains("| review required | yes |"));
+        assert!(md.contains("### Review Required"));
+        assert!(md.contains("evidence is incomplete"));
+        assert!(md.contains("| `memory_for_speed` | needs review |"));
     }
 
     #[test]
@@ -911,9 +956,11 @@ mod tests {
         let applied = render_reason_line(&compare, "tradeoff_memory_for_speed_applied");
         let missing = render_reason_line(&compare, "tradeoff_missing_required_metric");
         let unsatisfied = render_reason_line(&compare, "tradeoff_rule_not_satisfied");
+        let review = render_reason_line(&compare, "tradeoff_review_required");
 
         assert!(applied.contains("tradeoff applied"));
         assert!(missing.contains("required metric missing"));
         assert!(unsatisfied.contains("not satisfied"));
+        assert!(review.contains("requires review"));
     }
 }

--- a/crates/perfgate/src/app/tradeoff.rs
+++ b/crates/perfgate/src/app/tradeoff.rs
@@ -5,9 +5,9 @@ use perfgate_types::{
     TradeoffAllowanceOutcome, TradeoffDecision, TradeoffDecisionStatus, TradeoffDowngrade,
     TradeoffProbeOutcome, TradeoffReceipt, TradeoffRequirement, TradeoffRequirementOutcome,
     TradeoffRule, TradeoffRuleOutcome, VERDICT_REASON_TRADEOFF_MISSING_REQUIRED_METRIC,
-    VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED, Verdict,
+    VERDICT_REASON_TRADEOFF_REVIEW_REQUIRED, VERDICT_REASON_TRADEOFF_RULE_NOT_SATISFIED, Verdict,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -46,6 +46,9 @@ impl TradeoffUseCase {
         let mut rule_outcomes = Vec::new();
         let mut accepted_reasons = Vec::new();
         let mut rejected_reasons = Vec::new();
+        let mut accepted_metrics = BTreeSet::new();
+        let mut review_candidates = Vec::new();
+        let mut review_reasons = Vec::new();
 
         for rule in &req.rules {
             let outcome = evaluate_rule(rule, &weighted_deltas, &probe_index);
@@ -53,7 +56,20 @@ impl TradeoffUseCase {
                 if let Some(delta) = weighted_deltas.get_mut(rule.if_failed.as_str()) {
                     delta.status = downgrade_status(rule.downgrade_to);
                 }
+                accepted_metrics.insert(rule.if_failed);
                 accepted_reasons.push(format!("tradeoff_{}_applied", rule.name));
+            } else if matches!(outcome.status, TradeoffDecisionStatus::NeedsReview) {
+                review_candidates.push((
+                    rule.if_failed,
+                    format!(
+                        "tradeoff '{}' requires review: {}",
+                        rule.name,
+                        outcome
+                            .reason
+                            .as_deref()
+                            .unwrap_or("evidence is incomplete")
+                    ),
+                ));
             } else if matches!(outcome.status, TradeoffDecisionStatus::Rejected) {
                 if outcome
                     .requirements
@@ -72,21 +88,40 @@ impl TradeoffUseCase {
             }
             rule_outcomes.push(outcome);
         }
+
+        for (metric, reason) in review_candidates {
+            if accepted_metrics.contains(&metric) {
+                continue;
+            }
+            if let Some(delta) = weighted_deltas.get_mut(metric.as_str()) {
+                delta.status = MetricStatus::Warn;
+            }
+            push_unique(&mut review_reasons, reason);
+        }
         let probes = tradeoff_probe_outcomes(&probe_index);
 
         let mut verdict = verdict_from_weighted_deltas(&weighted_deltas);
         verdict
             .reasons
             .extend(non_pass_reason_tokens(&weighted_deltas));
+        if !review_reasons.is_empty() {
+            push_unique(
+                &mut verdict.reasons,
+                VERDICT_REASON_TRADEOFF_REVIEW_REQUIRED.to_string(),
+            );
+        }
         for reason in accepted_reasons.iter().chain(rejected_reasons.iter()) {
             push_unique(&mut verdict.reasons, reason.clone());
         }
 
         let accepted = rule_outcomes.iter().any(|outcome| outcome.accepted);
+        let review_required = !review_reasons.is_empty();
         let decision = TradeoffDecision {
             accepted_tradeoff: accepted,
+            review_required,
+            review_reasons,
             status: metric_status_from_verdict(&verdict),
-            reason: decision_reason(accepted, &rule_outcomes, &verdict),
+            reason: decision_reason(accepted, review_required, &rule_outcomes, &verdict),
         };
 
         let mut warnings = req.scenario.warnings;
@@ -154,11 +189,14 @@ fn evaluate_rule(
     let accepted = !requirements.is_empty()
         && requirements.iter().all(|requirement| requirement.satisfied)
         && allowances.iter().all(|allowance| allowance.satisfied);
+    let needs_review = !accepted && evidence_incomplete_but_satisfied(&requirements, &allowances);
 
     TradeoffRuleOutcome {
         name: rule.name.clone(),
         status: if accepted {
             TradeoffDecisionStatus::Accepted
+        } else if needs_review {
+            TradeoffDecisionStatus::NeedsReview
         } else {
             TradeoffDecisionStatus::Rejected
         },
@@ -171,12 +209,40 @@ fn evaluate_rule(
                 "all required compensating improvements and local regression caps were satisfied"
                     .to_string()
             }
+        } else if needs_review {
+            "required tradeoff evidence is incomplete; review required".to_string()
         } else {
             "one or more required compensating improvements or local regression caps were not satisfied".to_string()
         }),
         requirements,
         allowances,
     }
+}
+
+fn evidence_incomplete_but_satisfied(
+    requirements: &[TradeoffRequirementOutcome],
+    allowances: &[TradeoffAllowanceOutcome],
+) -> bool {
+    let missing_review_evidence = requirements
+        .iter()
+        .any(|requirement| requirement.probe.is_some() && requirement.observed_change.is_none())
+        || allowances
+            .iter()
+            .any(|allowance| allowance.observed_regression.is_none());
+    if !missing_review_evidence {
+        return false;
+    }
+
+    let requirements_satisfied_or_missing_review_evidence =
+        requirements.iter().all(|requirement| {
+            requirement.satisfied
+                || (requirement.probe.is_some() && requirement.observed_change.is_none())
+        });
+    let allowances_satisfied_or_missing = allowances
+        .iter()
+        .all(|allowance| allowance.satisfied || allowance.observed_regression.is_none());
+
+    requirements_satisfied_or_missing_review_evidence && allowances_satisfied_or_missing
 }
 
 fn evaluate_requirements(
@@ -446,11 +512,20 @@ fn metric_status_from_verdict(verdict: &Verdict) -> MetricStatus {
 
 fn decision_reason(
     accepted: bool,
+    review_required: bool,
     rule_outcomes: &[TradeoffRuleOutcome],
     verdict: &Verdict,
 ) -> String {
     if accepted && let Some(rule) = rule_outcomes.iter().find(|outcome| outcome.accepted) {
         return format!("tradeoff '{}' accepted", rule.name);
+    }
+
+    if review_required
+        && let Some(rule) = rule_outcomes
+            .iter()
+            .find(|outcome| matches!(outcome.status, TradeoffDecisionStatus::NeedsReview))
+    {
+        return format!("tradeoff '{}' requires review", rule.name);
     }
 
     if matches!(verdict.status, perfgate_types::VerdictStatus::Fail) {
@@ -802,7 +877,7 @@ mod tests {
     }
 
     #[test]
-    fn tradeoff_evaluate_rejects_missing_allowed_local_probe() {
+    fn tradeoff_evaluate_marks_missing_allowed_local_probe_needs_review() {
         let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
             scenario: scenario_receipt(96.0, MetricStatus::Fail),
             probe_compares: vec![probe_compare_receipt("parser.batch_loop", 80.0)],
@@ -819,7 +894,8 @@ mod tests {
 
         let receipt = outcome.receipt;
         assert!(!receipt.decision.accepted_tradeoff);
-        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
+        assert!(receipt.decision.review_required);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::NeedsReview);
         assert_eq!(receipt.rules[0].allowances[0].observed_regression, None);
         assert!(
             receipt.rules[0].allowances[0]
@@ -827,11 +903,21 @@ mod tests {
                 .as_deref()
                 .is_some_and(|reason| reason.contains("allowed probe"))
         );
-        assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
+        assert_eq!(
+            receipt.weighted_deltas["max_rss_kb"].status,
+            MetricStatus::Warn
+        );
+        assert_eq!(receipt.verdict.status, VerdictStatus::Warn);
+        assert!(
+            receipt
+                .verdict
+                .reasons
+                .contains(&perfgate_types::VERDICT_REASON_TRADEOFF_REVIEW_REQUIRED.to_string())
+        );
     }
 
     #[test]
-    fn tradeoff_evaluate_rejects_missing_probe_requirement() {
+    fn tradeoff_evaluate_marks_missing_probe_requirement_needs_review() {
         let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
             scenario: scenario_receipt(96.0, MetricStatus::Fail),
             probe_compares: vec![probe_compare_receipt("parser.tokenize", 80.0)],
@@ -845,7 +931,8 @@ mod tests {
 
         let receipt = outcome.receipt;
         assert!(!receipt.decision.accepted_tradeoff);
-        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
+        assert!(receipt.decision.review_required);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::NeedsReview);
         assert_eq!(receipt.rules[0].requirements[0].observed_change, None);
         assert!(
             receipt.rules[0].requirements[0]
@@ -855,6 +942,26 @@ mod tests {
         );
         assert_eq!(receipt.probes.len(), 1);
         assert_eq!(receipt.probes[0].name, "parser.tokenize");
+        assert_eq!(receipt.verdict.status, VerdictStatus::Warn);
+    }
+
+    #[test]
+    fn tradeoff_evaluate_rejects_unsatisfied_present_probe_requirement() {
+        let outcome = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario: scenario_receipt(96.0, MetricStatus::Fail),
+            probe_compares: vec![probe_compare_receipt("parser.batch_loop", 96.0)],
+            rules: vec![memory_for_probe_speed_rule(TradeoffDowngrade::Pass)],
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.16.0".to_string(),
+            },
+        })
+        .expect("evaluate tradeoff");
+
+        let receipt = outcome.receipt;
+        assert!(!receipt.decision.accepted_tradeoff);
+        assert!(!receipt.decision.review_required);
+        assert_eq!(receipt.rules[0].status, TradeoffDecisionStatus::Rejected);
         assert_eq!(receipt.verdict.status, VerdictStatus::Fail);
     }
 }

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -181,8 +181,10 @@ max_regression = 0.03
 ```
 
 `max_regression = 0.03` allows at most a 3% regression for the named probe.
-Missing probe evidence or a regression above the cap rejects the tradeoff even
-when the compensating improvement requirement passes.
+Missing named probe evidence marks the decision as review required when the
+available compensating evidence otherwise satisfies the rule. A regression above
+the cap rejects the tradeoff even when the compensating improvement requirement
+passes.
 
 For the normal local workflow, run scenario evaluation, tradeoff evaluation, and
 decision Markdown rendering together:

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -136,6 +136,11 @@ If scenarios configure `probe_baseline`, `probe_current`, and `probe_compare`,
 decision mode also creates the probe comparison receipt before evaluating the
 scenario and tradeoff receipts.
 
+When evidence is incomplete but otherwise supports a configured tradeoff,
+`decision.md` marks the result as review required. The action still treats the
+machine verdict as `warn`; reviewers should inspect the listed
+`review_reasons` before treating the tradeoff as accepted.
+
 ## 4) Manual PR performance gate workflow
 
 Create `.github/workflows/perfgate.yml`:

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -165,6 +165,23 @@ summary. If `check` exits `2` for a policy failure, the action can defer the
 final result to the decision receipt so an accepted tradeoff owns the final
 policy outcome.
 
+## Needs Review
+
+Some evidence gaps should not silently pass or hard-fail the workflow. When a
+tradeoff's compensating evidence is otherwise satisfied but a configured named
+probe or local regression cap is missing, perfgate marks the decision as review
+required:
+
+```text
+Decision: warn, review required
+Reason: required tradeoff evidence is incomplete
+```
+
+The machine verdict remains `warn`, and the `perfgate.tradeoff.v1` receipt sets
+`decision.review_required = true` with `review_reasons`. Present evidence that
+disproves the tradeoff, such as a local probe exceeding `max_regression`, still
+rejects the tradeoff and preserves the failing verdict.
+
 ## Primitive Commands
 
 The lower-level commands are still useful for debugging and custom pipelines:

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -133,7 +133,9 @@ delta. Probe-backed requirement outcomes record the probe name, and matching
 probe deltas are copied into the tradeoff receipt's `probes` section for review.
 When a rule includes `[[tradeoff.allow]]`, the receipt also records local
 regression cap outcomes so reviewers can see whether a probe stayed within the
-accepted bound.
+accepted bound. If named probe evidence is missing but the available evidence
+otherwise supports the tradeoff, the receipt keeps the machine status at `warn`
+and sets `decision.review_required = true` with review reasons.
 
 Render the decision evidence for review:
 

--- a/schemas/perfgate.tradeoff.v1.schema.json
+++ b/schemas/perfgate.tradeoff.v1.schema.json
@@ -427,6 +427,16 @@
         "reason": {
           "type": "string"
         },
+        "review_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "review_required": {
+          "type": "boolean",
+          "default": false
+        },
         "status": {
           "$ref": "#/$defs/MetricStatus"
         }
@@ -443,6 +453,7 @@
       "enum": [
         "accepted",
         "rejected",
+        "needs_review",
         "not_evaluated"
       ]
     },


### PR DESCRIPTION
## Summary
- add a review-required tradeoff decision state for incomplete named-probe evidence
- keep machine policy at warn while recording `decision.review_required` and `review_reasons`
- render review-required decisions in decision Markdown and document the behavior

## Validation
- `cargo test -p perfgate-types tradeoff --all-features`
- `cargo test -p perfgate app::tradeoff --all-features`
- `cargo test -p perfgate app::render --all-features`
- `cargo test -p perfgate-cli --test cli_tradeoff_tests --all-features`
- `cargo run -p xtask -- schema`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo clippy -p perfgate -p perfgate-types -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run -p xtask -- ci`