### PR TITLE
decision: add artifact index receipt

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ workflow after `check`:
 perfgate decision evaluate --config perfgate.toml
 ```
 
-It writes `scenario.json`, `tradeoff.json`, and `decision.md` under the
-configured artifact directory. `decision.md` is the review surface: it explains
-the weighted workload result, probe movement, accepted or rejected tradeoff
-rules, policy reasons, evidence files, and the local reproduction command.
+It writes `scenario.json`, `tradeoff.json`, `decision.md`, and
+`decision.index.json` under the configured artifact directory. `decision.md` is
+the review surface: it explains the weighted workload result, probe movement,
+accepted or rejected tradeoff rules, policy reasons, evidence files, and the
+local reproduction command. `decision.index.json` is the machine-readable
+manifest for the evidence files behind that review.
 When scenarios configure probe baseline/current paths, `decision evaluate` also
 writes the configured `probe-compare.json` before evaluating the decision.
 

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,7 @@ inputs:
     required: false
     default: "false"
   decision:
-    description: "Run perfgate decision evaluate after check and publish scenario/tradeoff/decision artifacts"
+    description: "Run perfgate decision evaluate after check and publish scenario/tradeoff/decision artifacts plus the decision index"
     required: false
     default: "false"
   github_token:
@@ -423,7 +423,7 @@ runs:
 
           local listing
           listing="$(mktemp)"
-          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name probe-compare.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name comment.md -o -name 'perfgate.*.json' -o -name 'sensor.report.v1.json' \) | sort > "${listing}"
+          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name probe-compare.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name decision.index.json -o -name comment.md -o -name 'perfgate.*.json' -o -name 'sensor.report.v1.json' \) | sort > "${listing}"
 
           local count
           count="$(wc -l < "${listing}" | tr -d ' ')"

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -47,11 +47,11 @@ use perfgate_types::config::{
 use perfgate_types::error::{ConfigValidationError, IoError, PerfgateError};
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
-    ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, FailIfNOfM, HostMismatchPolicy,
-    MetricStatus, OtelSpanIdentifiers, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
-    REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairGitMetadata,
-    RepairMetricBreach, RunReceipt, ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus,
-    ToolInfo, TradeoffReceipt, VerdictStatus,
+    ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_INDEX_SCHEMA_V1,
+    DecisionArtifactIndex, FailIfNOfM, HostMismatchPolicy, MetricStatus, OtelSpanIdentifiers,
+    PerfgateReport, ProbeCompareReceipt, ProbeReceipt, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
+    RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
+    ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt, VerdictStatus,
 };
 use regex::Regex;
 use std::collections::{BTreeMap, BTreeSet};
@@ -1380,6 +1380,10 @@ pub struct DecisionEvaluateArgs {
     /// Output decision markdown path.
     #[arg(long)]
     pub decision_out: Option<PathBuf>,
+
+    /// Output decision artifact index path.
+    #[arg(long)]
+    pub index_out: Option<PathBuf>,
 
     /// Pretty-print JSON receipts.
     #[arg(long, default_value_t = false)]
@@ -3680,6 +3684,10 @@ fn execute_decision_evaluate(args: DecisionEvaluateArgs) -> anyhow::Result<()> {
         .decision_out
         .clone()
         .unwrap_or_else(|| out_dir.join("decision.md"));
+    let index_out = args
+        .index_out
+        .clone()
+        .unwrap_or_else(|| out_dir.join("decision.index.json"));
 
     run_configured_probe_compares(&config, args.scenario.as_deref(), args.pretty)?;
 
@@ -3690,11 +3698,12 @@ fn execute_decision_evaluate(args: DecisionEvaluateArgs) -> anyhow::Result<()> {
         args.workload_name,
         &out_dir,
     )?;
-    write_json(&scenario_out, &scenario_outcome.receipt, args.pretty)?;
+    let scenario_receipt = scenario_outcome.receipt;
+    write_json(&scenario_out, &scenario_receipt, args.pretty)?;
     eprintln!("Scenario receipt written to {}", scenario_out.display());
 
     let tradeoff_outcome =
-        evaluate_configured_tradeoffs(&config, &args.config, scenario_outcome.receipt)?;
+        evaluate_configured_tradeoffs(&config, &args.config, scenario_receipt.clone())?;
     write_json(&tradeoff_out, &tradeoff_outcome.receipt, args.pretty)?;
     eprintln!("Tradeoff receipt written to {}", tradeoff_out.display());
 
@@ -3708,10 +3717,63 @@ fn execute_decision_evaluate(args: DecisionEvaluateArgs) -> anyhow::Result<()> {
     atomic_write(&decision_out, markdown.as_bytes())?;
     eprintln!("Decision markdown written to {}", decision_out.display());
 
+    let index = build_decision_artifact_index(
+        &scenario_out,
+        &tradeoff_out,
+        &decision_out,
+        &scenario_receipt,
+    );
+    write_json(&index_out, &index, args.pretty)?;
+    eprintln!("Decision artifact index written to {}", index_out.display());
+
     match tradeoff_outcome.receipt.verdict.status {
         VerdictStatus::Fail => exit_with_code(2),
         VerdictStatus::Pass | VerdictStatus::Warn | VerdictStatus::Skip => Ok(()),
     }
+}
+
+fn build_decision_artifact_index(
+    scenario_out: &Path,
+    tradeoff_out: &Path,
+    decision_out: &Path,
+    scenario: &ScenarioReceipt,
+) -> DecisionArtifactIndex {
+    let mut probe_compares = BTreeSet::new();
+    let mut compare_receipts = BTreeSet::new();
+
+    for component in &scenario.components {
+        if let Some(path) = component
+            .probe_compare_ref
+            .as_ref()
+            .and_then(|reference| reference.path.as_ref())
+        {
+            probe_compares.insert(normalize_artifact_path(path));
+        }
+        if let Some(path) = component
+            .compare_ref
+            .as_ref()
+            .and_then(|reference| reference.path.as_ref())
+        {
+            compare_receipts.insert(normalize_artifact_path(path));
+        }
+    }
+
+    DecisionArtifactIndex {
+        schema: DECISION_INDEX_SCHEMA_V1.to_string(),
+        scenario: artifact_path_string(scenario_out),
+        tradeoff: artifact_path_string(tradeoff_out),
+        decision: artifact_path_string(decision_out),
+        probe_compares: probe_compares.into_iter().collect(),
+        compare_receipts: compare_receipts.into_iter().collect(),
+    }
+}
+
+fn artifact_path_string(path: &Path) -> String {
+    normalize_artifact_path(&path.display().to_string())
+}
+
+fn normalize_artifact_path(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 fn execute_badge(args: BadgeArgs) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
+++ b/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
@@ -59,7 +59,8 @@ fn performance_decision_example_runs_end_to_end() {
         .stderr(predicate::str::contains("Probe compare receipt written"))
         .stderr(predicate::str::contains("Scenario receipt written"))
         .stderr(predicate::str::contains("Tradeoff receipt written"))
-        .stderr(predicate::str::contains("Decision markdown written"));
+        .stderr(predicate::str::contains("Decision markdown written"))
+        .stderr(predicate::str::contains("Decision artifact index written"));
 
     let probe_compare: perfgate_types::ProbeCompareReceipt = serde_json::from_str(
         &fs::read_to_string(root.join("artifacts/perfgate/large-file/probe-compare.json"))
@@ -132,6 +133,24 @@ fn performance_decision_example_runs_end_to_end() {
     assert!(decision.contains("Accepted / Rejected Tradeoffs"));
     assert!(decision.contains("Evidence Files"));
     assert!(decision.contains("Local Reproduction"));
+
+    let decision_index: perfgate_types::DecisionArtifactIndex = serde_json::from_str(
+        &fs::read_to_string(root.join("artifacts/perfgate/decision.index.json"))
+            .expect("read decision artifact index"),
+    )
+    .expect("decision artifact index should deserialize");
+    assert_eq!(decision_index.schema, "perfgate.decision_index.v1");
+    assert_eq!(
+        decision_index.probe_compares,
+        vec!["artifacts/perfgate/large-file/probe-compare.json"]
+    );
+    assert_eq!(
+        decision_index.compare_receipts,
+        vec![
+            "examples/performance-decision/receipts/large-file.compare.json",
+            "examples/performance-decision/receipts/small-edit.compare.json"
+        ]
+    );
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) {

--- a/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
+++ b/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
@@ -301,11 +301,13 @@ fn decision_evaluate_runs_structured_decision_workflow() {
         .stderr(predicate::str::contains("Probe compare receipt written"))
         .stderr(predicate::str::contains("Scenario receipt written"))
         .stderr(predicate::str::contains("Tradeoff receipt written"))
-        .stderr(predicate::str::contains("Decision markdown written"));
+        .stderr(predicate::str::contains("Decision markdown written"))
+        .stderr(predicate::str::contains("Decision artifact index written"));
 
     let scenario_path = root.join("artifacts/perfgate/scenario.json");
     let tradeoff_path = root.join("artifacts/perfgate/tradeoff.json");
     let decision_path = root.join("artifacts/perfgate/decision.md");
+    let decision_index_path = root.join("artifacts/perfgate/decision.index.json");
     assert!(
         probe_compare_path.exists(),
         "decision evaluate should write configured probe compare receipt"
@@ -354,6 +356,23 @@ fn decision_evaluate_runs_structured_decision_workflow() {
     assert!(decision.contains("perfgate tradeoff: warn"));
     assert!(decision.contains("tradeoff 'memory_for_probe_speed' accepted"));
     assert!(decision.contains("Probe Evidence"));
+
+    let decision_index: perfgate_types::DecisionArtifactIndex = serde_json::from_str(
+        &fs::read_to_string(decision_index_path).expect("read decision artifact index"),
+    )
+    .expect("decision artifact index should deserialize");
+    assert_eq!(decision_index.schema, "perfgate.decision_index.v1");
+    assert_eq!(decision_index.scenario, "artifacts/perfgate/scenario.json");
+    assert_eq!(decision_index.tradeoff, "artifacts/perfgate/tradeoff.json");
+    assert_eq!(decision_index.decision, "artifacts/perfgate/decision.md");
+    assert_eq!(
+        decision_index.probe_compares,
+        vec![toml_path(&probe_compare_path)]
+    );
+    assert_eq!(
+        decision_index.compare_receipts,
+        vec!["artifacts/perfgate/parser/compare.json".to_string()]
+    );
 }
 
 fn write_controlled_compare_receipt(path: &Path) {

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision_evaluate.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision_evaluate.snap
@@ -14,6 +14,7 @@ Options:
       --scenario-out <SCENARIO_OUT> Output scenario receipt path
       --tradeoff-out <TRADEOFF_OUT> Output tradeoff receipt path
       --decision-out <DECISION_OUT> Output decision markdown path
+      --index-out <INDEX_OUT> Output decision artifact index path
       --pretty Pretty-print JSON receipts
   -h, --help Print help
 

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -62,6 +62,7 @@ pub const PROBE_SCHEMA_V1: &str = "perfgate.probe.v1";
 pub const PROBE_COMPARE_SCHEMA_V1: &str = "perfgate.probe_compare.v1";
 pub const SCENARIO_SCHEMA_V1: &str = "perfgate.scenario.v1";
 pub const TRADEOFF_SCHEMA_V1: &str = "perfgate.tradeoff.v1";
+pub const DECISION_INDEX_SCHEMA_V1: &str = "perfgate.decision_index.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
 pub const RATCHET_SCHEMA_V1: &str = "perfgate.ratchet.v1";

--- a/crates/perfgate-types/src/structured_evidence.rs
+++ b/crates/perfgate-types/src/structured_evidence.rs
@@ -342,12 +342,24 @@ pub struct TradeoffReceipt {
     pub warnings: Vec<String>,
 }
 
+/// A manifest for the artifacts produced by `perfgate decision evaluate`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct DecisionArtifactIndex {
+    pub schema: String,
+    pub scenario: String,
+    pub tradeoff: String,
+    pub decision: String,
+    pub probe_compares: Vec<String>,
+    pub compare_receipts: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        PROBE_COMPARE_SCHEMA_V1, PROBE_SCHEMA_V1, SCENARIO_SCHEMA_V1, TRADEOFF_SCHEMA_V1,
-        U64Summary, VerdictCounts, VerdictStatus,
+        DECISION_INDEX_SCHEMA_V1, PROBE_COMPARE_SCHEMA_V1, PROBE_SCHEMA_V1, SCENARIO_SCHEMA_V1,
+        TRADEOFF_SCHEMA_V1, U64Summary, VerdictCounts, VerdictStatus,
     };
 
     fn tool() -> ToolInfo {
@@ -584,6 +596,28 @@ mod tests {
         let parsed: TradeoffReceipt = serde_json::from_str(&json).expect("parse tradeoff receipt");
         assert_eq!(parsed.schema, TRADEOFF_SCHEMA_V1);
         assert!(parsed.decision.accepted_tradeoff);
+    }
+
+    #[test]
+    fn decision_artifact_index_round_trips() {
+        let receipt = DecisionArtifactIndex {
+            schema: DECISION_INDEX_SCHEMA_V1.into(),
+            scenario: "artifacts/perfgate/scenario.json".into(),
+            tradeoff: "artifacts/perfgate/tradeoff.json".into(),
+            decision: "artifacts/perfgate/decision.md".into(),
+            probe_compares: vec!["artifacts/perfgate/large-file/probe-compare.json".into()],
+            compare_receipts: vec!["artifacts/perfgate/large-file/compare.json".into()],
+        };
+
+        let json = serde_json::to_string(&receipt).expect("serialize decision index");
+        let parsed: DecisionArtifactIndex =
+            serde_json::from_str(&json).expect("parse decision index");
+        assert_eq!(parsed.schema, DECISION_INDEX_SCHEMA_V1);
+        assert_eq!(parsed.scenario, "artifacts/perfgate/scenario.json");
+        assert_eq!(
+            parsed.probe_compares,
+            vec!["artifacts/perfgate/large-file/probe-compare.json"]
+        );
     }
 
     #[test]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -93,8 +93,9 @@ perfgate check --config perfgate.toml --all
 perfgate decision evaluate --config perfgate.toml
 ```
 
-`decision evaluate` writes `scenario.json`, `tradeoff.json`, and `decision.md`
-under `[defaults].out_dir` unless output paths are overridden. Use
+`decision evaluate` writes `scenario.json`, `tradeoff.json`, `decision.md`,
+and `decision.index.json` under `[defaults].out_dir` unless output paths are
+overridden. Use
 `perfgate scenario evaluate` directly only when debugging or composing a custom
 pipeline.
 
@@ -211,7 +212,8 @@ perfgate decision evaluate --config perfgate.toml
 ```
 
 It uses the configured artifact directory for compare lookups and writes
-`scenario.json`, `tradeoff.json`, and `decision.md` there by default.
+`scenario.json`, `tradeoff.json`, `decision.md`, and `decision.index.json`
+there by default.
 
 The primitive commands remain available when you need to inspect an intermediate
 receipt. Evaluate the rules against a scenario receipt to produce

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -119,12 +119,13 @@ comment, opt in to decision mode:
 ```
 
 Decision mode runs `perfgate decision evaluate --config perfgate.toml` after
-`check`, writes `scenario.json`, `tradeoff.json`, and `decision.md` under the
-resolved artifact directory, and appends `decision.md` to the GitHub step
-summary. If `check` reports a policy failure with exit code `2`, the action
-defers the final policy result to the decision receipt so an accepted tradeoff
-can downgrade the result according to configured policy. Runtime errors and
-`--fail-on-warn` failures still stop the action.
+`check`, writes `scenario.json`, `tradeoff.json`, `decision.md`, and
+`decision.index.json` under the resolved artifact directory, and appends
+`decision.md` to the GitHub step summary. If `check` reports a policy failure
+with exit code `2`, the action defers the final policy result to the decision
+receipt so an accepted tradeoff can downgrade the result according to
+configured policy. Runtime errors and `--fail-on-warn` failures still stop the
+action.
 
 Use decision mode when `perfgate.toml` contains `[[scenario]]` weights,
 `[[tradeoff]]` policy, or probe comparison evidence. The lower-level

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -26,11 +26,14 @@ artifacts/perfgate/
   scenario.json
   tradeoff.json
   decision.md
+  decision.index.json
 ```
 
 `decision.md` is the human review surface. It summarizes the weighted workload,
 probe evidence, accepted or rejected tradeoff rules, policy reasons, evidence
 files, and the local reproduction command.
+`decision.index.json` is the machine-readable artifact manifest for actions,
+servers, dashboards, and agents that need to find the generated evidence set.
 
 ## Workflow Levels
 

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -12,6 +12,7 @@ perfgate uses versioned JSON receipts at every stage of the pipeline.
 | `perfgate.probe_compare.v1` | `probe compare` | Probe-level deltas between two probe receipts |
 | `perfgate.scenario.v1` | `scenario evaluate` | Weighted workload-scenario evidence across benchmarks, phases, or probe groups |
 | `perfgate.tradeoff.v1` | `tradeoff evaluate` | Structured decision evidence for accepted or rejected performance tradeoffs |
+| `perfgate.decision_index.v1` | `decision evaluate` | Artifact manifest linking scenario, tradeoff, markdown, probe-compare, and compare evidence |
 | `perfgate.report.v1` | `report`, `check` | Cockpit-compatible report envelope with findings, summary, and optional `profile_path` diagnostic |
 | `sensor.report.v1` | `check --mode cockpit` | Sensor integration envelope for dashboards |
 | `perfgate.baseline.v1` | baseline service | Stored baseline record returned by the server |
@@ -30,7 +31,7 @@ perfgate decision evaluate --config perfgate.toml
 
 That command reads the configured compare receipts, evaluates scenarios,
 evaluates tradeoff rules, and renders `decision.md` alongside
-`scenario.json` and `tradeoff.json`.
+`scenario.json`, `tradeoff.json`, and `decision.index.json`.
 
 ## Additional Generated Schemas
 
@@ -43,6 +44,7 @@ perfgate also commits generated schemas for tooling and editor integration:
 | `schemas/perfgate.probe_compare.v1.schema.json` | Validates probe delta receipts used to explain local phase movement |
 | `schemas/perfgate.scenario.v1.schema.json` | Validates weighted scenario receipts used to explain workload-level outcomes |
 | `schemas/perfgate.tradeoff.v1.schema.json` | Validates tradeoff receipts that explain why local regressions were accepted or rejected |
+| `schemas/perfgate.decision_index.v1.schema.json` | Validates the decision artifact manifest produced by `decision evaluate` |
 | `schemas/perfgate.report.v1.schema.json` | Validates report receipts, including additive diagnostics such as `profile_path` |
 
 ## JSON Schema Generation
@@ -160,7 +162,12 @@ By default it writes:
 artifacts/perfgate/scenario.json
 artifacts/perfgate/tradeoff.json
 artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
 ```
+
+The index receipt uses `perfgate.decision_index.v1` and records the generated
+scenario, tradeoff, and Markdown paths plus the compare and probe-compare
+receipts that fed the decision.
 
 For a runnable probe/scenario/tradeoff fixture, see
 [`examples/performance-decision`](../examples/performance-decision/README.md).
@@ -187,7 +194,8 @@ with external consumers.
 Historical compatibility fixtures live under `fixtures/schema/<release>/`.
 `schema-compat` checks v0.15 examples for `perfgate.run.v1`,
 `perfgate.compare.v1`, `perfgate.report.v1`, `sensor.report.v1`,
-and `perfgate.health.v1`.
+`perfgate.health.v1`, and structured-decision receipts including
+`perfgate.decision_index.v1`.
 It also checks v0.16 baseline-service and fleet contract fixtures for
 `perfgate.baseline.v1`, `perfgate.verdict.v1`, `perfgate.audit.v1`,
 `perfgate.health.v1`, `perfgate.dependency_event.v1`, and

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -24,6 +24,7 @@ artifacts/perfgate/
   scenario.json
   tradeoff.json
   decision.md
+  decision.index.json
 ```
 
 The fixture models a memory-for-speed decision:

--- a/fixtures/schema/v0.16/perfgate.decision_index.v1.json
+++ b/fixtures/schema/v0.16/perfgate.decision_index.v1.json
@@ -1,0 +1,13 @@
+{
+  "schema": "perfgate.decision_index.v1",
+  "scenario": "artifacts/perfgate/scenario.json",
+  "tradeoff": "artifacts/perfgate/tradeoff.json",
+  "decision": "artifacts/perfgate/decision.md",
+  "probe_compares": [
+    "artifacts/perfgate/large-file/probe-compare.json"
+  ],
+  "compare_receipts": [
+    "artifacts/perfgate/large-file/compare.json",
+    "artifacts/perfgate/small-edit/compare.json"
+  ]
+}

--- a/schemas/perfgate.decision_index.v1.schema.json
+++ b/schemas/perfgate.decision_index.v1.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DecisionArtifactIndex",
+  "description": "A manifest for the artifacts produced by `perfgate decision evaluate`.",
+  "type": "object",
+  "properties": {
+    "compare_receipts": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "decision": {
+      "type": "string"
+    },
+    "probe_compares": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "scenario": {
+      "type": "string"
+    },
+    "schema": {
+      "type": "string"
+    },
+    "tradeoff": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema",
+    "scenario",
+    "tradeoff",
+    "decision",
+    "probe_compares",
+    "compare_receipts"
+  ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,13 +16,14 @@ const TARGET_PUBLIC_PACKAGES: [&str; 5] = [
     "perfgate-cli",
 ];
 
-const SCHEMA_FILES: [&str; 12] = [
+const SCHEMA_FILES: [&str; 13] = [
     "perfgate.run.v1.schema.json",
     "perfgate.compare.v1.schema.json",
     "perfgate.probe.v1.schema.json",
     "perfgate.probe_compare.v1.schema.json",
     "perfgate.scenario.v1.schema.json",
     "perfgate.tradeoff.v1.schema.json",
+    "perfgate.decision_index.v1.schema.json",
     "perfgate.config.v1.schema.json",
     "perfgate.report.v1.schema.json",
     "perfgate.aggregate.v1.schema.json",
@@ -698,6 +699,7 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
             && line.contains("-name scenario.json")
             && line.contains("-name tradeoff.json")
             && line.contains("-name decision.md")
+            && line.contains("-name decision.index.json")
             && line.contains("-name comment.md")
             && line.contains("-name 'perfgate.*.json'")
     }) {
@@ -2200,36 +2202,42 @@ fn cmd_schema(out_dir: &PathBuf) -> anyhow::Result<()> {
     write_schema(
         out_dir,
         SCHEMA_FILES[6],
-        schema_for!(perfgate_types::ConfigFile),
+        schema_for!(perfgate_types::DecisionArtifactIndex),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[7],
-        schema_for!(perfgate_types::PerfgateReport),
+        schema_for!(perfgate_types::ConfigFile),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[8],
-        schema_for!(perfgate_types::AggregateReceipt),
+        schema_for!(perfgate_types::PerfgateReport),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[9],
-        schema_for!(perfgate_types::RatchetReceipt),
+        schema_for!(perfgate_types::AggregateReceipt),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[10],
+        schema_for!(perfgate_types::RatchetReceipt),
+    )?;
+
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[11],
         schema_for!(perfgate_types::RepairContextReceipt),
     )?;
 
     // Sensor report schema is vendored from contracts/, not generated.
     let vendored_schema = PathBuf::from("contracts/schemas/sensor.report.v1.schema.json");
-    let dest = out_dir.join(SCHEMA_FILES[11]);
+    let dest = out_dir.join(SCHEMA_FILES[12]);
     fs::copy(&vendored_schema, &dest).with_context(|| {
         format!(
             "copy vendored schema {} -> {}",
@@ -2337,6 +2345,9 @@ fn cmd_schema_compat(fixtures_dir: &Path) -> anyhow::Result<()> {
             }
             "perfgate.tradeoff.v1" => {
                 serde_json::from_value::<perfgate_types::TradeoffReceipt>(value).map(|_| ())
+            }
+            "perfgate.decision_index.v1" => {
+                serde_json::from_value::<perfgate_types::DecisionArtifactIndex>(value).map(|_| ())
             }
             "perfgate.report.v1" => {
                 serde_json::from_value::<perfgate_types::PerfgateReport>(value).map(|_| ())
@@ -3806,6 +3817,11 @@ fn validate_versioned_json_example(
                 .context("deserialize perfgate.tradeoff.v1 example")?;
             Ok(Some(perfgate_types::TRADEOFF_SCHEMA_V1))
         }
+        Some(perfgate_types::DECISION_INDEX_SCHEMA_V1) => {
+            serde_json::from_value::<perfgate_types::DecisionArtifactIndex>(value)
+                .context("deserialize perfgate.decision_index.v1 example")?;
+            Ok(Some(perfgate_types::DECISION_INDEX_SCHEMA_V1))
+        }
         Some(perfgate_types::AGGREGATE_SCHEMA_V1) => {
             serde_json::from_value::<perfgate_types::AggregateReceipt>(value)
                 .context("deserialize perfgate.aggregate.v1 example")?;
@@ -4173,7 +4189,7 @@ runs:
           echo "  ${decision_repro_line}"
           echo "### perfgate local reproduction"
           echo "${decision_repro_line}"
-          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name probe-compare.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name comment.md -o -name 'perfgate.*.json' \) | sort
+          find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name probe-compare.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name decision.index.json -o -name comment.md -o -name 'perfgate.*.json' \) | sort
         } >> "${GITHUB_STEP_SUMMARY}"
     - name: Post PR comment
       run: |


### PR DESCRIPTION
## Summary
- add `perfgate.decision_index.v1` and generated schema for decision artifact manifests
- make `perfgate decision evaluate` write `decision.index.json` alongside scenario/tradeoff/decision outputs
- include compare/probe-compare evidence paths in the index and surface it in docs, examples, action artifact discovery, and schema-compat fixtures

## Validation
- `cargo test -p perfgate-types structured_evidence --all-features`
- `cargo test -p perfgate-cli --test cli_structured_decision_e2e_tests --all-features`
- `cargo test -p perfgate-cli --test cli_performance_decision_example_tests --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- schema-compat`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- action-check`
- `cargo clippy -p perfgate-types -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- ci`
- `git diff --check`