### PR TITLE
decision: summarize accepted tradeoff debt

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -60,7 +60,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::process::ExitCode;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use url::Url;
 
 const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured; set `--baseline-server`, `PERFGATE_SERVER_URL`, or `[baseline_server].url` in `perfgate.toml`";
@@ -1309,6 +1309,8 @@ pub enum DecisionAction {
     History(DecisionHistoryArgs),
     /// Show the latest stored decision receipt from the baseline server.
     Latest(DecisionLatestArgs),
+    /// Summarize accepted tradeoff debt from the baseline server decision ledger.
+    Debt(DecisionDebtArgs),
 }
 
 #[derive(Debug, Args)]
@@ -1451,6 +1453,21 @@ pub struct DecisionLatestArgs {
     /// Project name (uses --project flag or PERFGATE_PROJECT if not specified).
     #[arg(long)]
     pub project: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct DecisionDebtArgs {
+    /// Project name (uses --project flag or PERFGATE_PROJECT if not specified).
+    #[arg(long)]
+    pub project: Option<String>,
+
+    /// Number of recent days to summarize. Use 0 to include all fetched records.
+    #[arg(long, default_value_t = 30)]
+    pub days: u32,
+
+    /// Maximum number of decision records to fetch from the server.
+    #[arg(long, default_value_t = 1000)]
+    pub limit: u32,
 }
 
 #[derive(Debug, Args)]
@@ -3735,6 +3752,7 @@ fn execute_decision_action(
         DecisionAction::Upload(args) => execute_decision_upload(args, server_flags),
         DecisionAction::History(args) => execute_decision_history(args, server_flags),
         DecisionAction::Latest(args) => execute_decision_latest(args, server_flags),
+        DecisionAction::Debt(args) => execute_decision_debt(args, server_flags),
     }
 }
 
@@ -3859,6 +3877,180 @@ fn execute_decision_latest(
     })?;
 
     Ok(())
+}
+
+fn execute_decision_debt(args: DecisionDebtArgs, server_flags: &ServerFlags) -> anyhow::Result<()> {
+    let (server_config, _config_file) = resolve_server_config_from_path(server_flags, None)?;
+    let client = server_config.require_fallback_client(None, BASELINE_SERVER_NOT_CONFIGURED)?;
+    let project = server_config.resolve_project(args.project)?;
+    let cutoff = decision_debt_cutoff(args.days)?;
+    let query = ListDecisionsQuery::new().with_limit(args.limit);
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let response = client
+            .list_decisions(&project, &query)
+            .await
+            .with_context(|| format!("Failed to list decisions for project '{}'", project))?;
+
+        let records: Vec<_> = response
+            .decisions
+            .iter()
+            .filter(|record| {
+                cutoff
+                    .map(|cutoff| record.created_at.timestamp() >= cutoff)
+                    .unwrap_or(true)
+            })
+            .collect();
+
+        if response.pagination.has_more {
+            eprintln!(
+                "Warning: scanned {} of {} decisions; increase --limit for a fuller debt summary.",
+                response.decisions.len(),
+                response.pagination.total
+            );
+        }
+
+        print_decision_debt_summary(&project, args.days, &records);
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+fn decision_debt_cutoff(days: u32) -> anyhow::Result<Option<i64>> {
+    if days == 0 {
+        return Ok(None);
+    }
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system time is before UNIX_EPOCH")?
+        .as_secs() as i64;
+    Ok(Some(now - i64::from(days) * 86_400))
+}
+
+#[derive(Default)]
+struct DecisionDebtAreaSummary {
+    accepted_count: u32,
+    review_required_count: u32,
+    rule_counts: BTreeMap<String, u32>,
+    max_cap_used: Option<f64>,
+}
+
+fn print_decision_debt_summary(
+    project: &str,
+    days: u32,
+    records: &[&perfgate_client::DecisionRecord],
+) {
+    let mut areas: BTreeMap<String, DecisionDebtAreaSummary> = BTreeMap::new();
+    let mut accepted_total = 0_u32;
+    let mut review_required_total = 0_u32;
+
+    for record in records {
+        if record.accepted_rules.is_empty() {
+            continue;
+        }
+
+        let area_name = record
+            .scenario
+            .clone()
+            .unwrap_or_else(|| "unspecified".to_string());
+        let area = areas.entry(area_name).or_default();
+        area.accepted_count += 1;
+        accepted_total += 1;
+
+        if record.review_required {
+            area.review_required_count += 1;
+            review_required_total += 1;
+        }
+
+        for rule in &record.accepted_rules {
+            *area.rule_counts.entry(rule.clone()).or_insert(0) += 1;
+        }
+
+        if let Some(cap_used) = decision_record_max_cap_used(record) {
+            area.max_cap_used = Some(area.max_cap_used.map_or(cap_used, |current| {
+                if cap_used > current {
+                    cap_used
+                } else {
+                    current
+                }
+            }));
+        }
+    }
+
+    let window = if days == 0 {
+        "all fetched records".to_string()
+    } else {
+        format!("last {days} days")
+    };
+
+    println!(
+        "Decision debt for {} ({}, {} records scanned):",
+        project,
+        window,
+        records.len()
+    );
+    println!("Accepted tradeoff records: {accepted_total}");
+    println!("Review-required accepted records: {review_required_total}");
+
+    if areas.is_empty() {
+        println!("\nNo accepted tradeoffs found.");
+        return;
+    }
+
+    println!();
+    println!(
+        "{:<24} {:>5} {:>6} {:>8}  common rule",
+        "area", "count", "review", "cap used"
+    );
+
+    for (area, summary) in areas {
+        println!(
+            "{:<24} {:>5} {:>6} {:>8}  {}",
+            area,
+            summary.accepted_count,
+            summary.review_required_count,
+            format_cap_used(summary.max_cap_used),
+            most_common_rule(&summary.rule_counts)
+        );
+    }
+}
+
+fn decision_record_max_cap_used(record: &perfgate_client::DecisionRecord) -> Option<f64> {
+    record
+        .tradeoff_receipt
+        .rules
+        .iter()
+        .filter(|rule| rule.accepted)
+        .flat_map(|rule| rule.allowances.iter())
+        .filter_map(|allowance| {
+            if allowance.max_regression <= 0.0 {
+                return None;
+            }
+            let observed = allowance.observed_regression?;
+            Some((observed.max(0.0) / allowance.max_regression).max(0.0))
+        })
+        .reduce(f64::max)
+}
+
+fn format_cap_used(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{:.0}%", value * 100.0))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn most_common_rule(rule_counts: &BTreeMap<String, u32>) -> String {
+    rule_counts
+        .iter()
+        .max_by(|(left_rule, left_count), (right_rule, right_count)| {
+            left_count
+                .cmp(right_count)
+                .then_with(|| right_rule.cmp(left_rule))
+        })
+        .map(|(rule, count)| format!("{rule} ({count})"))
+        .unwrap_or_else(|| "none".to_string())
 }
 
 fn print_decision_record(label: &str, record: &perfgate_client::DecisionRecord) {

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -294,7 +294,8 @@ fn cli_help_decision() {
         .stdout(predicate::str::contains(
             "Evaluate scenario and tradeoff evidence",
         ))
-        .stdout(predicate::str::contains("evaluate"));
+        .stdout(predicate::str::contains("evaluate"))
+        .stdout(predicate::str::contains("debt"));
 }
 
 #[test]
@@ -310,6 +311,17 @@ fn cli_help_decision_evaluate() {
         .stdout(predicate::str::contains("--scenario-out"))
         .stdout(predicate::str::contains("--tradeoff-out"))
         .stdout(predicate::str::contains("--decision-out"));
+}
+
+#[test]
+fn cli_help_decision_debt() {
+    perfgate_cmd()
+        .args(["decision", "debt", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Summarize accepted tradeoff debt"))
+        .stdout(predicate::str::contains("--days"))
+        .stdout(predicate::str::contains("--limit"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -116,19 +116,53 @@ fn tradeoff_receipt() -> serde_json::Value {
 }
 
 fn decision_record(project: &str, id: &str) -> serde_json::Value {
+    decision_record_with(
+        project,
+        id,
+        "release_workload",
+        &["memory_for_speed"],
+        false,
+        "2026-05-08T00:00:00Z",
+        None,
+    )
+}
+
+fn decision_record_with(
+    project: &str,
+    id: &str,
+    scenario: &str,
+    accepted_rules: &[&str],
+    review_required: bool,
+    created_at: &str,
+    cap_used: Option<(f64, f64)>,
+) -> serde_json::Value {
+    let mut tradeoff = tradeoff_receipt();
+    if let Some((observed_regression, max_regression)) = cap_used {
+        tradeoff["rules"][0]["allowances"] = serde_json::json!([{
+            "metric": "wall_ms",
+            "probe": "parser.tokenize",
+            "max_regression": max_regression,
+            "observed_regression": observed_regression,
+            "satisfied": observed_regression <= max_regression,
+            "status": "warn",
+            "reason": "local regression stayed inside cap"
+        }]);
+    }
+    tradeoff["scenario"] = serde_json::Value::String(scenario.to_string());
+
     serde_json::json!({
         "schema": "perfgate.decision_record.v1",
         "id": id,
         "project": project,
-        "scenario": "release_workload",
+        "scenario": scenario,
         "status": "warn",
         "verdict": "warn",
-        "accepted_rules": ["memory_for_speed"],
-        "review_required": false,
+        "accepted_rules": accepted_rules,
+        "review_required": review_required,
         "review_reasons": [],
         "git_ref": "refs/heads/main",
-        "tradeoff_receipt": tradeoff_receipt(),
-        "created_at": "2026-05-08T00:00:00Z"
+        "tradeoff_receipt": tradeoff,
+        "created_at": created_at
     })
 }
 
@@ -639,6 +673,83 @@ async fn test_decision_history_and_latest_use_server_ledger() {
         .stdout(predicate::str::contains("Latest decision decision-1"))
         .stdout(predicate::str::contains("status=warn"))
         .stdout(predicate::str::contains("verdict=warn"));
+}
+
+#[tokio::test]
+async fn test_decision_debt_summarizes_accepted_tradeoffs() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/projects/test-project/decisions"))
+        .and(header("Authorization", "Bearer decision-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "decisions": [
+                decision_record_with(
+                    "test-project",
+                    "decision-1",
+                    "parser",
+                    &["tokenizer-cost-for-batch-loop-win"],
+                    false,
+                    "2026-05-08T00:00:00Z",
+                    Some((0.021, 0.03))
+                ),
+                decision_record_with(
+                    "test-project",
+                    "decision-2",
+                    "parser",
+                    &["tokenizer-cost-for-batch-loop-win"],
+                    true,
+                    "2026-05-07T00:00:00Z",
+                    Some((0.015, 0.03))
+                ),
+                decision_record_with(
+                    "test-project",
+                    "decision-3",
+                    "renderer",
+                    &["memory-for-latency"],
+                    false,
+                    "2026-05-06T00:00:00Z",
+                    None
+                )
+            ],
+            "pagination": {
+                "total": 3,
+                "offset": 0,
+                "limit": 1000,
+                "has_more": false
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("decision-key")
+        .arg("--project")
+        .arg("test-project")
+        .arg("decision")
+        .arg("debt")
+        .arg("--days")
+        .arg("0");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Decision debt for test-project (all fetched records, 3 records scanned)",
+        ))
+        .stdout(predicate::str::contains("Accepted tradeoff records: 3"))
+        .stdout(predicate::str::contains(
+            "Review-required accepted records: 1",
+        ))
+        .stdout(predicate::str::contains("parser"))
+        .stdout(predicate::str::contains("70%"))
+        .stdout(predicate::str::contains(
+            "tokenizer-cost-for-batch-loop-win (2)",
+        ))
+        .stdout(predicate::str::contains("renderer"))
+        .stdout(predicate::str::contains("memory-for-latency (1)"));
 }
 
 #[tokio::test]

--- a/crates/perfgate-cli/tests/cli_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_server_tests.rs
@@ -1098,6 +1098,20 @@ async fn run_live_server_cli_workflow(
         .stdout(predicate::str::contains("Decision history"))
         .stdout(predicate::str::contains(&decision_scenario));
 
+    let mut decision_debt = perfgate_cmd();
+    decision_debt
+        .arg("decision")
+        .arg("debt")
+        .arg("--days")
+        .arg("0");
+    add_server_flags(&mut decision_debt, server.url(), project, api_key);
+    decision_debt
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Decision debt"))
+        .stdout(predicate::str::contains(&decision_scenario))
+        .stdout(predicate::str::contains("memory_for_speed (1)"));
+
     let mut delete = perfgate_cmd();
     delete
         .arg("baseline")

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
@@ -11,6 +11,7 @@ Commands:
   upload Upload a perfgate.tradeoff.v1 receipt to the baseline server decision ledger
   history List stored decision receipts from the baseline server
   latest Show the latest stored decision receipt from the baseline server
+  debt Summarize accepted tradeoff debt from the baseline server decision ledger
   help Print this message or the help of the given subcommand(s)
 
 Options:

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -181,6 +181,9 @@ The current CLI surfaces that talk to the baseline service are:
 | `baseline verdicts` | Query pass/warn/fail verdict history |
 | `baseline submit-verdict` | Submit verdict data from a compare receipt |
 | `baseline migrate` | Upload local baseline JSON files to the server |
+| `decision upload` | Store a structured performance decision receipt |
+| `decision history` | List stored performance decisions |
+| `decision debt` | Summarize accepted tradeoff debt by scenario |
 | `audit list` | List admin audit events |
 | `audit export --format jsonl` | Export audit events for external review |
 
@@ -212,6 +215,9 @@ The server exposes these top-level surfaces:
   data
 - `POST /api/v1/projects/{project}/verdicts`: submit a verdict
 - `GET /api/v1/projects/{project}/verdicts`: list verdicts
+- `POST /api/v1/projects/{project}/decisions`: upload a decision receipt
+- `GET /api/v1/projects/{project}/decisions`: list decision receipts
+- `GET /api/v1/projects/{project}/decisions/latest`: fetch latest decision
 - `GET /api/v1/audit`: list audit events
 - `POST /api/v1/keys`: create an API key
 - `GET /api/v1/keys`: list API keys

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -207,12 +207,18 @@ server can store decisions as audit-backed ledger entries:
 perfgate decision upload --file artifacts/perfgate/tradeoff.json --index artifacts/perfgate/decision.index.json
 perfgate decision latest
 perfgate decision history --limit 20
+perfgate decision debt --days 30
 ```
 
 The server returns `perfgate.decision_record.v1` records. Each record stores the
 tradeoff receipt, optional scenario receipt, optional artifact index, accepted
 rule names, final status/verdict, review state, git metadata, and creation
 time. Uploads emit an audit event with resource type `decision`.
+
+`decision debt` summarizes accepted tradeoff records by scenario so teams can
+spot repeated exceptions before they become invisible performance debt. When a
+tradeoff rule used local regression caps, the summary reports the highest cap
+usage observed in the selected window.
 
 ## Primitive Commands
 


### PR DESCRIPTION
## Summary
- add `perfgate decision debt` to summarize accepted tradeoff records from the server decision ledger
- group debt by scenario, report review-required accepted records, most common accepted rule, and local-regression cap usage when present
- extend mock-server and live server CLI workflows, plus decision help/docs

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-cli --test cli_mock_server_tests decision_debt --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests decision_debt --all-features`
- `cargo test -p perfgate-cli --test cli_mock_server_tests decision --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests help_decision --all-features`
- `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo test -p perfgate-cli --test cli_server_tests live_server_cli_workflow_memory --all-features`
- `cargo test -p perfgate-cli --test cli_server_tests live_server_cli_workflow_sqlite --all-features`
- `cargo test -p perfgate-cli --test cli_server_tests live_server_cli_workflow_postgres --all-features`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- ci`
- `git diff --check`

Note: local Postgres live workflow exits successfully and skips when `PERFGATE_TEST_POSTGRES_URL` is unset.