### PR TITLE
dashboard: expose decision ledger

### DIFF
--- a/crates/perfgate-server/assets/index.html
+++ b/crates/perfgate-server/assets/index.html
@@ -709,6 +709,50 @@
             </div>
         </div>
 
+        <!-- Performance Decisions -->
+        <div class="card">
+            <h2>Performance Decisions</h2>
+
+            <div class="filter-bar">
+                <div class="checkbox-group">
+                    <label><input type="checkbox" id="decisionPass" checked onchange="resetAndLoadDecisions()"> Pass</label>
+                    <label><input type="checkbox" id="decisionWarn" checked onchange="resetAndLoadDecisions()"> Warn</label>
+                    <label><input type="checkbox" id="decisionFail" checked onchange="resetAndLoadDecisions()"> Fail</label>
+                    <label><input type="checkbox" id="decisionSkip" checked onchange="resetAndLoadDecisions()"> Skip</label>
+                    <label><input type="checkbox" id="decisionReviewOnly" onchange="resetAndLoadDecisions()"> Needs Review</label>
+                </div>
+                <button onclick="resetAndLoadDecisions()">Load Decisions</button>
+            </div>
+
+            <div style="overflow-x:auto;">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Scenario</th>
+                            <th>Status</th>
+                            <th>Verdict</th>
+                            <th>Review</th>
+                            <th>Accepted Rules</th>
+                            <th>Git Ref</th>
+                            <th>Created</th>
+                        </tr>
+                    </thead>
+                    <tbody id="decisionsBody">
+                        <tr><td colspan="7" class="empty-state"><p>Load a project to see performance decisions</p></td></tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <div id="decisionPagination" class="pagination" style="display:none;">
+                <span id="decisionPaginationInfo"></span>
+                <div class="pagination-controls">
+                    <button class="btn-sm btn-secondary" id="decisionPrevBtn" onclick="changeDecisionPage(-1)" disabled>&laquo; Prev</button>
+                    <span id="decisionPageIndicator"></span>
+                    <button class="btn-sm btn-secondary" id="decisionNextBtn" onclick="changeDecisionPage(1)" disabled>Next &raquo;</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Audit Events -->
         <div class="card">
             <h2>Audit Events</h2>
@@ -729,6 +773,7 @@
                     <select id="auditResourceType" onchange="resetAndLoadAuditEvents()">
                         <option value="">All</option>
                         <option value="baseline">Baseline</option>
+                        <option value="decision">Decision</option>
                         <option value="key">Key</option>
                         <option value="verdict">Verdict</option>
                     </select>
@@ -836,6 +881,9 @@
         let verdictPage = 0;
         let verdictPageSize = 20;
         let totalVerdicts = 0;
+        let decisionPage = 0;
+        let decisionPageSize = 20;
+        let totalDecisions = 0;
         let auditPage = 0;
         let auditPageSize = 20;
         let totalAuditEvents = 0;
@@ -922,6 +970,13 @@
             return '<span class="badge">' + safe + '</span>';
         }
 
+        function reviewBadge(reviewRequired) {
+            if (reviewRequired) {
+                return '<span class="badge badge-warn">review</span>';
+            }
+            return '<span class="badge badge-pass">clear</span>';
+        }
+
         /* ======= API fetch ======= */
         async function fetchApi(url) {
             hideError();
@@ -1004,8 +1059,9 @@
             applyClientFilters();
             updatePagination();
 
-            // Also load verdicts
+            // Also load related operational views.
             loadVerdicts();
+            loadDecisions();
         }
 
         function applyClientFilters() {
@@ -1140,6 +1196,89 @@
             verdictPage += delta;
             if (verdictPage < 0) verdictPage = 0;
             loadVerdicts();
+        }
+
+        /* ======= Decision ledger ======= */
+        function resetAndLoadDecisions() {
+            decisionPage = 0;
+            loadDecisions();
+        }
+
+        async function loadDecisions() {
+            var project = getProject();
+            var body = document.getElementById('decisionsBody');
+            body.innerHTML = loadingRow(7);
+
+            var statusFilters = [];
+            if (document.getElementById('decisionPass').checked) statusFilters.push('pass');
+            if (document.getElementById('decisionWarn').checked) statusFilters.push('warn');
+            if (document.getElementById('decisionFail').checked) statusFilters.push('fail');
+            if (document.getElementById('decisionSkip').checked) statusFilters.push('skip');
+            var reviewOnly = document.getElementById('decisionReviewOnly').checked;
+
+            var url = '/api/v1/projects/' + encodeURIComponent(project)
+                + '/decisions?limit=' + decisionPageSize
+                + '&offset=' + (decisionPage * decisionPageSize);
+
+            var data = await fetchApi(url);
+            if (!data) {
+                body.innerHTML = emptyRow(7, 'Failed to load decisions.');
+                document.getElementById('decisionPagination').style.display = 'none';
+                return;
+            }
+
+            var decisions = (data.decisions || []).filter(function(d) {
+                if (statusFilters.indexOf(d.status) === -1) return false;
+                if (reviewOnly && !d.review_required) return false;
+                return true;
+            });
+            totalDecisions = data.pagination ? data.pagination.total : decisions.length;
+
+            if (decisions.length === 0) {
+                body.innerHTML = emptyRow(7, 'No decisions match your filters.');
+                document.getElementById('decisionPagination').style.display = 'none';
+                return;
+            }
+
+            body.innerHTML = '';
+            decisions.forEach(function(d) {
+                var rules = (d.accepted_rules || []).join(', ') || '-';
+                var gitRef = d.git_ref || d.git_sha || '-';
+                var row = document.createElement('tr');
+                row.innerHTML =
+                    '<td><strong>' + escHtml(d.scenario || 'unspecified') + '</strong></td>'
+                    + '<td>' + verdictBadge(d.status) + '</td>'
+                    + '<td>' + verdictBadge(d.verdict) + '</td>'
+                    + '<td>' + reviewBadge(!!d.review_required) + '</td>'
+                    + '<td>' + escHtml(rules) + '</td>'
+                    + '<td><code>' + escHtml(gitRef) + '</code></td>'
+                    + '<td>' + fmtDate(d.created_at) + '</td>';
+                body.appendChild(row);
+            });
+
+            updateDecisionPagination();
+        }
+
+        function updateDecisionPagination() {
+            var pag = document.getElementById('decisionPagination');
+            var totalPages = Math.max(1, Math.ceil(totalDecisions / decisionPageSize));
+            if (totalDecisions <= decisionPageSize) {
+                pag.style.display = 'none';
+                return;
+            }
+            pag.style.display = 'flex';
+            document.getElementById('decisionPaginationInfo').textContent =
+                totalDecisions + ' decisions total';
+            document.getElementById('decisionPageIndicator').textContent =
+                'Page ' + (decisionPage + 1) + ' of ' + totalPages;
+            document.getElementById('decisionPrevBtn').disabled = decisionPage === 0;
+            document.getElementById('decisionNextBtn').disabled = decisionPage >= totalPages - 1;
+        }
+
+        function changeDecisionPage(delta) {
+            decisionPage += delta;
+            if (decisionPage < 0) decisionPage = 0;
+            loadDecisions();
         }
 
         /* ======= Audit events ======= */

--- a/crates/perfgate-server/src/handlers/dashboard.rs
+++ b/crates/perfgate-server/src/handlers/dashboard.rs
@@ -48,5 +48,18 @@ mod tests {
         assert!(INDEX_HTML.contains("id=\"auditAction\""));
         assert!(INDEX_HTML.contains("id=\"auditResourceType\""));
         assert!(INDEX_HTML.contains("id=\"auditActor\""));
+        assert!(INDEX_HTML.contains("<option value=\"decision\">Decision</option>"));
+    }
+
+    #[test]
+    fn dashboard_exposes_decision_ledger_panel() {
+        assert!(INDEX_HTML.contains("<h2>Performance Decisions</h2>"));
+        assert!(INDEX_HTML.contains("id=\"decisionsBody\""));
+        assert!(INDEX_HTML.contains("function loadDecisions()"));
+        assert!(INDEX_HTML.contains("'/decisions?limit='"));
+        assert!(INDEX_HTML.contains("id=\"decisionSkip\""));
+        assert!(INDEX_HTML.contains("id=\"decisionReviewOnly\""));
+        assert!(INDEX_HTML.contains("id=\"decisionPagination\""));
+        assert!(INDEX_HTML.contains("loadDecisions();"));
     }
 }

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -97,6 +97,7 @@ are real server capabilities, but they are not yet first-class CLI flags.
 `perfgate serve` runs the service in local mode:
 
 - dashboard enabled
+- baseline, verdict, flakiness, decision-ledger, and audit-event views
 - auth disabled for API routes
 - SQLite-backed local storage
 - intended for one developer on one machine
@@ -122,6 +123,9 @@ Public routes currently exposed by the server are:
 | `GET /api/v1/projects/{project}/baselines/{benchmark}/trend` | fetch trend data |
 | `POST /api/v1/projects/{project}/verdicts` | submit a verdict |
 | `GET /api/v1/projects/{project}/verdicts` | list verdicts |
+| `POST /api/v1/projects/{project}/decisions` | upload a decision receipt |
+| `GET /api/v1/projects/{project}/decisions` | list decision receipts |
+| `GET /api/v1/projects/{project}/decisions/latest` | fetch latest decision |
 | `GET /api/v1/audit` | list audit events |
 | `POST /api/v1/keys` | create an API key |
 | `GET /api/v1/keys` | list API keys |
@@ -148,6 +152,9 @@ The main server-aware CLI workflows are:
 | `baseline flaky` | inspect benchmarks with elevated historical noise |
 | `baseline submit-verdict` | persist compare verdicts |
 | `baseline migrate` | upload local baseline JSON files recursively |
+| `decision upload` | store a structured performance decision receipt |
+| `decision history` | list stored performance decisions |
+| `decision debt` | summarize accepted tradeoff debt by scenario |
 | `audit list` | inspect append-only audit events |
 | `audit export --format jsonl` | export audit events for operators or compliance review |
 | `fleet alerts` | list fleet-wide dependency regression alerts |

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -68,9 +68,9 @@ perfgate compare \
 
 `perfgate serve` runs in local mode and is intended for one developer on one
 machine. Do not treat it as a shared or internet-facing deployment.
-The dashboard at `/` includes baseline, verdict, flakiness, and audit-event
-views; shared authenticated servers require an API key in the dashboard header
-before protected API data can load.
+The dashboard at `/` includes baseline, verdict, flakiness, decision-ledger,
+and audit-event views; shared authenticated servers require an API key in the
+dashboard header before protected API data can load.
 
 ## Shared Server
 


### PR DESCRIPTION
## Summary
- add a Performance Decisions panel to the server dashboard that lists stored decision receipts with status, verdict, review requirement, accepted rules, git ref, and creation time
- add decision as an audit resource filter and load decision records alongside baseline/verdict dashboard data
- update baseline server docs to include decision-ledger routes, CLI mapping, and dashboard visibility

## Validation
- cargo fmt --all -- --check
- cargo test -p perfgate-server dashboard --all-features
- cargo clippy -p perfgate-server --all-targets --all-features -- -D warnings
- cargo run -p xtask -- docs-check
- cargo run -p xtask -- doc-test
- cargo run -p xtask -- public-surface --strict
- cargo run -p xtask -- arch
- cargo run -p xtask -- action-check
- cargo run -p xtask -- ci
- git diff --check