### PR TITLE
decision: export portable evidence bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ local reproduction command. `decision.index.json` is the machine-readable
 manifest for the evidence files behind that review.
 When scenarios configure probe baseline/current paths, `decision evaluate` also
 writes the configured `probe-compare.json` before evaluating the decision.
+To attach or archive the whole decision evidence set, export the indexed
+bundle:
+
+```bash
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
 
 In GitHub Actions, opt in with:
 

--- a/crates/perfgate-cli/README.md
+++ b/crates/perfgate-cli/README.md
@@ -73,6 +73,7 @@ Commands are organized by workflow stage.
 | `summary`            | Print a terminal table from one or more compare receipts |
 | `github-annotations` | Emit `::error::`/`::warning::` lines for GitHub Actions |
 | `export`             | Export to CSV, JSONL, HTML, Prometheus, or JUnit |
+| `decision bundle`    | Export indexed decision evidence as a portable JSON bundle |
 
 ### Manage
 

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -45,15 +45,19 @@ use perfgate_types::config::{
     apply_ratchet_toml_changes, load_config_file, preview_ratchet_toml_changes,
 };
 use perfgate_types::error::{ConfigValidationError, IoError, PerfgateError};
+use perfgate_types::fingerprint::sha256_hex;
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
-    ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_INDEX_SCHEMA_V1,
-    DecisionArtifactIndex, FailIfNOfM, HostMismatchPolicy, MetricStatus, OtelSpanIdentifiers,
+    ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_BUNDLE_SCHEMA_V1,
+    DECISION_INDEX_SCHEMA_V1, DecisionArtifactIndex, DecisionBundleArtifact,
+    DecisionBundleArtifactContent, DecisionBundleArtifactKind, DecisionBundleMetadata,
+    DecisionBundleReceipt, FailIfNOfM, HostMismatchPolicy, MetricStatus, OtelSpanIdentifiers,
     PerfgateReport, ProbeCompareReceipt, ProbeReceipt, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
     RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
     ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt, VerdictStatus,
 };
 use regex::Regex;
+use serde_json::Value as JsonValue;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -1303,6 +1307,8 @@ pub enum TradeoffAction {
 pub enum DecisionAction {
     /// Evaluate configured scenarios and tradeoffs, then render decision markdown.
     Evaluate(DecisionEvaluateArgs),
+    /// Export indexed decision evidence as one portable JSON bundle.
+    Bundle(DecisionBundleArgs),
     /// Upload a perfgate.tradeoff.v1 receipt to the baseline server decision ledger.
     Upload(DecisionUploadArgs),
     /// List stored decision receipts from the baseline server.
@@ -1394,6 +1400,29 @@ pub struct DecisionEvaluateArgs {
     pub index_out: Option<PathBuf>,
 
     /// Pretty-print JSON receipts.
+    #[arg(long, default_value_t = false)]
+    pub pretty: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DecisionBundleArgs {
+    /// Path to a perfgate.decision_index.v1 receipt.
+    #[arg(long, default_value = "artifacts/perfgate/decision.index.json")]
+    pub index: PathBuf,
+
+    /// Output perfgate.decision_bundle.v1 receipt path.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    /// Git reference associated with this bundle. Defaults to the current branch when available.
+    #[arg(long)]
+    pub git_ref: Option<String>,
+
+    /// Git commit SHA associated with this bundle. Defaults to the current commit when available.
+    #[arg(long)]
+    pub git_sha: Option<String>,
+
+    /// Pretty-print JSON.
     #[arg(long, default_value_t = false)]
     pub pretty: bool,
 }
@@ -3749,11 +3778,213 @@ fn execute_decision_action(
 ) -> anyhow::Result<()> {
     match action {
         DecisionAction::Evaluate(args) => execute_decision_evaluate(args),
+        DecisionAction::Bundle(args) => execute_decision_bundle(args),
         DecisionAction::Upload(args) => execute_decision_upload(args, server_flags),
         DecisionAction::History(args) => execute_decision_history(args, server_flags),
         DecisionAction::Latest(args) => execute_decision_latest(args, server_flags),
         DecisionAction::Debt(args) => execute_decision_debt(args, server_flags),
     }
+}
+
+fn execute_decision_bundle(args: DecisionBundleArgs) -> anyhow::Result<()> {
+    let index: DecisionArtifactIndex = read_json(&args.index).with_context(|| {
+        format!(
+            "Failed to read decision artifact index from {}",
+            args.index.display()
+        )
+    })?;
+    if index.schema != DECISION_INDEX_SCHEMA_V1 {
+        anyhow::bail!(
+            "decision artifact index must use schema '{}', got '{}'",
+            DECISION_INDEX_SCHEMA_V1,
+            index.schema
+        );
+    }
+
+    let tradeoff_path = resolve_index_artifact_path(&args.index, &index.tradeoff);
+    let tradeoff: TradeoffReceipt = read_json(&tradeoff_path).with_context(|| {
+        format!(
+            "Failed to read tradeoff receipt from {}",
+            tradeoff_path.display()
+        )
+    })?;
+
+    let artifacts = build_decision_bundle_artifacts(&args.index, &index)?;
+    let git = git_metadata();
+    let metadata = DecisionBundleMetadata {
+        index_path: artifact_path_string(&args.index),
+        git_ref: args
+            .git_ref
+            .or_else(|| git.as_ref().and_then(|metadata| metadata.branch.clone())),
+        git_sha: args
+            .git_sha
+            .or_else(|| git.as_ref().and_then(|metadata| metadata.sha.clone())),
+    };
+    let bundle = DecisionBundleReceipt {
+        schema: DECISION_BUNDLE_SCHEMA_V1.to_string(),
+        tool: ToolInfo {
+            name: "perfgate".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        run: tradeoff.run,
+        metadata,
+        index,
+        artifacts,
+    };
+
+    let out = args.out.unwrap_or_else(|| {
+        args.index
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .map(|parent| parent.join("decision-bundle.json"))
+            .unwrap_or_else(|| PathBuf::from("decision-bundle.json"))
+    });
+    write_json(&out, &bundle, args.pretty)?;
+    eprintln!("Decision bundle written to {}", out.display());
+
+    Ok(())
+}
+
+fn build_decision_bundle_artifacts(
+    index_path: &Path,
+    index: &DecisionArtifactIndex,
+) -> anyhow::Result<Vec<DecisionBundleArtifact>> {
+    let mut artifacts = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    push_decision_bundle_artifact(
+        &mut artifacts,
+        &mut seen,
+        index_path,
+        &artifact_path_string(index_path),
+        DecisionBundleArtifactKind::DecisionIndex,
+    )?;
+    push_decision_bundle_artifact(
+        &mut artifacts,
+        &mut seen,
+        index_path,
+        &index.scenario,
+        DecisionBundleArtifactKind::Scenario,
+    )?;
+    push_decision_bundle_artifact(
+        &mut artifacts,
+        &mut seen,
+        index_path,
+        &index.tradeoff,
+        DecisionBundleArtifactKind::Tradeoff,
+    )?;
+    push_decision_bundle_artifact(
+        &mut artifacts,
+        &mut seen,
+        index_path,
+        &index.decision,
+        DecisionBundleArtifactKind::DecisionMarkdown,
+    )?;
+    for path in &index.probe_compares {
+        push_decision_bundle_artifact(
+            &mut artifacts,
+            &mut seen,
+            index_path,
+            path,
+            DecisionBundleArtifactKind::ProbeCompare,
+        )?;
+    }
+    for path in &index.compare_receipts {
+        push_decision_bundle_artifact(
+            &mut artifacts,
+            &mut seen,
+            index_path,
+            path,
+            DecisionBundleArtifactKind::CompareReceipt,
+        )?;
+    }
+
+    Ok(artifacts)
+}
+
+fn push_decision_bundle_artifact(
+    artifacts: &mut Vec<DecisionBundleArtifact>,
+    seen: &mut BTreeSet<String>,
+    index_path: &Path,
+    artifact_path: &str,
+    kind: DecisionBundleArtifactKind,
+) -> anyhow::Result<()> {
+    let normalized = normalize_artifact_path(artifact_path);
+    if !seen.insert(normalized.clone()) {
+        return Ok(());
+    }
+
+    let resolved = if matches!(kind, DecisionBundleArtifactKind::DecisionIndex) {
+        index_path.to_path_buf()
+    } else {
+        resolve_index_artifact_path(index_path, artifact_path)
+    };
+    let bytes = fs::read(&resolved)
+        .with_context(|| format!("read decision bundle artifact {}", resolved.display()))?;
+    let sha256 = sha256_hex(&bytes);
+
+    let (media_type, schema, content) = match kind {
+        DecisionBundleArtifactKind::DecisionMarkdown => {
+            let text = String::from_utf8(bytes).with_context(|| {
+                format!(
+                    "decision markdown artifact must be UTF-8: {}",
+                    resolved.display()
+                )
+            })?;
+            (
+                "text/markdown; charset=utf-8".to_string(),
+                None,
+                DecisionBundleArtifactContent::Text { value: text },
+            )
+        }
+        DecisionBundleArtifactKind::DecisionIndex
+        | DecisionBundleArtifactKind::Scenario
+        | DecisionBundleArtifactKind::Tradeoff
+        | DecisionBundleArtifactKind::ProbeCompare
+        | DecisionBundleArtifactKind::CompareReceipt => {
+            let value: JsonValue = serde_json::from_slice(&bytes).with_context(|| {
+                format!(
+                    "decision bundle artifact must be JSON: {}",
+                    resolved.display()
+                )
+            })?;
+            let schema = value
+                .get("schema")
+                .or_else(|| value.get("report_type"))
+                .and_then(|schema| schema.as_str())
+                .map(str::to_string);
+            (
+                "application/json".to_string(),
+                schema,
+                DecisionBundleArtifactContent::Json { value },
+            )
+        }
+    };
+
+    artifacts.push(DecisionBundleArtifact {
+        path: normalized,
+        kind,
+        media_type,
+        sha256,
+        schema,
+        content,
+    });
+
+    Ok(())
+}
+
+fn resolve_index_artifact_path(index_path: &Path, artifact_path: &str) -> PathBuf {
+    let path = PathBuf::from(artifact_path);
+    if path.is_absolute() || path.exists() {
+        return path;
+    }
+
+    index_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .map(|parent| parent.join(artifact_path))
+        .filter(|candidate| candidate.exists())
+        .unwrap_or(path)
 }
 
 fn execute_decision_upload(

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -325,6 +325,19 @@ fn cli_help_decision_debt() {
 }
 
 #[test]
+fn cli_help_decision_bundle() {
+    perfgate_cmd()
+        .args(["decision", "bundle", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Export indexed decision evidence as one portable JSON bundle",
+        ))
+        .stdout(predicate::str::contains("--index"))
+        .stdout(predicate::str::contains("--out"));
+}
+
+#[test]
 fn cli_help_probe() {
     perfgate_cmd()
         .args(["probe", "--help"])
@@ -509,6 +522,14 @@ fn snapshot_help_decision_evaluate() {
     insta::assert_snapshot!(
         "help_decision_evaluate",
         help_output(&["decision", "evaluate", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_decision_bundle() {
+    insta::assert_snapshot!(
+        "help_decision_bundle",
+        help_output(&["decision", "bundle", "--help"])
     );
 }
 

--- a/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
+++ b/crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs
@@ -151,6 +151,65 @@ fn performance_decision_example_runs_end_to_end() {
             "examples/performance-decision/receipts/small-edit.compare.json"
         ]
     );
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "decision",
+            "bundle",
+            "--index",
+            "artifacts/perfgate/decision.index.json",
+            "--out",
+            "artifacts/perfgate/decision-bundle.json",
+            "--git-ref",
+            "main",
+            "--git-sha",
+            "abc123",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Decision bundle written"));
+
+    let bundle: perfgate_types::DecisionBundleReceipt = serde_json::from_str(
+        &fs::read_to_string(root.join("artifacts/perfgate/decision-bundle.json"))
+            .expect("read decision bundle"),
+    )
+    .expect("decision bundle should deserialize");
+    assert_eq!(bundle.schema, "perfgate.decision_bundle.v1");
+    assert_eq!(bundle.metadata.git_ref.as_deref(), Some("main"));
+    assert_eq!(bundle.metadata.git_sha.as_deref(), Some("abc123"));
+    assert_eq!(bundle.index.schema, "perfgate.decision_index.v1");
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind
+                == perfgate_types::DecisionBundleArtifactKind::DecisionIndex)
+    );
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == perfgate_types::DecisionBundleArtifactKind::Scenario)
+    );
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == perfgate_types::DecisionBundleArtifactKind::Tradeoff)
+    );
+    assert!(
+        bundle.artifacts.iter().any(|artifact| artifact.kind
+            == perfgate_types::DecisionBundleArtifactKind::DecisionMarkdown)
+    );
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.path == "artifacts/perfgate/large-file/probe-compare.json")
+    );
+    assert!(bundle.artifacts.iter().any(|artifact| artifact.path
+        == "examples/performance-decision/receipts/large-file.compare.json"));
 }
 
 fn copy_dir_all(source: &Path, destination: &Path) {

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 517
 expression: "help_output(&[\"decision\", \"--help\"])"
 ---
 Evaluate scenario and tradeoff evidence into a review-ready decision summary
@@ -8,6 +9,7 @@ Usage: perfgate decision [OPTIONS] <COMMAND>
 
 Commands:
   evaluate Evaluate configured scenarios and tradeoffs, then render decision markdown
+  bundle Export indexed decision evidence as one portable JSON bundle
   upload Upload a perfgate.tradeoff.v1 receipt to the baseline server decision ledger
   history List stored decision receipts from the baseline server
   latest Show the latest stored decision receipt from the baseline server

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision_bundle.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision_bundle.snap
@@ -1,0 +1,21 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 530
+expression: "help_output(&[\"decision\", \"bundle\", \"--help\"])"
+---
+Export indexed decision evidence as one portable JSON bundle
+
+Usage: perfgate decision bundle [OPTIONS]
+
+Options:
+      --index <INDEX> Path to a perfgate.decision_index.v1 receipt [default: artifacts/perfgate/decision.index.json]
+      --out <OUT> Output perfgate.decision_bundle.v1 receipt path
+      --git-ref <GIT_REF> Git reference associated with this bundle. Defaults to the current branch when available
+      --git-sha <GIT_SHA> Git commit SHA associated with this bundle. Defaults to the current commit when available
+      --pretty Pretty-print JSON
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-types/src/lib.rs
+++ b/crates/perfgate-types/src/lib.rs
@@ -63,6 +63,7 @@ pub const PROBE_COMPARE_SCHEMA_V1: &str = "perfgate.probe_compare.v1";
 pub const SCENARIO_SCHEMA_V1: &str = "perfgate.scenario.v1";
 pub const TRADEOFF_SCHEMA_V1: &str = "perfgate.tradeoff.v1";
 pub const DECISION_INDEX_SCHEMA_V1: &str = "perfgate.decision_index.v1";
+pub const DECISION_BUNDLE_SCHEMA_V1: &str = "perfgate.decision_bundle.v1";
 pub const REPORT_SCHEMA_V1: &str = "perfgate.report.v1";
 pub const CONFIG_SCHEMA_V1: &str = "perfgate.config.v1";
 pub const RATCHET_SCHEMA_V1: &str = "perfgate.ratchet.v1";

--- a/crates/perfgate-types/src/structured_evidence.rs
+++ b/crates/perfgate-types/src/structured_evidence.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::BTreeMap;
 
 /// Scope of a named performance probe inside a workload.
@@ -354,12 +355,70 @@ pub struct DecisionArtifactIndex {
     pub compare_receipts: Vec<String>,
 }
 
+/// Metadata captured when exporting a portable decision bundle.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct DecisionBundleMetadata {
+    pub index_path: String,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub git_ref: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub git_sha: Option<String>,
+}
+
+/// Kind of artifact embedded in a portable decision bundle.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DecisionBundleArtifactKind {
+    DecisionIndex,
+    Scenario,
+    Tradeoff,
+    DecisionMarkdown,
+    ProbeCompare,
+    CompareReceipt,
+}
+
+/// Embedded artifact content.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DecisionBundleArtifactContent {
+    Json { value: Value },
+    Text { value: String },
+}
+
+/// One artifact embedded in a portable decision bundle.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct DecisionBundleArtifact {
+    pub path: String,
+    pub kind: DecisionBundleArtifactKind,
+    pub media_type: String,
+    pub sha256: String,
+
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub schema: Option<String>,
+
+    pub content: DecisionBundleArtifactContent,
+}
+
+/// A portable receipt bundle for structured performance decisions.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct DecisionBundleReceipt {
+    pub schema: String,
+    pub tool: ToolInfo,
+    pub run: RunMeta,
+    pub metadata: DecisionBundleMetadata,
+    pub index: DecisionArtifactIndex,
+    pub artifacts: Vec<DecisionBundleArtifact>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        DECISION_INDEX_SCHEMA_V1, PROBE_COMPARE_SCHEMA_V1, PROBE_SCHEMA_V1, SCENARIO_SCHEMA_V1,
-        TRADEOFF_SCHEMA_V1, U64Summary, VerdictCounts, VerdictStatus,
+        DECISION_BUNDLE_SCHEMA_V1, DECISION_INDEX_SCHEMA_V1, PROBE_COMPARE_SCHEMA_V1,
+        PROBE_SCHEMA_V1, SCENARIO_SCHEMA_V1, TRADEOFF_SCHEMA_V1, U64Summary, VerdictCounts,
+        VerdictStatus,
     };
 
     fn tool() -> ToolInfo {
@@ -617,6 +676,68 @@ mod tests {
         assert_eq!(
             parsed.probe_compares,
             vec!["artifacts/perfgate/large-file/probe-compare.json"]
+        );
+    }
+
+    #[test]
+    fn decision_bundle_receipt_round_trips() {
+        let index = DecisionArtifactIndex {
+            schema: DECISION_INDEX_SCHEMA_V1.into(),
+            scenario: "artifacts/perfgate/scenario.json".into(),
+            tradeoff: "artifacts/perfgate/tradeoff.json".into(),
+            decision: "artifacts/perfgate/decision.md".into(),
+            probe_compares: vec!["artifacts/perfgate/large-file/probe-compare.json".into()],
+            compare_receipts: vec!["artifacts/perfgate/large-file/compare.json".into()],
+        };
+        let receipt = DecisionBundleReceipt {
+            schema: DECISION_BUNDLE_SCHEMA_V1.into(),
+            tool: tool(),
+            run: run(),
+            metadata: DecisionBundleMetadata {
+                index_path: "artifacts/perfgate/decision.index.json".into(),
+                git_ref: Some("main".into()),
+                git_sha: Some("abc123".into()),
+            },
+            index,
+            artifacts: vec![
+                DecisionBundleArtifact {
+                    path: "artifacts/perfgate/decision.index.json".into(),
+                    kind: DecisionBundleArtifactKind::DecisionIndex,
+                    media_type: "application/json".into(),
+                    sha256: "00".repeat(32),
+                    schema: Some(DECISION_INDEX_SCHEMA_V1.into()),
+                    content: DecisionBundleArtifactContent::Json {
+                        value: serde_json::json!({
+                            "schema": DECISION_INDEX_SCHEMA_V1,
+                            "scenario": "artifacts/perfgate/scenario.json",
+                            "tradeoff": "artifacts/perfgate/tradeoff.json",
+                            "decision": "artifacts/perfgate/decision.md",
+                            "probe_compares": [],
+                            "compare_receipts": []
+                        }),
+                    },
+                },
+                DecisionBundleArtifact {
+                    path: "artifacts/perfgate/decision.md".into(),
+                    kind: DecisionBundleArtifactKind::DecisionMarkdown,
+                    media_type: "text/markdown; charset=utf-8".into(),
+                    sha256: "11".repeat(32),
+                    schema: None,
+                    content: DecisionBundleArtifactContent::Text {
+                        value: "# Decision".into(),
+                    },
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&receipt).expect("serialize decision bundle");
+        let parsed: DecisionBundleReceipt =
+            serde_json::from_str(&json).expect("parse decision bundle");
+        assert_eq!(parsed.schema, DECISION_BUNDLE_SCHEMA_V1);
+        assert_eq!(parsed.artifacts.len(), 2);
+        assert_eq!(
+            parsed.artifacts[0].kind,
+            DecisionBundleArtifactKind::DecisionIndex
         );
     }
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -35,6 +35,18 @@ files, and the local reproduction command.
 `decision.index.json` is the machine-readable artifact manifest for actions,
 servers, dashboards, and agents that need to find the generated evidence set.
 
+Export a portable JSON bundle when the decision evidence needs to travel with a
+release, issue, audit, or agent handoff:
+
+```bash
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+The bundle uses `perfgate.decision_bundle.v1` and embeds the indexed scenario,
+tradeoff, decision markdown, probe-compare, and compare artifacts with SHA-256
+hashes plus git metadata when available. It is a transport artifact; the
+original receipts remain the source of truth.
+
 ## Workflow Levels
 
 ### Normal Gate

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -123,6 +123,7 @@ artifacts/perfgate/
   tradeoff.json
   decision.md
   decision.index.json
+  decision-bundle.json   # optional portable export from decision.index.json
 ```
 
 `xtask action-check` guards the GitHub Action decision path: when
@@ -276,6 +277,9 @@ The **core local gating pipeline** is production-quality:
   compare, scenario, probe-compare, and tradeoff receipts, writes
   `decision.md` plus `decision.index.json`, and is the taught advanced workflow
   for reviewable performance tradeoffs.
+- **Portable decision bundles** — `perfgate decision bundle` exports
+  `perfgate.decision_bundle.v1` from `decision.index.json` for release,
+  audit, issue, or agent handoff attachment without requiring the server.
 - **Probe evidence and tradeoff guardrails** — `perfgate ingest probes`,
   `perfgate probe compare`, scenario-attached probe evidence, probe-backed
   tradeoff requirements, local-regression caps, and noise-aware review policies

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -15,6 +15,7 @@ Receipt schemas are public API. The following schema IDs are stable:
 - `perfgate.tradeoff.v1`
 - `perfgate.decision_index.v1`
 - `perfgate.decision_record.v1`
+- `perfgate.decision_bundle.v1`
 - `perfgate.report.v1`
 - `perfgate.config.v1`
 - `sensor.report.v1` (cockpit mode envelope, vendored at `contracts/schemas/`)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -47,6 +47,7 @@ perfgate also commits generated schemas for tooling and editor integration:
 | `schemas/perfgate.tradeoff.v1.schema.json` | Validates tradeoff receipts that explain why local regressions were accepted or rejected |
 | `schemas/perfgate.decision_index.v1.schema.json` | Validates the decision artifact manifest produced by `decision evaluate` |
 | `schemas/perfgate.decision_record.v1.schema.json` | Validates server-side decision ledger records returned by `decision upload`, `decision latest`, and `decision history` |
+| `schemas/perfgate.decision_bundle.v1.schema.json` | Validates portable decision bundles exported from `decision.index.json` |
 | `schemas/perfgate.report.v1.schema.json` | Validates report receipts, including additive diagnostics such as `profile_path` |
 
 ## JSON Schema Generation
@@ -171,6 +172,19 @@ The index receipt uses `perfgate.decision_index.v1` and records the generated
 scenario, tradeoff, and Markdown paths plus the compare and probe-compare
 receipts that fed the decision.
 
+Use `decision bundle` when that indexed evidence needs to travel with a
+release, issue, audit, or agent handoff:
+
+```bash
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+The bundle receipt uses `perfgate.decision_bundle.v1`, embeds the referenced
+JSON/Markdown artifacts, records SHA-256 hashes for each embedded file, and
+captures git metadata when available. It is additive: existing
+`decision.index.json`, scenario, tradeoff, and probe-compare receipts remain
+valid and independently consumable.
+
 Server mode can persist the resulting decision as a ledger entry:
 
 ```bash
@@ -210,7 +224,7 @@ Historical compatibility fixtures live under `fixtures/schema/<release>/`.
 `schema-compat` checks v0.15 examples for `perfgate.run.v1`,
 `perfgate.compare.v1`, `perfgate.report.v1`, `sensor.report.v1`,
 `perfgate.health.v1`, and structured-decision receipts including
-`perfgate.decision_index.v1`.
+`perfgate.decision_index.v1` and `perfgate.decision_bundle.v1`.
 It also checks v0.16 baseline-service and fleet contract fixtures for
 `perfgate.baseline.v1`, `perfgate.verdict.v1`, `perfgate.audit.v1`,
 `perfgate.health.v1`, `perfgate.decision_record.v1`,

--- a/fixtures/schema/v0.16/perfgate.decision_bundle.v1.json
+++ b/fixtures/schema/v0.16/perfgate.decision_bundle.v1.json
@@ -1,0 +1,83 @@
+{
+  "schema": "perfgate.decision_bundle.v1",
+  "tool": {
+    "name": "perfgate",
+    "version": "0.16.0"
+  },
+  "run": {
+    "id": "decision-bundle-run",
+    "started_at": "2026-05-08T00:00:00Z",
+    "ended_at": "2026-05-08T00:00:01Z",
+    "host": {
+      "os": "linux",
+      "arch": "x86_64"
+    }
+  },
+  "metadata": {
+    "index_path": "artifacts/perfgate/decision.index.json",
+    "git_ref": "refs/heads/main",
+    "git_sha": "abc123"
+  },
+  "index": {
+    "schema": "perfgate.decision_index.v1",
+    "scenario": "artifacts/perfgate/scenario.json",
+    "tradeoff": "artifacts/perfgate/tradeoff.json",
+    "decision": "artifacts/perfgate/decision.md",
+    "probe_compares": [
+      "artifacts/perfgate/large-file/probe-compare.json"
+    ],
+    "compare_receipts": [
+      "artifacts/perfgate/large-file/compare.json"
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "artifacts/perfgate/decision.index.json",
+      "kind": "decision_index",
+      "media_type": "application/json",
+      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "schema": "perfgate.decision_index.v1",
+      "content": {
+        "type": "json",
+        "value": {
+          "schema": "perfgate.decision_index.v1",
+          "scenario": "artifacts/perfgate/scenario.json",
+          "tradeoff": "artifacts/perfgate/tradeoff.json",
+          "decision": "artifacts/perfgate/decision.md",
+          "probe_compares": [
+            "artifacts/perfgate/large-file/probe-compare.json"
+          ],
+          "compare_receipts": [
+            "artifacts/perfgate/large-file/compare.json"
+          ]
+        }
+      }
+    },
+    {
+      "path": "artifacts/perfgate/tradeoff.json",
+      "kind": "tradeoff",
+      "media_type": "application/json",
+      "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "schema": "perfgate.tradeoff.v1",
+      "content": {
+        "type": "json",
+        "value": {
+          "schema": "perfgate.tradeoff.v1",
+          "decision": {
+            "status": "warn"
+          }
+        }
+      }
+    },
+    {
+      "path": "artifacts/perfgate/decision.md",
+      "kind": "decision_markdown",
+      "media_type": "text/markdown; charset=utf-8",
+      "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+      "content": {
+        "type": "text",
+        "value": "# Performance Decision\n\nDecision: warn with accepted tradeoff\n"
+      }
+    }
+  ]
+}

--- a/schemas/perfgate.decision_bundle.v1.schema.json
+++ b/schemas/perfgate.decision_bundle.v1.schema.json
@@ -1,0 +1,262 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "DecisionBundleReceipt",
+  "description": "A portable receipt bundle for structured performance decisions.",
+  "type": "object",
+  "properties": {
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/DecisionBundleArtifact"
+      }
+    },
+    "index": {
+      "$ref": "#/$defs/DecisionArtifactIndex"
+    },
+    "metadata": {
+      "$ref": "#/$defs/DecisionBundleMetadata"
+    },
+    "run": {
+      "$ref": "#/$defs/RunMeta"
+    },
+    "schema": {
+      "type": "string"
+    },
+    "tool": {
+      "$ref": "#/$defs/ToolInfo"
+    }
+  },
+  "required": [
+    "schema",
+    "tool",
+    "run",
+    "metadata",
+    "index",
+    "artifacts"
+  ],
+  "$defs": {
+    "DecisionArtifactIndex": {
+      "description": "A manifest for the artifacts produced by `perfgate decision evaluate`.",
+      "type": "object",
+      "properties": {
+        "compare_receipts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "decision": {
+          "type": "string"
+        },
+        "probe_compares": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scenario": {
+          "type": "string"
+        },
+        "schema": {
+          "type": "string"
+        },
+        "tradeoff": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema",
+        "scenario",
+        "tradeoff",
+        "decision",
+        "probe_compares",
+        "compare_receipts"
+      ]
+    },
+    "DecisionBundleArtifact": {
+      "description": "One artifact embedded in a portable decision bundle.",
+      "type": "object",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/DecisionBundleArtifactContent"
+        },
+        "kind": {
+          "$ref": "#/$defs/DecisionBundleArtifactKind"
+        },
+        "media_type": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "schema": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sha256": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "kind",
+        "media_type",
+        "sha256",
+        "content"
+      ]
+    },
+    "DecisionBundleArtifactContent": {
+      "description": "Embedded artifact content.",
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "json"
+            },
+            "value": true
+          },
+          "required": [
+            "type",
+            "value"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "text"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ]
+        }
+      ]
+    },
+    "DecisionBundleArtifactKind": {
+      "description": "Kind of artifact embedded in a portable decision bundle.",
+      "type": "string",
+      "enum": [
+        "decision_index",
+        "scenario",
+        "tradeoff",
+        "decision_markdown",
+        "probe_compare",
+        "compare_receipt"
+      ]
+    },
+    "DecisionBundleMetadata": {
+      "description": "Metadata captured when exporting a portable decision bundle.",
+      "type": "object",
+      "properties": {
+        "git_ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "git_sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "index_path": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "index_path"
+      ]
+    },
+    "HostInfo": {
+      "type": "object",
+      "properties": {
+        "arch": {
+          "description": "CPU architecture (e.g., \"x86_64\", \"aarch64\")",
+          "type": "string"
+        },
+        "cpu_count": {
+          "description": "Number of logical CPUs (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "hostname_hash": {
+          "description": "Hashed hostname for fingerprinting (opt-in, privacy-preserving).\nWhen present, this is a SHA-256 hash of the actual hostname.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "memory_bytes": {
+          "description": "Total system memory in bytes (best-effort, None if unavailable)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0
+        },
+        "os": {
+          "description": "Operating system (e.g., \"linux\", \"macos\", \"windows\")",
+          "type": "string"
+        }
+      },
+      "required": [
+        "os",
+        "arch"
+      ]
+    },
+    "RunMeta": {
+      "type": "object",
+      "properties": {
+        "ended_at": {
+          "type": "string"
+        },
+        "host": {
+          "$ref": "#/$defs/HostInfo"
+        },
+        "id": {
+          "type": "string"
+        },
+        "started_at": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "started_at",
+        "ended_at",
+        "host"
+      ]
+    },
+    "ToolInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ]
+    }
+  }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,7 +16,7 @@ const TARGET_PUBLIC_PACKAGES: [&str; 5] = [
     "perfgate-cli",
 ];
 
-const SCHEMA_FILES: [&str; 14] = [
+const SCHEMA_FILES: [&str; 15] = [
     "perfgate.run.v1.schema.json",
     "perfgate.compare.v1.schema.json",
     "perfgate.probe.v1.schema.json",
@@ -25,6 +25,7 @@ const SCHEMA_FILES: [&str; 14] = [
     "perfgate.tradeoff.v1.schema.json",
     "perfgate.decision_index.v1.schema.json",
     "perfgate.decision_record.v1.schema.json",
+    "perfgate.decision_bundle.v1.schema.json",
     "perfgate.config.v1.schema.json",
     "perfgate.report.v1.schema.json",
     "perfgate.aggregate.v1.schema.json",
@@ -2215,36 +2216,42 @@ fn cmd_schema(out_dir: &PathBuf) -> anyhow::Result<()> {
     write_schema(
         out_dir,
         SCHEMA_FILES[8],
-        schema_for!(perfgate_types::ConfigFile),
+        schema_for!(perfgate_types::DecisionBundleReceipt),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[9],
-        schema_for!(perfgate_types::PerfgateReport),
+        schema_for!(perfgate_types::ConfigFile),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[10],
-        schema_for!(perfgate_types::AggregateReceipt),
+        schema_for!(perfgate_types::PerfgateReport),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[11],
-        schema_for!(perfgate_types::RatchetReceipt),
+        schema_for!(perfgate_types::AggregateReceipt),
     )?;
 
     write_schema(
         out_dir,
         SCHEMA_FILES[12],
+        schema_for!(perfgate_types::RatchetReceipt),
+    )?;
+
+    write_schema(
+        out_dir,
+        SCHEMA_FILES[13],
         schema_for!(perfgate_types::RepairContextReceipt),
     )?;
 
     // Sensor report schema is vendored from contracts/, not generated.
     let vendored_schema = PathBuf::from("contracts/schemas/sensor.report.v1.schema.json");
-    let dest = out_dir.join(SCHEMA_FILES[13]);
+    let dest = out_dir.join(SCHEMA_FILES[14]);
     fs::copy(&vendored_schema, &dest).with_context(|| {
         format!(
             "copy vendored schema {} -> {}",
@@ -2355,6 +2362,9 @@ fn cmd_schema_compat(fixtures_dir: &Path) -> anyhow::Result<()> {
             }
             "perfgate.decision_index.v1" => {
                 serde_json::from_value::<perfgate_types::DecisionArtifactIndex>(value).map(|_| ())
+            }
+            "perfgate.decision_bundle.v1" => {
+                serde_json::from_value::<perfgate_types::DecisionBundleReceipt>(value).map(|_| ())
             }
             "perfgate.decision_record.v1" => {
                 serde_json::from_value::<perfgate_types::baseline_service::DecisionRecord>(value)
@@ -3832,6 +3842,11 @@ fn validate_versioned_json_example(
             serde_json::from_value::<perfgate_types::DecisionArtifactIndex>(value)
                 .context("deserialize perfgate.decision_index.v1 example")?;
             Ok(Some(perfgate_types::DECISION_INDEX_SCHEMA_V1))
+        }
+        Some(perfgate_types::DECISION_BUNDLE_SCHEMA_V1) => {
+            serde_json::from_value::<perfgate_types::DecisionBundleReceipt>(value)
+                .context("deserialize perfgate.decision_bundle.v1 example")?;
+            Ok(Some(perfgate_types::DECISION_BUNDLE_SCHEMA_V1))
         }
         Some(perfgate_types::baseline_service::DECISION_RECORD_SCHEMA_V1) => {
             serde_json::from_value::<perfgate_types::baseline_service::DecisionRecord>(value)


### PR DESCRIPTION
## Summary
- add `perfgate.decision_bundle.v1` as a portable JSON bundle receipt for indexed decision evidence
- add `perfgate decision bundle` to embed the decision index, scenario/tradeoff receipts, decision markdown, probe compares, and compare receipts with SHA-256 hashes and git metadata
- document the bundle path, generate schema/compat fixtures, and extend the performance-decision example plus CLI help snapshots

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-types decision_bundle_receipt_round_trips --all-features`
- `cargo test -p perfgate-cli --test cli_performance_decision_example_tests --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests decision --all-features`
- `cargo clippy -p perfgate-types -p perfgate-cli -p xtask --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- schema`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- schema-compat`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- ci`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- action-check`
- `git diff --check`