### PR TITLE
decision: report debt headroom signals

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -4167,6 +4167,13 @@ struct DecisionDebtAreaSummary {
     review_required_count: u32,
     rule_counts: BTreeMap<String, u32>,
     max_cap_used: Option<f64>,
+    max_accepted_delta: Option<DecisionDebtMetricDelta>,
+}
+
+#[derive(Clone)]
+struct DecisionDebtMetricDelta {
+    metric: String,
+    regression: f64,
 }
 
 fn print_decision_debt_summary(
@@ -4209,6 +4216,13 @@ fn print_decision_debt_summary(
                 }
             }));
         }
+
+        if let Some(delta) = decision_record_max_accepted_delta(record) {
+            area.max_accepted_delta = Some(area.max_accepted_delta.as_ref().map_or_else(
+                || delta.clone(),
+                |current| max_metric_delta(current, &delta),
+            ));
+        }
     }
 
     let window = if days == 0 {
@@ -4233,17 +4247,19 @@ fn print_decision_debt_summary(
 
     println!();
     println!(
-        "{:<24} {:>5} {:>6} {:>8}  common rule",
-        "area", "count", "review", "cap used"
+        "{:<24} {:>5} {:>6} {:>8} {:>14} {:>11}  common rule",
+        "area", "count", "review", "cap used", "accepted delta", "budget used"
     );
 
     for (area, summary) in areas {
         println!(
-            "{:<24} {:>5} {:>6} {:>8}  {}",
+            "{:<24} {:>5} {:>6} {:>8} {:>14} {:>11}  {}",
             area,
             summary.accepted_count,
             summary.review_required_count,
             format_cap_used(summary.max_cap_used),
+            format_accepted_delta(summary.max_accepted_delta.as_ref()),
+            format_budget_headroom_used(None),
             most_common_rule(&summary.rule_counts)
         );
     }
@@ -4266,7 +4282,57 @@ fn decision_record_max_cap_used(record: &perfgate_client::DecisionRecord) -> Opt
         .reduce(f64::max)
 }
 
+fn decision_record_max_accepted_delta(
+    record: &perfgate_client::DecisionRecord,
+) -> Option<DecisionDebtMetricDelta> {
+    record
+        .tradeoff_receipt
+        .rules
+        .iter()
+        .filter(|rule| rule.accepted)
+        .filter_map(|rule| {
+            let configured = record
+                .tradeoff_receipt
+                .configured_rules
+                .iter()
+                .find(|configured| configured.name == rule.name)?;
+            let metric = configured.if_failed.as_str();
+            let delta = record.tradeoff_receipt.weighted_deltas.get(metric)?;
+            if delta.regression <= 0.0 {
+                return None;
+            }
+            Some(DecisionDebtMetricDelta {
+                metric: metric.to_string(),
+                regression: delta.regression,
+            })
+        })
+        .reduce(|current, next| max_metric_delta(&current, &next))
+}
+
+fn max_metric_delta(
+    left: &DecisionDebtMetricDelta,
+    right: &DecisionDebtMetricDelta,
+) -> DecisionDebtMetricDelta {
+    if right.regression > left.regression {
+        right.clone()
+    } else {
+        left.clone()
+    }
+}
+
 fn format_cap_used(value: Option<f64>) -> String {
+    value
+        .map(|value| format!("{:.0}%", value * 100.0))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_accepted_delta(value: Option<&DecisionDebtMetricDelta>) -> String {
+    value
+        .map(|delta| format!("{} +{:.1}%", delta.metric, delta.regression * 100.0))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn format_budget_headroom_used(value: Option<f64>) -> String {
     value
         .map(|value| format!("{:.0}%", value * 100.0))
         .unwrap_or_else(|| "n/a".to_string())

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -137,8 +137,36 @@ fn decision_record_with(
     cap_used: Option<(f64, f64)>,
 ) -> serde_json::Value {
     let mut tradeoff = tradeoff_receipt();
-    if let Some((observed_regression, max_regression)) = cap_used {
-        tradeoff["rules"][0]["allowances"] = serde_json::json!([{
+    let configured_rules: Vec<_> = accepted_rules
+        .iter()
+        .map(|rule| {
+            serde_json::json!({
+                "name": rule,
+                "if_failed": "max_rss_kb",
+                "require": [{
+                    "metric": "wall_ms",
+                    "min_improvement_ratio": 1.10
+                }],
+                "downgrade_to": "warn"
+            })
+        })
+        .collect();
+    let mut rule_outcomes: Vec<_> = accepted_rules
+        .iter()
+        .map(|rule| {
+            serde_json::json!({
+                "name": rule,
+                "status": "accepted",
+                "accepted": true,
+                "downgrade_to": "warn",
+                "reason": "tradeoff accepted"
+            })
+        })
+        .collect();
+    if let Some((observed_regression, max_regression)) = cap_used
+        && let Some(rule) = rule_outcomes.first_mut()
+    {
+        rule["allowances"] = serde_json::json!([{
             "metric": "wall_ms",
             "probe": "parser.tokenize",
             "max_regression": max_regression,
@@ -148,7 +176,17 @@ fn decision_record_with(
             "reason": "local regression stayed inside cap"
         }]);
     }
+    tradeoff["configured_rules"] = serde_json::Value::Array(configured_rules);
+    tradeoff["rules"] = serde_json::Value::Array(rule_outcomes);
     tradeoff["scenario"] = serde_json::Value::String(scenario.to_string());
+    tradeoff["weighted_deltas"]["max_rss_kb"] = serde_json::json!({
+        "baseline": 1000.0,
+        "current": 1030.0,
+        "ratio": 1.03,
+        "pct": 0.03,
+        "regression": 0.03,
+        "status": "warn"
+    });
 
     serde_json::json!({
         "schema": "perfgate.decision_record.v1",
@@ -745,6 +783,10 @@ async fn test_decision_debt_summarizes_accepted_tradeoffs() {
         ))
         .stdout(predicate::str::contains("parser"))
         .stdout(predicate::str::contains("70%"))
+        .stdout(predicate::str::contains("accepted delta"))
+        .stdout(predicate::str::contains("max_rss_kb +3.0%"))
+        .stdout(predicate::str::contains("budget used"))
+        .stdout(predicate::str::contains("n/a"))
         .stdout(predicate::str::contains(
             "tokenizer-cost-for-batch-loop-win (2)",
         ))

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -154,7 +154,7 @@ The main server-aware CLI workflows are:
 | `baseline migrate` | upload local baseline JSON files recursively |
 | `decision upload` | store a structured performance decision receipt |
 | `decision history` | list stored performance decisions |
-| `decision debt` | summarize accepted tradeoff debt by scenario |
+| `decision debt` | summarize accepted tradeoff debt, cap usage, and accepted deltas by scenario |
 | `audit list` | inspect append-only audit events |
 | `audit export --format jsonl` | export audit events for operators or compliance review |
 | `fleet alerts` | list fleet-wide dependency regression alerts |

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -183,7 +183,7 @@ The current CLI surfaces that talk to the baseline service are:
 | `baseline migrate` | Upload local baseline JSON files to the server |
 | `decision upload` | Store a structured performance decision receipt |
 | `decision history` | List stored performance decisions |
-| `decision debt` | Summarize accepted tradeoff debt by scenario |
+| `decision debt` | Summarize accepted tradeoff debt, cap usage, and accepted deltas by scenario |
 | `audit list` | List admin audit events |
 | `audit export --format jsonl` | Export audit events for external review |
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -230,7 +230,11 @@ time. Uploads emit an audit event with resource type `decision`.
 `decision debt` summarizes accepted tradeoff records by scenario so teams can
 spot repeated exceptions before they become invisible performance debt. When a
 tradeoff rule used local regression caps, the summary reports the highest cap
-usage observed in the selected window.
+usage observed in the selected window. When the uploaded tradeoff receipt still
+contains its configured rule and weighted deltas, the summary also reports the
+largest accepted failed-metric regression, such as `max_rss_kb +3.0%`. Budget
+headroom usage is reported as `n/a` until receipts include the original budget
+threshold denominator; perfgate does not infer that value from status alone.
 
 ## Primitive Commands
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -289,8 +289,9 @@ The **core local gating pipeline** is production-quality:
   check policy failure to an accepted tradeoff receipt.
 - **Decision ledger and debt** — the baseline server stores
   `perfgate.decision_record.v1` records, decision uploads emit audit events,
-  `decision history|latest|debt` expose the ledger from the CLI, and the
-  dashboard shows stored performance decisions.
+  `decision history|latest|debt` expose the ledger from the CLI, debt summaries
+  include cap usage and accepted failed-metric deltas when receipt evidence is
+  present, and the dashboard shows stored performance decisions.
 - **Dashboard decision visibility** — the dashboard now includes baseline,
   verdict/flakiness, decision-ledger, and audit-event views.
 


### PR DESCRIPTION
## Summary
- extend `perfgate decision debt` with accepted failed-metric delta and budget-usage columns alongside existing cap usage
- compute accepted deltas from accepted tradeoff rules plus weighted deltas when the uploaded receipt preserved configured rules
- document that budget usage stays `n/a` until receipts include the original threshold denominator instead of inferring it from status

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-cli --test cli_mock_server_tests test_decision_debt_summarizes_accepted_tradeoffs --all-features`
- `cargo test -p perfgate-cli --test cli_mock_server_tests --all-features`
- `cargo test -p perfgate-cli --test cli_server_tests --all-features`
- `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- ci`
- `git diff --check`