### PR TITLE
decision: add ledger filters

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1468,9 +1468,21 @@ pub struct DecisionHistoryArgs {
     #[arg(long, value_parser = parse_metric_status)]
     pub status: Option<MetricStatus>,
 
+    /// Optional final policy verdict to filter by (pass|warn|fail|skip).
+    #[arg(long, value_parser = parse_verdict_status)]
+    pub verdict: Option<VerdictStatus>,
+
     /// Optional review-required filter.
-    #[arg(long)]
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
     pub review_required: Option<bool>,
+
+    /// Optional accepted-tradeoff filter.
+    #[arg(long, num_args = 0..=1, default_missing_value = "true")]
+    pub accepted: Option<bool>,
+
+    /// Optional accepted tradeoff rule name to filter by.
+    #[arg(long)]
+    pub rule: Option<String>,
 
     /// Maximum number of records to list.
     #[arg(long, default_value_t = 20)]
@@ -4058,8 +4070,17 @@ fn execute_decision_history(
     if let Some(status) = args.status {
         query = query.with_status(status);
     }
+    if let Some(verdict) = args.verdict {
+        query = query.with_verdict(verdict);
+    }
     if let Some(review_required) = args.review_required {
         query = query.with_review_required(review_required);
+    }
+    if let Some(accepted) = args.accepted {
+        query = query.with_accepted(accepted);
+    }
+    if let Some(rule) = args.rule {
+        query = query.with_rule(rule);
     }
 
     let rt = tokio::runtime::Runtime::new()?;

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -314,6 +314,23 @@ fn cli_help_decision_evaluate() {
 }
 
 #[test]
+fn cli_help_decision_history() {
+    perfgate_cmd()
+        .args(["decision", "history", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "List stored decision receipts from the baseline server",
+        ))
+        .stdout(predicate::str::contains("--scenario"))
+        .stdout(predicate::str::contains("--status"))
+        .stdout(predicate::str::contains("--verdict"))
+        .stdout(predicate::str::contains("--review-required"))
+        .stdout(predicate::str::contains("--accepted"))
+        .stdout(predicate::str::contains("--rule"));
+}
+
+#[test]
 fn cli_help_decision_debt() {
     perfgate_cmd()
         .args(["decision", "debt", "--help"])

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -654,6 +654,13 @@ async fn test_decision_history_and_latest_use_server_ledger() {
     Mock::given(method("GET"))
         .and(path("/api/v1/projects/test-project/decisions"))
         .and(header("Authorization", "Bearer decision-key"))
+        .and(query_param("scenario", "release_workload"))
+        .and(query_param("status", "warn"))
+        .and(query_param("verdict", "warn"))
+        .and(query_param("review_required", "false"))
+        .and(query_param("accepted", "true"))
+        .and(query_param("rule", "memory_for_speed"))
+        .and(query_param("limit", "20"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "decisions": [decision_record("test-project", "decision-1")],
             "pagination": {
@@ -684,7 +691,18 @@ async fn test_decision_history_and_latest_use_server_ledger() {
         .arg("--project")
         .arg("test-project")
         .arg("decision")
-        .arg("history");
+        .arg("history")
+        .arg("--scenario")
+        .arg("release_workload")
+        .arg("--status")
+        .arg("warn")
+        .arg("--verdict")
+        .arg("warn")
+        .arg("--review-required")
+        .arg("false")
+        .arg("--accepted")
+        .arg("--rule")
+        .arg("memory_for_speed");
 
     history
         .assert()

--- a/crates/perfgate-server/assets/index.html
+++ b/crates/perfgate-server/assets/index.html
@@ -714,12 +714,49 @@
             <h2>Performance Decisions</h2>
 
             <div class="filter-bar">
-                <div class="checkbox-group">
-                    <label><input type="checkbox" id="decisionPass" checked onchange="resetAndLoadDecisions()"> Pass</label>
-                    <label><input type="checkbox" id="decisionWarn" checked onchange="resetAndLoadDecisions()"> Warn</label>
-                    <label><input type="checkbox" id="decisionFail" checked onchange="resetAndLoadDecisions()"> Fail</label>
-                    <label><input type="checkbox" id="decisionSkip" checked onchange="resetAndLoadDecisions()"> Skip</label>
-                    <label><input type="checkbox" id="decisionReviewOnly" onchange="resetAndLoadDecisions()"> Needs Review</label>
+                <div class="filter-group">
+                    <label for="decisionStatus">Status</label>
+                    <select id="decisionStatus" onchange="resetAndLoadDecisions()">
+                        <option value="">Any</option>
+                        <option value="pass">Pass</option>
+                        <option value="warn">Warn</option>
+                        <option value="fail">Fail</option>
+                        <option value="skip">Skip</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="decisionVerdict">Verdict</label>
+                    <select id="decisionVerdict" onchange="resetAndLoadDecisions()">
+                        <option value="">Any</option>
+                        <option value="pass">Pass</option>
+                        <option value="warn">Warn</option>
+                        <option value="fail">Fail</option>
+                        <option value="skip">Skip</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="decisionReviewRequired">Review</label>
+                    <select id="decisionReviewRequired" onchange="resetAndLoadDecisions()">
+                        <option value="">Any</option>
+                        <option value="true">Required</option>
+                        <option value="false">Not required</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="decisionAccepted">Accepted</label>
+                    <select id="decisionAccepted" onchange="resetAndLoadDecisions()">
+                        <option value="">Any</option>
+                        <option value="true">Accepted</option>
+                        <option value="false">None</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label for="decisionScenario">Scenario</label>
+                    <input type="text" id="decisionScenario" placeholder="scenario" onkeydown="decisionFilterKeydown(event)">
+                </div>
+                <div class="filter-group">
+                    <label for="decisionRule">Rule</label>
+                    <input type="text" id="decisionRule" placeholder="accepted rule" onkeydown="decisionFilterKeydown(event)">
                 </div>
                 <button onclick="resetAndLoadDecisions()">Load Decisions</button>
             </div>
@@ -1204,21 +1241,33 @@
             loadDecisions();
         }
 
+        function decisionFilterKeydown(e) {
+            if (e.key === 'Enter') resetAndLoadDecisions();
+        }
+
         async function loadDecisions() {
             var project = getProject();
             var body = document.getElementById('decisionsBody');
             body.innerHTML = loadingRow(7);
 
-            var statusFilters = [];
-            if (document.getElementById('decisionPass').checked) statusFilters.push('pass');
-            if (document.getElementById('decisionWarn').checked) statusFilters.push('warn');
-            if (document.getElementById('decisionFail').checked) statusFilters.push('fail');
-            if (document.getElementById('decisionSkip').checked) statusFilters.push('skip');
-            var reviewOnly = document.getElementById('decisionReviewOnly').checked;
+            var params = new URLSearchParams();
+            params.set('limit', decisionPageSize);
+            params.set('offset', decisionPage * decisionPageSize);
+            var status = document.getElementById('decisionStatus').value;
+            var verdict = document.getElementById('decisionVerdict').value;
+            var reviewRequired = document.getElementById('decisionReviewRequired').value;
+            var accepted = document.getElementById('decisionAccepted').value;
+            var scenario = document.getElementById('decisionScenario').value.trim();
+            var rule = document.getElementById('decisionRule').value.trim();
+            if (status) params.set('status', status);
+            if (verdict) params.set('verdict', verdict);
+            if (reviewRequired) params.set('review_required', reviewRequired);
+            if (accepted) params.set('accepted', accepted);
+            if (scenario) params.set('scenario', scenario);
+            if (rule) params.set('rule', rule);
 
             var url = '/api/v1/projects/' + encodeURIComponent(project)
-                + '/decisions?limit=' + decisionPageSize
-                + '&offset=' + (decisionPage * decisionPageSize);
+                + '/decisions?' + params.toString();
 
             var data = await fetchApi(url);
             if (!data) {
@@ -1227,11 +1276,7 @@
                 return;
             }
 
-            var decisions = (data.decisions || []).filter(function(d) {
-                if (statusFilters.indexOf(d.status) === -1) return false;
-                if (reviewOnly && !d.review_required) return false;
-                return true;
-            });
+            var decisions = data.decisions || [];
             totalDecisions = data.pagination ? data.pagination.total : decisions.length;
 
             if (decisions.length === 0) {

--- a/crates/perfgate-server/src/handlers/dashboard.rs
+++ b/crates/perfgate-server/src/handlers/dashboard.rs
@@ -56,9 +56,14 @@ mod tests {
         assert!(INDEX_HTML.contains("<h2>Performance Decisions</h2>"));
         assert!(INDEX_HTML.contains("id=\"decisionsBody\""));
         assert!(INDEX_HTML.contains("function loadDecisions()"));
-        assert!(INDEX_HTML.contains("'/decisions?limit='"));
-        assert!(INDEX_HTML.contains("id=\"decisionSkip\""));
-        assert!(INDEX_HTML.contains("id=\"decisionReviewOnly\""));
+        assert!(INDEX_HTML.contains("'/decisions?' + params.toString()"));
+        assert!(INDEX_HTML.contains("id=\"decisionStatus\""));
+        assert!(INDEX_HTML.contains("id=\"decisionVerdict\""));
+        assert!(INDEX_HTML.contains("id=\"decisionReviewRequired\""));
+        assert!(INDEX_HTML.contains("id=\"decisionAccepted\""));
+        assert!(INDEX_HTML.contains("id=\"decisionScenario\""));
+        assert!(INDEX_HTML.contains("id=\"decisionRule\""));
+        assert!(INDEX_HTML.contains("params.set('rule', rule)"));
         assert!(INDEX_HTML.contains("id=\"decisionPagination\""));
         assert!(INDEX_HTML.contains("loadDecisions();"));
     }

--- a/crates/perfgate-server/src/storage/memory.rs
+++ b/crates/perfgate-server/src/storage/memory.rs
@@ -380,8 +380,27 @@ impl BaselineStore for InMemoryStore {
                 {
                     return false;
                 }
+                if let Some(verdict) = query.verdict
+                    && record.verdict != verdict
+                {
+                    return false;
+                }
                 if let Some(review_required) = query.review_required
                     && record.review_required != review_required
+                {
+                    return false;
+                }
+                if let Some(accepted) = query.accepted {
+                    let has_accepted_tradeoff = !record.accepted_rules.is_empty();
+                    if has_accepted_tradeoff != accepted {
+                        return false;
+                    }
+                }
+                if let Some(ref rule) = query.rule
+                    && !record
+                        .accepted_rules
+                        .iter()
+                        .any(|accepted| accepted == rule)
                 {
                     return false;
                 }

--- a/crates/perfgate-server/src/storage/postgres.rs
+++ b/crates/perfgate-server/src/storage/postgres.rs
@@ -887,9 +887,24 @@ impl BaselineStore for PostgresStore {
             params_count += 1;
             filter_sql.push_str(&format!(" AND status = ${}", params_count));
         }
+        if query.verdict.is_some() {
+            params_count += 1;
+            filter_sql.push_str(&format!(" AND verdict = ${}", params_count));
+        }
         if query.review_required.is_some() {
             params_count += 1;
             filter_sql.push_str(&format!(" AND review_required = ${}", params_count));
+        }
+        if let Some(accepted) = query.accepted {
+            if accepted {
+                filter_sql.push_str(" AND jsonb_array_length(accepted_rules) > 0");
+            } else {
+                filter_sql.push_str(" AND jsonb_array_length(accepted_rules) = 0");
+            }
+        }
+        if query.rule.is_some() {
+            params_count += 1;
+            filter_sql.push_str(&format!(" AND accepted_rules @> ${}::jsonb", params_count));
         }
 
         let count_sql = format!("SELECT COUNT(*){}", filter_sql);
@@ -900,8 +915,14 @@ impl BaselineStore for PostgresStore {
         if let Some(status) = query.status {
             count_query = count_query.bind(status.as_str());
         }
+        if let Some(verdict) = query.verdict {
+            count_query = count_query.bind(verdict.as_str());
+        }
         if let Some(review_required) = query.review_required {
             count_query = count_query.bind(review_required);
+        }
+        if let Some(rule) = &query.rule {
+            count_query = count_query.bind(serde_json::json!([rule]));
         }
         let total = count_query
             .fetch_one(&self.pool)
@@ -924,8 +945,14 @@ impl BaselineStore for PostgresStore {
         if let Some(status) = query.status {
             q = q.bind(status.as_str());
         }
+        if let Some(verdict) = query.verdict {
+            q = q.bind(verdict.as_str());
+        }
         if let Some(review_required) = query.review_required {
             q = q.bind(review_required);
+        }
+        if let Some(rule) = &query.rule {
+            q = q.bind(serde_json::json!([rule]));
         }
         q = q.bind(query.limit as i64).bind(query.offset as i64);
 

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -755,9 +755,26 @@ impl BaselineStore for SqliteStore {
             sql.push_str(" AND status = ?");
             params_vec.push(status.as_str().to_string().into());
         }
+        if let Some(verdict) = query.verdict {
+            sql.push_str(" AND verdict = ?");
+            params_vec.push(verdict.as_str().to_string().into());
+        }
         if let Some(review_required) = query.review_required {
             sql.push_str(" AND review_required = ?");
             params_vec.push((if review_required { 1i64 } else { 0i64 }).into());
+        }
+        if let Some(accepted) = query.accepted {
+            if accepted {
+                sql.push_str(" AND accepted_rules != '[]'");
+            } else {
+                sql.push_str(" AND accepted_rules = '[]'");
+            }
+        }
+        if let Some(rule) = &query.rule {
+            sql.push_str(" AND instr(accepted_rules, ?) > 0");
+            let encoded_rule =
+                serde_json::to_string(rule).map_err(StoreError::SerializationError)?;
+            params_vec.push(encoded_rule.into());
         }
 
         let count_sql = format!("SELECT COUNT(*) FROM ({})", sql);
@@ -1207,7 +1224,7 @@ mod tests {
             "2026-05-08T00:00:00Z",
             false,
         );
-        let second = create_test_decision(
+        let mut second = create_test_decision(
             "decision-2",
             "my-project",
             "interactive",
@@ -1215,6 +1232,16 @@ mod tests {
             "2026-05-09T00:00:00Z",
             true,
         );
+        second.accepted_rules = vec!["latency_guard".to_string()];
+        let mut no_tradeoff = create_test_decision(
+            "decision-4",
+            "my-project",
+            "batch",
+            perfgate_types::MetricStatus::Pass,
+            "2026-05-07T00:00:00Z",
+            false,
+        );
+        no_tradeoff.accepted_rules.clear();
         let other_project = create_test_decision(
             "decision-3",
             "other-project",
@@ -1226,6 +1253,7 @@ mod tests {
 
         store.create_decision(&first).await.unwrap();
         store.create_decision(&second).await.unwrap();
+        store.create_decision(&no_tradeoff).await.unwrap();
         store.create_decision(&other_project).await.unwrap();
 
         let latest = store
@@ -1257,6 +1285,42 @@ mod tests {
             .unwrap();
         assert_eq!(review_required.decisions.len(), 1);
         assert_eq!(review_required.decisions[0].id, "decision-2");
+
+        let accepted = store
+            .list_decisions("my-project", &ListDecisionsQuery::new().with_accepted(true))
+            .await
+            .unwrap();
+        assert_eq!(accepted.pagination.total, 2);
+
+        let no_accepted_tradeoff = store
+            .list_decisions(
+                "my-project",
+                &ListDecisionsQuery::new().with_accepted(false),
+            )
+            .await
+            .unwrap();
+        assert_eq!(no_accepted_tradeoff.decisions.len(), 1);
+        assert_eq!(no_accepted_tradeoff.decisions[0].id, "decision-4");
+
+        let rule = store
+            .list_decisions(
+                "my-project",
+                &ListDecisionsQuery::new().with_rule("latency_guard"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rule.decisions.len(), 1);
+        assert_eq!(rule.decisions[0].id, "decision-2");
+
+        let verdict = store
+            .list_decisions(
+                "my-project",
+                &ListDecisionsQuery::new().with_verdict(perfgate_types::VerdictStatus::Fail),
+            )
+            .await
+            .unwrap();
+        assert_eq!(verdict.decisions.len(), 1);
+        assert_eq!(verdict.decisions[0].id, "decision-2");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/perfgate-types/src/baseline_service.rs
+++ b/crates/perfgate-types/src/baseline_service.rs
@@ -275,7 +275,10 @@ pub struct UploadDecisionRequest {
 pub struct ListDecisionsQuery {
     pub scenario: Option<String>,
     pub status: Option<MetricStatus>,
+    pub verdict: Option<VerdictStatus>,
     pub review_required: Option<bool>,
+    pub accepted: Option<bool>,
+    pub rule: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: u32,
     #[serde(default)]
@@ -287,7 +290,10 @@ impl Default for ListDecisionsQuery {
         Self {
             scenario: None,
             status: None,
+            verdict: None,
             review_required: None,
+            accepted: None,
+            rule: None,
             limit: default_limit(),
             offset: 0,
         }
@@ -306,8 +312,20 @@ impl ListDecisionsQuery {
         self.status = Some(status);
         self
     }
+    pub fn with_verdict(mut self, verdict: VerdictStatus) -> Self {
+        self.verdict = Some(verdict);
+        self
+    }
     pub fn with_review_required(mut self, review_required: bool) -> Self {
         self.review_required = Some(review_required);
+        self
+    }
+    pub fn with_accepted(mut self, accepted: bool) -> Self {
+        self.accepted = Some(accepted);
+        self
+    }
+    pub fn with_rule(mut self, rule: impl Into<String>) -> Self {
+        self.rule = Some(rule.into());
         self
     }
     pub fn with_limit(mut self, limit: u32) -> Self {

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -153,7 +153,7 @@ The main server-aware CLI workflows are:
 | `baseline submit-verdict` | persist compare verdicts |
 | `baseline migrate` | upload local baseline JSON files recursively |
 | `decision upload` | store a structured performance decision receipt |
-| `decision history` | list stored performance decisions |
+| `decision history` | list stored performance decisions with scenario/status/verdict/review/rule filters |
 | `decision debt` | summarize accepted tradeoff debt, cap usage, and accepted deltas by scenario |
 | `audit list` | inspect append-only audit events |
 | `audit export --format jsonl` | export audit events for operators or compliance review |

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -182,7 +182,7 @@ The current CLI surfaces that talk to the baseline service are:
 | `baseline submit-verdict` | Submit verdict data from a compare receipt |
 | `baseline migrate` | Upload local baseline JSON files to the server |
 | `decision upload` | Store a structured performance decision receipt |
-| `decision history` | List stored performance decisions |
+| `decision history` | List stored performance decisions, with scenario/status/verdict/review/rule filters |
 | `decision debt` | Summarize accepted tradeoff debt, cap usage, and accepted deltas by scenario |
 | `audit list` | List admin audit events |
 | `audit export --format jsonl` | Export audit events for external review |
@@ -218,6 +218,11 @@ The server exposes these top-level surfaces:
 - `POST /api/v1/projects/{project}/decisions`: upload a decision receipt
 - `GET /api/v1/projects/{project}/decisions`: list decision receipts
 - `GET /api/v1/projects/{project}/decisions/latest`: fetch latest decision
+
+Decision history accepts `scenario`, `status`, `verdict`, `review_required`,
+`accepted`, and `rule` query parameters so operators can drill into accepted
+tradeoffs, review-required records, and specific policy rules without scanning
+the full ledger locally.
 - `GET /api/v1/audit`: list audit events
 - `POST /api/v1/keys`: create an API key
 - `GET /api/v1/keys`: list API keys

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -227,6 +227,17 @@ tradeoff receipt, optional scenario receipt, optional artifact index, accepted
 rule names, final status/verdict, review state, git metadata, and creation
 time. Uploads emit an audit event with resource type `decision`.
 
+Use `decision history` filters to inspect a specific part of the ledger:
+
+```bash
+perfgate decision history --accepted true --rule memory_for_probe_speed
+perfgate decision history --review-required true
+perfgate decision history --scenario large_file_parse --verdict warn
+```
+
+The dashboard exposes the same drilldowns for status, verdict, review state,
+accepted-tradeoff presence, scenario, and accepted rule.
+
 `decision debt` summarizes accepted tradeoff records by scenario so teams can
 spot repeated exceptions before they become invisible performance debt. When a
 tradeoff rule used local regression caps, the summary reports the highest cap

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -291,7 +291,9 @@ The **core local gating pipeline** is production-quality:
   `perfgate.decision_record.v1` records, decision uploads emit audit events,
   `decision history|latest|debt` expose the ledger from the CLI, debt summaries
   include cap usage and accepted failed-metric deltas when receipt evidence is
-  present, and the dashboard shows stored performance decisions.
+  present, history can be filtered by scenario, status, verdict, review state,
+  accepted-tradeoff presence, and rule, and the dashboard shows stored
+  performance decisions with the same drilldowns.
 - **Dashboard decision visibility** — the dashboard now includes baseline,
   verdict/flakiness, decision-ledger, and audit-event views.
 


### PR DESCRIPTION
## Summary
- add typed decision history filters for verdict, accepted-tradeoff presence, and accepted rule names
- apply decision ledger filters consistently across memory, SQLite, Postgres, CLI, and dashboard query paths
- document server decision history drilldowns for scenario/status/verdict/review/accepted/rule filtering

## Validation
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo test -p perfgate-server --all-features`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo test -p perfgate-cli --test cli_mock_server_tests --all-features`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo test -p perfgate-cli --test cli_help_snapshot_tests --all-features`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo clippy -p perfgate-client -p perfgate-server -p perfgate-cli --all-targets --all-features -- -D warnings`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo run -p xtask -- schema`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo run -p xtask -- docs-check`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo run -p xtask -- doc-test`
- `CARGO_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters PERFGATE_CI_TARGET_DIR=F:\cargo-target\perfgate-decision-ledger-filters cargo run -p xtask -- ci`
- `git diff --check`