### PR TITLE
action: configure review-required decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ In GitHub Actions, opt in with:
     all: "true"
     require_baseline: "true"
     decision: "true"
+    review_required: "warn"
 ```
+
+Use `review_required: "fail"` when review-required decisions should block
+branch protection, or `review_required: "pass"` when another workflow step owns
+that review policy.
 
 ## Daily Use
 

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: "Run perfgate decision evaluate after check and publish scenario/tradeoff/decision artifacts plus the decision index"
     required: false
     default: "false"
+  review_required:
+    description: "How decision=true handles review-required decisions: warn, fail, or pass"
+    required: false
+    default: "warn"
   github_token:
     description: "GitHub token for posting PR comments (defaults to github.token)"
     required: false
@@ -94,6 +98,12 @@ outputs:
   decision_exit_code:
     description: "perfgate decision evaluate exit code when decision=true"
     value: ${{ steps.run_decision.outputs.exit_code }}
+  review_required:
+    description: "Whether decision=true produced a review-required decision"
+    value: ${{ steps.handle_review_required.outputs.review_required }}
+  review_required_reason:
+    description: "Review-required reasons reported by the decision receipt"
+    value: ${{ steps.handle_review_required.outputs.review_required_reason }}
 
 runs:
   using: "composite"
@@ -349,8 +359,82 @@ runs:
           } >> "${GITHUB_STEP_SUMMARY}"
         fi
 
+    - id: handle_review_required
+      name: Handle review-required decision
+      if: always() && inputs.decision == 'true' && steps.run_decision.outputs.exit_code == '0'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        policy="${{ inputs.review_required }}"
+        case "${policy}" in
+          pass|warn|fail) ;;
+          *)
+            echo "::error::input 'review_required' must be pass, warn, or fail"
+            echo "review_required=false" >> "${GITHUB_OUTPUT}"
+            echo "review_required_reason=invalid review_required policy" >> "${GITHUB_OUTPUT}"
+            echo "exit_code=1" >> "${GITHUB_OUTPUT}"
+            exit 1
+            ;;
+        esac
+
+        out="${{ steps.resolve_out_dir.outputs.out_dir }}"
+        tradeoff=""
+        for candidate in "${out}/tradeoff.json" "${out}/perfgate.tradeoff.v1.json" "${out}/extras/perfgate.tradeoff.v1.json"; do
+          if [[ -f "${candidate}" ]]; then
+            tradeoff="${candidate}"
+            break
+          fi
+        done
+
+        if [[ -z "${tradeoff}" ]]; then
+          echo "review_required=false" >> "${GITHUB_OUTPUT}"
+          echo "review_required_reason=" >> "${GITHUB_OUTPUT}"
+          echo "exit_code=0" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        if command -v python3 >/dev/null 2>&1; then
+          py=python3
+        elif command -v python >/dev/null 2>&1; then
+          py=python
+        else
+          echo "::warning::Python is not available; cannot inspect decision review_required state"
+          echo "review_required=false" >> "${GITHUB_OUTPUT}"
+          echo "review_required_reason=unable to inspect decision receipt" >> "${GITHUB_OUTPUT}"
+          echo "exit_code=0" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        review_required="$("${py}" -c 'import json, sys; data = json.load(open(sys.argv[1], encoding="utf-8")); decision = data.get("decision") or {}; print("true" if decision.get("review_required") else "false")' "${tradeoff}")"
+        review_reason="$("${py}" -c 'import json, sys; data = json.load(open(sys.argv[1], encoding="utf-8")); decision = data.get("decision") or {}; reasons = decision.get("review_reasons") or []; print("; ".join(str(reason).replace("\n", " ").replace("\r", " ") for reason in reasons) if reasons else "decision receipt requires review")' "${tradeoff}")"
+
+        echo "review_required=${review_required}" >> "${GITHUB_OUTPUT}"
+        echo "review_required_reason=${review_reason}" >> "${GITHUB_OUTPUT}"
+
+        if [[ "${review_required}" != "true" ]]; then
+          echo "exit_code=0" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        case "${policy}" in
+          pass)
+            echo "perfgate decision requires review, but review_required=pass leaves the action successful: ${review_reason}"
+            echo "exit_code=0" >> "${GITHUB_OUTPUT}"
+            ;;
+          warn)
+            echo "::warning::perfgate decision requires review: ${review_reason}"
+            echo "exit_code=0" >> "${GITHUB_OUTPUT}"
+            ;;
+          fail)
+            echo "::error::perfgate decision requires review: ${review_reason}"
+            echo "exit_code=2" >> "${GITHUB_OUTPUT}"
+            exit 2
+            ;;
+        esac
+
     - name: Print perfgate failure summary
-      if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0'))
+      if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0') || (inputs.decision == 'true' && steps.handle_review_required.outputs.exit_code != '' && steps.handle_review_required.outputs.exit_code != '0'))
       shell: bash
       run: |
         set -euo pipefail
@@ -358,10 +442,14 @@ runs:
         out="${{ steps.resolve_out_dir.outputs.out_dir }}"
         exit_code="${{ steps.run_check.outputs.exit_code }}"
         decision_exit_code="${{ steps.run_decision.outputs.exit_code }}"
+        review_exit_code="${{ steps.handle_review_required.outputs.exit_code }}"
         exit_source="check"
         if [[ "${{ inputs.decision }}" == "true" && -n "${decision_exit_code}" && "${decision_exit_code}" != "0" ]]; then
           exit_code="${decision_exit_code}"
           exit_source="decision"
+        elif [[ "${{ inputs.decision }}" == "true" && -n "${review_exit_code}" && "${review_exit_code}" != "0" ]]; then
+          exit_code="${review_exit_code}"
+          exit_source="decision review"
         fi
         if [[ -z "${exit_code}" ]]; then
           exit_code="unknown"

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -115,6 +115,7 @@ comment, opt in to decision mode:
           all: "true"
           require_baseline: "true"
           decision: "true"
+          review_required: "warn"
           comment: "true"
 ```
 
@@ -139,8 +140,20 @@ scenario and tradeoff receipts.
 
 When evidence is incomplete or too noisy but otherwise supports a configured
 tradeoff, `decision.md` marks the result as review required. The action still
-treats the machine verdict as `warn`; reviewers should inspect the listed
-`review_reasons` before treating the tradeoff as accepted.
+treats the machine verdict as `warn` by default and emits a workflow warning;
+reviewers should inspect the listed `review_reasons` before treating the
+tradeoff as accepted.
+
+Set `review_required` to choose how branch protection handles those decisions:
+
+| value | behavior |
+| --- | --- |
+| `warn` | Default. Keep the action successful and emit a GitHub warning. |
+| `fail` | Fail the action when `decision.review_required = true`. |
+| `pass` | Keep the action successful without a GitHub warning. |
+
+The action also exposes `review_required` and `review_required_reason` outputs
+for downstream workflow steps.
 
 ## 4) Manual PR performance gate workflow
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -287,13 +287,17 @@ Enable decision mode in the repository action:
     all: "true"
     require_baseline: "true"
     decision: "true"
+    review_required: "warn"
 ```
 
 Decision mode runs `perfgate decision evaluate --config perfgate.toml` after
 `check`, uploads the decision artifacts, and appends `decision.md` to the job
 summary. If `check` exits `2` for a policy failure, the action can defer the
 final result to the decision receipt so an accepted tradeoff owns the final
-policy outcome.
+policy outcome. `review_required` controls how needs-review decisions affect
+branch protection: `warn` keeps the action successful and emits a warning,
+`fail` blocks the action, and `pass` leaves the review signal to downstream
+steps.
 
 ## Needs Review
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -130,7 +130,10 @@ artifacts/perfgate/
 `decision: "true"` is enabled, the action runs `perfgate decision evaluate`,
 lists `probe-compare.json`, `scenario.json`, `tradeoff.json`, `decision.md`,
 and `decision.index.json` among discovered artifacts, and prints the local
-`perfgate decision evaluate --config perfgate.toml` reproduction command.
+`perfgate decision evaluate --config perfgate.toml` reproduction command. It
+also guards `review_required: "warn" | "fail" | "pass"` so teams can choose
+whether needs-review decisions emit a warning, block branch protection, or stay
+advisory for downstream workflow policy.
 
 ## Historical Record: v0.15.1
 
@@ -286,7 +289,8 @@ The **core local gating pipeline** is production-quality:
   are implemented and documented.
 - **GitHub Action decision mode** — the action accepts `decision: "true"`,
   runs `perfgate decision evaluate`, uploads decision artifacts, and can defer a
-  check policy failure to an accepted tradeoff receipt.
+  check policy failure to an accepted tradeoff receipt. Needs-review decisions
+  are explicit through `review_required: "warn" | "fail" | "pass"`.
 - **Decision ledger and debt** — the baseline server stores
   `perfgate.decision_record.v1` records, decision uploads emit audit events,
   `decision history|latest|debt` expose the ledger from the CLI, debt summaries

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -445,6 +445,17 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
                 .to_string(),
         );
     }
+    if action
+        .inputs
+        .get("review_required")
+        .and_then(|input| input.default.as_deref())
+        != Some("warn")
+    {
+        errors.push(
+            "action.yml review_required input must exist and default to warn for needs-review decisions"
+                .to_string(),
+        );
+    }
 
     let Some(binary_install_run) = action.step_run("Install perfgate (pre-built binary)") else {
         errors.push("action.yml must include the pre-built binary install step".to_string());
@@ -609,6 +620,77 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
         errors.push("action.yml decision step must expose its exit code".to_string());
     }
 
+    let Some(handle_review_run) = action.step_run("Handle review-required decision") else {
+        errors
+            .push("action.yml must include the review-required decision handling step".to_string());
+        return errors;
+    };
+    if action
+        .step("Handle review-required decision")
+        .and_then(|step| step.id.as_deref())
+        != Some("handle_review_required")
+    {
+        errors.push(
+            "action.yml review-required step must use id handle_review_required for downstream outputs"
+                .to_string(),
+        );
+    }
+    let handle_review_lines = active_shell_lines(handle_review_run);
+    if !raw_action.contains(
+        "if: always() && inputs.decision == 'true' && steps.run_decision.outputs.exit_code == '0'",
+    ) {
+        errors.push(
+            "action.yml review-required step must inspect successful decision receipts".to_string(),
+        );
+    }
+    if !handle_review_lines
+        .iter()
+        .any(|line| line == "policy=\"${{ inputs.review_required }}\"")
+        || !handle_review_lines
+            .iter()
+            .any(|line| line == "pass|warn|fail) ;;")
+    {
+        errors.push(
+            "action.yml review_required input must accept pass, warn, and fail policies"
+                .to_string(),
+        );
+    }
+    if !handle_review_lines
+        .iter()
+        .any(|line| line == "out=\"${{ steps.resolve_out_dir.outputs.out_dir }}\"")
+        || !handle_review_lines
+            .iter()
+            .any(|line| line.contains("${out}/tradeoff.json"))
+    {
+        errors.push(
+            "action.yml review-required step must inspect the resolved tradeoff receipt"
+                .to_string(),
+        );
+    }
+    if !raw_action.contains("decision.get(\"review_required\")")
+        || !handle_review_lines.iter().any(|line| {
+            line == "echo \"review_required=${review_required}\" >> \"${GITHUB_OUTPUT}\""
+        })
+        || !handle_review_lines.iter().any(|line| {
+            line == "echo \"review_required_reason=${review_reason}\" >> \"${GITHUB_OUTPUT}\""
+        })
+    {
+        errors
+            .push("action.yml review-required step must expose decision review state".to_string());
+    }
+    if !handle_review_lines
+        .iter()
+        .any(|line| line == "echo \"exit_code=2\" >> \"${GITHUB_OUTPUT}\"")
+        || !handle_review_lines
+            .iter()
+            .any(|line| line == "echo \"exit_code=0\" >> \"${GITHUB_OUTPUT}\"")
+    {
+        errors.push(
+            "action.yml review-required step must expose a final review policy exit code"
+                .to_string(),
+        );
+    }
+
     let Some(decision_summary_run) = action.step_run("Append perfgate decision summary") else {
         errors.push("action.yml must append decision.md to GITHUB_STEP_SUMMARY".to_string());
         return errors;
@@ -639,6 +721,7 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
     let failure_summary_lines = active_shell_lines(failure_summary_run);
     if !raw_action.contains("steps.run_check.outputs.policy_failure_deferred != 'true'")
         || !raw_action.contains("steps.run_decision.outputs.exit_code != '0'")
+        || !raw_action.contains("steps.handle_review_required.outputs.exit_code != '0'")
     {
         errors.push(
             "action.yml failure summary must respect decision-mode final verdicts".to_string(),
@@ -655,6 +738,9 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
     if !failure_summary_lines
         .iter()
         .any(|line| line == "exit_code=\"${{ steps.run_check.outputs.exit_code }}\"")
+        || !failure_summary_lines.iter().any(|line| {
+            line == "review_exit_code=\"${{ steps.handle_review_required.outputs.exit_code }}\""
+        })
     {
         errors.push("action.yml failure summary must include the perfgate exit code".to_string());
     }
@@ -757,12 +843,15 @@ struct ActionDefinition {
 }
 
 impl ActionDefinition {
+    fn step(&self, name: &str) -> Option<&ActionStep> {
+        self.runs
+            .steps
+            .iter()
+            .find(|step| step.name.as_deref() == Some(name))
+    }
+
     fn step_run(&self, name: &str) -> Option<&str> {
-        self.runs.steps.iter().find_map(|step| {
-            (step.name.as_deref() == Some(name))
-                .then_some(step.run.as_deref())
-                .flatten()
-        })
+        self.step(name).and_then(|step| step.run.as_deref())
     }
 }
 
@@ -780,6 +869,7 @@ struct ActionRuns {
 
 #[derive(Debug, Deserialize)]
 struct ActionStep {
+    id: Option<String>,
     name: Option<String>,
     run: Option<String>,
 }
@@ -4164,6 +4254,9 @@ inputs:
   decision:
     description: "Run structured decision evaluation"
     default: "false"
+  review_required:
+    description: "How decision=true handles review-required decisions"
+    default: "warn"
 runs:
   using: "composite"
   steps:
@@ -4202,6 +4295,25 @@ runs:
           args+=(--out-dir "${{ inputs.out_dir }}")
         fi
         echo "exit_code=${status}" >> "${GITHUB_OUTPUT}"
+    - id: handle_review_required
+      name: Handle review-required decision
+      if: always() && inputs.decision == 'true' && steps.run_decision.outputs.exit_code == '0'
+      run: |
+        policy="${{ inputs.review_required }}"
+        case "${policy}" in
+          pass|warn|fail) ;;
+        esac
+        out="${{ steps.resolve_out_dir.outputs.out_dir }}"
+        tradeoff="${out}/tradeoff.json"
+        review_required="$(python - <<'PY'
+        decision.get("review_required")
+        PY
+        )"
+        review_reason="review required"
+        echo "review_required=${review_required}" >> "${GITHUB_OUTPUT}"
+        echo "review_required_reason=${review_reason}" >> "${GITHUB_OUTPUT}"
+        echo "exit_code=0" >> "${GITHUB_OUTPUT}"
+        echo "exit_code=2" >> "${GITHUB_OUTPUT}"
     - name: Append perfgate decision summary
       if: always() && inputs.decision == 'true'
       run: |
@@ -4210,10 +4322,11 @@ runs:
           cat "${out}/decision.md"
         fi
     - name: Print perfgate failure summary
-      if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0'))
+      if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0') || (inputs.decision == 'true' && steps.handle_review_required.outputs.exit_code != '' && steps.handle_review_required.outputs.exit_code != '0'))
       run: |
         out="${{ steps.resolve_out_dir.outputs.out_dir }}"
         exit_code="${{ steps.run_check.outputs.exit_code }}"
+        review_exit_code="${{ steps.handle_review_required.outputs.exit_code }}"
         repro=(perfgate check --config "${{ inputs.config }}")
         decision_repro=(perfgate decision evaluate --config "${{ inputs.config }}")
         decision_repro_line="$(format_command "${decision_repro[@]}")"
@@ -4272,6 +4385,23 @@ pkg-fmt = "zip"
     }
 
     #[test]
+    fn action_check_rejects_missing_review_required_input() {
+        let action = valid_action_install_surface().replace(
+            "  review_required:\n    description: \"How decision=true handles review-required decisions\"\n    default: \"warn\"\n",
+            "",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("review_required input")),
+            "errors should mention review_required input: {:?}",
+            errors
+        );
+    }
+
+    #[test]
     fn action_check_rejects_missing_decision_step() {
         let action = valid_action_install_surface().replace(
             "    - name: Run perfgate decision",
@@ -4284,6 +4414,40 @@ pkg-fmt = "zip"
                 .iter()
                 .any(|error| error.contains("decision evaluation step")),
             "errors should mention missing decision step: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn action_check_rejects_missing_review_required_step() {
+        let action = valid_action_install_surface().replace(
+            "      name: Handle review-required decision",
+            "      name: Handle review decision",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("review-required decision handling")),
+            "errors should mention review-required handling: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn action_check_rejects_review_required_step_without_output_id() {
+        let action = valid_action_install_surface().replace(
+            "    - id: handle_review_required\n      name: Handle review-required decision",
+            "    - name: Handle review-required decision",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("id handle_review_required")),
+            "errors should mention review-required step id: {:?}",
             errors
         );
     }


### PR DESCRIPTION
## Summary
- add a `review_required` action input (`warn` default, plus `fail` and `pass`) for `decision: "true"` workflows
- expose `review_required` and `review_required_reason` action outputs from the tradeoff receipt
- extend `xtask action-check` so action drift catches missing review-required input, step id, receipt inspection, outputs, and failure-summary wiring
- document review-required action behavior in README, GitHub Actions, performance decision, and release-readiness docs

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p xtask action_check --all-features`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo clippy -p xtask --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- ci`
- `git diff --check`
