### PR TITLE
decision: add ledger export and prune

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ bundle:
 perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
 ```
 
+Teams running the baseline server can persist that decision evidence as a
+ledger, export it for audits, and prune old records explicitly:
+
+```bash
+perfgate decision upload --file artifacts/perfgate/tradeoff.json --index artifacts/perfgate/decision.index.json
+perfgate decision export --days 90 --out artifacts/perfgate/decision-history.jsonl
+perfgate decision prune --older-than 365d --dry-run
+```
+
 In GitHub Actions, opt in with:
 
 ```yaml

--- a/crates/perfgate-cli/Cargo.toml
+++ b/crates/perfgate-cli/Cargo.toml
@@ -25,6 +25,7 @@ perfgate = { workspace = true, features = ["github"] }
 anyhow.workspace = true
 glob.workspace = true
 clap.workspace = true
+chrono = { version = "0.4", features = ["serde"] }
 humantime.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/perfgate-cli/README.md
+++ b/crates/perfgate-cli/README.md
@@ -81,6 +81,7 @@ Commands are organized by workflow stage.
 |-------------|---------|
 | `promote`   | Copy a run receipt into baseline storage |
 | `baseline`  | Manage baselines on a centralized server (list, upload, download, delete, history, verdicts, migrate) |
+| `decision`  | Manage decision ledger records (upload, history, latest, export, prune, debt) |
 | `serve`     | Start or preflight a local SQLite-backed dashboard server |
 | `aggregate` | Merge multiple run receipts (e.g. from a fleet) into one |
 | `fleet`     | Fleet-wide dependency regression alerts and impact analysis |

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -34,8 +34,9 @@ use perfgate_client::types::auth::Role;
 use perfgate_client::types::{BaselineRecord, CreateKeyRequest, KeyEntry};
 use perfgate_client::{
     AuthMethod, BaselineClient, ClientConfig, ListAuditEventsQuery, ListAuditEventsResponse,
-    ListBaselinesQuery, ListDecisionsQuery, ListVerdictsQuery, ResolvedServerConfig, RetryConfig,
-    SubmitVerdictRequest, UploadBaselineRequest, UploadDecisionRequest, resolve_server_config,
+    ListBaselinesQuery, ListDecisionsQuery, ListVerdictsQuery, PruneDecisionsRequest,
+    ResolvedServerConfig, RetryConfig, SubmitVerdictRequest, UploadBaselineRequest,
+    UploadDecisionRequest, resolve_server_config,
 };
 use perfgate_domain::scaling::{
     ScalingReport, SizeMeasurement, classify_complexity, parse_complexity, render_ascii_chart,
@@ -1317,6 +1318,10 @@ pub enum DecisionAction {
     Latest(DecisionLatestArgs),
     /// Summarize accepted tradeoff debt from the baseline server decision ledger.
     Debt(DecisionDebtArgs),
+    /// Export stored decision records as JSONL or JSON.
+    Export(DecisionExportArgs),
+    /// Prune old decision records from the baseline server ledger.
+    Prune(DecisionPruneArgs),
 }
 
 #[derive(Debug, Args)]
@@ -1509,6 +1514,54 @@ pub struct DecisionDebtArgs {
     /// Maximum number of decision records to fetch from the server.
     #[arg(long, default_value_t = 1000)]
     pub limit: u32,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum DecisionExportFormat {
+    Jsonl,
+    Json,
+}
+
+#[derive(Debug, Args)]
+pub struct DecisionExportArgs {
+    /// Project name (uses --project flag or PERFGATE_PROJECT if not specified).
+    #[arg(long)]
+    pub project: Option<String>,
+
+    /// Number of recent days to export. Use 0 to include all fetched records.
+    #[arg(long, default_value_t = 90)]
+    pub days: u32,
+
+    /// Maximum number of decision records to fetch from the server.
+    #[arg(long, default_value_t = 1000)]
+    pub limit: u32,
+
+    /// Output format.
+    #[arg(long, default_value = "jsonl")]
+    format: DecisionExportFormat,
+
+    /// Output file. Defaults to stdout.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+}
+
+#[derive(Debug, Args)]
+pub struct DecisionPruneArgs {
+    /// Project name (uses --project flag or PERFGATE_PROJECT if not specified).
+    #[arg(long)]
+    pub project: Option<String>,
+
+    /// Retention age such as 90d, 12w, or 365d.
+    #[arg(long)]
+    pub older_than: String,
+
+    /// Report matching decisions without deleting them.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+
+    /// Confirm deletion. Required unless --dry-run is set.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1729,6 +1782,7 @@ enum AuditResourceFilter {
     Baseline,
     Key,
     Verdict,
+    Decision,
 }
 
 impl AuditResourceFilter {
@@ -1737,6 +1791,7 @@ impl AuditResourceFilter {
             Self::Baseline => "baseline",
             Self::Key => "key",
             Self::Verdict => "verdict",
+            Self::Decision => "decision",
         }
     }
 }
@@ -3795,6 +3850,8 @@ fn execute_decision_action(
         DecisionAction::History(args) => execute_decision_history(args, server_flags),
         DecisionAction::Latest(args) => execute_decision_latest(args, server_flags),
         DecisionAction::Debt(args) => execute_decision_debt(args, server_flags),
+        DecisionAction::Export(args) => execute_decision_export(args, server_flags),
+        DecisionAction::Prune(args) => execute_decision_prune(args, server_flags),
     }
 }
 
@@ -4170,6 +4227,150 @@ fn execute_decision_debt(args: DecisionDebtArgs, server_flags: &ServerFlags) -> 
     Ok(())
 }
 
+fn execute_decision_export(
+    args: DecisionExportArgs,
+    server_flags: &ServerFlags,
+) -> anyhow::Result<()> {
+    let (server_config, _config_file) = resolve_server_config_from_path(server_flags, None)?;
+    let client = server_config.require_fallback_client(None, BASELINE_SERVER_NOT_CONFIGURED)?;
+    let project = server_config.resolve_project(args.project)?;
+    let cutoff = decision_debt_cutoff(args.days)?;
+    let query = ListDecisionsQuery::new().with_limit(args.limit);
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let response = client
+            .list_decisions(&project, &query)
+            .await
+            .with_context(|| format!("Failed to export decisions for project '{}'", project))?;
+
+        let records: Vec<_> = response
+            .decisions
+            .iter()
+            .filter(|record| {
+                cutoff
+                    .map(|cutoff| record.created_at.timestamp() >= cutoff)
+                    .unwrap_or(true)
+            })
+            .collect();
+
+        if response.pagination.has_more {
+            eprintln!(
+                "Warning: exported {} of {} fetched decisions; increase --limit for a fuller export.",
+                response.decisions.len(),
+                response.pagination.total
+            );
+        }
+
+        let rendered = render_decision_export(&project, args.days, &records, args.format)?;
+        if let Some(out) = args.out {
+            if let Some(parent) = out.parent()
+                && !parent.as_os_str().is_empty()
+            {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("failed to create {}", parent.display()))?;
+            }
+            atomic_write(&out, rendered.as_bytes())?;
+            eprintln!(
+                "Exported {} decision record(s) to {}",
+                records.len(),
+                out.display()
+            );
+        } else {
+            print!("{rendered}");
+        }
+
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+fn execute_decision_prune(
+    args: DecisionPruneArgs,
+    server_flags: &ServerFlags,
+) -> anyhow::Result<()> {
+    let (server_config, _config_file) = resolve_server_config_from_path(server_flags, None)?;
+    let client = server_config.require_fallback_client(None, BASELINE_SERVER_NOT_CONFIGURED)?;
+    let project = server_config.resolve_project(args.project)?;
+    let older_than = decision_prune_cutoff(&args.older_than)?;
+
+    if !args.dry_run && !args.force {
+        eprintln!(
+            "Warning: This will permanently delete decision records older than '{}' from project '{}'.",
+            args.older_than, project
+        );
+        eprintln!("Use --dry-run to preview or --force to confirm deletion.");
+        anyhow::bail!("Decision prune not confirmed. Use --force to proceed.");
+    }
+
+    let request = PruneDecisionsRequest {
+        older_than,
+        dry_run: args.dry_run,
+    };
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let response = client
+            .prune_decisions(&project, &request)
+            .await
+            .with_context(|| format!("Failed to prune decisions for project '{}'", project))?;
+
+        if response.dry_run {
+            println!(
+                "Decision prune dry run for {}: {} record(s) older than {} would be deleted.",
+                response.project,
+                response.matched,
+                response.older_than.to_rfc3339()
+            );
+        } else {
+            println!(
+                "Pruned {} decision record(s) from {} older than {}.",
+                response.deleted,
+                response.project,
+                response.older_than.to_rfc3339()
+            );
+        }
+
+        if !response.decision_ids.is_empty() {
+            println!("decision_ids={}", response.decision_ids.join(","));
+        }
+
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+fn render_decision_export(
+    project: &str,
+    days: u32,
+    records: &[&perfgate_client::DecisionRecord],
+    format: DecisionExportFormat,
+) -> anyhow::Result<String> {
+    match format {
+        DecisionExportFormat::Jsonl => {
+            let mut out = String::new();
+            for record in records {
+                out.push_str(&serde_json::to_string(record)?);
+                out.push('\n');
+            }
+            Ok(out)
+        }
+        DecisionExportFormat::Json => serde_json::to_string_pretty(&serde_json::json!({
+            "project": project,
+            "days": days,
+            "exported": records.len(),
+            "decisions": records,
+        }))
+        .map(|mut json| {
+            json.push('\n');
+            json
+        })
+        .map_err(Into::into),
+    }
+}
+
 fn decision_debt_cutoff(days: u32) -> anyhow::Result<Option<i64>> {
     if days == 0 {
         return Ok(None);
@@ -4180,6 +4381,30 @@ fn decision_debt_cutoff(days: u32) -> anyhow::Result<Option<i64>> {
         .context("system time is before UNIX_EPOCH")?
         .as_secs() as i64;
     Ok(Some(now - i64::from(days) * 86_400))
+}
+
+fn decision_prune_cutoff(older_than: &str) -> anyhow::Result<chrono::DateTime<chrono::Utc>> {
+    let duration = parse_retention_duration(older_than)?;
+    let chrono_duration = chrono::Duration::from_std(duration)
+        .with_context(|| format!("retention duration is too large: {older_than}"))?;
+    Ok(chrono::Utc::now() - chrono_duration)
+}
+
+fn parse_retention_duration(input: &str) -> anyhow::Result<Duration> {
+    let trimmed = input.trim();
+    if let Some(days) = trimmed.strip_suffix('d') {
+        let days: u64 = days
+            .parse()
+            .with_context(|| format!("invalid retention duration: {input}"))?;
+        return Ok(Duration::from_secs(days.saturating_mul(86_400)));
+    }
+    if let Some(weeks) = trimmed.strip_suffix('w') {
+        let weeks: u64 = weeks
+            .parse()
+            .with_context(|| format!("invalid retention duration: {input}"))?;
+        return Ok(Duration::from_secs(weeks.saturating_mul(7 * 86_400)));
+    }
+    parse_duration(trimmed)
 }
 
 #[derive(Default)]
@@ -8533,6 +8758,26 @@ mod tests {
             msg
         );
         assert!(msg.contains("not-a-duration"), "unexpected error: {}", msg);
+    }
+
+    #[test]
+    fn parse_retention_duration_accepts_days_and_weeks() {
+        assert_eq!(
+            parse_retention_duration("365d").unwrap(),
+            Duration::from_secs(365 * 86_400)
+        );
+        assert_eq!(
+            parse_retention_duration("12w").unwrap(),
+            Duration::from_secs(12 * 7 * 86_400)
+        );
+    }
+
+    #[test]
+    fn parse_retention_duration_accepts_humantime() {
+        assert_eq!(
+            parse_retention_duration("2h").unwrap(),
+            Duration::from_secs(2 * 60 * 60)
+        );
     }
 
     #[test]

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -295,7 +295,9 @@ fn cli_help_decision() {
             "Evaluate scenario and tradeoff evidence",
         ))
         .stdout(predicate::str::contains("evaluate"))
-        .stdout(predicate::str::contains("debt"));
+        .stdout(predicate::str::contains("debt"))
+        .stdout(predicate::str::contains("export"))
+        .stdout(predicate::str::contains("prune"));
 }
 
 #[test]
@@ -339,6 +341,34 @@ fn cli_help_decision_debt() {
         .stdout(predicate::str::contains("Summarize accepted tradeoff debt"))
         .stdout(predicate::str::contains("--days"))
         .stdout(predicate::str::contains("--limit"));
+}
+
+#[test]
+fn cli_help_decision_export() {
+    perfgate_cmd()
+        .args(["decision", "export", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Export stored decision records as JSONL or JSON",
+        ))
+        .stdout(predicate::str::contains("--days"))
+        .stdout(predicate::str::contains("--format"))
+        .stdout(predicate::str::contains("--out"));
+}
+
+#[test]
+fn cli_help_decision_prune() {
+    perfgate_cmd()
+        .args(["decision", "prune", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Prune old decision records from the baseline server ledger",
+        ))
+        .stdout(predicate::str::contains("--older-than"))
+        .stdout(predicate::str::contains("--dry-run"))
+        .stdout(predicate::str::contains("--force"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_mock_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_mock_server_tests.rs
@@ -4,7 +4,7 @@ use perfgate_types::{BASELINE_SCHEMA_V1, RUN_SCHEMA_V1};
 use predicates::prelude::*;
 use std::fs;
 use tempfile::TempDir;
-use wiremock::matchers::{header, method, path, query_param};
+use wiremock::matchers::{body_partial_json, header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 mod common;
@@ -810,6 +810,160 @@ async fn test_decision_debt_summarizes_accepted_tradeoffs() {
         ))
         .stdout(predicate::str::contains("renderer"))
         .stdout(predicate::str::contains("memory-for-latency (1)"));
+}
+
+#[tokio::test]
+async fn test_decision_export_writes_jsonl_from_server_ledger() {
+    let mock_server = MockServer::start().await;
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let export_path = temp_dir.path().join("decisions.jsonl");
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/projects/test-project/decisions"))
+        .and(header("Authorization", "Bearer decision-key"))
+        .and(query_param("limit", "1000"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "decisions": [
+                decision_record_with(
+                    "test-project",
+                    "decision-1",
+                    "parser",
+                    &["memory_for_speed"],
+                    false,
+                    "2026-05-08T00:00:00Z",
+                    Some((0.021, 0.03))
+                )
+            ],
+            "pagination": {
+                "total": 1,
+                "offset": 0,
+                "limit": 1000,
+                "has_more": false
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("decision-key")
+        .arg("--project")
+        .arg("test-project")
+        .arg("decision")
+        .arg("export")
+        .arg("--days")
+        .arg("0")
+        .arg("--out")
+        .arg(&export_path);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Exported 1 decision record"));
+
+    let exported = fs::read_to_string(&export_path).expect("read decision export");
+    let lines: Vec<_> = exported.lines().collect();
+    assert_eq!(lines.len(), 1);
+    let record: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("decision export line should be JSON");
+    assert_eq!(record["id"], "decision-1");
+    assert_eq!(record["accepted_rules"][0], "memory_for_speed");
+}
+
+#[tokio::test]
+async fn test_decision_prune_dry_run_and_force_use_server_ledger() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/projects/test-project/decisions/prune"))
+        .and(header("Authorization", "Bearer decision-key"))
+        .and(body_partial_json(serde_json::json!({"dry_run": true})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "project": "test-project",
+            "older_than": "2026-05-09T00:00:00Z",
+            "dry_run": true,
+            "matched": 1,
+            "deleted": 0,
+            "decision_ids": ["decision-1"]
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let mut dry_run = perfgate_cmd();
+    dry_run
+        .arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("decision-key")
+        .arg("--project")
+        .arg("test-project")
+        .arg("decision")
+        .arg("prune")
+        .arg("--older-than")
+        .arg("0s")
+        .arg("--dry-run");
+
+    dry_run
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Decision prune dry run"))
+        .stdout(predicate::str::contains("decision_ids=decision-1"));
+
+    let mut unconfirmed = perfgate_cmd();
+    unconfirmed
+        .arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("decision-key")
+        .arg("--project")
+        .arg("test-project")
+        .arg("decision")
+        .arg("prune")
+        .arg("--older-than")
+        .arg("0s");
+
+    unconfirmed
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Decision prune not confirmed"));
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/projects/test-project/decisions/prune"))
+        .and(header("Authorization", "Bearer decision-key"))
+        .and(body_partial_json(serde_json::json!({"dry_run": false})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "project": "test-project",
+            "older_than": "2026-05-09T00:00:00Z",
+            "dry_run": false,
+            "matched": 1,
+            "deleted": 1,
+            "decision_ids": ["decision-1"]
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let mut force = perfgate_cmd();
+    force
+        .arg("--baseline-server")
+        .arg(format!("{}/api/v1", mock_server.uri()))
+        .arg("--api-key")
+        .arg("decision-key")
+        .arg("--project")
+        .arg("test-project")
+        .arg("decision")
+        .arg("prune")
+        .arg("--older-than")
+        .arg("0s")
+        .arg("--force");
+
+    force
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pruned 1 decision record"))
+        .stdout(predicate::str::contains("decision_ids=decision-1"));
 }
 
 #[tokio::test]

--- a/crates/perfgate-cli/tests/cli_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_server_tests.rs
@@ -1112,6 +1112,113 @@ async fn run_live_server_cli_workflow(
         .stdout(predicate::str::contains(&decision_scenario))
         .stdout(predicate::str::contains("memory_for_speed (1)"));
 
+    let decision_export_path = temp_dir.path().join("decision-history.jsonl");
+    let mut decision_export = perfgate_cmd();
+    decision_export
+        .arg("decision")
+        .arg("export")
+        .arg("--days")
+        .arg("0")
+        .arg("--out")
+        .arg(&decision_export_path);
+    add_server_flags(&mut decision_export, server.url(), project, api_key);
+    decision_export
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Exported 1 decision record"));
+    let exported = fs::read_to_string(&decision_export_path).expect("read decision export");
+    assert!(
+        exported.contains(&decision_scenario),
+        "decision export should include uploaded scenario: {exported}"
+    );
+
+    let mut decision_prune_dry_run = perfgate_cmd();
+    decision_prune_dry_run
+        .arg("decision")
+        .arg("prune")
+        .arg("--older-than")
+        .arg("0s")
+        .arg("--dry-run");
+    add_server_flags(
+        &mut decision_prune_dry_run,
+        server.url(),
+        project,
+        admin_key,
+    );
+    decision_prune_dry_run
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Decision prune dry run"))
+        .stdout(predicate::str::contains("1 record"));
+
+    let mut decision_prune_unconfirmed = perfgate_cmd();
+    decision_prune_unconfirmed
+        .arg("decision")
+        .arg("prune")
+        .arg("--older-than")
+        .arg("0s");
+    add_server_flags(
+        &mut decision_prune_unconfirmed,
+        server.url(),
+        project,
+        admin_key,
+    );
+    decision_prune_unconfirmed
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Decision prune not confirmed"));
+
+    let mut decision_prune = perfgate_cmd();
+    decision_prune
+        .arg("decision")
+        .arg("prune")
+        .arg("--older-than")
+        .arg("0s")
+        .arg("--force");
+    add_server_flags(&mut decision_prune, server.url(), project, admin_key);
+    decision_prune
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pruned 1 decision record"));
+
+    let mut decision_history_after_prune = perfgate_cmd();
+    decision_history_after_prune
+        .arg("decision")
+        .arg("history")
+        .arg("--limit")
+        .arg("5");
+    add_server_flags(
+        &mut decision_history_after_prune,
+        server.url(),
+        project,
+        api_key,
+    );
+    decision_history_after_prune
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "No decisions found for project '{project}'."
+        )));
+
+    let mut decision_prune_audit = perfgate_cmd();
+    decision_prune_audit
+        .arg("audit")
+        .arg("list")
+        .arg("--project")
+        .arg(project)
+        .arg("--resource-type")
+        .arg("decision")
+        .arg("--action")
+        .arg("delete")
+        .arg("--limit")
+        .arg("5");
+    add_server_auth_flags(&mut decision_prune_audit, server.url(), admin_key);
+    decision_prune_audit
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("decision"))
+        .stdout(predicate::str::contains("delete"));
+
     let mut delete = perfgate_cmd();
     delete
         .arg("baseline")

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 517
+assertion_line: 564
 expression: "help_output(&[\"decision\", \"--help\"])"
 ---
 Evaluate scenario and tradeoff evidence into a review-ready decision summary
@@ -14,6 +14,8 @@ Commands:
   history List stored decision receipts from the baseline server
   latest Show the latest stored decision receipt from the baseline server
   debt Summarize accepted tradeoff debt from the baseline server decision ledger
+  export Export stored decision records as JSONL or JSON
+  prune Prune old decision records from the baseline server ledger
   help Print this message or the help of the given subcommand(s)
 
 Options:

--- a/crates/perfgate-client/src/client.rs
+++ b/crates/perfgate-client/src/client.rs
@@ -451,6 +451,42 @@ impl BaselineClient {
         .await
     }
 
+    /// Prunes old performance decisions from the server ledger.
+    pub async fn prune_decisions(
+        &self,
+        project: &str,
+        request: &PruneDecisionsRequest,
+    ) -> Result<PruneDecisionsResponse, ClientError> {
+        self.execute_with_retry(|| {
+            let url = self.url(&format!("projects/{}/decisions/prune", project));
+            debug!(url = %url, "Pruning performance decisions");
+
+            let client = self.inner.clone();
+            let request = request.clone();
+            async move {
+                let response = client
+                    .post(url)
+                    .json(&request)
+                    .send()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+
+                if !response.status().is_success() {
+                    let status = response.status().as_u16();
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(ClientError::from_http(status, &body));
+                }
+
+                let body = response
+                    .json::<PruneDecisionsResponse>()
+                    .await
+                    .map_err(ClientError::RequestError)?;
+                Ok(body)
+            }
+        })
+        .await
+    }
+
     /// Lists audit events. Requires an admin API key on authenticated servers.
     pub async fn list_audit_events(
         &self,
@@ -899,5 +935,43 @@ mod tests {
         assert_eq!(response.events.len(), 1);
         assert_eq!(response.events[0].id, "audit_123");
         assert_eq!(response.events[0].project, "my-project");
+    }
+
+    #[tokio::test]
+    async fn test_prune_decisions() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/projects/my-project/decisions/prune"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "project": "my-project",
+                "older_than": "2026-01-01T00:00:00Z",
+                "dry_run": true,
+                "matched": 1,
+                "deleted": 0,
+                "decision_ids": ["decision-1"]
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = BaselineClient::new(test_config(&mock_server.uri())).unwrap();
+        let response = client
+            .prune_decisions(
+                "my-project",
+                &PruneDecisionsRequest {
+                    older_than: chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                        .unwrap()
+                        .with_timezone(&chrono::Utc),
+                    dry_run: true,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.project, "my-project");
+        assert!(response.dry_run);
+        assert_eq!(response.matched, 1);
+        assert_eq!(response.deleted, 0);
+        assert_eq!(response.decision_ids, vec!["decision-1".to_string()]);
     }
 }

--- a/crates/perfgate-client/src/fallback.rs
+++ b/crates/perfgate-client/src/fallback.rs
@@ -197,6 +197,15 @@ impl FallbackClient {
         self.client.latest_decision(project).await
     }
 
+    /// Prunes performance decisions (server only, no fallback).
+    pub async fn prune_decisions(
+        &self,
+        project: &str,
+        request: &PruneDecisionsRequest,
+    ) -> Result<PruneDecisionsResponse, ClientError> {
+        self.client.prune_decisions(project, request).await
+    }
+
     /// Lists audit events (server only, no fallback).
     pub async fn list_audit_events(
         &self,

--- a/crates/perfgate-client/src/lib.rs
+++ b/crates/perfgate-client/src/lib.rs
@@ -118,9 +118,10 @@ pub use types::{
     ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse,
     ListDecisionsQuery, ListDecisionsResponse, ListFleetAlertsQuery, ListFleetAlertsResponse,
     ListVerdictsQuery, ListVerdictsResponse, PaginationInfo, PromoteBaselineRequest,
-    PromoteBaselineResponse, RecordDependencyEventRequest, RecordDependencyEventResponse,
-    StorageHealth, SubmitVerdictRequest, UploadBaselineRequest, UploadBaselineResponse,
-    UploadDecisionRequest, VerdictRecord,
+    PromoteBaselineResponse, PruneDecisionsRequest, PruneDecisionsResponse,
+    RecordDependencyEventRequest, RecordDependencyEventResponse, StorageHealth,
+    SubmitVerdictRequest, UploadBaselineRequest, UploadBaselineResponse, UploadDecisionRequest,
+    VerdictRecord,
 };
 
 #[cfg(test)]

--- a/crates/perfgate-server/README.md
+++ b/crates/perfgate-server/README.md
@@ -55,6 +55,10 @@ All data endpoints live under `/api/v1`. The health check and dashboard are at t
 | `POST` | `/api/v1/projects/{project}/baselines/{bench}/promote` | Y | Promote a version |
 | `POST` | `/api/v1/projects/{project}/verdicts` | Y | Submit a verdict |
 | `GET` | `/api/v1/projects/{project}/verdicts` | Y | List verdicts |
+| `POST` | `/api/v1/projects/{project}/decisions` | Y | Upload a performance decision |
+| `GET` | `/api/v1/projects/{project}/decisions` | Y | List performance decisions |
+| `GET` | `/api/v1/projects/{project}/decisions/latest` | Y | Get latest performance decision |
+| `POST` | `/api/v1/projects/{project}/decisions/prune` | Y | Prune old performance decisions |
 | `GET` | `/api/v1/audit` | Y | List audit events |
 | `POST` | `/api/v1/keys` | Y | Create an API key |
 | `GET` | `/api/v1/keys` | Y | List API keys |

--- a/crates/perfgate-server/src/handlers/baselines.rs
+++ b/crates/perfgate-server/src/handlers/baselines.rs
@@ -512,6 +512,15 @@ mod tests {
         ) -> Result<ListDecisionsResponse, StoreError> {
             Err(storage_failure())
         }
+
+        async fn prune_decisions(
+            &self,
+            _project: &str,
+            _older_than: chrono::DateTime<chrono::Utc>,
+            _dry_run: bool,
+        ) -> Result<perfgate_types::baseline_service::PruneDecisionsResponse, StoreError> {
+            Err(storage_failure())
+        }
     }
 
     #[async_trait]

--- a/crates/perfgate-server/src/handlers/decisions.rs
+++ b/crates/perfgate-server/src/handlers/decisions.rs
@@ -12,7 +12,8 @@ use crate::auth::{AuthContext, Scope, check_scope};
 use crate::metrics;
 use crate::models::{
     ApiError, AuditAction, AuditEvent, AuditResourceType, DECISION_RECORD_SCHEMA_V1,
-    DecisionRecord, ListDecisionsQuery, UploadDecisionRequest, generate_ulid,
+    DecisionRecord, ListDecisionsQuery, PruneDecisionsRequest, UploadDecisionRequest,
+    generate_ulid,
 };
 use crate::server::AppState;
 use perfgate_types::{DECISION_INDEX_SCHEMA_V1, SCENARIO_SCHEMA_V1, TRADEOFF_SCHEMA_V1};
@@ -145,6 +146,65 @@ pub async fn latest_decision(
         Err(e) => {
             metrics::record_storage_error("latest_decision");
             error!(error = %e, "Failed to get latest performance decision");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ApiError::internal_error(&e.to_string())),
+            ))
+        }
+    }
+}
+
+/// Prune old performance decisions from the server ledger.
+pub async fn prune_decisions(
+    Path(project): Path<String>,
+    Extension(auth_ctx): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<PruneDecisionsRequest>,
+) -> Result<impl IntoResponse, (StatusCode, Json<ApiError>)> {
+    check_scope(Some(&auth_ctx), &project, None, Scope::Delete)?;
+
+    match state
+        .store
+        .prune_decisions(&project, request.older_than, request.dry_run)
+        .await
+    {
+        Ok(response) => {
+            if !request.dry_run {
+                let audit_event = AuditEvent {
+                    id: generate_ulid(),
+                    timestamp: chrono::Utc::now(),
+                    actor: auth_ctx.api_key.id.clone(),
+                    action: AuditAction::Delete,
+                    resource_type: AuditResourceType::Decision,
+                    resource_id: project.clone(),
+                    project: project.clone(),
+                    metadata: serde_json::json!({
+                        "older_than": request.older_than.to_rfc3339(),
+                        "matched": response.matched,
+                        "deleted": response.deleted,
+                        "decision_ids": response.decision_ids.clone(),
+                    }),
+                };
+                if let Err(e) = state.audit.log_event(&audit_event).await {
+                    metrics::record_storage_error("audit_log");
+                    warn!(error = %e, "Failed to log decision prune audit event");
+                }
+            }
+
+            info!(
+                project = %project,
+                older_than = %request.older_than.to_rfc3339(),
+                dry_run = request.dry_run,
+                matched = response.matched,
+                deleted = response.deleted,
+                "Performance decisions pruned"
+            );
+
+            Ok(Json(response))
+        }
+        Err(e) => {
+            metrics::record_storage_error("prune_decisions");
+            error!(error = %e, "Failed to prune performance decisions");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ApiError::internal_error(&e.to_string())),

--- a/crates/perfgate-server/src/handlers/health.rs
+++ b/crates/perfgate-server/src/handlers/health.rs
@@ -186,6 +186,15 @@ mod tests {
         ) -> Result<ListDecisionsResponse, StoreError> {
             Err(storage_failure())
         }
+
+        async fn prune_decisions(
+            &self,
+            _project: &str,
+            _older_than: chrono::DateTime<chrono::Utc>,
+            _dry_run: bool,
+        ) -> Result<perfgate_types::baseline_service::PruneDecisionsResponse, StoreError> {
+            Err(storage_failure())
+        }
     }
 
     #[async_trait]

--- a/crates/perfgate-server/src/lib.rs
+++ b/crates/perfgate-server/src/lib.rs
@@ -43,6 +43,7 @@
 //! | POST | `/api/v1/projects/{project}/decisions` | Upload a performance decision receipt |
 //! | GET | `/api/v1/projects/{project}/decisions/latest` | Get latest performance decision |
 //! | GET | `/api/v1/projects/{project}/decisions` | List performance decisions |
+//! | POST | `/api/v1/projects/{project}/decisions/prune` | Prune old performance decisions |
 //! | GET | `/api/v1/audit` | List audit events (admin only) |
 //! | POST | `/api/v1/keys` | Create an API key (admin only) |
 //! | GET | `/api/v1/keys` | List API keys (admin only) |

--- a/crates/perfgate-server/src/server.rs
+++ b/crates/perfgate-server/src/server.rs
@@ -30,8 +30,8 @@ use crate::handlers::{
     DefaultRetentionDays, admin_cleanup, create_key, dashboard_index, delete_baseline,
     dependency_impact, get_baseline, get_latest_baseline, get_trend, health_check, latest_decision,
     list_audit_events, list_baselines, list_decisions, list_fleet_alerts, list_keys, list_verdicts,
-    promote_baseline, record_dependency_event, revoke_key, static_asset, submit_verdict,
-    upload_baseline, upload_decision,
+    promote_baseline, prune_decisions, record_dependency_event, revoke_key, static_asset,
+    submit_verdict, upload_baseline, upload_decision,
 };
 use crate::metrics::{metrics_handler, metrics_middleware, setup_metrics_recorder};
 use crate::oidc::{OidcConfig, OidcProvider, OidcRegistry};
@@ -558,6 +558,7 @@ pub(crate) fn create_router(
         .route("/projects/{project}/decisions", post(upload_decision))
         .route("/projects/{project}/decisions", get(list_decisions))
         .route("/projects/{project}/decisions/latest", get(latest_decision))
+        .route("/projects/{project}/decisions/prune", post(prune_decisions))
         .route(
             "/projects/{project}/baselines/{benchmark}/promote",
             post(promote_baseline),

--- a/crates/perfgate-server/src/storage/memory.rs
+++ b/crates/perfgate-server/src/storage/memory.rs
@@ -11,7 +11,7 @@ use crate::models::{
     AuditEvent, BaselineRecord, BaselineSummary, BaselineVersion, DecisionRecord,
     ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse,
     ListDecisionsQuery, ListDecisionsResponse, ListVerdictsQuery, ListVerdictsResponse,
-    PaginationInfo, VerdictRecord,
+    PaginationInfo, PruneDecisionsResponse, VerdictRecord,
 };
 
 /// In-memory storage backend for baselines.
@@ -424,6 +424,38 @@ impl BaselineStore for InMemoryStore {
                 offset: query.offset,
                 has_more,
             },
+        })
+    }
+
+    async fn prune_decisions(
+        &self,
+        project: &str,
+        older_than: chrono::DateTime<chrono::Utc>,
+        dry_run: bool,
+    ) -> Result<PruneDecisionsResponse, StoreError> {
+        let mut decisions = self.decisions.write().await;
+        let decision_ids: Vec<String> = decisions
+            .iter()
+            .filter(|record| record.project == project && record.created_at < older_than)
+            .map(|record| record.id.clone())
+            .collect();
+        let matched = decision_ids.len() as u64;
+
+        let deleted = if dry_run {
+            0
+        } else {
+            decisions
+                .retain(|record| !(record.project == project && record.created_at < older_than));
+            matched
+        };
+
+        Ok(PruneDecisionsResponse {
+            project: project.to_string(),
+            older_than,
+            dry_run,
+            matched,
+            deleted,
+            decision_ids,
         })
     }
 }

--- a/crates/perfgate-server/src/storage/mod.rs
+++ b/crates/perfgate-server/src/storage/mod.rs
@@ -22,7 +22,8 @@ use crate::error::StoreError;
 use crate::models::{
     AuditEvent, BaselineRecord, BaselineVersion, DecisionRecord, ListAuditEventsQuery,
     ListAuditEventsResponse, ListBaselinesQuery, ListBaselinesResponse, ListDecisionsQuery,
-    ListDecisionsResponse, ListVerdictsQuery, ListVerdictsResponse, PoolMetrics, VerdictRecord,
+    ListDecisionsResponse, ListVerdictsQuery, ListVerdictsResponse, PoolMetrics,
+    PruneDecisionsResponse, VerdictRecord,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -147,6 +148,14 @@ pub trait BaselineStore: Send + Sync {
         project: &str,
         query: &ListDecisionsQuery,
     ) -> Result<ListDecisionsResponse, StoreError>;
+
+    /// Prunes performance decision records created before a cutoff.
+    async fn prune_decisions(
+        &self,
+        project: &str,
+        older_than: DateTime<Utc>,
+        dry_run: bool,
+    ) -> Result<PruneDecisionsResponse, StoreError>;
 }
 
 /// Trait for append-only audit event storage.

--- a/crates/perfgate-server/src/storage/postgres.rs
+++ b/crates/perfgate-server/src/storage/postgres.rs
@@ -9,7 +9,7 @@ use crate::models::{
     AuditAction, AuditEvent, AuditResourceType, BaselineRecord, BaselineSource, BaselineVersion,
     DecisionRecord, ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery,
     ListBaselinesResponse, ListDecisionsQuery, ListDecisionsResponse, ListVerdictsQuery,
-    ListVerdictsResponse, PaginationInfo, VerdictRecord,
+    ListVerdictsResponse, PaginationInfo, PruneDecisionsResponse, VerdictRecord,
 };
 use crate::server::PostgresPoolConfig;
 use async_trait::async_trait;
@@ -974,6 +974,44 @@ impl BaselineStore for PostgresStore {
                 limit: query.limit,
                 has_more: (query.offset + query.limit as u64) < total as u64,
             },
+        })
+    }
+
+    async fn prune_decisions(
+        &self,
+        project: &str,
+        older_than: chrono::DateTime<chrono::Utc>,
+        dry_run: bool,
+    ) -> Result<PruneDecisionsResponse, StoreError> {
+        let ids = sqlx::query_scalar::<_, String>(
+            "SELECT id FROM decisions WHERE project = $1 AND created_at < $2 ORDER BY created_at ASC",
+        )
+        .bind(project)
+        .bind(older_than)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| StoreError::QueryError(e.to_string()))?;
+        let matched = ids.len() as u64;
+
+        let deleted = if dry_run {
+            0
+        } else {
+            sqlx::query("DELETE FROM decisions WHERE project = $1 AND created_at < $2")
+                .bind(project)
+                .bind(older_than)
+                .execute(&self.pool)
+                .await
+                .map_err(|e| StoreError::QueryError(e.to_string()))?
+                .rows_affected()
+        };
+
+        Ok(PruneDecisionsResponse {
+            project: project.to_string(),
+            older_than,
+            dry_run,
+            matched,
+            deleted,
+            decision_ids: ids,
         })
     }
 }

--- a/crates/perfgate-server/src/storage/sqlite.rs
+++ b/crates/perfgate-server/src/storage/sqlite.rs
@@ -11,7 +11,7 @@ use crate::models::{
     AuditAction, AuditEvent, AuditResourceType, BaselineRecord, BaselineSource, BaselineVersion,
     DecisionRecord, ListAuditEventsQuery, ListAuditEventsResponse, ListBaselinesQuery,
     ListBaselinesResponse, ListDecisionsQuery, ListDecisionsResponse, ListVerdictsQuery,
-    ListVerdictsResponse, PaginationInfo, VerdictRecord,
+    ListVerdictsResponse, PaginationInfo, PruneDecisionsResponse, VerdictRecord,
 };
 use perfgate_types::{MetricStatus, VerdictCounts, VerdictStatus};
 
@@ -820,6 +820,53 @@ impl BaselineStore for SqliteStore {
             },
         })
     }
+
+    async fn prune_decisions(
+        &self,
+        project: &str,
+        older_than: chrono::DateTime<chrono::Utc>,
+        dry_run: bool,
+    ) -> Result<PruneDecisionsResponse, StoreError> {
+        let cutoff = older_than.to_rfc3339();
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| StoreError::LockError(e.to_string()))?;
+
+        let mut stmt = conn
+            .prepare(
+                "SELECT id FROM decisions WHERE project = ?1 AND created_at < ?2 ORDER BY created_at ASC",
+            )
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![project, cutoff], |row| row.get::<_, String>(0))
+            .map_err(|e| StoreError::QueryError(e.to_string()))?;
+        let mut decision_ids = Vec::new();
+        for row in rows {
+            decision_ids.push(row.map_err(StoreError::from)?);
+        }
+        let matched = decision_ids.len() as u64;
+        drop(stmt);
+
+        let deleted = if dry_run {
+            0
+        } else {
+            conn.execute(
+                "DELETE FROM decisions WHERE project = ?1 AND created_at < ?2",
+                params![project, older_than.to_rfc3339()],
+            )
+            .map_err(|e| StoreError::QueryError(e.to_string()))? as u64
+        };
+
+        Ok(PruneDecisionsResponse {
+            project: project.to_string(),
+            older_than,
+            dry_run,
+            matched,
+            deleted,
+            decision_ids,
+        })
+    }
 }
 
 impl SqliteStore {
@@ -1321,6 +1368,82 @@ mod tests {
             .unwrap();
         assert_eq!(verdict.decisions.len(), 1);
         assert_eq!(verdict.decisions[0].id, "decision-2");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_decision_prune_dry_run_and_delete() {
+        let store = SqliteStore::in_memory().unwrap();
+        let old = create_test_decision(
+            "decision-old",
+            "my-project",
+            "release_workload",
+            perfgate_types::MetricStatus::Warn,
+            "2026-05-01T00:00:00Z",
+            false,
+        );
+        let recent = create_test_decision(
+            "decision-recent",
+            "my-project",
+            "release_workload",
+            perfgate_types::MetricStatus::Warn,
+            "2026-05-09T00:00:00Z",
+            false,
+        );
+        let other_project = create_test_decision(
+            "decision-other",
+            "other-project",
+            "release_workload",
+            perfgate_types::MetricStatus::Warn,
+            "2026-05-01T00:00:00Z",
+            false,
+        );
+        store.create_decision(&old).await.unwrap();
+        store.create_decision(&recent).await.unwrap();
+        store.create_decision(&other_project).await.unwrap();
+
+        let cutoff = chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let dry_run = store
+            .prune_decisions("my-project", cutoff, true)
+            .await
+            .unwrap();
+        assert!(dry_run.dry_run);
+        assert_eq!(dry_run.matched, 1);
+        assert_eq!(dry_run.deleted, 0);
+        assert_eq!(dry_run.decision_ids, vec!["decision-old".to_string()]);
+        assert_eq!(
+            store
+                .list_decisions("my-project", &ListDecisionsQuery::new())
+                .await
+                .unwrap()
+                .pagination
+                .total,
+            2
+        );
+
+        let pruned = store
+            .prune_decisions("my-project", cutoff, false)
+            .await
+            .unwrap();
+        assert!(!pruned.dry_run);
+        assert_eq!(pruned.matched, 1);
+        assert_eq!(pruned.deleted, 1);
+        assert_eq!(pruned.decision_ids, vec!["decision-old".to_string()]);
+
+        let remaining = store
+            .list_decisions("my-project", &ListDecisionsQuery::new())
+            .await
+            .unwrap();
+        assert_eq!(remaining.pagination.total, 1);
+        assert_eq!(remaining.decisions[0].id, "decision-recent");
+
+        let other = store
+            .list_decisions("other-project", &ListDecisionsQuery::new())
+            .await
+            .unwrap();
+        assert_eq!(other.pagination.total, 1);
+        assert_eq!(other.decisions[0].id, "decision-other");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/perfgate-types/src/baseline_service.rs
+++ b/crates/perfgate-types/src/baseline_service.rs
@@ -345,6 +345,34 @@ pub struct ListDecisionsResponse {
     pub pagination: PaginationInfo,
 }
 
+/// Request for pruning old performance decision records.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct PruneDecisionsRequest {
+    /// Delete records created before this timestamp.
+    pub older_than: DateTime<Utc>,
+    /// When true, report matching records without deleting them.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+/// Response for a decision prune operation.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct PruneDecisionsResponse {
+    /// Project identifier.
+    pub project: String,
+    /// Records older than this timestamp were matched.
+    pub older_than: DateTime<Utc>,
+    /// Whether the operation was a dry run.
+    pub dry_run: bool,
+    /// Number of records matched by the retention cutoff.
+    pub matched: u64,
+    /// Number of records deleted. Always zero for dry runs.
+    pub deleted: u64,
+    /// Decision record ids matched by the retention cutoff.
+    #[serde(default)]
+    pub decision_ids: Vec<String>,
+}
+
 /// Version history metadata (without full receipt).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct BaselineVersion {

--- a/docs/BASELINE_SERVICE_DESIGN.md
+++ b/docs/BASELINE_SERVICE_DESIGN.md
@@ -154,7 +154,9 @@ The main server-aware CLI workflows are:
 | `baseline migrate` | upload local baseline JSON files recursively |
 | `decision upload` | store a structured performance decision receipt |
 | `decision history` | list stored performance decisions with scenario/status/verdict/review/rule filters |
+| `decision export` | export decision ledger records as JSONL or JSON |
 | `decision debt` | summarize accepted tradeoff debt, cap usage, and accepted deltas by scenario |
+| `decision prune --dry-run` / `--force` | preview or delete old decision ledger records |
 | `audit list` | inspect append-only audit events |
 | `audit export --format jsonl` | export audit events for operators or compliance review |
 | `fleet alerts` | list fleet-wide dependency regression alerts |

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -183,7 +183,9 @@ The current CLI surfaces that talk to the baseline service are:
 | `baseline migrate` | Upload local baseline JSON files to the server |
 | `decision upload` | Store a structured performance decision receipt |
 | `decision history` | List stored performance decisions, with scenario/status/verdict/review/rule filters |
+| `decision export` | Export decision ledger records as JSONL or JSON |
 | `decision debt` | Summarize accepted tradeoff debt, cap usage, and accepted deltas by scenario |
+| `decision prune --dry-run` / `--force` | Preview or delete old decision ledger records |
 | `audit list` | List admin audit events |
 | `audit export --format jsonl` | Export audit events for external review |
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -331,6 +331,7 @@ server can store decisions as audit-backed ledger entries:
 perfgate decision upload --file artifacts/perfgate/tradeoff.json --index artifacts/perfgate/decision.index.json
 perfgate decision latest
 perfgate decision history --limit 20
+perfgate decision export --days 90 --out artifacts/perfgate/decision-history.jsonl
 perfgate decision debt --days 30
 ```
 
@@ -350,6 +351,11 @@ perfgate decision history --scenario large_file_parse --verdict warn
 The dashboard exposes the same drilldowns for status, verdict, review state,
 accepted-tradeoff presence, scenario, and accepted rule.
 
+Use `decision export` when ledger evidence needs to leave the server for a
+release, audit, incident review, or offline analysis. JSONL is the default so
+records can be streamed into external tools; `--format json` writes a single
+JSON object with metadata and the selected records.
+
 `decision debt` summarizes accepted tradeoff records by scenario so teams can
 spot repeated exceptions before they become invisible performance debt. When a
 tradeoff rule used local regression caps, the summary reports the highest cap
@@ -358,6 +364,17 @@ contains its configured rule and weighted deltas, the summary also reports the
 largest accepted failed-metric regression, such as `max_rss_kb +3.0%`. Budget
 headroom usage is reported as `n/a` until receipts include the original budget
 threshold denominator; perfgate does not infer that value from status alone.
+
+Decision retention is explicit. Preview old records first, then force deletion
+only after the export/audit window is safe to remove:
+
+```bash
+perfgate decision prune --older-than 365d --dry-run
+perfgate decision prune --older-than 365d --force
+```
+
+Pruning requires delete/admin credentials. Non-dry-run prune operations emit a
+decision audit event with the cutoff and affected decision ids.
 
 ## Primitive Commands
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -26,7 +26,7 @@ performance-decision workflow are now in their intended release shape:
 | First-run paved road | Covered | `crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs` |
 | Baseline bootstrap UX | Covered | `crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs` |
 | Structured decision workflow | Covered | `crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs`, `crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs`, `crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs`, and GitHub Action `decision: "true"` |
-| Decision ledger and debt | Covered | `decision upload|history|latest|debt`, `perfgate.decision_record.v1`, decision upload audit events, and dashboard decision-ledger tests |
+| Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, and dashboard decision-ledger tests |
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
 | Full repo CI | Passing | Hosted `ci`, `Coverage`, and `perfgate-self` on merge commit `a1ffb0e`; PR #323 also passed `fuzz` |
@@ -185,7 +185,7 @@ These commands were tested end-to-end on Windows (x86_64, Rust 1.92):
 | `baseline list` | **Works** | Lists uploaded baselines correctly |
 | `baseline download` | **Works** | Note: uses `--output` not `--out` |
 | `baseline history` | **Works** | Local-mode smoke flow re-verified in 0.15.1 prep |
-| `baseline delete/verdicts` | **Not tested** | Server is functional, but these were not re-run for this patch |
+| `baseline delete/verdicts` | **Works** | Live server CLI workflow covers implicit-latest delete plus verdict submit/list |
 | `check --mode cockpit` | **Works** | Produces sensor.report.v1 envelope + extras |
 
 ## Known Bugs
@@ -293,11 +293,13 @@ The **core local gating pipeline** is production-quality:
   are explicit through `review_required: "warn" | "fail" | "pass"`.
 - **Decision ledger and debt** — the baseline server stores
   `perfgate.decision_record.v1` records, decision uploads emit audit events,
-  `decision history|latest|debt` expose the ledger from the CLI, debt summaries
-  include cap usage and accepted failed-metric deltas when receipt evidence is
-  present, history can be filtered by scenario, status, verdict, review state,
-  accepted-tradeoff presence, and rule, and the dashboard shows stored
-  performance decisions with the same drilldowns.
+  `decision history|latest|export|prune|debt` expose the ledger from the CLI,
+  prune operations require explicit `--dry-run` or `--force` and emit audit
+  events when records are deleted, debt summaries include cap usage and
+  accepted failed-metric deltas when receipt evidence is present, history can be
+  filtered by scenario, status, verdict, review state, accepted-tradeoff
+  presence, and rule, and the dashboard shows stored performance decisions with
+  the same drilldowns.
 - **Dashboard decision visibility** — the dashboard now includes baseline,
   verdict/flakiness, decision-ledger, and audit-event views.
 


### PR DESCRIPTION
## Summary
- add `decision export` for JSONL/JSON ledger exports from the baseline server
- add `decision prune --older-than ... --dry-run|--force`, backed by a new server prune endpoint, storage implementations, delete-scope authorization, and delete audit events
- extend live/mock CLI coverage and docs for decision retention, export, prune, and audit behavior

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p perfgate-client test_prune_decisions --all-features`
- `cargo test -p perfgate-server test_decision_prune_dry_run_and_delete --all-features`
- `cargo test -p perfgate-cli --test cli_mock_server_tests decision_ --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests cli_help_decision --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests snapshot_help_decision --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests cli_help_audit --all-features`
- `cargo test -p perfgate-cli --test cli_help_snapshot_tests snapshot_help_main --all-features`
- `cargo test -p perfgate-cli parse_retention_duration --all-features`
- `cargo test -p perfgate-cli --test cli_server_tests live_server_cli_workflow_memory --all-features`
- `cargo test -p perfgate-cli --test cli_server_tests live_server_cli_workflow_sqlite --all-features`
- `cargo check -p perfgate-client -p perfgate-server -p perfgate-cli --all-targets --all-features`
- `cargo clippy -p perfgate-client -p perfgate-server -p perfgate-cli --all-targets --all-features -- -D warnings`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- schema-check`
- `cargo run -p xtask -- ci`
- `git diff --check`