### PR TITLE
docs: clarify structured decision adoption path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `perfgate.scenario.v1`, and `perfgate.tradeoff.v1`.
 - Added `perfgate ingest probes --file probes.jsonl` to convert
   language-agnostic probe JSONL into `perfgate.probe.v1` receipts.
+- Added adoption documentation for a three-level structured decision path:
+  basic gate, decision mode, and server-ledger mode, plus a clear install ->
+  init -> check -> decision -> ledger sequence for early adopters.
 - Added `perfgate probe compare` and `perfgate.probe_compare.v1` receipts for
   named probe deltas between baseline and current structured evidence.
 - Added `perfgate scenario evaluate` to turn configured weighted scenarios and

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ Use `review_required: "fail"` when review-required decisions should block
 branch protection, or `review_required: "pass"` when another workflow step owns
 that review policy.
 
+### Adoption levels
+
+Perfgate is designed to be adopted in stages:
+
+- **Basic gate** — `perfgate check` and tracked baselines.
+- **Decision mode** — add `[[scenario]]` and `[[tradeoff]]` config plus
+  `perfgate decision evaluate`.
+- **Ledger mode** — connect a baseline server, upload decisions, and use
+  `decision export|history|debt|prune` for auditability.
+
+Use that order to start quickly, then opt into richer tradeoff review and
+auditable governance as teams become ready.
+
 ## Daily Use
 
 Run the whole configured suite:

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -81,7 +81,54 @@ markdown rendering
 It does not run benchmarks. It consumes the receipts already produced by
 `check`.
 
-### Probe Evidence
+## Adoption Levels
+
+Adopt these three levels in this order to minimize ramp-up:
+
+### 1) Basic gate
+
+Keep the local baseline path and make sure the normal gate is stable:
+
+```bash
+perfgate init --ci github --profile standard
+perfgate check --config perfgate.toml --all
+```
+
+Add baseline promotion after you trust the first run:
+
+```bash
+perfgate baseline promote --config perfgate.toml --all
+```
+
+### 2) Decision mode
+
+Enable weighted-workload tradeoff reasoning without server dependencies:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+You now have structured evidence for review (`decision.md`, `decision.index.json`)
+that can be pasted into PR comments, issue attachments, or incident notes.
+
+### 3) Server ledger
+
+Persist decisions in the baseline server for retention and audit:
+
+```bash
+perfgate serve
+perfgate decision upload --file artifacts/perfgate/tradeoff.json --index artifacts/perfgate/decision.index.json
+perfgate decision history --project default
+perfgate decision export --project default --days 90 --out artifacts/perfgate/decision-history.jsonl
+```
+
+Use `decision debt --project default` for debt/headroom insight, and `decision
+prune --project default --older-than 365d --dry-run` before any destructive
+prune.
+
+## Probe Evidence
 
 Named probes explain internal phase movement. Ingest probe observations from any
 language or harness:

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,13 +1,13 @@
 # Release Readiness
 
-Last verified: 2026-05-09 after merging the 0.16 public-surface collapse,
+Last verified: 2026-05-10 after merging the 0.16 public-surface collapse,
 first-run onboarding hardening, server operations visibility, structured
-performance-decision workflow, decision ledger/debt, and dashboard
-decision-ledger visibility through PR #323.
+performance-decision workflow, decision ledger/debt, and server-ledger
+decision visibility through PR #333.
 
 ## Current Main Snapshot
 
-Verified on 2026-05-09 after merging release-readiness work through PR #323.
+Verified on 2026-05-10 after merging release-readiness work through PR #333.
 
 The current `main` branch is not a published release, but the 0.16 public crate
 surface, paved first-run workflow, baseline-service operations, and structured
@@ -19,10 +19,14 @@ performance-decision workflow are now in their intended release shape:
 | Architecture boundary enforcement | Passing | `cargo run -p xtask -- arch` |
 | Publish metadata preflight | Passing | `cargo run -p xtask -- publish-check` |
 | Package file-list proof | Release-prep gate | `cargo run -p xtask -- publish-check --package-list` |
+| Adoption path docs | Covered | `README.md`, `docs/PERFORMANCE_DECISIONS.md` |
 | Publish dry-run proof | Per-package release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
+| Publish dry-run matrix | Failing (expected) | `cargo run -p xtask -- publish-check --dry-run --package-list` not yet safe for all public crates: `perfgate-types` passes, remaining public crates currently fail on unresolved re-exports/API drift and dependency/version pin mismatches |
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
+| Install smoke proof | Verified | `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force` and `cargo-binstall perfgate-cli --version 0.15.1 --force` |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |
 | Documentation examples | Passing | `cargo run -p xtask -- docs-check` and `cargo run -p xtask -- doc-test` |
+| Structured decision end-to-end | Verified | `perfgate ingest probes`, `perfgate decision evaluate`, `perfgate decision bundle` on `examples/performance-decision`, plus `perfgate serve --no-open` and `decision upload/history/debt/prune --dry-run` |
 | First-run paved road | Covered | `crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs` |
 | Baseline bootstrap UX | Covered | `crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs` |
 | Structured decision workflow | Covered | `crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs`, `crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs`, `crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs`, and GitHub Action `decision: "true"` |


### PR DESCRIPTION
## Summary
- Adds a clear adoption narrative for structured decisions: basic gate, decision mode, and ledger mode.
- Updates `README.md`, `docs/PERFORMANCE_DECISIONS.md`, `docs/RELEASE_READINESS.md`, and `CHANGELOG.md`.
- Keeps the path explicit and boring: install -> init/check -> decision -> ledger.

## Validation
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- schema-compat`
- `cargo run -p xtask -- ci` (failed locally from disk limit / linker error LNK1180 at the local machine; other checks above passed)

## Release readiness proof references
- `cargo install --path crates/perfgate-cli --root C:\perfgate-smoke\from --force`
- `cargo-binstall perfgate-cli --version 0.15.1 --force`
- `C:\perfgate-smoke\from\bin\perfgate.exe --version`
- `C:\perfgate-smoke\from\bin\perfgate.exe ingest probes`
- `C:\perfgate-smoke\from\bin\perfgate.exe decision evaluate`
- `C:\perfgate-smoke\from\bin\perfgate.exe decision bundle`
- `C:\perfgate-smoke\from\bin\perfgate.exe serve --no-open`
- `C:\perfgate-smoke\from\bin\perfgate.exe decision upload/history/debt/prune --dry-run`

## Known follow-up
- Keep PR #334 (automated nightly baseline/trend refresh) separate from release/adoption packaging.
- Known open release blocker remains on publish dry-run matrix and is handled in a follow-up PR.
