### PR TITLE
release: prepare 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- No new changes yet.
+
+## [0.16.0] - 2026-05-11
+
+### Added
 - Added `perfgate doctor` to diagnose local setup, config loading, benchmark
   command availability, baseline presence, artifact directory writability, CI
   detection, and baseline-server health.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 rust-version = "1.93"
 license = "MIT OR Apache-2.0"
@@ -121,18 +121,18 @@ wiremock = "0.6"
 libc = "0.2.182"
 
 # Internal crates
-perfgate-error = { path = "crates/perfgate-error", version = "0.15.1" }
-perfgate-api = { path = "crates/perfgate-api", version = "0.15.1" }
-perfgate-types = { path = "crates/perfgate-types", version = "0.15.1" }
-perfgate-domain = { path = "crates/perfgate-domain", version = "0.15.1" }
-perfgate-paired = { path = "crates/perfgate-paired", version = "0.15.1" }
-perfgate-render = { path = "crates/perfgate-render", version = "0.15.1" }
-perfgate-export = { path = "crates/perfgate-export", version = "0.15.1" }
-perfgate-sensor = { path = "crates/perfgate-sensor", version = "0.15.1" }
-perfgate-fake = { path = "crates/perfgate-fake", version = "0.15.1" }
-perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.15.1" }
-perfgate-app = { path = "crates/perfgate-app", version = "0.15.1" }
-perfgate-server = { path = "crates/perfgate-server", version = "0.15.1" }
-perfgate-client = { path = "crates/perfgate-client", version = "0.15.1" }
-perfgate-github = { path = "crates/perfgate-github", version = "0.15.1" }
-perfgate = { path = "crates/perfgate", version = "0.15.1" }
+perfgate-error = { path = "crates/perfgate-error", version = "0.16.0" }
+perfgate-api = { path = "crates/perfgate-api", version = "0.16.0" }
+perfgate-types = { path = "crates/perfgate-types", version = "0.16.0" }
+perfgate-domain = { path = "crates/perfgate-domain", version = "0.16.0" }
+perfgate-paired = { path = "crates/perfgate-paired", version = "0.16.0" }
+perfgate-render = { path = "crates/perfgate-render", version = "0.16.0" }
+perfgate-export = { path = "crates/perfgate-export", version = "0.16.0" }
+perfgate-sensor = { path = "crates/perfgate-sensor", version = "0.16.0" }
+perfgate-fake = { path = "crates/perfgate-fake", version = "0.16.0" }
+perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.16.0" }
+perfgate-app = { path = "crates/perfgate-app", version = "0.16.0" }
+perfgate-server = { path = "crates/perfgate-server", version = "0.16.0" }
+perfgate-client = { path = "crates/perfgate-client", version = "0.16.0" }
+perfgate-github = { path = "crates/perfgate-github", version = "0.16.0" }
+perfgate = { path = "crates/perfgate", version = "0.16.0" }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The generated GitHub workflow uses the repository action:
     upload_artifact: "true"
 ```
 
-Use `@v0.15.1` for an exact patch pin, or `@v0.15` / `@v0` to follow the
+Use `@v0.16.0` for an exact patch pin, or `@v0.16` / `@v0` to follow the
 current compatible action tag.
 
 ## Performance Decisions

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -1,7 +1,7 @@
 # Getting Started with the Baseline Server
 
 This guide documents the current, shipped baseline-server workflow in
-`perfgate 0.15.1`. Every CLI example below has been validated against the
+`perfgate 0.16.0`. Every CLI example below has been validated against the
 actual binary. It intentionally focuses on commands and flags that exist today.
 
 ## Pick a Mode
@@ -244,7 +244,7 @@ inspect server logs for the full database error.
 ```json
 {
   "status": "healthy",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "storage": {
     "backend": "postgres",
     "status": "healthy"

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.15.1
+        uses: EffortlessMetrics/perfgate@v0.16.0
         with:
           config: perfgate.toml
           all: "true"
@@ -85,7 +85,7 @@ Omit `out_dir` to let the action use `[defaults].out_dir` from
 `perfgate.toml`. Set `out_dir` only when the workflow should override the
 config.
 
-Use `@v0.15.1` when you want an exact patch pin. If you prefer a moving tag,
+Use `@v0.16.0` when you want an exact patch pin. If you prefer a moving tag,
 the published action aliases `@v0.15` and `@v0` now track the current
 compatible release.
 
@@ -109,7 +109,7 @@ comment, opt in to decision mode:
 ```yaml
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.15.1
+        uses: EffortlessMetrics/perfgate@v0.16.0
         with:
           config: perfgate.toml
           all: "true"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1002,7 +1002,7 @@ fn publish_check_patch_crates(package: &str) -> &'static [&'static str] {
     match package {
         "perfgate" => &["perfgate-types"],
         "perfgate-client" => &["perfgate-types"],
-        "perfgate-server" => &["perfgate-types", "perfgate"],
+        "perfgate-server" => &["perfgate-types", "perfgate", "perfgate-client"],
         "perfgate-cli" => &[
             "perfgate-types",
             "perfgate",


### PR DESCRIPTION
Release preparation for `0.16.0`.

- Bump workspace and in-crate dependency version pins from `0.15.1` to `0.16.0`.
- Update installation/docs pinning examples in README and getting started docs.
- Move completed unreleased notes into the new `0.16.0` changelog section.
- Extend `xtask publish-check --dry-run` patch mapping so `perfgate-server` validates against local unpublished `perfgate-client`.

Validation:
- `cargo fmt --all`
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `cargo run -p xtask -- schema-compat`
- all five `publish-check --dry-run` package checks
