### PR TITLE
docs(policy): map Rust 1.95 and 0.17.0 governance rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- No new changes yet.
+- Planned the Rust 1.95 and 0.17.0 governance rollout for staged Clippy,
+  no-panic, non-Rust file-surface, CI evidence-lane, and release-proof policy.
 
 ## [0.16.0] - 2026-05-11
 

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,58 @@
+# Clippy Policy
+
+perfgate treats Clippy as a staged policy surface. The current workspace policy
+is intentionally light: `all = "warn"` at workspace level, with CI invoking
+Clippy under `-D warnings`.
+
+The Rust 1.95 rollout moves this to an explicit ledger model without enabling
+blanket categories by accident.
+
+## Target Files
+
+| File | Role |
+|------|------|
+| `clippy.toml` | Tool-level MSRV declaration, starting with `msrv = "1.95"`. |
+| `policy/clippy-lints.toml` | Active and planned lint ledger. |
+| `policy/clippy-debt.toml` | Known debt that is not yet ratcheted. |
+| `policy/clippy-exceptions.toml` | Narrow exceptions with owners, reasons, and review dates. |
+
+## Policy Defaults
+
+| Setting | Target |
+|---------|--------|
+| MSRV | `1.95` |
+| Panic-free tests | true |
+| Test carveouts | false by default |
+| Suppressions | `expect` or allow with a reason |
+| Blanket categories | false |
+
+Initial active lints should be small and reviewable:
+
+| Lint | Level | Reason |
+|------|-------|--------|
+| `clippy::dbg_macro` | deny | Debug macros are not reviewable diagnostics. |
+| `clippy::todo` | deny | TODO execution paths are not allowed. |
+| `clippy::unimplemented` | deny | Unimplemented execution paths are not allowed. |
+
+Rust 1.95 ratchets must be measured before activation:
+
+| Lint | Candidate Level |
+|------|-----------------|
+| `clippy::same_length_and_capacity` | deny |
+| `clippy::manual_checked_ops` | warn |
+| `clippy::manual_take` | warn |
+| `clippy::manual_pop_if` | warn |
+| `clippy::duration_suboptimal_units` | warn |
+
+Because CI uses `-D warnings`, warning-level ratchets become hard failures in
+practice. Do not add noisy warning lints unless the PR also fixes the warnings.
+
+## Rollout Rules
+
+1. Add the ledger before enforcement.
+2. Measure each candidate lint against the workspace.
+3. Activate only clean or cheap lints in the ratchet PR.
+4. Keep `disallowed_fields` out until protected seams are real.
+5. Keep every exception scoped to a selector, owner, reason, and review date.
+
+See [Rust 1.95 and 0.17.0 Governance Rollout](development/RUST_1_95_ROLLOUT.md).

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -1,0 +1,54 @@
+# File Policy
+
+perfgate has important release and trust surfaces outside Rust source. The
+Rust 1.95 governance rollout adds non-Rust file-surface policy so those files
+are reviewed as contracts instead of incidental repository contents.
+
+## Governed Surfaces
+
+The initial allowlist should cover:
+
+| Surface | Examples |
+|---------|----------|
+| GitHub workflows | `.github/workflows/*.yml` |
+| Composite action | `action.yml` |
+| Schemas | `schemas/*.json`, `contracts/schemas/*.json` |
+| Fixtures | `fixtures/`, `contracts/fixtures/` |
+| Docs | `README.md`, `docs/**/*.md` |
+| Baselines and trends | `.ci/`, `baselines/`, trend artifacts |
+| Coverage config | `codecov.yml` |
+| Dependency policy | `deny.toml` |
+
+## Required Fields
+
+Every allowlist entry should include:
+
+| Field | Purpose |
+|-------|---------|
+| `id` | Stable review identifier. |
+| `glob` | File or file-family selector. |
+| `kind` | Workflow, docs, schema, fixture, config, baseline, generated, or executable. |
+| `language` | File format or language. |
+| `surface` | User, CI, release, schema, dependency, or internal surface. |
+| `classification` | Contract, generated, evidence, configuration, or documentation. |
+| `owner` | Responsible reviewer or owner. |
+| `reason` | Why the file is allowed and governed. |
+| `covered_by` | Validation command, workflow, or review policy. |
+| `created` | Date the entry was introduced. |
+| `review_after` | Date or release for reevaluation. |
+
+## Companion Ledgers
+
+The planned policy files are:
+
+- `policy/non-rust-allowlist.toml`
+- `policy/generated-allowlist.toml`
+- `policy/executable-allowlist.toml`
+- `policy/workflow-allowlist.toml`
+- `policy/dependency-surface-allowlist.toml`
+
+The allowlists are contracts, not ignore files. New non-Rust files should either
+fit an existing governed glob or add a reviewed entry with ownership and proof.
+
+See [Policy Allowlists](POLICY_ALLOWLISTS.md) and
+[Rust 1.95 and 0.17.0 Governance Rollout](development/RUST_1_95_ROLLOUT.md).

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,0 +1,60 @@
+# No-Panic Policy
+
+perfgate currently has no enforced panic-family policy. The Rust 1.95 and
+0.17.0 governance rollout adds one as a no-new-debt gate rather than a broad
+cleanup commit.
+
+This policy must start with exact identities. A scanner keyed only by file and
+family can hide new callsites inside an already-allowed file.
+
+## Governed Families
+
+The first scanner should classify panic-family callsites such as:
+
+- `panic!`
+- `unreachable!`
+- `todo!`
+- `unimplemented!`
+- `unwrap`
+- `expect`
+
+The policy should distinguish production, test, doc-test, generated, and
+example surfaces instead of granting a blanket test carveout.
+
+## Exact Identity
+
+Each allowed or baselined callsite must include:
+
+| Field | Purpose |
+|-------|---------|
+| `path` | Source path containing the callsite. |
+| `family` | Panic-family group. |
+| `selector_kind` | Macro, method, function, or other selector class. |
+| `selector_callee` | Exact callee or macro selector. |
+| `snippet` | Stable local source snippet for review. |
+| `count` | Expected count for that identity. |
+| `owner` | Owner responsible for review. |
+| `reason` | Why the debt is intentional or temporarily accepted. |
+| `review_after` | Date or release when it must be revisited. |
+
+## Baseline Rule
+
+The generated baseline may shrink when debt disappears. It must not silently
+absorb new debt.
+
+Allowed refresh behavior:
+
+- remove identities that no longer exist,
+- update generated ordering,
+- fail when a new unallowed identity appears,
+- fail when an existing identity count increases without an allowlist update.
+
+## Rollout Rules
+
+1. Add exact policy and scanner first.
+2. Add the generated no-new-debt baseline in the next PR.
+3. Mark the baseline generated in `.gitattributes`.
+4. Keep production and test policy choices explicit.
+5. Treat broad carveouts as temporary debt with an owner and review date.
+
+See [Rust 1.95 and 0.17.0 Governance Rollout](development/RUST_1_95_ROLLOUT.md).

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -1,0 +1,51 @@
+# Policy Allowlists
+
+Policy allowlists describe intentional repository surface. They are narrow,
+owned ledgers that let automation distinguish accepted contracts from accidental
+drift.
+
+## Existing Policy Files
+
+| File | Purpose |
+|------|---------|
+| `policy/public_crates.txt` | Public publishable crate surface. |
+| `policy/absorbed_crates.txt` | Workspace-only compatibility and absorbed crate dispositions. |
+
+The public crate policy currently allows only:
+
+```text
+perfgate
+perfgate-cli
+perfgate-types
+perfgate-client
+perfgate-server
+```
+
+This five-crate surface must stay enforced by
+`cargo run -p xtask -- public-surface --strict`.
+
+## Planned Policy Files
+
+| File | Purpose |
+|------|---------|
+| `policy/clippy-lints.toml` | Active and planned Clippy lint policy. |
+| `policy/clippy-debt.toml` | Known Clippy debt not yet ratcheted. |
+| `policy/clippy-exceptions.toml` | Narrow Clippy exceptions. |
+| `policy/no-panic-allowlist.toml` | Intentional panic-family callsites. |
+| `policy/no-panic-baseline.toml` | Generated no-new-debt panic-family baseline. |
+| `policy/non-rust-allowlist.toml` | Governed non-Rust file surface. |
+| `policy/generated-allowlist.toml` | Generated files and refresh rules. |
+| `policy/executable-allowlist.toml` | Executable files and permission expectations. |
+| `policy/workflow-allowlist.toml` | Workflow files and CI ownership. |
+| `policy/dependency-surface-allowlist.toml` | Dependency-policy and lockfile surfaces. |
+
+## Review Rules
+
+1. Every allowance needs an owner, reason, and review date.
+2. Generated baselines may remove disappeared debt but must not absorb new debt.
+3. Exceptions must be selector-scoped where possible.
+4. Release PRs must report which policy gates were run.
+5. Policy files must change in the same PR as the governed surface change.
+
+See [Clippy Policy](CLIPPY_POLICY.md), [No-Panic Policy](NO_PANIC_POLICY.md),
+and [File Policy](FILE_POLICY.md).

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,29 +1,27 @@
 # Release Readiness
 
-Last verified: 2026-05-10 after merging the 0.16 public-surface collapse,
-first-run onboarding hardening, server operations visibility, structured
-performance-decision workflow, decision ledger/debt, and server-ledger
-decision visibility through PR #333.
+Last verified: 2026-05-11 after merging PR #338 (release prep for v0.16.0) and PR #337
+(`publish-check` dry-run matrix repair).
 
 ## Current Main Snapshot
 
-Verified on 2026-05-10 after merging release-readiness work through PR #333.
+Verified on 2026-05-11 after merging PRs #333 through #337 and #338.
 
-The current `main` branch is not a published release, but the 0.16 public crate
-surface, paved first-run workflow, baseline-service operations, and structured
-performance-decision workflow are now in their intended release shape:
+The `main` branch is published as `v0.16.0` and the 0.16 public crate surface,
+paved first-run workflow, baseline-service operations, and structured performance
+decision workflow are in their intended release shape:
 
 | Gate | Status | Evidence |
 |------|--------|----------|
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
 | Architecture boundary enforcement | Passing | `cargo run -p xtask -- arch` |
 | Publish metadata preflight | Passing | `cargo run -p xtask -- publish-check` |
-| Package file-list proof | Release-prep gate | `cargo run -p xtask -- publish-check --package-list` |
+| Package file-list proof | Passing | `cargo run -p xtask -- publish-check --package-list` |
 | Adoption path docs | Covered | `README.md`, `docs/PERFORMANCE_DECISIONS.md` |
 | Publish dry-run proof | Per-package release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
-| Publish dry-run matrix | Failing (expected) | `cargo run -p xtask -- publish-check --dry-run --package-list` not yet safe for all public crates: `perfgate-types` passes, remaining public crates currently fail on unresolved re-exports/API drift and dependency/version pin mismatches |
+| Publish dry-run matrix | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
-| Install smoke proof | Verified | `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force` and `cargo-binstall perfgate-cli --version 0.15.1 --force` |
+| Install smoke proof | Verified | `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force` and `cargo-binstall perfgate-cli --version 0.16.0 --force` |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |
 | Documentation examples | Passing | `cargo run -p xtask -- docs-check` and `cargo run -p xtask -- doc-test` |
 | Structured decision end-to-end | Verified | `perfgate ingest probes`, `perfgate decision evaluate`, `perfgate decision bundle` on `examples/performance-decision`, plus `perfgate serve --no-open` and `decision upload/history/debt/prune --dry-run` |
@@ -33,7 +31,7 @@ performance-decision workflow are now in their intended release shape:
 | Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, and dashboard decision-ledger tests |
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
-| Full repo CI | Passing | Hosted `ci`, `Coverage`, and `perfgate-self` on merge commit `a1ffb0e`; PR #323 also passed `fuzz` |
+| Full repo CI | Passing | Hosted `ci`, `Coverage`, and `perfgate-self` on merge commit `2cda12c`; PR #338 also passed `fuzz` |
 
 The only publishable packages allowed by policy are:
 
@@ -45,13 +43,17 @@ perfgate-client
 perfgate-server
 ```
 
-Before cutting a 0.16 release, run the package proof without `--allow-dirty`:
+Release proof commands run for v0.16.0 (run without `--allow-dirty`):
 
 ```bash
 cargo run -p xtask -- public-surface --strict
 cargo run -p xtask -- arch
 cargo run -p xtask -- publish-check --package-list
 cargo run -p xtask -- publish-check --dry-run --package perfgate-types
+cargo run -p xtask -- publish-check --dry-run --package perfgate
+cargo run -p xtask -- publish-check --dry-run --package perfgate-client
+cargo run -p xtask -- publish-check --dry-run --package perfgate-server
+cargo run -p xtask -- publish-check --dry-run --package perfgate-cli
 cargo run -p xtask -- action-check
 cargo run -p xtask -- docs-check
 cargo run -p xtask -- doc-test
@@ -61,17 +63,17 @@ cargo run -p xtask -- ci
 
 Run `publish-check --dry-run --package <name>` immediately before publishing each
 crate in dependency order. Cargo verifies packaged dependencies against
-crates.io, so downstream crates such as `perfgate` and `perfgate-cli` cannot be
-dry-run verified until their same-release workspace dependencies have already
-been published.
+crates.io, so downstream crates such as `perfgate` and `perfgate-cli` require
+same-release workspace dependencies to be on the current path first.
 
 For PR validation before the branch is committed or while release notes are still
 being edited, `publish-check` also accepts `--allow-dirty`. Release operators
 should omit it.
 
-The GitHub release workflow builds the platform archives, unpacks each generated
-archive, verifies the binary exists, and runs `perfgate --version` plus
-`perfgate doctor --help` on native targets before uploading release assets.
+The GitHub release workflow (published as v0.16.0) builds platform archives,
+unpacks each generated archive, verifies the binary exists, and runs
+`perfgate --version` plus `perfgate doctor --help` on native targets before
+uploading release assets.
 
 The GitHub Action path is also guarded: `xtask action-check` verifies action
 inputs and install wiring, and the action prints a local reproduction command

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -1,0 +1,61 @@
+# CI Evidence Lanes
+
+perfgate should keep ordinary PR verification fast enough to run consistently
+while routing expensive evidence to labels, `main`, schedules, or explicit
+release-proof work.
+
+## Default PR Lane
+
+Default PRs should prove the change is buildable, reviewable, and contract-safe:
+
+```text
+fmt
+clippy
+tests
+docs-check
+doc-test
+schema-compat
+public-surface
+arch
+action-check
+no-panic policy
+file policy
+lint policy
+```
+
+Policy gates are added as their rollout PRs land. Until then, this document is
+the routing target, not a claim that those commands exist today.
+
+## Label, Main, Scheduled, or Release-Proof Lanes
+
+Run heavier evidence when it buys signal:
+
+| Lane | Routing |
+|------|---------|
+| Coverage | `main`, `workflow_dispatch`, or PR labels such as `coverage` and `full-ci`. |
+| Fuzz | Scheduled, manual, release-proof, or high-risk parser/schema changes. |
+| Baseline refresh | Dedicated refresh PRs, scheduled calibration, or explicit release proof. |
+| Bench and trend refresh | Mainline/scheduled evidence lanes or labeled PRs. |
+| Mutation testing | Dedicated policy lane if added later, not default PR traffic. |
+
+This matches the existing coverage model in [coverage.md](coverage.md), where
+coverage is execution-surface evidence and not a substitute for release,
+schema, baseline, or mutation proof.
+
+## Release Proof
+
+Release proof should include the default PR lane plus package and schema proof:
+
+```bash
+cargo run -p xtask -- docs-check
+cargo run -p xtask -- doc-test
+cargo run -p xtask -- action-check
+cargo run -p xtask -- public-surface --strict
+cargo run -p xtask -- arch
+cargo run -p xtask -- schema-compat
+cargo run -p xtask -- publish-check --package-list
+```
+
+Dry-run publish proof must run per publishable crate in release order. Do not
+hide expensive proof inside every ordinary PR to make a release checklist look
+shorter.

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,0 +1,190 @@
+# Rust 1.95 and 0.17.0 Governance Rollout
+
+This is the control map for the perfgate 0.17.0 trust/governance release.
+The 0.16.0 line delivered the structured-decision product surface.
+The 0.17.0 line makes the implementation and release conveyor governed.
+
+The MSRV increase makes this a minor release. Do not ship the Rust 1.95 floor
+as a 0.16.x patch.
+
+Release themes:
+
+- Rust 1.95 floor
+- staged Clippy policy
+- panic-family governance
+- non-Rust file-surface governance
+- release-order publish proof
+- schema, action, docs, and public-surface gates
+- explicit CI evidence-lane routing
+
+## Scope Guard
+
+The first PR in this rollout is documentation-only.
+It must not change `Cargo.toml`, `rust-toolchain.toml`, workflows, or Rust source.
+
+Do not continue any partial local no-panic implementation in this roadmap PR.
+That work belongs in a planned no-panic policy lane after the MSRV and lint
+policy foundation is explicit.
+
+This rollout is separate from baseline or trend refresh work such as #334.
+
+## Current and Target State
+
+| Layer | Current | Target |
+|-------|---------|--------|
+| Edition | 2024 | 2024 |
+| Version | 0.16.0 | 0.17.0 |
+| MSRV | 1.93 | 1.95 |
+| Toolchain | 1.93.0 | 1.95.0 |
+| CI and coverage pins | 1.93.0 | 1.95.0 |
+| `clippy.toml` | absent | present, `msrv = "1.95"` |
+| Rust lints | `unsafe_code = "warn"` | explicit 1.95 floor |
+| Clippy policy | light | staged ledger/checker |
+| No-panic policy | absent | no-new-debt baseline/allowlist |
+| Non-Rust file policy | absent | allowlist plus companion ledgers |
+| Public crate surface | five crates | keep enforced |
+| Release proof | working | keep publish matrix boring |
+| CI economics | basic routed lanes | explicit evidence lane policy |
+
+## PR Ladder
+
+1. `docs(policy): map Rust 1.95 and 0.17.0 governance rollout`
+   - Documentation-only roadmap, policy targets, release-readiness truth, and changelog note.
+2. `chore(msrv): probe Rust 1.95 compatibility`
+   - Run current `main` under Rust 1.95 and record the audit before support changes.
+3. `chore(msrv): raise workspace toolchain to Rust 1.95`
+   - Bump MSRV, toolchain, CI pins, coverage pins, and `clippy.toml`; do not bump versions.
+4. `policy(rust): enable Rust 1.95 compiler lint floor`
+   - Add low-noise Rust compiler lints while keeping `unsafe_code = "warn"`.
+5. `policy(clippy): add staged lint policy ledger`
+   - Add lint, debt, and exception ledgers; enforcement can follow if it is not small.
+6. `policy(clippy): activate Rust 1.95 lint ratchets`
+   - Measure first, then activate only clean or cheap Rust 1.95 Clippy ratchets.
+7. `policy(panic): add exact no-panic policy`
+   - Add exact panic-family policy and scanner using counted identities.
+8. `policy(panic): add no-new-debt baseline`
+   - Add the generated baseline and forbid silent new-debt absorption.
+9. `policy(files): add non-Rust file allowlist`
+   - Add non-Rust, generated, executable, workflow, and dependency-surface allowlists.
+10. `ci: document and route evidence lanes`
+   - Keep heavy evidence out of ordinary PRs unless explicitly routed.
+11. `refactor: use Rust 1.95 APIs in decision and policy builders`
+   - Apply targeted cleanup only where it reduces risk or noise.
+12. `release: prepare 0.17.0 for Rust 1.95`
+   - Bump versions, docs, examples, internal dependencies, and changelog.
+13. `release: validate 0.17.0 publish readiness`
+   - Run release proof, publish dry-runs in dependency order, and tag only after `main` is green.
+
+## Acceptance Gates
+
+The roadmap PR must pass:
+
+```bash
+cargo run -p xtask -- docs-check
+cargo run -p xtask -- doc-test
+cargo run -p xtask -- action-check
+cargo run -p xtask -- public-surface --strict
+cargo run -p xtask -- arch
+git diff --check
+```
+
+The release-proof PR must additionally include:
+
+```bash
+cargo run -p xtask -- schema-compat
+cargo run -p xtask -- publish-check --package-list
+cargo run -p xtask -- publish-check --dry-run --package perfgate-types
+cargo run -p xtask -- publish-check --dry-run --package perfgate
+cargo run -p xtask -- publish-check --dry-run --package perfgate-client
+cargo run -p xtask -- publish-check --dry-run --package perfgate-server
+cargo run -p xtask -- publish-check --dry-run --package perfgate-cli
+```
+
+The dry-run order must stay boring: package each public crate only after its
+same-release workspace dependencies are available through the current release
+path.
+
+## Policy Targets
+
+### Clippy
+
+The target is a staged ledger, not blanket category activation. Initial active
+lints should be explicit, low-noise lints such as `clippy::dbg_macro`,
+`clippy::todo`, and `clippy::unimplemented`.
+Planned Rust 1.95 ratchets include `clippy::same_length_and_capacity`,
+`clippy::manual_checked_ops`, `clippy::manual_take`,
+`clippy::manual_pop_if`, and `clippy::duration_suboptimal_units` only after
+measurement.
+
+Warnings are effectively hard failures when CI runs Clippy with `-D warnings`,
+so warning-level additions must be clean or cleaned in the same PR.
+
+### No-Panic Family
+
+The policy must use exact counted identities from the start:
+
+| Field | Purpose |
+|-------|---------|
+| `path` | Source path containing the callsite. |
+| `family` | Panic-family group. |
+| `selector_kind` | How the callsite was matched. |
+| `selector_callee` | Exact macro or method selector. |
+| `snippet` | Stable local source snippet. |
+| `count` | Expected count for that identity. |
+| `owner` | Review owner for the allowance. |
+| `reason` | Why the debt exists or is acceptable. |
+| `review_after` | Date or release when the allowance must be revisited. |
+
+Do not key only by path and panic family. Baseline refreshes may drop
+disappeared debt, but must not silently absorb new debt.
+
+### Non-Rust File Surface
+
+Every governed non-Rust surface should carry:
+
+```text
+id
+glob
+kind
+language
+surface
+classification
+owner
+reason
+covered_by
+created
+review_after
+```
+
+Important surfaces include GitHub workflows, the composite `action.yml`, schema
+JSON, fixtures, docs, baselines and trends, Codecov config, and `deny.toml`.
+
+### CI Evidence Lanes
+
+Default PRs should stay fast and reviewable:
+
+```text
+fmt
+clippy
+tests
+docs-check
+doc-test
+schema-compat
+public-surface
+arch
+action-check
+no-panic/file/lint policy
+```
+
+Coverage, fuzzing, baseline refreshes, heavier benchmark and trend lanes, and
+mutation testing belong on labels, `main`, schedules, or explicit release-proof
+work where their cost buys signal.
+
+## References
+
+- [Clippy Policy](../CLIPPY_POLICY.md)
+- [No-Panic Policy](../NO_PANIC_POLICY.md)
+- [File Policy](../FILE_POLICY.md)
+- [Policy Allowlists](../POLICY_ALLOWLISTS.md)
+- [CI Evidence Lanes](../ci/test-evidence-lanes.md)
+- [Release Readiness](../RELEASE_READINESS.md)


### PR DESCRIPTION
## Summary
- add the Rust 1.95 / 0.17.0 governance rollout control map
- add target policy docs for staged Clippy, no-panic exact identity, non-Rust file surfaces, allowlists, and CI evidence lanes
- update release readiness to reflect the fixed v0.16.0 publish dry-run matrix and add an Unreleased changelog note

## Validation
- `cargo run -p xtask -- docs-check`
- `cargo run -p xtask -- doc-test`
- `cargo run -p xtask -- action-check`
- `cargo run -p xtask -- public-surface --strict`
- `cargo run -p xtask -- arch`
- `git diff --check`

Note: cargo-based validation used `CARGO_TARGET_DIR=C:\perfgate-target-roadmap` because `D:` was full during validation; workspace source files were unchanged by that workaround.