### PR TITLE
policy(rust): enable Rust 1.95 compiler lint floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Raised the declared Rust MSRV, local toolchain, and hosted Rust workflow pins
   to Rust 1.95.
+- Enabled the Rust 1.95 compiler lint floor while keeping `unsafe_code` at
+  `warn` for a later audit.
 
 ## [0.16.0] - 2026-05-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,12 @@ all = { level = "warn", priority = -1 }
 
 [workspace.lints.rust]
 unsafe_code = "warn"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+unused_visibilities = "warn"
 
 # Root package for workspace-level integration tests (BDD/cucumber)
 [package]

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -38,7 +38,7 @@ This rollout is separate from baseline or trend refresh work such as #334.
 | Toolchain | 1.95.0 | 1.95.0 |
 | Hosted Rust workflow pins | 1.95.0 | 1.95.0 |
 | `clippy.toml` | present, `msrv = "1.95"` | present, `msrv = "1.95"` |
-| Rust lints | `unsafe_code = "warn"` | explicit 1.95 floor |
+| Rust lints | explicit 1.95 floor | explicit 1.95 floor |
 | Clippy policy | light | staged ledger/checker |
 | No-panic policy | absent | no-new-debt baseline/allowlist |
 | Non-Rust file policy | absent | allowlist plus companion ledgers |


### PR DESCRIPTION
## Summary
- enable the low-noise Rust 1.95 compiler lint floor in workspace lints
- keep `unsafe_code = "warn"` for the later unsafe audit lane
- update the 0.17.0 rollout roadmap and changelog to show the Rust lint floor is now active

## Validation
- `rustc +1.95.0 -W help` checked the new lint names exist
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 check --workspace --all-targets --all-features --locked`
- `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0 test --workspace --all-targets --all-features --locked`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

Note: local Cargo validation used `CARGO_TARGET_DIR=C:\perfgate-target-msrv` to avoid the nearly-full `D:` drive.