### PR TITLE
policy(clippy): add staged lint policy ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to Rust 1.95.
 - Enabled the Rust 1.95 compiler lint floor while keeping `unsafe_code` at
   `warn` for a later audit.
+- Added staged Clippy lint, debt, and exception policy ledgers for the Rust
+  1.95 governance rollout.
 
 ## [0.16.0] - 2026-05-11
 

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,11 +1,9 @@
 # Clippy Policy
 
-perfgate treats Clippy as a staged policy surface. The current workspace policy
-is intentionally light: `all = "warn"` at workspace level, with CI invoking
-Clippy under `-D warnings`.
-
-The Rust 1.95 rollout moves this to an explicit ledger model without enabling
-blanket categories by accident.
+perfgate treats Clippy as a staged policy surface. The workspace still keeps
+`all = "warn"` at workspace level, with CI invoking Clippy under
+`-D warnings`, but the Rust 1.95 rollout now records active, planned, debt,
+and exception policy in explicit ledgers.
 
 ## Target Files
 
@@ -13,8 +11,8 @@ blanket categories by accident.
 |------|------|
 | `clippy.toml` | Tool-level MSRV declaration, starting with `msrv = "1.95"`. |
 | `policy/clippy-lints.toml` | Active and planned lint ledger. |
-| `policy/clippy-debt.toml` | Known debt that is not yet ratcheted. |
-| `policy/clippy-exceptions.toml` | Narrow exceptions with owners, reasons, and review dates. |
+| `policy/clippy-debt.toml` | Known debt that is not yet ratcheted; empty at introduction. |
+| `policy/clippy-exceptions.toml` | Narrow exceptions with owners, reasons, and review dates; empty at introduction. |
 
 ## Policy Defaults
 
@@ -26,7 +24,7 @@ blanket categories by accident.
 | Suppressions | `expect` or allow with a reason |
 | Blanket categories | false |
 
-Initial active lints should be small and reviewable:
+The initial active ledger is small and reviewable:
 
 | Lint | Level | Reason |
 |------|-------|--------|
@@ -49,10 +47,13 @@ practice. Do not add noisy warning lints unless the PR also fixes the warnings.
 
 ## Rollout Rules
 
-1. Add the ledger before enforcement.
+1. Keep ledger changes separate from lint activation unless the activation is
+   already measured and cheap.
 2. Measure each candidate lint against the workspace.
 3. Activate only clean or cheap lints in the ratchet PR.
 4. Keep `disallowed_fields` out until protected seams are real.
 5. Keep every exception scoped to a selector, owner, reason, and review date.
+6. Add checker enforcement in a later PR unless it is small enough to review
+   with the ledger change.
 
 See [Rust 1.95 and 0.17.0 Governance Rollout](development/RUST_1_95_ROLLOUT.md).

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -39,7 +39,7 @@ This rollout is separate from baseline or trend refresh work such as #334.
 | Hosted Rust workflow pins | 1.95.0 | 1.95.0 |
 | `clippy.toml` | present, `msrv = "1.95"` | present, `msrv = "1.95"` |
 | Rust lints | explicit 1.95 floor | explicit 1.95 floor |
-| Clippy policy | light | staged ledger/checker |
+| Clippy policy | staged ledger | staged ledger/checker |
 | No-panic policy | absent | no-new-debt baseline/allowlist |
 | Non-Rust file policy | absent | allowlist plus companion ledgers |
 | Public crate surface | five crates | keep enforced |

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,9 @@
+schema_version = "1.0"
+msrv = "1.95"
+
+[policy]
+source = "policy/clippy-lints.toml"
+refresh_rule = "Debt may shrink; new debt requires explicit review before it is recorded."
+
+# No Clippy debt is recorded at ledger introduction.
+debt = []

--- a/policy/clippy-exceptions.toml
+++ b/policy/clippy-exceptions.toml
@@ -1,0 +1,9 @@
+schema_version = "1.0"
+msrv = "1.95"
+
+[policy]
+source = "policy/clippy-lints.toml"
+suppression_style = "expect-with-reason"
+
+# Exceptions must include lint, path, selector, owner, reason, and review_after.
+exceptions = []

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,48 @@
+schema_version = "1.0"
+msrv = "1.95"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[active]]
+name = "clippy::dbg_macro"
+level = "deny"
+reason = "Debug macros are not reviewable diagnostics."
+
+[[active]]
+name = "clippy::todo"
+level = "deny"
+reason = "TODO execution paths are not allowed."
+
+[[active]]
+name = "clippy::unimplemented"
+level = "deny"
+reason = "Unimplemented execution paths are not allowed."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.95"
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"


### PR DESCRIPTION
## Summary
- add the staged Clippy lint ledger with active and planned lint entries
- add empty Clippy debt and exception ledgers for future ratchets
- update the Clippy policy docs, rollout roadmap, and changelog

## Scope note
This PR intentionally stays docs/data only. It does not add `xtask check-lint-policy`; enforcement can land in a later, reviewable code lane.

## Validation
- `python -c "import pathlib, tomllib; [tomllib.loads(path.read_text()) for path in pathlib.Path('policy').glob('clippy-*.toml')]; print('ok')"`
- `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro -D clippy::todo -D clippy::unimplemented`
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

Note: local Cargo validation used `CARGO_TARGET_DIR=C:\perfgate-target-msrv` to avoid the nearly-full `D:` drive.