### PR TITLE
policy(clippy): activate Rust 1.95 lint ratchets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `warn` for a later audit.
 - Added staged Clippy lint, debt, and exception policy ledgers for the Rust
   1.95 governance rollout.
+- Activated the clean Rust 1.95 Clippy ratchets and recorded noisy or
+  unavailable candidates as policy debt or blocked work.
 
 ## [0.16.0] - 2026-05-11
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,13 @@ categories = ["development-tools", "command-line-utilities"]
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+same_length_and_capacity = "deny"
+manual_checked_ops = "warn"
+manual_take = "warn"
+unnecessary_trailing_comma = "warn"
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -31,16 +31,18 @@ The initial active ledger is small and reviewable:
 | `clippy::dbg_macro` | deny | Debug macros are not reviewable diagnostics. |
 | `clippy::todo` | deny | TODO execution paths are not allowed. |
 | `clippy::unimplemented` | deny | Unimplemented execution paths are not allowed. |
+| `clippy::same_length_and_capacity` | deny | Vec raw-parts conversions must not conflate length and capacity. |
+| `clippy::manual_checked_ops` | warn | Manual checked arithmetic is easier to weaken than standard checked APIs. |
+| `clippy::manual_take` | warn | Prefer the standard take helper over open-coded replacement patterns. |
+| `clippy::unnecessary_trailing_comma` | warn | Avoid formatter-noise patterns from unnecessary trailing commas in expressions. |
 
 Rust 1.95 ratchets must be measured before activation:
 
-| Lint | Candidate Level |
-|------|-----------------|
-| `clippy::same_length_and_capacity` | deny |
-| `clippy::manual_checked_ops` | warn |
-| `clippy::manual_take` | warn |
-| `clippy::manual_pop_if` | warn |
-| `clippy::duration_suboptimal_units` | warn |
+| Lint | Candidate Level | Status |
+|------|-----------------|--------|
+| `clippy::duration_suboptimal_units` | warn | Measured with existing warnings; tracked as debt. |
+| `clippy::needless_type_cast` | warn | Measured with existing warnings; tracked as debt. |
+| `clippy::manual_pop_if` | warn | Not recognized by Rust 1.95.0 Clippy. |
 
 Because CI uses `-D warnings`, warning-level ratchets become hard failures in
 practice. Do not add noisy warning lints unless the PR also fixes the warnings.

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -39,7 +39,7 @@ This rollout is separate from baseline or trend refresh work such as #334.
 | Hosted Rust workflow pins | 1.95.0 | 1.95.0 |
 | `clippy.toml` | present, `msrv = "1.95"` | present, `msrv = "1.95"` |
 | Rust lints | explicit 1.95 floor | explicit 1.95 floor |
-| Clippy policy | staged ledger | staged ledger/checker |
+| Clippy policy | staged ledger plus clean ratchets | staged ledger/checker |
 | No-panic policy | absent | no-new-debt baseline/allowlist |
 | Non-Rust file policy | absent | allowlist plus companion ledgers |
 | Public crate surface | five crates | keep enforced |

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -5,5 +5,16 @@ msrv = "1.95"
 source = "policy/clippy-lints.toml"
 refresh_rule = "Debt may shrink; new debt requires explicit review before it is recorded."
 
-# No Clippy debt is recorded at ledger introduction.
-debt = []
+[[debt]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+measured_with = "Rust 1.95.0 Clippy"
+reason = "Existing Duration construction warnings appear in client, server, and CLI configuration/test paths."
+review_after = "0.17.0 cleanup"
+
+[[debt]]
+name = "clippy::needless_type_cast"
+level = "warn"
+measured_with = "Rust 1.95.0 Clippy"
+reason = "Existing SQL count conversion warnings appear in SQLite and Postgres storage paths."
+review_after = "0.17.0 cleanup"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -22,27 +22,33 @@ name = "clippy::unimplemented"
 level = "deny"
 reason = "Unimplemented execution paths are not allowed."
 
-[[planned]]
+[[active]]
 name = "clippy::same_length_and_capacity"
 level = "deny"
-activate_when_msrv = "1.95"
+reason = "Vec raw-parts conversions must not conflate length and capacity."
 
-[[planned]]
+[[active]]
 name = "clippy::manual_checked_ops"
 level = "warn"
-activate_when_msrv = "1.95"
+reason = "Manual checked arithmetic is easier to weaken than the standard checked APIs."
 
-[[planned]]
+[[active]]
 name = "clippy::manual_take"
 level = "warn"
-activate_when_msrv = "1.95"
+reason = "Use the standard take helper instead of open-coded replacement patterns."
 
-[[planned]]
-name = "clippy::manual_pop_if"
+[[active]]
+name = "clippy::unnecessary_trailing_comma"
 level = "warn"
-activate_when_msrv = "1.95"
+reason = "Avoid formatter-noise patterns from unnecessary trailing commas in expressions."
 
 [[planned]]
 name = "clippy::duration_suboptimal_units"
 level = "warn"
 activate_when_msrv = "1.95"
+status = "measured-existing-warnings"
+
+[[blocked]]
+name = "clippy::manual_pop_if"
+level = "warn"
+reason = "Not recognized by Clippy in Rust 1.95.0; re-check before activation."


### PR DESCRIPTION
## Summary
- activate the clean Clippy policy lints in workspace lint configuration
- move clean Rust 1.95 ratchets from planned to active in the Clippy ledger
- record `duration_suboptimal_units` and `needless_type_cast` as measured Clippy debt
- mark `manual_pop_if` blocked because Rust 1.95.0 Clippy does not recognize it

## Measurement
Clean and activated:
- `clippy::same_length_and_capacity`
- `clippy::manual_checked_ops`
- `clippy::manual_take`
- `clippy::unnecessary_trailing_comma`
- existing active policy lints: `dbg_macro`, `todo`, `unimplemented`

Measured but not activated:
- `clippy::duration_suboptimal_units` has existing warnings in client/server/CLI duration construction
- `clippy::needless_type_cast` has existing warnings in SQL count conversion paths
- `clippy::manual_pop_if` is unavailable in Rust 1.95.0 Clippy

## Validation
- `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -W clippy::same_length_and_capacity -W clippy::manual_checked_ops -W clippy::manual_take -W clippy::manual_pop_if -W clippy::duration_suboptimal_units -W clippy::needless_type_cast -W clippy::unnecessary_trailing_comma`
- `cargo +1.95.0 clippy -- -W help` to confirm lint availability
- `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `python -c "import pathlib, tomllib; [tomllib.loads(path.read_text()) for path in pathlib.Path('policy').glob('clippy-*.toml')]; tomllib.loads(pathlib.Path('Cargo.toml').read_text()); print('ok')"`
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

Note: local Cargo validation used `CARGO_TARGET_DIR=C:\perfgate-target-msrv` to avoid the nearly-full `D:` drive.