### PR TITLE
policy(panic): add no-new-debt baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+policy/no-panic-baseline.toml text eol=lf linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unavailable candidates as policy debt or blocked work.
 - Added the exact no-panic family scanner and initial allowlist for the
   governance rollout.
+- Added the generated no-panic baseline so policy checks reject new
+  unallowlisted panic-family debt.
 
 ## [0.16.0] - 2026-05-11
 

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -1,8 +1,8 @@
 # No-Panic Policy
 
-perfgate has an exact panic-family scanner and an intentionally empty
-allowlist. The Rust 1.95 and 0.17.0 governance rollout adds this as a
-no-new-debt gate rather than a broad cleanup commit.
+perfgate has an exact panic-family scanner, an intentionally empty allowlist,
+and a generated baseline. The Rust 1.95 and 0.17.0 governance rollout uses
+these as a no-new-debt gate rather than a broad cleanup commit.
 
 This policy must start with exact identities. A scanner keyed only by file and
 family can hide new callsites inside an already-allowed file.
@@ -27,15 +27,19 @@ Run the current policy scanner with:
 cargo run -p xtask -- policy check-no-panic-family
 ```
 
-Use strict mode only after the generated baseline lands:
+Refresh the generated baseline only after removing existing debt:
 
 ```bash
-cargo run -p xtask -- policy check-no-panic-family --fail-on-unlisted
+cargo run -p xtask -- policy check-no-panic-family --write-baseline
 ```
+
+Baseline refreshes fail before writing if they would absorb a new
+unallowlisted identity or a count increase. Intentional new debt belongs in
+`policy/no-panic-allowlist.toml` with an owner, reason, and review date.
 
 ## Exact Identity
 
-Each allowed callsite must use `policy/no-panic-allowlist.toml` and include:
+Each allowed or baselined identity must include:
 
 | Field | Purpose |
 |-------|---------|
@@ -45,14 +49,19 @@ Each allowed callsite must use `policy/no-panic-allowlist.toml` and include:
 | `selector_callee` | Exact callee or macro selector. |
 | `snippet` | Stable local source snippet for review. |
 | `count` | Expected count for that identity. |
+
+Allowlist entries additionally require:
+
+| Field | Purpose |
+|-------|---------|
 | `owner` | Owner responsible for review. |
 | `reason` | Why the debt is intentional or temporarily accepted. |
 | `review_after` | Date or release when it must be revisited. |
 
 ## Baseline Rule
 
-The generated baseline lands in the next PR. It may shrink when debt
-disappears. It must not silently absorb new debt.
+The generated baseline may shrink when debt disappears. It must not silently
+absorb new debt.
 
 Allowed refresh behavior:
 
@@ -64,8 +73,8 @@ Allowed refresh behavior:
 ## Rollout Rules
 
 1. Add exact policy and scanner first.
-2. Add the generated no-new-debt baseline in the next PR.
-3. Mark the baseline generated in `.gitattributes`.
+2. Keep the generated no-new-debt baseline marked in `.gitattributes`.
+3. Refresh the baseline only when debt shrinks or disappears.
 4. Keep production and test policy choices explicit.
 5. Treat broad carveouts as temporary debt with an owner and review date.
 

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -40,7 +40,7 @@ This rollout is separate from baseline or trend refresh work such as #334.
 | `clippy.toml` | present, `msrv = "1.95"` | present, `msrv = "1.95"` |
 | Rust lints | explicit 1.95 floor | explicit 1.95 floor |
 | Clippy policy | staged ledger plus clean ratchets | staged ledger/checker |
-| No-panic policy | exact scanner and allowlist | no-new-debt baseline/allowlist |
+| No-panic policy | no-new-debt baseline/allowlist | no-new-debt baseline/allowlist |
 | Non-Rust file policy | absent | allowlist plus companion ledgers |
 | Public crate surface | five crates | keep enforced |
 | Release proof | working | keep publish matrix boring |

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -1,0 +1,11314 @@
+schema_version = "1.0"
+generated_by = "cargo run -p xtask -- policy check-no-panic-family --write-baseline"
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "panic!(\"exit {code}\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable!"
+snippet = "unreachable!(\"local baseline actions are handled before server dispatch\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((parse_significance_alpha(\"0.0\").unwrap() - 0.0).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((parse_significance_alpha(\"0.05\").unwrap() - 0.05).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((parse_significance_alpha(\"0.5\").unwrap() - 0.5).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((parse_significance_alpha(\"1.0\").unwrap() - 1.0).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(location_exists(&path).unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "atomic_write(&path, b\"hello\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir_all(&new_path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir_all(&out_dir).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir_all(&stale_dir).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&old_path, \"data\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&path, \"not-json\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&stale, \"data\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&stale_compare, \"stale\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(extras.join(\"report.json\"), \"report\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(extras.join(\"run.json\"), \"run\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (k, v) = parse_key_val_f64(\"wall_ms=0.25\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (k, v) = parse_key_val_string(\"KEY=VALUE\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let contents = fs::read_to_string(&path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let d = parse_duration(\"150ms\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempdir().unwrap();"
+count = 14
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let entries: Vec<_> = fs::read_dir(dir.path()).unwrap().collect();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let mode = parse_aggregate_weight_mode(\"inverse_variance\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let read: serde_json::Value = read_json(&path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let read: serde_json::Value = read_json_from_location(&path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "maybe_write_repair_context(&outcome, None, false, true).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "maybe_write_repair_context(&outcome, None, true, true).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_host_mismatch_policy(\"error\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_host_mismatch_policy(\"ignore\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_host_mismatch_policy(\"warn\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_retention_duration(\"12w\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_retention_duration(\"2h\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_retention_duration(\"365d\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "remove_stale_file(&stale).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "rename_extras_to_versioned(extras).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::from_str(&create_compare_receipt_json(\"fail\", \"fail\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::from_str(&create_compare_receipt_json(\"pass\", \"pass\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "write_check_artifacts(&outcome, false).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "write_json(&path, &receipt, false).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "write_json(&path, &value, true).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "write_json_to_location(&path, &value, false).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"parse report\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, \"not valid toml {{{\").expect(\"write bad config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, \"this is not valid toml {{{\").expect(\"write bad config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, content).expect(\"Failed to write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "jsonschema::validator_for(&schema_value).expect(\"compile schema\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let artifacts = report[\"artifacts\"].as_array().expect(\"artifacts array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&fixture_path).expect(\"read error fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&fixture_path).expect(\"read fail fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&fixture_path).expect(\"read multi_bench fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&fixture_path).expect(\"read no_baseline fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&fixture_path).expect(\"read pass fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&fixture_path).expect(\"read warn fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&report_path).expect(\"read cockpit report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&report_path).expect(\"read error report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let findings = report[\"findings\"].as_array().expect(\"findings array\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse cockpit report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse error fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse error report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse fail fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse multi_bench fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse no_baseline fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse pass fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse warn fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute check\");"
+count = 10
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let schema_content = fs::read_to_string(&schema_path).expect(\"read vendored schema\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let schema_value: Value = serde_json::from_str(&schema_content).expect(\"parse vendored schema\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 10
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(&report_path).expect(\"read report\"))"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let curr_path = artifacts[i][\"path\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let curr_type = artifacts[i][\"type\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let fp = finding[\"fingerprint\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prev_path = artifacts[i - 1][\"path\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_abi_conformance_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prev_type = artifacts[i - 1][\"type\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"inputs should be an array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"reasons should be an array\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"variant receipt should be written\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&out).expect(\"aggregate receipt should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&out).expect(\"aggregate receipt should still be written\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(source).expect(\"fixture should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mut receipt: Value = serde_json::from_str(&content).expect(\"fixture should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let receipt: Value = serde_json::from_str(&content).expect(\"aggregate receipt should be JSON\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"receipt should serialize\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_aggregate_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let temp_dir = tempdir().unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_annotations_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to generate compare receipt\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_annotations_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"first annotations run\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_annotations_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"second annotations run\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_annotations_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute command\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_annotations_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"copy baseline fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"copy run fixture\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"parse run fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"promoted baseline is json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write config\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write existing baseline\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write run fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&run_dir).expect(\"create run dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(path.parent().expect(\"run fixture has parent\")).expect(\"create run parent\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(temp_dir.path().join(\"baselines\")).expect(\"create baselines\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempfile::tempdir().expect(\"create temp dir\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(baseline_path).expect(\"read promoted baseline\"))"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize run fixture\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::from_str(&fs::read_to_string(fixtures_dir().join(\"baseline.json\")).unwrap())"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cargo_bench_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let tmp = tempfile::TempDir::new().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cargo_bench_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "out.to_str().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cargo_bench_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "tmp.path().to_str().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write baseline\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write config file\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"findings should be an array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"reasons should be an array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write config\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write template\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&baselines_dir).expect(\"Failed to create baselines dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&out_dir).expect(\"Failed to create artifacts dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(parent).expect(\"Failed to create baseline parent dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(out_dir.join(\"comment.md\")).expect(\"failed to read comment.md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(out_dir.join(\"compare.json\")).expect(\"read compare.json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config_content).expect(\"Failed to write config file\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config_content).expect(\"write config file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&out_dir, \"not a directory\").expect(\"Failed to create output file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&stale_compare, \"{\\\"stale\\\": true}\").expect(\"Failed to write stale compare.json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(path, serde_json::to_string_pretty(&receipt).unwrap()).expect(\"write baseline\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&github_output).expect(\"read GITHUB_OUTPUT\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(out_dir.join(\"comment.md\")).expect(\"read comment.md\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute check\");"
+count = 23
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report_content = fs::read_to_string(out_dir.join(\"report.json\")).expect(\"read report.json\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let run_content = fs::read_to_string(out_dir.join(\"run.json\")).expect(\"read run.json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 25
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&compare_content).expect(\"compare.json should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&report_content).expect(\"report.json should be valid JSON\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&run_content).expect(\"run.json should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap())"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(path, serde_json::to_string_pretty(&receipt).unwrap()).expect(\"write baseline\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_check_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&receipt).unwrap(),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write baseline\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write config file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"finding should have fingerprint\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"parse report\");"
+count = 9
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"reasons array\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"should have tool.runtime finding\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write baseline\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write bench-a baseline\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write template\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&baselines_dir).expect(\"Failed to create baselines dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&baselines_dir).expect(\"create baselines dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&out_dir).expect(\"create out_dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(prefix.join(\"perfgate.report.v1.json\")).expect(\"read native report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(prefix.join(\"perfgate.run.v1.json\")).expect(\"read run receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, \"not valid toml {{{\").expect(\"write broken config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, \"this is not valid toml {{{\").expect(\"write invalid config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config_content).expect(\"Failed to write config file\");"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config_content).expect(\"write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&out_dir, \"not a directory\").expect(\"write out_dir file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(out_dir.join(\"extras\"), \"not a dir\").expect(\"write extras file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "jsonschema::validator_for(&schema_value).expect(\"compile schema\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let artifacts = report[\"artifacts\"].as_array().expect(\"artifacts array\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let compare: Value = serde_json::from_str(&compare_content).expect(\"parse compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&github_output).expect(\"read GITHUB_OUTPUT\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&report_path).expect(\"read report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&report_path).expect(\"read report.json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(out_dir.join(\"comment.md\")).expect(\"read comment.md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let findings = instance[\"findings\"].as_array().expect(\"findings\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let findings = report[\"findings\"].as_array().expect(\"findings array\");"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let instance: Value = serde_json::from_str(&content).expect(\"parse report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let md = fs::read_to_string(out_dir.join(\"comment.md\")).expect(\"read comment.md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute check\");"
+count = 23
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report: Value = serde_json::from_str(&content).expect(\"parse report.json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report: Value = serde_json::from_str(&report_content).expect(\"failed to parse report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report_content = fs::read_to_string(&report_path).expect(\"failed to read report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let run: Value = serde_json::from_str(&run_content).expect(\"parse run receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let schema_content = fs::read_to_string(&schema_path).expect(\"read schema\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let schema_value: Value = serde_json::from_str(&schema_content).expect(\"parse schema\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 36
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let validator = jsonschema::validator_for(&schema_value).expect(\"compile schema\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(&report_path).expect(\"read report\"))"
+count = 9
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&report_content).expect(\"parse native report\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "&fs::read_to_string(out_dir.join(\"extras/perfgate.report.v1.json\")).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap())"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let a_path = window[0][\"path\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let a_type = window[0][\"type\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let b_path = window[1][\"path\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let b_type = window[1][\"type\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let error = counts[\"error\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let error_count = report[\"verdict\"][\"counts\"][\"error\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let info = counts[\"info\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let verdict_status = report[\"verdict\"][\"status\"].as_str().unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let warn = counts[\"warn\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::from_str(&fs::read_to_string(out_dir.join(\"report.json\")).unwrap()).unwrap();"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&baseline).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&fast_baseline).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&receipt).unwrap(),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cockpit_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "summary[\"total_count\"].as_u64().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_comment_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to generate compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_comment_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let dir = tempdir().expect(\"failed to create temp dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_compare_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&output_path).expect(\"failed to read output file\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_compare_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute perfgate compare\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_compare_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 10
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_compare_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"output should be valid JSON\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"cpu_ms should be a valid u64\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"samples should be an array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write baseline\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write current\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&compare_path).expect(\"failed to read compare file\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&export_path).expect(\"failed to read export file\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&output_path).expect(\"failed to read output file\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let header = content.lines().next().expect(\"CSV should have header\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let md_content = fs::read_to_string(&md_path).expect(\"failed to read markdown file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(lines[0]).expect(\"should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 9
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"compare.json should be valid JSON\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"output should be valid JSON\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let max = cpu_stats[\"max\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let median = cpu_stats[\"median\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let min = cpu_stats[\"min\"].as_u64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let regression = cpu_delta[\"regression\"].as_f64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&baseline).unwrap(),"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_cpu_time_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&current).unwrap(),"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"run diff\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&baselines_dir).expect(\"create baselines dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config_content).expect(\"write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(&stdout).expect(\"valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let stdout = String::from_utf8(output.stdout).expect(\"UTF-8 stdout\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let stdout = String::from_utf8(output.stdout).expect(\"UTF-8\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_diff_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let tmp = tempdir().unwrap();"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write baseline marker\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write config\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir(&project_dir).expect(\"create project dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir(project_dir.join(\"baselines\")).expect(\"create project baselines\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::set_permissions(&script, fs::Permissions::from_mode(0o644)).expect(\"chmod script\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&script, \"#!/bin/sh\\nexit 0\\n\").expect(\"write script\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(project_dir.join(\"bench.cmd\"), \"@echo off\\r\\nexit /b 0\\r\\n\").expect(\"write bench\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_doctor_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let dir = tempdir().expect(\"tempdir\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to generate compare receipt\");"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&export_path).expect(\"failed to read export file\");"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content1 = fs::read_to_string(&export_path1).expect(\"failed to read export1\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content2 = fs::read_to_string(&export_path2).expect(\"failed to read export2\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(line).expect(\"should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(lines[0]).expect(\"should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_export_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 14
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(root.join(\"baselines/parser.json\")).expect(\"read baseline\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"baseline should be json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write Cargo.toml\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(config_path, tuned).expect(\"write tuned config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let generated = fs::read_to_string(config_path).expect(\"read generated config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempfile::tempdir().expect(\"create temp dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_help_snapshot_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to run perfgate\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_help_snapshot_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let text = String::from_utf8(output.stdout).expect(\"non-UTF-8 help output\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_help_snapshot_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "&& !lines.last().unwrap().is_empty()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_help_snapshot_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let last = lines.last_mut().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write baseline\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&baselines_dir).expect(\"Failed to create baselines dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config_content).expect(\"Failed to write config file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&output_path).expect(\"failed to read output file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute check\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 20
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"output should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_host_mismatch_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string_pretty(&receipt).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&output_path).expect(\"failed to read ingest output\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&output_path).expect(\"failed to read probe output\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write hyperfine input\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write probe input\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest output should be JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"probe output should be JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_ingest_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write Cargo.toml\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(temp_dir.path().join(\"perfgate.toml\")).expect(\"read generated config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let config = fs::read_to_string(&config_path).expect(\"read generated config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let onboarding = fs::read_to_string(&onboarding_path).expect(\"read onboarding README\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let stderr = String::from_utf8(output).expect(\"stderr is utf8\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempfile::tempdir().expect(\"create temp dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_init_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let workflow = fs::read_to_string(&workflow_path).expect(\"read generated workflow\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to generate compare receipt\");"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"first md run\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"second md run\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write template\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(&compare_receipt_path).expect(\"failed to read compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&md_output_path).expect(\"failed to read markdown file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 9
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_md_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"compare receipt should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(1)"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let exported = fs::read_to_string(&export_path).expect(\"read decision export\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = TempDir::new().expect(\"failed to create temp dir\");"
+count = 13
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(lines[0]).expect(\"decision export line should be JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir_all(&project_dir).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let requests = mock_server.received_requests().await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let temp_dir = TempDir::new().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::from_str(&fs::read_to_string(&compare_path).unwrap()).unwrap();"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&baseline_record(project, benchmark, run_id, wall_ms)).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&current_content).unwrap(),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&run_receipt(run_id, benchmark, wall_ms)).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_mock_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&tradeoff_receipt()).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_paired_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"baseline_command should be array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_paired_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"current_command should be array\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_paired_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"samples should be an array\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_paired_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&output_path).expect(\"failed to read output file\");"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_paired_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 12
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_paired_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"output should be valid JSON\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"crate should live under crates/perfgate-cli\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"decision artifact index should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"decision bundle should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"probe compare receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read decision artifact index\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read decision bundle\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read probe compare receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read scenario receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read tradeoff receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"scenario receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"tradeoff receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "for entry in fs::read_dir(source).expect(\"read source directory\") {"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::copy(&entry_source, &entry_destination).expect(\"copy source file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(destination).expect(\"create destination directory\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(root.join(\"artifacts/perfgate/decision.md\")).expect(\"read decision md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "if entry.file_type().expect(\"read source entry type\").is_dir() {"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let entry = entry.expect(\"read source directory entry\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"create temp dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&output_path).expect(\"failed to read probe compare receipt\"),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write probe receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"probe compare receipt should be JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"probe compare receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_value(receipt.clone()).expect(\"probe compare receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_probe_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize probe receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to read temp dir\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, config).expect(\"write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&invalid_json, \"{ invalid json }\").expect(\"failed to write invalid json\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&baseline_path).expect(\"failed to read baseline file\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&baseline_path).expect(\"failed to read promoted\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let original_content = fs::read_to_string(&current).expect(\"failed to read original\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let promoted_content = fs::read_to_string(&baseline_path).expect(\"failed to read promoted\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 10
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let updated_cfg = fs::read_to_string(&config_path).expect(\"read config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"output should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&original_content).expect(\"failed to parse original\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_promote_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&promoted_content).expect(\"failed to parse promoted\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"decision artifact index should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read decision artifact index\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read scenario receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read tradeoff receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"scenario receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"tradeoff receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write Cargo.toml\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write baseline probes jsonl\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write controlled compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write current probes jsonl\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(root.join(\"artifacts\")).expect(\"create probe jsonl dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(root.join(\"artifacts/perfgate/decision.md\")).expect(\"read decision md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(config_path, format!(\"{tuned}{decision_config}\")).expect(\"write tuned config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let generated = fs::read_to_string(config_path).expect(\"read generated config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"create temp dir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize controlled compare receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(report[\"findings\"].as_array().unwrap().is_empty());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(report[\"findings\"].as_array().unwrap().len(), 1);"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&compare_path, create_compare_receipt(\"fail\", \"fail\")).unwrap();"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&compare_path, pass_compare).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&compare_path, warn_compare).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let content = fs::read_to_string(&report_path).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let content1 = fs::read_to_string(&report_path1).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let content2 = fs::read_to_string(&report_path2).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempdir().unwrap();"
+count = 11
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let md_content = fs::read_to_string(&md_path).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_report_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let report: serde_json::Value = serde_json::from_str(&content).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_run_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"samples should be an array\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_run_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&output_path).expect(\"failed to read output file\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_run_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to execute perfgate run\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_run_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_run_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"output should be valid JSON\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&output_path).expect(\"failed to read scenario receipt\"),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write compare fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write config\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write probe compare fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"scenario receipt should be JSON\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"scenario warnings should be array\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(parent).expect(\"failed to create compare fixture directory\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(parent).expect(\"failed to create probe compare fixture directory\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_value(receipt.clone()).expect(\"scenario receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize compare fixture\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_scenario_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize probe compare fixture\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_serve_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let listener = TcpListener::bind(\"127.0.0.1:0\").expect(\"bind test port\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_serve_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let port = listener.local_addr().expect(\"local addr\").port();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_serve_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"temp dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&compare_path).expect(\"compare receipt should be readable\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&downloaded_path).expect(\"downloaded baseline should be readable\"),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare receipt should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"downloaded baseline should be valid JSON\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"health request should write\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"health response should read\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"system clock should be after unix epoch\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"test server root URL should use http\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write decision tradeoff receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let exported = fs::read_to_string(&decision_export_path).expect(\"read decision export\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mut stream = TcpStream::connect(addr).expect(\"root health socket should connect\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute command\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = TempDir::new().expect(\"failed to create temp dir\");"
+count = 13
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize decision tradeoff receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&baseline_content).unwrap(),"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&current_content).unwrap(),"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_server_tests.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_string(&receipt_content).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&probe_compare_path).expect(\"read probe compare receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(decision_index_path).expect(\"read decision artifact index\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"decision artifact index should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"probe compare receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"scenario receipt should deserialize\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"tradeoff receipt should deserialize\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write controlled compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write probe config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write probe receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::read_to_string(root.join(\"artifacts/perfgate/decision.md\")).expect(\"read decision md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let decision = fs::read_to_string(decision_path).expect(\"read decision md\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"create temp dir\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(&scenario_path).expect(\"read scenario receipt\"))"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(&tradeoff_path).expect(\"read tradeoff receipt\"))"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(scenario_path).expect(\"read scenario receipt\"))"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&fs::read_to_string(tradeoff_path).expect(\"read tradeoff receipt\"))"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize controlled compare receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize probe receipt\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "&fs::read_to_string(&output_path).expect(\"failed to read tradeoff receipt\"),"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"allowance reason\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write config\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write probe compare fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to write scenario fixture\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"reasons array\")"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"review reason\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"tradeoff receipt should be JSON\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, \"[defaults]\\nthreshold = 0.20\\n\").expect(\"failed to write config\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let temp_dir = tempdir().expect(\"failed to create temp dir\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_value(receipt.clone()).expect(\"tradeoff receipt should deserialize\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize probe compare fixture\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-cli/tests/cli_tradeoff_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_string_pretty(&receipt).expect(\"serialize scenario fixture\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-client/src/client.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-client/src/client.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-client/src/client.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let client = BaselineClient::new(test_config(&mock_server.uri())).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-client/src/config.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let url = self.url.as_ref().expect(\"checked by is_configured\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-client/src/config.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(resolved.create_client().unwrap().is_none());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-client/src/fallback.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-client/src/fallback.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir_all(&project_dir).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-client/src/fallback.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&file_path, serde_json::to_string_pretty(&record).unwrap())"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-client/src/fallback.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let client = BaselineClient::new(config).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-client/src/fallback.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let temp_dir = tempdir().unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-client/tests/client_server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let client = BaselineClient::new(test_config(&mock_server.uri())).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/blame_example.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable!"
+snippet = "_ => unreachable!(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/budget_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let result = evaluate_budget(100.0, 105.0, &budget, None).expect(\"evaluate\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/budget_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let result = evaluate_budget(100.0, 115.0, &budget, None).expect(\"evaluate\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/budget_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let result = evaluate_budget(100.0, 125.0, &budget, None).expect(\"evaluate\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/domain_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let baseline_stats = compute_stats(&baseline_samples, None).expect(\"baseline stats\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/domain_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let comparison = compare_stats(&baseline_stats, &current_stats, &budgets).expect(\"compare\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/domain_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let current_stats = compute_stats(&current_samples, None).expect(\"current stats\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/domain_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_u64(&values).expect(\"summarize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let f64_summary = summarize_f64(&f64_samples).expect(\"should have samples\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let p50 = percentile(latency_samples.clone(), 0.50).expect(\"should have samples\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let p90 = percentile(latency_samples.clone(), 0.90).expect(\"should have samples\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let p95 = percentile(latency_samples.clone(), 0.95).expect(\"should have samples\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let p99 = percentile(latency_samples.clone(), 0.99).expect(\"should have samples\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let single_summary = summarize_u64(&single).expect(\"should work with single element\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let u64_summary = summarize_u64(&u64_samples).expect(\"should have samples\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let even_summary = summarize_u64(&even_count).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-domain/examples/stats_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let odd_summary = summarize_u64(&odd_count).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-export/examples/export_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "ExportUseCase::export_compare(&compare_receipt, ExportFormat::Jsonl).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-export/examples/export_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "ExportUseCase::export_compare(&compare_receipt, ExportFormat::Prometheus).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-export/examples/export_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let compare_csv = ExportUseCase::export_compare(&compare_receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-export/examples/export_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv = ExportUseCase::export_run(&run_receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-export/examples/export_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl = ExportUseCase::export_run(&run_receipt, ExportFormat::Jsonl).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-export/examples/export_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prom = ExportUseCase::export_run(&run_receipt, ExportFormat::Prometheus).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/examples/fake_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let r1 = runner.run(&spec3).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/examples/fake_example.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let r2 = runner.run(&spec3).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/clock.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mut inner = self.inner.lock().expect(\"lock\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/clock.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").millis"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/clock.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").millis = 0;"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/clock.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").millis = millis;"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/clock.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let _results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let inner = self.inner.lock().expect(\"lock\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").arch = arch.to_string();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").cpu_count = None;"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").cpu_count = Some(count);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").hostname_hash = Some(hash.to_string());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").memory_bytes = None;"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").memory_bytes = Some(bytes);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.inner.lock().expect(\"lock\").os = os.to_string();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/host_probe.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "*self.fallback.lock().expect(\"lock\") = None;"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "*self.fallback.lock().expect(\"lock\") = Some(result);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"lock\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let fallback = self.fallback.lock().expect(\"lock\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let results = self.results.lock().expect(\"lock\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").clear();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").clone()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").get(n).cloned()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").len()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").push(spec.clone());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.results.lock().expect(\"lock\").clear();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.results.lock().expect(\"lock\").insert(key, result);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(runner.nth_call(0).unwrap().argv, vec![\"first\"]);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(runner.nth_call(1).unwrap().argv, vec![\"second\"]);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "h.join().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = runner.run(&make_spec(vec![\"echo\", \"hello\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = runner.run(&make_spec(vec![\"echo\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = runner.run(&make_spec(vec![\"unknown\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "r.run(&make_spec(vec![\"cmd\", &i.to_string()])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "runner.run(&make_spec(vec![\"cmd\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "runner.run(&make_spec(vec![\"cmd1\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "runner.run(&make_spec(vec![\"cmd2\", \"arg\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "runner.run(&make_spec(vec![\"echo\", \"hello\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "runner.run(&make_spec(vec![\"first\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-fake/src/process_runner.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "runner.run(&make_spec(vec![\"second\"])).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-sensor/examples/sensor_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&sensor_report).expect(\"serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/auth.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap(),"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-server/src/auth.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-server/src/auth.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "encode(&Header::default(), claims, &fixture.encoding_key()).unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/auth.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let retrieved = retrieved.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/auth.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let seed = Seed::from_env_value(\"perfgate-server-auth-tests\").unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = ".oidc(parse_custom_oidc_provider(provider_spec).unwrap_or_else(|e| panic!(\"{}\", e)));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = ".unwrap_or_else(|_| panic!(\"Invalid bind address\"))"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = ".unwrap_or_else(|e| panic!(\"Invalid bind address: {}\", e));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = ".unwrap_or_else(|e| panic!(\"Invalid storage type: {}\", e));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "let loaded = source.load().unwrap_or_else(|e| panic!(\"{}\", e));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "parse_oidc_mapping(mapping, \"--github-oidc\").unwrap_or_else(|e| panic!(\"{}\", e));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "parse_oidc_mapping(mapping, \"--gitlab-oidc\").unwrap_or_else(|e| panic!(\"{}\", e));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ").unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg = parse_api_key(\"ADMIN:pg_live_abc\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg = parse_api_key(\"Contributor:pg_live_abc\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg = parse_api_key(\"admin:pg_live_abc123\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg = parse_api_key(\"contributor:pg_live_key:my-proj:*\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg = parse_api_key(\"contributor:pg_live_key:my-proj:^bench-.*$\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg = parse_api_key(\"viewer:pg_live_xyz789\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg2 = parse_api_key(\"contributor:pg_live_key:my-proj:.*\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let arg3 = parse_api_key(\"contributor:pg_live_key:my-proj:^bench-.*$\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let args = Args::try_parse_from([\"perfgate-server\"]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/bin/perfgate-server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_oidc_mapping(\"org/repo:my-proj:contributor\", \"--github-oidc\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/cleanup.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let mut deleted = self.deleted.lock().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/cleanup.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let objects = self.objects.lock().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/cleanup.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = run_cleanup(&store, 30).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/cleanup.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = run_cleanup(&store, 7).await.unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/cleanup.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "self.deleted.lock().unwrap().clone()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/credential_source.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/credential_source.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let creds = parse_credentials_document(doc).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/credential_source.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let creds = src.load().unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/credential_source.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let temp = tempfile::NamedTempFile::new().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/credential_source.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let temp_dir = tempfile::tempdir().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/handlers/baselines.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "Ok(_) => panic!(\"handler should return an internal server error\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/handlers/dashboard.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "headers.insert(header::CONTENT_TYPE, mime.as_ref().parse().unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/handlers/health.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let serialized = serde_json::to_string(&response).expect(\"serialize health response\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/handlers/verdicts.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let actual = actual.expect(\"score should be present\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/metrics.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to install Prometheus recorder\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/metrics.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/oidc.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "other => panic!(\"Expected InvalidToken, got: {:?}\", other),"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-server/src/oidc.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "encode(&header, &claims, encoding_key).unwrap()"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/oidc.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let api_key = provider.validate_token(&token).await.unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-server/src/oidc.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let api_key = registry.validate_token(&token).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/oidc.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let encoding_key = EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_PEM).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to install Ctrl+C handler\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to install signal handler\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "\"memory\".parse::<StorageBackend>().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "\"postgres\".parse::<StorageBackend>().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "\"sqlite\".parse::<StorageBackend>().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "bind: \"0.0.0.0:8080\".parse().unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (storage, _audit) = create_storage(&config).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let key_store = create_key_store(&config).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/server.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let viewer_key = keys.iter().find(|k| k.role == Role::Viewer).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/fleet.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/fleet.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let resp = store.record_dependency_events(&req).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/fleet.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.record_dependency_events(&req).await.unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/fleet.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.record_dependency_events(&req1).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/fleet.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.record_dependency_events(&req2).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/key_store.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let found = store.validate_key(&raw).await.unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/key_store.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let keys = store.list_keys().await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/key_store.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = store.revoke_key(\"nonexistent-id\").await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/key_store.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let revoked = store.revoke_key(&id).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/key_store.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let store = SqliteKeyStore::in_memory().unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/key_store.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_key(&rec).await.unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/postgres.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"table schema should be present\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/postgres.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"latest decision should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"test tradeoff receipt should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 19
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let conn = open_configured_memory_connection().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let conn = store.conn.lock().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempdir().unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let reader = open_configured_connection(&db_path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = store.list_events(&query).await.unwrap();"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let retrieved = retrieved.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let retrieved = store.get(\"my-project\", \"my-bench\", \"v1.0.0\").await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let setup = open_configured_connection(&db_path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let store = SqliteStore::in_memory().unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let store = SqliteStore::new(&db_path, None).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let writer = open_configured_connection(&db_path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "reader.execute_batch(\"BEGIN;\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "reader.execute_batch(\"COMMIT;\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create(&record).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_decision(&first).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_decision(&no_tradeoff).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_decision(&old).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_decision(&other_project).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_decision(&recent).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.create_decision(&second).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/storage/sqlite.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "store.log_event(&event).await.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/src/testing.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to create key store\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/testing.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"failed to create storage\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/testing.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "axum::serve(listener, app).await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/testing.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let addr = listener.local_addr().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/src/testing.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let listener = TcpListener::bind(\"127.0.0.1:0\").await.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"audit request failed\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"audit response should decode\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"create key audit event should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"create key failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"delete failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"first verdict should submit\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"get latest failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"list failed\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"revoke key audit event should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"revoke key failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"second verdict should submit\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"test request should have a version\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"upload failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let actual = actual.expect(\"flakiness score should be present\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let health = client.health_check().await.expect(\"health check failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let listed = admin_client.list_keys().await.expect(\"list keys failed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "BaselineClient::new(ClientConfig::new(&server.url).with_api_key(ADMIN_KEY)).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/tests/real_server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "BaselineClient::new(ClientConfig::new(&server.url).with_api_key(CONTRIBUTOR_KEY)).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to connect to server\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to list baselines\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to upload\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let body: serde_json::Value = response.json().await.expect(\"Failed to parse response\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let client = BaselineClient::new(config).expect(\"Failed to create client\");"
+count = 10
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let baseline = result.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let health = result.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-server/tests/server_integration.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let response = result.unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-types/examples/types_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&receipt).expect(\"serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/examples/types_example.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: RunReceipt = serde_json::from_str(&json).expect(\"deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/baseline_service.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let detailed: HealthResponse = serde_json::from_value(detailed).expect(\"detailed health\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/baseline_service.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let legacy: HealthResponse = serde_json::from_value(legacy).expect(\"legacy health\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/baseline_service.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "Utc.with_ymd_and_hms(2026, 1, 2, 3, 4, 5).unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/baseline_service/auth.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/config.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let changed = apply_ratchet_toml_changes(&path, \"bench-a\", &changes).expect(\"apply\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/config.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let dir = tempfile::tempdir().expect(\"tempdir\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/config.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let updated = std::fs::read_to_string(&path).expect(\"read\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/config.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "std::fs::write(&path, src).expect(\"write\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/io.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempfile::tempdir().unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/io.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result: serde_json::Value = read_json_file(&path).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/io.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(&path, \"not valid json {{{\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/io.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(&path, r#\"{\"key\": \"value\"}\"#).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"BenchConfigFile should serialize to JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"BenchConfigFile should serialize to TOML\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Budget metric should exist in deserialized\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Budget should serialize to JSON\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"BudgetOverride metric should exist in deserialized\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"BudgetOverride should serialize to JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"CompareReceipt should serialize to JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ConfigFile should serialize to JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ConfigFile should serialize to TOML\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Delta metric should exist in deserialized\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to BenchConfigFile\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to Budget\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to BudgetOverride\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to CompareReceipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to ConfigFile\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to PerfgateReport\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"JSON should deserialize back to RunReceipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"PerfgateReport should serialize to JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"RunReceipt should serialize to JSON\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"TOML should deserialize back to BenchConfigFile\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"TOML should deserialize back to ConfigFile\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"parse config\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: Delta = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: F64Summary = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: HostInfo = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: Sample = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: Stats = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: U64Summary = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let back: Verdict = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let cv = s.cv().expect(\"should return Some\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let info: HostInfo = serde_json::from_str(json).expect(\"should parse old format\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&delta).expect(\"Delta should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&info).expect(\"HostInfo should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&info).expect(\"should serialize\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&original).expect(\"should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&sample).expect(\"Sample should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&stats).expect(\"Stats should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&summary).expect(\"F64Summary should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&summary).expect(\"U64Summary should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&verdict).expect(\"Verdict should serialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: HostInfo = serde_json::from_str(&json).expect(\"should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let receipt: RunReceipt = serde_json::from_str(json).expect(\"should parse old format\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let value = serde_json::to_value(&info).expect(\"serialize HostInfo\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(FIXTURE_ERROR).expect(\"fixture should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(FIXTURE_FAIL).expect(\"fixture should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(FIXTURE_MULTI_BENCH).expect(\"fixture should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(FIXTURE_NO_BASELINE).expect(\"fixture should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(FIXTURE_PASS).expect(\"fixture should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(FIXTURE_WARN).expect(\"fixture should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(json).expect(\"compare without significance\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(json).expect(\"old format without host extensions\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(json).expect(\"should parse without engine\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(json).expect(\"unknown fields should be ignored\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: CompareReceipt = serde_json::from_str(&json).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: ConfigFile = serde_json::from_str(&json).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: PerfgateReport = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: RunReceipt = serde_json::from_str(&json).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: SensorReport = serde_json::from_str(&json).unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: Stats = serde_json::from_str(&json).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let delta = receipt.deltas.get(&Metric::WallMs).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&caps).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&config).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&m).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&receipt).unwrap();"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&report).unwrap();"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&stats).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let parsed: SensorCapabilities = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let value: serde_json::Value = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "self.url.is_some() && !self.url.as_ref().unwrap().is_empty()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/lib.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "vals.sort_by(|x, y| x.partial_cmp(y).unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let diag = decoded.noise_diagnostics.expect(\"should have diagnostics\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize paired receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&json).expect(\"deserialize paired receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let decoded: NoiseDiagnostics = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let decoded: PairedRunReceipt = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&diag).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&receipt).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::from_str(&serde_json::to_string(&receipt).unwrap()).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize decision bundle\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize decision index\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize probe compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize probe receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize scenario receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string(&receipt).expect(\"serialize tradeoff receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: ProbeReceipt = serde_json::from_str(&json).expect(\"parse probe receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: ScenarioReceipt = serde_json::from_str(&json).expect(\"parse scenario receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: TradeoffReceipt = serde_json::from_str(&json).expect(\"parse tradeoff receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&json).expect(\"parse decision bundle\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&json).expect(\"parse decision index\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/structured_evidence.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&json).expect(\"parse probe compare receipt\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate-types/src/validation.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "panic!(\"expected TooLong error\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "> noisy_input.runner.effective_weight.unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&first_path, serde_json::to_string(&first).unwrap()).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&noisy_path, serde_json::to_string(&noisy).unwrap()).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&second_path, serde_json::to_string(&second).unwrap()).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&stable_a_path, serde_json::to_string(&stable_a).unwrap()).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&stable_b_path, serde_json::to_string(&stable_b).unwrap()).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempdir().unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "receipt.stats = compute_stats(&receipt.samples, receipt.bench.work_units).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/aggregate.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "stable_input.runner.effective_weight.unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/badge.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/app/bisect.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = if build_res.is_err() || build_res.unwrap().exit_code != 0 {"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((result.error_ns.unwrap() - 10.0).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((result.error_ns.unwrap() - 12_345.0).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((result.error_ns.unwrap() - 150.0).abs() < f64::EPSILON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let estimates: CriterionEstimates = serde_json::from_str(json).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = parse_libtest_line(line).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let results = scan_criterion_dir(&criterion_dir).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let tmp = tempfile::tempdir().unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(&bench_dir).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(&criterion_dir).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(&dir).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(&report_dir).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(tmp.path().join(\"criterion\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(dir.join(\"estimates.json\"), estimates_json(*ns)).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/cargo_bench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(report_dir.join(\"estimates.json\"), \"{}\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"build budgets\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"build run request\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"check should succeed\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let max_rss = budgets.get(&Metric::MaxRssKb).expect(\"max_rss budget\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mut runs = self.runs.lock().expect(\"lock runs\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let wall = budgets.get(&Metric::WallMs).expect(\"wall budget\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable!"
+snippet = "MetricStatus::Pass | MetricStatus::Skip => unreachable!(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/check.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "outcome.compare_receipt.as_ref().unwrap().verdict.status,"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = render_json_diff(&outcome).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let tmp = tempfile::tempdir().unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(&child).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(&config_path, \"[defaults]\\n\").unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(&json_path, \"{}\").unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/diff.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(&toml_path, \"[defaults]\\n\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "tempfile::tempdir().expect(\"failed to create temp dir\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir(&bench_dir).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir(&benches_dir).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir(&git_dir).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&md_file, \"# Hello\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&py_file, \"print('hello')\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&sh_file, \"#!/bin/bash\\necho hello\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&shebang_file, \"#!/usr/bin/env python\\nprint('bench')\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(bench_dir.join(\"README.md\"), \"# Benchmarks\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(bench_dir.join(\"alpha.sh\"), \"#!/bin/bash\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(bench_dir.join(\"run_perf.sh\"), \"#!/bin/bash\\necho hello\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(bench_dir.join(\"zebra.sh\"), \"#!/bin/bash\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/discover.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(git_dir.join(\"config\"), \"core\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"unexpected metric: {}\", metric),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(parsed[\"baseline_value\"].as_f64().unwrap() > 0.0);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(parsed[\"current_value\"].as_f64().unwrap() > 0.0);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let _: serde_json::Value = serde_json::from_str(line).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv = ExportUseCase::export_compare(&receipt, ExportFormat::Csv).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv = ExportUseCase::export_run(&receipt, ExportFormat::Csv).unwrap();"
+count = 13
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv1 = ExportUseCase::export_compare(&receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv1 = ExportUseCase::export_run(&receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv2 = ExportUseCase::export_compare(&receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv2 = ExportUseCase::export_run(&receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let data_line = csv.lines().nth(1).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let html = ExportUseCase::export_compare(&receipt, ExportFormat::Html).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let html = ExportUseCase::export_run(&receipt, ExportFormat::Html).unwrap();"
+count = 11
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = parsed.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl = ExportUseCase::export_compare(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl = ExportUseCase::export_run(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 11
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl1 = ExportUseCase::export_run(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl2 = ExportUseCase::export_run(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let junit = ExportUseCase::export_compare(&receipt, ExportFormat::JUnit).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let max_rss_pos = csv.find(\"max_rss_kb\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let metric = parsed[\"metric\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let metric_name = parsed[\"metric\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(jsonl.trim()).unwrap();"
+count = 9
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(line).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prom = ExportUseCase::export_compare(&receipt, ExportFormat::Prometheus).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prom = ExportUseCase::export_run(&receipt, ExportFormat::Prometheus).unwrap();"
+count = 10
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let regression_pct = parsed[\"regression_pct\"].as_f64().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let status = parsed[\"status\"].as_str().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let wall_ms_pos = csv.find(\"wall_ms\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(json[\"bench_name\"].as_str().unwrap(), receipt.bench.name);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "receipt.stats.cpu_ms.as_ref().unwrap().median"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "receipt.stats.max_rss_kb.as_ref().unwrap().median"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/export.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "vals.sort_by(|x, y| x.partial_cmp(y).unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let parsed: ConfigFile = toml::from_str(&toml_str).expect(\"rendered TOML should parse\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 13
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir(&benches_dir).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::create_dir_all(&sub).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(dir.path().join(\"go.mod\"), \"module example\\n\").unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(dir.path().join(\"go.mod\"), \"module mixed\\n\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(dir.path().join(\"requirements.txt\"), \"pytest-benchmark\\n\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/init.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempfile::tempdir().unwrap();"
+count = 11
+
+[[baseline]]
+path = "crates/perfgate/src/app/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ignore mismatch should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"matching hosts should not error\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let rendered = render_markdown_template(&compare, template).expect(\"render template\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/mod.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable!"
+snippet = "MetricStatus::Pass | MetricStatus::Skip => unreachable!(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (metric, status) = parsed.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let annotation = matching_annotation.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"lock options\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"paired run should succeed\");"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/app/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"should have noise diagnostics\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mut runs = self.runs.lock().expect(\"lock runs\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let seen = host_probe.seen_include_hash.lock().expect(\"lock seen\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare probes\");"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/app/ratchet.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"wall delta\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/render.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let rendered = render_markdown_template(&compare, template).expect(\"render template\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/render.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (metric, status) = parsed.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/render/summary.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/render/summary.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "files: vec![path.to_str().unwrap().to_string()],"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/render/summary.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::write(&path, serde_json::to_string(&receipt).unwrap()).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/render/summary.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dir = tempdir().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "insta::assert_json_snapshot!(\"report_fail\", serde_json::to_value(&result.report).unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "insta::assert_json_snapshot!(\"report_pass\", serde_json::to_value(&result.report).unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "insta::assert_json_snapshot!(\"report_warn\", serde_json::to_value(&result.report).unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json1 = serde_json::to_string(&result1.report).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json2 = serde_json::to_string(&result2.report).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "serde_json::to_value(&result.report).unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let result = runner.run(&spec).expect(\"command should succeed\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let n = reader.read(&mut buf).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "result.page_faults.unwrap() > 0,"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime/fake.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "*self.fallback.lock().expect(\"lock\") = Some(result);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime/fake.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let fallback = self.fallback.lock().expect(\"lock\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime/fake.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let results = self.results.lock().expect(\"lock\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime/fake.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").clone()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime/fake.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.history.lock().expect(\"lock\").push(spec.clone());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/runtime/fake.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.results.lock().expect(\"lock\").insert(key, result);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/scenario.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"evaluate scenario with advisory probe warnings\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/app/scenario.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"evaluate scenario\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/tradeoff.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"evaluate tradeoff\");"
+count = 12
+
+[[baseline]]
+path = "crates/perfgate/src/app/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let outcome = TrendUseCase.execute(request).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/app/watch.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let remaining = d.remaining_ms().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let r1 = evaluate_budget(baseline, current, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let r2 = evaluate_budget(baseline, current, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(100.0, 105.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(100.0, 115.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(100.0, 130.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/budget.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(baseline, current, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/host.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let reasons = detect_host_mismatch(&baseline, &current).unwrap().reasons;"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/domain/host.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let reasons = mismatch.unwrap().reasons;"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate/src/domain/host.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert!(mismatch.unwrap().reasons.iter().any(|r| r.contains(\"OS mismatch\")));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/host.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert!(mismatch.unwrap().reasons.iter().any(|r| r.contains(\"architecture mismatch\")));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/host.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert!(mismatch.unwrap().reasons.iter().any(|r| r.contains(\"hostname mismatch\")));"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ThroughputPerS delta should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"WallMs delta should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"combined samples with non-warmup should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare advisory\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare enforced\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare with missing required metric\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare with tradeoff\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare with unsatisfied tradeoff\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare_stats should succeed with valid inputs\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"compare_stats should succeed\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"cpu_ms delta should exist\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"delta should exist\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"evaluate_budget is infallible for bv > 0\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"median should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"non-empty non-warmup samples should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"p95 should exist\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"samples with modified warmup should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"samples with original warmup should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "compare_runs(&baseline, &current, &budgets, &stats, None).expect(\"compare runs\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let (mean, var) = mean_and_variance(&values).expect(\"finite values\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let advisory_delta = advisory.deltas.get(&Metric::WallMs).expect(\"wall delta\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let cpu_stats = stats.cpu_ms.expect(\"cpu_ms should be present\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let cv = metric_cv(&stats, Metric::CpuMs).expect(\"should return Some\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let cv = metric_cv(&stats, Metric::ThroughputPerS).expect(\"should return Some\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let cv = metric_cv(&stats, Metric::WallMs).expect(\"should return Some\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let delta = comparison.deltas.get(&Metric::WallMs).expect(\"wall delta\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let enforced_delta = enforced.deltas.get(&Metric::WallMs).expect(\"wall delta\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let stats = compute_stats(&samples, None).expect(\"compute stats\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_f64(&[value]).expect(\"single element should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_f64(&values).expect(\"non-empty vec should succeed\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_u64(&[value]).expect(\"single element should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_u64(&values).expect(\"non-empty vec should succeed\");"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "Err(other) => panic!(\"expected NoSamples error, got: {:?}\", other),"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "Ok(_) => panic!(\"expected error, got Ok\"),"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "other => panic!(\"expected InvalidAlpha for alpha={alpha}, got: {other:?}\"),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unreachable"
+selector_kind = "macro"
+selector_callee = "unreachable!"
+snippet = "_ => unreachable!(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "compare_stats_with_tradeoffs(&baseline, &current, &budgets(), &[rule]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "compare_stats_with_tradeoffs(&baseline, &current, &budgets(), &rules).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "compare_stats_with_tradeoffs(&baseline, &current, &budgets, &[rule]).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "comparison.deltas.get(&Metric::MaxRssKb).unwrap().status,"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let c = compare_stats(&baseline, &current, &budgets).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let c1 = compare_runs(&baseline, &current, &budgets, &stats_map, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let c2 = compare_runs(&baseline, &current, &budgets, &stats_map, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let cmp = compare_stats(&mk(baseline), &mk(current), &budgets).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let comparison = compare_stats(&baseline, &current, &budgets).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let cpu_stats = stats.cpu_ms.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let d = c.deltas.get(&Metric::ThroughputPerS).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let d = c.deltas.get(&Metric::WallMs).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let expected = summarize_u64(&walls).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let expected_max = *sorted.last().unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let expected_min = *sorted.first().unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let fwd = compare_stats(&mk(a), &mk(b), &budgets).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p = policy.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let r1 = compare_stats(&baseline, &current, &budgets).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let r2 = compare_stats(&baseline, &current, &budgets).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = compare_stats(&baseline, &current, &budgets).unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let rev = compare_stats(&mk(b), &mk(a), &budgets).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let s = summarize_f64(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let s = summarize_u64(&[10, 20]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let s = summarize_u64(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_stats(&samples, None).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_stats(std::slice::from_ref(&sample), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = result.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "result.deltas.get(&Metric::MaxRssKb).unwrap().status,"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "result.deltas.get(&Metric::ThroughputPerS).unwrap().status,"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "result.deltas.get(&Metric::WallMs).unwrap().status,"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"should have baseline throughput\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"should have current throughput\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"should have throughput diff\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let baseline_rss = stats.baseline_max_rss_kb.expect(\"should have baseline RSS\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let current_rss = stats.current_max_rss_kb.expect(\"should have current RSS\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let rss_diff = stats.rss_diff_kb.expect(\"should have RSS diff\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let stats = compute_paired_stats(&samples, None, None).expect(\"should compute stats\");"
+count = 8
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let stats = compute_paired_stats(&samples, Some(100), None).expect(\"should compute stats\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let max = *sorted.last().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let min = *sorted.first().unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_paired_stats(&samples, None, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats1 = compute_paired_stats(&samples, None, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats2 = compute_paired_stats(&samples, None, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_paired_diffs(&[10.0, 10.0, 10.0, 10.0], None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_paired_diffs(&[5.0], None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/paired.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_paired_diffs(&diffs, None).unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"O(1)\").unwrap(), ComplexityClass::O1);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"O(2^n)\").unwrap(), ComplexityClass::OExp);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"O(n)\").unwrap(), ComplexityClass::ON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"O(n^2)\").unwrap(), ComplexityClass::ON2);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"O(n^3)\").unwrap(), ComplexityClass::ON3);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"constant\").unwrap(), ComplexityClass::O1);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"cubic\").unwrap(), ComplexityClass::ON3);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"linear\").unwrap(), ComplexityClass::ON);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(parse_complexity(\"quadratic\").unwrap(), ComplexityClass::ON2);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&constant_data(), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&linear_data(), None).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&linear_data(), Some(0.999)).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&linear_data(), Some(1.0)).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&measurements, None).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&nlogn_data(), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = classify_complexity(&quadratic_data(), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_complexity(\"O(log n)\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_complexity(\"O(n log n)\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "parse_complexity(\"exponential\").unwrap(),"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/models.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: ComplexityClass = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/models.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(class).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: ScalingResult = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let back: SizeMeasurement = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&m).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/scaling/report.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&result).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let sig = result.expect(\"very small baseline vs larger current should be significant\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "(sig.p_value.unwrap() - 1.0).abs() < 1e-10,"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(result.p_value.unwrap() < 0.001);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(result.p_value.unwrap() >= 0.0 && result.p_value.unwrap() <= 1.0);"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(sig.p_value.unwrap() < 0.001);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(result.p_value.unwrap(), 1.0);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_relative_eq!(result.p_value.unwrap(), 0.0);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_relative_eq!(result.p_value.unwrap(), 1.0);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_relative_eq!(result.p_value.unwrap(), 1.0, epsilon = 1e-10);"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_relative_eq!(sig.p_value.unwrap(), 0.0);"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_relative_eq!(sig.p_value.unwrap(), 1.0);"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&[10.0, 20.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&[100.0; 10]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&[42.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = compute_significance(&baseline, &current, 0.05, 8).unwrap();"
+count = 9
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = compute_significance(&samples, &samples, 0.05, 8).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result_lenient = compute_significance(&baseline, &current, 0.10, 8).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result_strict = compute_significance(&baseline, &current, 0.01, 8).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let sig = compute_significance(&baseline, &current, 0.05, 2).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let sig = compute_significance(&baseline, &current, 0.05, 8).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let sig = result.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert!(sig.p_value.unwrap() < 0.001, \"large shift should have small p-value\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert!(sig.p_value.unwrap() <= 1.0, \"p-value must be <= 1\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert!(sig.p_value.unwrap() >= 0.0, \"p-value must be >= 0\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(sig.significant, sig.p_value.unwrap() <= sig.alpha);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/significance.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "sig.p_value.unwrap()"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_f64(&values).expect(\"non-empty vec should succeed\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_u64(&values).expect(\"non-empty vec should succeed\");"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&[1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&[42.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = mean_and_variance(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, var) = result.unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let max = *v.last().unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let min = *v.first().unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p = percentile(vec![1.0, 2.0, 3.0, 4.0, 5.0], 0.0).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p = percentile(vec![1.0, 2.0, 3.0, 4.0, 5.0], 0.5).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p = percentile(vec![1.0, 2.0, 3.0, 4.0, 5.0], 1.0).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p = percentile(vec![42.0], 0.5).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p0 = percentile(values.clone(), 0.0).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p100 = percentile(values.clone(), 1.0).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p50 = percentile(values.clone(), 0.5).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p95 = percentile(values, 0.95).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_f64(&[10.0, 20.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_f64(&[10.0, 30.0, 20.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_f64(&[42.0]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&[10, 20, 30, 40]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&[10, 20]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&[10, 30, 20]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&[42]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&[value]).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&values).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(summary.max, *sorted.last().unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(summary.max, *values.iter().max().unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(summary.min, *sorted.first().unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "prop_assert_eq!(summary.min, *values.iter().min().unwrap());"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "analyze_trend(&values, \"wall_ms\", 100.0, true, &TrendConfig::default()).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(analysis.runs_to_breach.unwrap() <= 10);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (slope, _intercept, r2) = linear_regression(&points).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (slope, intercept, r2) = linear_regression(&points).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let analysis = result.unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/domain/stats/trend.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let br = breach.unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/github/client.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 6
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/github/client.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(found.unwrap().id, 2);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/github/client.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let client = GitHubClient::new(&mock_server.uri(), \"test-token\").unwrap();"
+count = 7
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/github/comment.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (owner, repo) = parse_github_repository(\"octocat/hello-world\").unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/criterion.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_criterion(CRITERION_ESTIMATES, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/criterion.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_criterion(CRITERION_ESTIMATES, Some(\"my-bench\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/criterion.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_criterion(input, Some(\"fast-bench\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/criterion.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_criterion(input, Some(\"slope-bench\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/gobench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(receipt.stats.max_rss_kb.unwrap().median, 1);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/gobench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_gobench(input, None).unwrap();"
+count = 5
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/gobench.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_gobench(input, Some(\"foo-bench\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/hyperfine.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_hyperfine(HYPERFINE_JSON, None).unwrap();"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/hyperfine.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_hyperfine(HYPERFINE_JSON, Some(\"sleep-bench\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/hyperfine.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_hyperfine(input, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((summary.mean.unwrap() - 300.0).abs() < 0.001);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((summary.mean.unwrap() - 42.0).abs() < 0.001);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/mod.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!((summary.stddev.unwrap()).abs() < 0.001);"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/otel.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest OTel\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/probes.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest probe JSONL\");"
+count = 2
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/pytest.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_pytest_benchmark(PYTEST_JSON, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/pytest.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_pytest_benchmark(PYTEST_JSON, Some(\"sort-bench\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/integrations/ingest/pytest.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let receipt = parse_pytest_benchmark(input, None).unwrap();"
+count = 3
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"flush criterion probe measurement\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest criterion JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest helper JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest tracing JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"serialize probe event\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write first event\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write second event\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "String::from_utf8(output.lock().expect(\"buffer lock\").clone()).expect(\"utf8 JSONL\");"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "layer.flush().expect(\"flush tracing probe layer\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = String::from_utf8(writer.into_inner()).expect(\"utf8 JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/runtime/profile/profiler.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "ensure_output_dir(&nested).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/runtime/profile/profiler.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "ensure_output_dir(tmp.path()).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/runtime/profile/profiler.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized: ProfileResult = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/runtime/profile/profiler.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let filename = path.file_name().unwrap().to_str().unwrap();"
+count = 4
+
+[[baseline]]
+path = "crates/perfgate/src/runtime/profile/profiler.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&result).unwrap();"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/runtime/profile/profiler.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let tmp = tempfile::tempdir().unwrap();"
+count = 2
+
+[[baseline]]
+path = "fuzz/fuzz_targets/fuzz_host_detect.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!("
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Change not found\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Compare receipt not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Expected budget evaluation to fail\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to execute perfgate check --all --fail-on-warn\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to execute perfgate check --all --mode cockpit\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to execute perfgate check --all\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to execute perfgate github-annotations\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to read temp dir\")"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write baseline lock\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Failed to write current lock\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"GitHub output path not set\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Markdown not rendered\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"No baseline path set\");"
+count = 8
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"No markdown path set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Perfgate report not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Run receipt not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Sensor report not built\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Significance result not set\");"
+count = 8
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Temp dir not initialized\")"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Validation not performed\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"Verdict not aggregated\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"baseline lock missing\"),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"current lock missing\"),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"wall_ms delta should exist\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".map(|s| s.trim().parse().expect(\"Failed to parse sample\"))"
+count = 4
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".map(|s| s.trim().parse().expect(\"Failed to parse value\"))"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "Command::cargo_bin(\"perfgate\").expect(\"Failed to find perfgate binary\")"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "Some(ExportUseCase::export_run(receipt, ExportFormat::Csv).expect(\"Failed to export\"));"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&artifacts_dir).expect(\"Failed to create artifacts dir\");"
+count = 16
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&baselines_dir).expect(\"Failed to create baselines dir\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(parent).expect(\"Failed to create parent directories\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&baseline_path, json).expect(\"Failed to write baseline receipt\");"
+count = 4
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&compare_path, json).expect(\"Failed to write compare receipt\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, \"[[bench\\n  name = broken\").expect(\"Failed to write config file\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, raw).expect(\"Failed to write config file\");"
+count = 4
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&config_path, toml).expect(\"Failed to write config file\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&current_path, json).expect(\"Failed to write current receipt\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&full_path, json).expect(\"Failed to write baseline receipt\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&path, \"\").expect(\"Failed to write empty file\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&path, \"{ not valid json }\").expect(\"Failed to write invalid JSON\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&path, content).expect(\"Failed to write baseline.lock\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&path, content).expect(\"Failed to write current.lock\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&source_path, \"{ invalid json }\").expect(\"Failed to write invalid JSON\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&source_path, json).expect(\"Failed to write source receipt\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&template_path, &content).expect(\"Failed to write template file\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(config_path, toml).expect(\"Failed to write config file\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(path, content).expect(\"Failed to write template file\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(path, json).expect(\"Failed to write run receipt\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(source_path, json).expect(\"Failed to write source\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let _ = cmd.output().expect(\"Failed to execute perfgate export\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let _ = cmd.output().expect(\"Failed to execute perfgate report\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let _: serde_json::Value = serde_json::from_str(&content).expect(\"Invalid JSON\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let actual = world.last_exit_code.expect(\"No exit code recorded\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let args: Vec<String> = shell_words::split(&command).expect(\"Failed to parse command\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let artifacts_dir = world.artifacts_dir.as_ref().expect(\"Artifacts dir not set\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let artifacts_dir = world.artifacts_dir.clone().expect(\"Artifacts dir not set\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let baseline = world.baseline_host.as_ref().expect(\"Baseline host not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let baseline = world.baseline_path.clone().expect(\"Baseline path not set\");"
+count = 10
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let blame = world.binary_blame.as_ref().expect(\"Blame analysis not run\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let budget = world.test_budget.as_ref().expect(\"Budget not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let compare = world.compare_path.clone().expect(\"Compare path not set\");"
+count = 13
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let config = world.config.as_mut().expect(\"Config not initialized\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let config_path = world.config_path.as_ref().expect(\"Config path not set\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let config_path = world.config_path.clone().expect(\"Config path not set\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&comment_path).expect(\"Failed to read comment.md\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&path).expect(\"Failed to read file\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&report_path).expect(\"Failed to read report.json\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(&run_path).expect(\"Failed to read run.json\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(baseline_path).expect(\"Failed to read baseline file\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(baseline_path).expect(\"Failed to read baseline\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(export_path).expect(\"Failed to read export file\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(md_path).expect(\"Failed to read markdown file\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(output_path).expect(\"Failed to read GITHUB_OUTPUT\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(output_path).expect(\"Failed to read output file\");"
+count = 21
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(path).expect(\"Failed to read aggregated receipt\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(report_path).expect(\"Failed to read report file\");"
+count = 8
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = fs::read_to_string(source_path).expect(\"Failed to read source\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content = step.docstring().expect(\"Docstring required\").to_string();"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content1 = fs::read_to_string(export_path1).expect(\"Failed to read export file 1\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content1 = fs::read_to_string(report_path1).expect(\"Failed to read report 1\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content2 = fs::read_to_string(export_path2).expect(\"Failed to read export file 2\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let content2 = fs::read_to_string(report_path2).expect(\"Failed to read report 2\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let current = world.current_host.as_ref().expect(\"Current host not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let current = world.current_path.clone().expect(\"Current path not set\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let err = world.perfgate_error.as_ref().expect(\"Error not set\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let export_path = world.export_path.as_ref().expect(\"No export path set\");"
+count = 4
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let export_path1 = world.export_path.as_ref().expect(\"No export path set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let export_path2 = world.export_path2.as_ref().expect(\"No export path 2 set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let hash = world.computed_hash.as_ref().expect(\"Hash not computed\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let header = output.lines().next().expect(\"No header line\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&receipt).expect(\"Failed to serialize baseline\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&receipt).expect(\"Failed to serialize compare\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&receipt).expect(\"Failed to serialize current\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&receipt).expect(\"Failed to serialize source receipt\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let json = serde_json::to_string_pretty(&receipt).expect(\"Failed to serialize\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let key = world.last_api_key.as_ref().expect(\"No API key generated\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let md_path = world.md_output_path.as_ref().expect(\"No markdown path set\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let median = world.computed_median.expect(\"Median not computed\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mismatch = world.host_mismatch.as_ref().expect(\"No mismatch detected\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute command\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate blame\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate check\");"
+count = 8
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate compare\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate export\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate md\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate paired\");"
+count = 8
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate promote\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate report\");"
+count = 4
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"Failed to execute perfgate run\");"
+count = 9
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = cmd.output().expect(\"failed to run command\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output = world.exported_output.as_ref().expect(\"Output not set\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let output_path = world.output_path.as_ref().expect(\"No output path set\");"
+count = 23
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let receipt: RunReceipt = serde_json::from_str(&content).expect(\"Failed to parse baseline\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let receipt: RunReceipt = serde_json::from_str(&content).expect(\"Failed to parse run receipt\");"
+count = 6
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let receipt: RunReceipt = serde_json::from_str(&content).expect(\"Failed to parse run.json\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report: PerfgateReport = serde_json::from_str(&content).expect(\"Failed to parse report\");"
+count = 7
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report_path = world.report_path.as_ref().expect(\"No report path set\");"
+count = 9
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report_path1 = world.report_path.as_ref().expect(\"No report path set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let report_path2 = world.report_path2.as_ref().expect(\"No report path 2 set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let result = world.budget_result.as_ref().expect(\"Budget result not set\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let role = world.current_role.expect(\"No role set\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let source = world.source_run_path.clone().expect(\"Source path not set\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let summary = summarize_u64(&world.stats_values).expect(\"Failed to compute stats\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let template = world.template_path.clone().expect(\"Template path not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let token = world.reason_token.as_ref().expect(\"Reason token not set\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let toml = toml::to_string_pretty(&config).expect(\"Failed to serialize config\");"
+count = 11
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let toml = toml::to_string_pretty(config).expect(\"Failed to serialize config\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "self.temp_dir = Some(TempDir::new().expect(\"Failed to create temp directory\"));"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_slice(&output.stdout).expect(\"Failed to parse blame JSON output\"),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Baseline file should be valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Failed to parse aggregate receipt\");"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Failed to parse compare receipt\");"
+count = 5
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Failed to parse paired receipt\");"
+count = 8
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Failed to parse report.json\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Failed to parse source\");"
+count = 3
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::from_str(&content).expect(\"Output file should contain valid JSON\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = ".unwrap_or_else(|_| panic!(\"Line {} should be valid JSON: {}\", i + 1, line));"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = ".unwrap_or_else(|| panic!(\"unknown metric: {}\", metric_name)),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"Invalid status: {}\", s),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"Invalid status: {}\", status),"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"Invalid status: {}\", status_str),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"Unknown role: {}\", role_str),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"Unknown scope: {}\", scope_str),"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "_ => panic!(\"unknown status\"),"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "panic"
+selector_kind = "macro"
+selector_callee = "panic!"
+snippet = "panic!(\"Only perfgate commands are supported in this generic step\");"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(change.new_version.as_ref().unwrap(), &new);"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert_eq!(change.old_version.as_ref().unwrap(), &old);"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let current: f64 = row[2].parse().unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&receipt).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string_pretty(&receipt).unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let max = *sorted.last().unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let min = *sorted.first().unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let pct: f64 = row[3].parse().unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "receipt.bench.name = path.file_stem().unwrap().to_string_lossy().to_string();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::create_dir_all(parent).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/cucumber.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "std::fs::write(path, json).unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let comparison = compare_runs(&baseline, &current, &budgets, &BTreeMap::new(), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let delta = comparison.deltas.get(&Metric::WallMs).unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(100.0, 105.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(100.0, 115.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let result = evaluate_budget(100.0, 130.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let sig = delta.significance.as_ref().unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_paired_stats(&samples, None, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/budget_significance_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = perfgate::domain::compute_stats(&sample_vec, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 2
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 9
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let cmp_a = compare_runs(&baseline, &current, &budgets_a, &BTreeMap::new(), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let cmp_b = compare_runs(&baseline, &current, &budgets_b, &BTreeMap::new(), None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let comparison = compare_runs(&baseline, &current, &budgets, &BTreeMap::new(), None).unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let config: ConfigFile = toml::from_str(toml_input).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let config: ConfigFile = toml::from_str(toml_str).unwrap();"
+count = 4
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let delta = comparison.deltas.get(&Metric::WallMs).unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deser_delta = deserialized.deltas.get(&Metric::WallMs).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized: CompareReceipt = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized: PairedRunReceipt = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized: RunReceipt = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized_baseline: RunReceipt = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let global_threshold = config.defaults.threshold.unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let global_warn_factor = config.defaults.warn_factor.unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&baseline).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string_pretty(&receipt).unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string_pretty(&result.receipt).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let orig_budgets = config.benches[0].budgets.as_ref().unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let orig_delta = result.receipt.deltas.get(&Metric::WallMs).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let roundtripped: ConfigFile = toml::from_str(&toml_output).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let rt_budgets = roundtripped.benches[0].budgets.as_ref().unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_stats(&samples, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let threshold_a = ovr_a.threshold.unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let threshold_b = ovr_b.threshold.unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let toml_output = toml::to_string_pretty(&config).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let wall_budget = budgets.get(&Metric::WallMs).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "orig_budgets.get(&Metric::WallMs).unwrap().threshold,"
+count = 1
+
+[[baseline]]
+path = "tests/integration/cross_crate_pipeline.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "rt_budgets.get(&Metric::WallMs).unwrap().threshold"
+count = 1
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv = ExportUseCase::export_compare(&receipt, ExportFormat::Csv).unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv = ExportUseCase::export_run(&receipt, ExportFormat::Csv).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let html = ExportUseCase::export_compare(&receipt, ExportFormat::Html).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let html = ExportUseCase::export_run(&receipt, ExportFormat::Html).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl = ExportUseCase::export_compare(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl = ExportUseCase::export_run(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prom = ExportUseCase::export_compare(&receipt, ExportFormat::Prometheus).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/export_render_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let prom = ExportUseCase::export_run(&receipt, ExportFormat::Prometheus).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "comparison.deltas.get(&Metric::MaxRssKb).unwrap().status,"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "comparison.deltas.get(&Metric::WallMs).unwrap().status,"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let baseline_stats = compute_stats(&baseline_samples, None).unwrap();"
+count = 5
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let comparison = compare_stats(&baseline_stats, &current_stats, &budgets).unwrap();"
+count = 5
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let csv = ExportUseCase::export_run(&receipt, ExportFormat::Csv).unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let current_stats = compute_stats(&current_samples, None).unwrap();"
+count = 5
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let delta = comparison.deltas.get(&Metric::WallMs).unwrap();"
+count = 4
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized: perfgate_types::SensorReport = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let fail = evaluate_budget(100.0, 125.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string_pretty(&sensor_report).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let jsonl = ExportUseCase::export_run(&receipt, ExportFormat::Jsonl).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let parsed: serde_json::Value = serde_json::from_str(line).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let pass = evaluate_budget(100.0, 105.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_stats(&samples, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/full_pipeline_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let warn = evaluate_budget(100.0, 115.0, &budget, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/host_detect_to_app.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/host_detect_to_app.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let info = mismatch.unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/sensor_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let deserialized: perfgate_types::SensorReport = serde_json::from_str(&json).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/sensor_flow.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let json = serde_json::to_string(&sensor_report).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let (mean, variance) = mean_and_variance(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let comparison = compare_stats(&baseline, &current, &budgets).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let delta = comparison.deltas.get(&Metric::WallMs).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p0 = percentile(values.clone(), 0.0).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p100 = percentile(values, 1.0).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p50 = percentile(values.clone(), 0.5).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let p95 = percentile(values.clone(), 0.95).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let stats = compute_stats(&samples, None).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary = summarize_u64(&values).unwrap();"
+count = 3
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary: F64Summary = summarize_f64(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/stats_to_domain.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let summary: U64Summary = summarize_u64(&values).unwrap();"
+count = 1
+
+[[baseline]]
+path = "tests/integration/validation_to_types.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = ".unwrap()"
+count = 2
+
+[[baseline]]
+path = "tests/integration/validation_to_types.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(config.defaults.threshold.unwrap().is_infinite());"
+count = 1
+
+[[baseline]]
+path = "tests/integration/validation_to_types.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "assert!(config.defaults.threshold.unwrap().is_nan());"
+count = 1
+
+[[baseline]]
+path = "tests/integration/validation_to_types.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let budget = config.benches[0].budgets.as_ref().unwrap();"
+count = 2
+
+[[baseline]]
+path = "tests/integration/validation_to_types.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let config: ConfigFile = toml::from_str(toml_str).unwrap();"
+count = 10
+
+[[baseline]]
+path = "tests/integration/validation_to_types.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let metrics = config.benches[0].metrics.as_ref().unwrap();"
+count = 1
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"time\")"
+count = 1
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&dir).expect(\"create temp dir\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let original = std::env::current_dir().expect(\"current dir\");"
+count = 2
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "manifest_dir.parent().expect(\"workspace root\").to_path_buf()"
+count = 1
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "std::env::set_current_dir(&original).expect(\"restore cwd\");"
+count = 2
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "std::env::set_current_dir(&root).expect(\"set repo cwd\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/lib.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "std::env::set_current_dir(&temp_dir).expect(\"set cwd\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"nested dogfood receipt should produce slug\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"panic identity\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"read canonical fixture\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"unwrap identity\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write bad fixture\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write current fixture\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write fixture\");"
+count = 3
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write legacy fixture\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write missed\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write outcomes\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write receipt\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"write source\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "check_fixture_mirror_at(&golden, &contracts).expect(\"mirror check ok\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_conform(None, Some(path)).expect(\"conform should succeed\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_conform(Some(temp_dir.clone()), None).expect(\"fixtures dir should validate\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_schema(&out_dir).expect(\"schema command\");"
+count = 5
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_schema_check(&out_dir).expect(\"schema check should pass\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_schema_compat(&root).expect(\"baseline service compat fixture should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_schema_compat(&root).expect(\"compat fixture should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_schema_compat(&root).expect(\"schema-less audit fixture should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "cmd_schema_compat(&root).expect(\"schema-less health fixtures should deserialize\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&contracts).expect(\"create contracts dir\");"
+count = 3
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&current_dir).expect(\"create current fixture dir\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&golden).expect(\"create golden dir\");"
+count = 4
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&legacy_dir).expect(\"create legacy fixture dir\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&outcomes_dir).expect(\"create mutants.out\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&src).expect(\"create src dir\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::create_dir_all(&version_dir).expect(\"create fixture dir\");"
+count = 3
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::remove_file(out_dir.join(SCHEMA_FILES[0])).expect(\"remove file\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&bad_path, r#\"{\"schema\":\"sensor.report.v1\"}\"#).expect(\"write bad file\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(contracts.join(\"sensor_report_diff.json\"), \"contracts\").expect(\"write contracts\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(contracts.join(\"sensor_report_ok.json\"), \"same\").expect(\"write contracts\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"not_sensor.json\"), \"no\").expect(\"write other\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"sensor_report.txt\"), \"no\").expect(\"write txt\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"sensor_report_a.json\"), \"a\").expect(\"write a\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"sensor_report_b.json\"), \"b\").expect(\"write b\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"sensor_report_diff.json\"), \"golden\").expect(\"write golden\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"sensor_report_missing.json\"), \"one\").expect(\"write missing\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(golden.join(\"sensor_report_ok.json\"), \"same\").expect(\"write golden\");"
+count = 2
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(out_dir.join(\"unexpected.schema.json\"), \"{}\").expect(\"write extra\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(out_dir.join(SCHEMA_FILES[1]), \"{}\").expect(\"rewrite schema\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(temp_dir.join(\"third_party_report.json\"), valid).expect(\"write fixture\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let bytes = fs::read(&path).expect(\"read schema\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let count = sync_fixtures(&golden, &contracts).expect(\"sync fixtures\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let findings = scan_no_panic_family(&root).expect(\"scan no-panic family\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "select_publishable_packages(&metadata, &requested).expect(\"selected packages\"),"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "serde_json::to_vec(&receipt).expect(\"serialize receipt\"),"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "validate_dogfood_run_receipt(&path).expect(\"successful samples should validate\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "validate_versioned_json_example(value).expect(\"valid run receipt\"),"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::read_to_string(contracts.join(\"sensor_report_a.json\")).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "fs::read_to_string(contracts.join(\"sensor_report_b.json\")).unwrap(),"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let contract_path = contracts_dir.join(path.file_name().unwrap());"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let dest = contracts_dir.join(path.file_name().unwrap());"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let flags = parse_flags_from_help(help).unwrap();"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let golden_path = golden_dir.join(path.file_name().unwrap());"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "let subs = parse_subcommands_from_help(help).unwrap();"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "path.file_name().unwrap().to_string_lossy()"
+count = 3
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"run xtask mutants\");"
+count = 1
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"run xtask publish-check\");"
+count = 1
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"run xtask schema\");"
+count = 1
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::set_permissions(&script, perms).expect(\"chmod cargo\");"
+count = 1
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&script, \"#!/bin/sh\\nexit 2\\n\").expect(\"write fake cargo\");"
+count = 1
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "fs::write(&script, \"@echo off\\r\\nexit /b 2\\r\\n\").expect(\"write fake cargo\");"
+count = 1
+
+[[baseline]]
+path = "xtask/tests/xtask_smoke_tests.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let mut perms = fs::metadata(&script).expect(\"stat cargo\").permissions();"
+count = 1

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1522,18 +1522,15 @@ fn write_no_panic_baseline(
 ) -> anyhow::Result<()> {
     let mut output = String::new();
     output.push_str("schema_version = \"1.0\"\n");
-    output.push_str("generated_by = \"cargo run -p xtask -- policy check-no-panic-family --write-baseline\"\n\n");
+    output.push_str(
+        "generated_by = \"cargo run -p xtask -- policy check-no-panic-family --write-baseline\"\n",
+    );
 
-    let mut first_entry = true;
     for finding in findings {
         if is_no_panic_allowed(&finding.identity, allowlist) {
             continue;
         }
-        if first_entry {
-            first_entry = false;
-        } else {
-            output.push('\n');
-        }
+        output.push('\n');
         output.push_str("[[baseline]]\n");
         output.push_str("path = ");
         output.push_str(&toml_basic_string(&finding.identity.path));

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -277,9 +277,13 @@ enum PolicyAction {
         #[arg(long, default_value = "policy/no-panic-allowlist.toml")]
         allowlist: PathBuf,
 
-        /// Fail when a detected identity is not listed in the allowlist.
+        /// Generated no-panic baseline file.
+        #[arg(long, default_value = "policy/no-panic-baseline.toml")]
+        baseline: PathBuf,
+
+        /// Refresh the generated baseline after validating it will not absorb new debt.
         #[arg(long)]
-        fail_on_unlisted: bool,
+        write_baseline: bool,
     },
 }
 
@@ -310,8 +314,9 @@ fn main() -> anyhow::Result<()> {
             PolicyAction::CheckNoPanicFamily {
                 root,
                 allowlist,
-                fail_on_unlisted,
-            } => cmd_check_no_panic_family(&root, &allowlist, fail_on_unlisted),
+                baseline,
+                write_baseline,
+            } => cmd_check_no_panic_family(&root, &allowlist, &baseline, write_baseline),
         },
         Command::Arch => cmd_arch(),
         Command::Conform { fixtures, file } => cmd_conform(fixtures, file),
@@ -1224,6 +1229,13 @@ struct NoPanicAllowlist {
 }
 
 #[derive(Debug, Deserialize)]
+struct NoPanicBaseline {
+    schema_version: String,
+    #[serde(default)]
+    baseline: Vec<NoPanicBaselineEntry>,
+}
+
+#[derive(Debug, Deserialize)]
 struct NoPanicAllowance {
     path: String,
     family: String,
@@ -1234,6 +1246,16 @@ struct NoPanicAllowance {
     owner: String,
     reason: String,
     review_after: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct NoPanicBaselineEntry {
+    path: String,
+    family: String,
+    selector_kind: String,
+    selector_callee: String,
+    snippet: String,
+    count: u32,
 }
 
 impl NoPanicAllowance {
@@ -1248,14 +1270,38 @@ impl NoPanicAllowance {
     }
 }
 
+impl NoPanicBaselineEntry {
+    fn identity(&self) -> NoPanicIdentity {
+        NoPanicIdentity {
+            path: self.path.clone(),
+            family: self.family.clone(),
+            selector_kind: self.selector_kind.clone(),
+            selector_callee: self.selector_callee.clone(),
+            snippet: self.snippet.clone(),
+        }
+    }
+}
+
 fn cmd_check_no_panic_family(
     root: &Path,
     allowlist: &Path,
-    fail_on_unlisted: bool,
+    baseline: &Path,
+    write_baseline: bool,
 ) -> anyhow::Result<()> {
     let findings = scan_no_panic_family(root)?;
     let allowlist = read_no_panic_allowlist(allowlist)?;
-    let errors = collect_no_panic_policy_errors(&findings, &allowlist, fail_on_unlisted);
+    let baseline_exists = baseline.exists();
+    let no_panic_baseline = if baseline_exists {
+        Some(read_no_panic_baseline(baseline)?)
+    } else if write_baseline {
+        None
+    } else {
+        anyhow::bail!(
+            "no-panic baseline {} is missing; run `cargo run -p xtask -- policy check-no-panic-family --write-baseline` to create the initial generated baseline",
+            baseline.display()
+        );
+    };
+    let errors = collect_no_panic_policy_errors(&findings, &allowlist, no_panic_baseline.as_ref());
 
     if !errors.is_empty() {
         println!("Found {} no-panic policy error(s):", errors.len());
@@ -1269,31 +1315,51 @@ fn cmd_check_no_panic_family(
         );
     }
 
+    if write_baseline {
+        write_no_panic_baseline(baseline, &findings, &allowlist)?;
+        println!(
+            "  OK  wrote generated no-panic baseline to {}",
+            baseline.display()
+        );
+        return Ok(());
+    }
+
+    let Some(baseline) = no_panic_baseline.as_ref() else {
+        anyhow::bail!("no-panic baseline was not loaded");
+    };
     let total_callsites: u32 = findings.iter().map(|finding| finding.count).sum();
     let allowed_callsites: u32 = allowlist
         .allow
         .iter()
         .map(|allowance| allowance.count)
         .sum();
-    let unlisted_identities = findings
+    let baseline_callsites: u32 = baseline.baseline.iter().map(|entry| entry.count).sum();
+    let baseline_refresh_candidates =
+        count_no_panic_baseline_refresh_candidates(&findings, &allowlist, baseline);
+    let unbaselined_identities = findings
         .iter()
         .filter(|finding| {
-            !allowlist
-                .allow
-                .iter()
-                .any(|allowance| allowance.identity() == finding.identity)
+            !is_no_panic_allowed(&finding.identity, &allowlist)
+                && !baseline
+                    .baseline
+                    .iter()
+                    .any(|entry| entry.identity() == finding.identity)
         })
         .count();
 
-    println!("  OK  no-panic allowlist identities are exact and current");
+    println!("  OK  no-panic baseline rejects new unallowlisted debt");
     println!(
         "      scanned {} exact panic-family identity/identities ({} callsite(s))",
         findings.len(),
         total_callsites
     );
     println!(
-        "      allowlist covers {} callsite(s); {} unlisted identity/identities await baseline policy",
-        allowed_callsites, unlisted_identities
+        "      allowlist covers {} callsite(s); baseline covers {} callsite(s)",
+        allowed_callsites, baseline_callsites
+    );
+    println!(
+        "      {} unbaselined identity/identities; {} baseline entry/entries can shrink or disappear on refresh",
+        unbaselined_identities, baseline_refresh_candidates
     );
     Ok(())
 }
@@ -1306,10 +1372,18 @@ fn read_no_panic_allowlist(path: &Path) -> anyhow::Result<NoPanicAllowlist> {
     Ok(allowlist)
 }
 
+fn read_no_panic_baseline(path: &Path) -> anyhow::Result<NoPanicBaseline> {
+    let content =
+        fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let baseline: NoPanicBaseline =
+        toml::from_str(&content).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(baseline)
+}
+
 fn collect_no_panic_policy_errors(
     findings: &[NoPanicFinding],
     allowlist: &NoPanicAllowlist,
-    fail_on_unlisted: bool,
+    baseline: Option<&NoPanicBaseline>,
 ) -> Vec<String> {
     let mut errors = Vec::new();
 
@@ -1352,19 +1426,188 @@ fn collect_no_panic_policy_errors(
         }
     }
 
-    if fail_on_unlisted {
-        for finding in findings {
-            if !seen.contains(&finding.identity) {
-                errors.push(format!(
-                    "unlisted panic-family identity: {} count={}",
-                    format_no_panic_identity(&finding.identity),
-                    finding.count
-                ));
-            }
-        }
+    if let Some(baseline) = baseline {
+        collect_no_panic_baseline_errors(findings, allowlist, baseline, &mut errors);
     }
 
     errors
+}
+
+fn collect_no_panic_baseline_errors(
+    findings: &[NoPanicFinding],
+    allowlist: &NoPanicAllowlist,
+    baseline: &NoPanicBaseline,
+    errors: &mut Vec<String>,
+) {
+    if baseline.schema_version != "1.0" {
+        errors.push(format!(
+            "policy/no-panic-baseline.toml schema_version must be 1.0, found {}",
+            baseline.schema_version
+        ));
+    }
+
+    let mut baseline_counts = BTreeMap::new();
+    let mut seen = BTreeSet::new();
+    for entry in &baseline.baseline {
+        validate_no_panic_baseline_entry(entry, errors);
+        let identity = entry.identity();
+        if !seen.insert(identity.clone()) {
+            errors.push(format!(
+                "duplicate no-panic baseline identity: {}",
+                format_no_panic_identity(&identity)
+            ));
+            continue;
+        }
+        baseline_counts.insert(identity, entry.count);
+    }
+
+    for finding in findings {
+        if is_no_panic_allowed(&finding.identity, allowlist) {
+            continue;
+        }
+        match baseline_counts.get(&finding.identity) {
+            Some(expected) if finding.count <= *expected => {}
+            Some(expected) => errors.push(format!(
+                "no-panic baseline count increased for {}: baseline {}, found {}",
+                format_no_panic_identity(&finding.identity),
+                expected,
+                finding.count
+            )),
+            None => errors.push(format!(
+                "new unbaselined panic-family identity: {} count={}",
+                format_no_panic_identity(&finding.identity),
+                finding.count
+            )),
+        }
+    }
+}
+
+fn count_no_panic_baseline_refresh_candidates(
+    findings: &[NoPanicFinding],
+    allowlist: &NoPanicAllowlist,
+    baseline: &NoPanicBaseline,
+) -> usize {
+    let finding_counts: BTreeMap<_, _> = findings
+        .iter()
+        .map(|finding| (finding.identity.clone(), finding.count))
+        .collect();
+
+    baseline
+        .baseline
+        .iter()
+        .filter(|entry| {
+            let identity = entry.identity();
+            if is_no_panic_allowed(&identity, allowlist) {
+                return true;
+            }
+            match finding_counts.get(&identity) {
+                Some(count) => *count < entry.count,
+                None => true,
+            }
+        })
+        .count()
+}
+
+fn is_no_panic_allowed(identity: &NoPanicIdentity, allowlist: &NoPanicAllowlist) -> bool {
+    allowlist
+        .allow
+        .iter()
+        .any(|allowance| allowance.identity() == *identity)
+}
+
+fn write_no_panic_baseline(
+    path: &Path,
+    findings: &[NoPanicFinding],
+    allowlist: &NoPanicAllowlist,
+) -> anyhow::Result<()> {
+    let mut output = String::new();
+    output.push_str("schema_version = \"1.0\"\n");
+    output.push_str("generated_by = \"cargo run -p xtask -- policy check-no-panic-family --write-baseline\"\n\n");
+
+    let mut first_entry = true;
+    for finding in findings {
+        if is_no_panic_allowed(&finding.identity, allowlist) {
+            continue;
+        }
+        if first_entry {
+            first_entry = false;
+        } else {
+            output.push('\n');
+        }
+        output.push_str("[[baseline]]\n");
+        output.push_str("path = ");
+        output.push_str(&toml_basic_string(&finding.identity.path));
+        output.push('\n');
+        output.push_str("family = ");
+        output.push_str(&toml_basic_string(&finding.identity.family));
+        output.push('\n');
+        output.push_str("selector_kind = ");
+        output.push_str(&toml_basic_string(&finding.identity.selector_kind));
+        output.push('\n');
+        output.push_str("selector_callee = ");
+        output.push_str(&toml_basic_string(&finding.identity.selector_callee));
+        output.push('\n');
+        output.push_str("snippet = ");
+        output.push_str(&toml_basic_string(&finding.identity.snippet));
+        output.push('\n');
+        output.push_str("count = ");
+        output.push_str(&finding.count.to_string());
+        output.push('\n');
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(path, output).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+fn toml_basic_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            ch if ch.is_ascii_graphic() || ch == ' ' => out.push(ch),
+            ch => {
+                let code = ch as u32;
+                if code <= 0xFFFF {
+                    out.push_str(&format!("\\u{code:04X}"));
+                } else {
+                    out.push_str(&format!("\\U{code:08X}"));
+                }
+            }
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn validate_no_panic_baseline_entry(entry: &NoPanicBaselineEntry, errors: &mut Vec<String>) {
+    let identity = entry.identity();
+    let formatted = format_no_panic_identity(&identity);
+    for (field, value) in [
+        ("path", entry.path.as_str()),
+        ("family", entry.family.as_str()),
+        ("selector_kind", entry.selector_kind.as_str()),
+        ("selector_callee", entry.selector_callee.as_str()),
+        ("snippet", entry.snippet.as_str()),
+    ] {
+        if value.trim().is_empty() {
+            errors.push(format!(
+                "no-panic baseline field `{field}` must be non-empty for {formatted}"
+            ));
+        }
+    }
+    if entry.count == 0 {
+        errors.push(format!(
+            "no-panic baseline count must be positive for {formatted}"
+        ));
+    }
 }
 
 fn validate_no_panic_allowance(allowance: &NoPanicAllowance, errors: &mut Vec<String>) {
@@ -4612,6 +4855,17 @@ mod tests {
         }
     }
 
+    fn no_panic_baseline_entry(identity: &NoPanicIdentity, count: u32) -> NoPanicBaselineEntry {
+        NoPanicBaselineEntry {
+            path: identity.path.clone(),
+            family: identity.family.clone(),
+            selector_kind: identity.selector_kind.clone(),
+            selector_callee: identity.selector_callee.clone(),
+            snippet: identity.snippet.clone(),
+            count,
+        }
+    }
+
     #[test]
     fn no_panic_scanner_uses_exact_counted_identities() {
         let root = unique_temp_dir("perfgate_no_panic_scan");
@@ -4666,7 +4920,7 @@ fn demo(value: Option<u8>) {
     }
 
     #[test]
-    fn no_panic_allowlist_rejects_count_drift_and_unlisted_strict_identities() {
+    fn no_panic_allowlist_rejects_count_drift() {
         let identity = no_panic_identity(
             "crates/example/src/lib.rs",
             "expect",
@@ -4683,28 +4937,93 @@ fn demo(value: Option<u8>) {
             schema_version: "1.0".to_string(),
             allow: vec![no_panic_allowance(&identity, 2)],
         };
-        assert!(collect_no_panic_policy_errors(&findings, &exact, true).is_empty());
+        assert!(collect_no_panic_policy_errors(&findings, &exact, None).is_empty());
 
         let drifted = NoPanicAllowlist {
             schema_version: "1.0".to_string(),
             allow: vec![no_panic_allowance(&identity, 1)],
         };
-        let errors = collect_no_panic_policy_errors(&findings, &drifted, false);
+        let errors = collect_no_panic_policy_errors(&findings, &drifted, None);
         assert!(
             errors.iter().any(|error| error.contains("count mismatch")),
             "expected count mismatch, got {errors:?}"
         );
+    }
 
-        let strict = NoPanicAllowlist {
+    #[test]
+    fn no_panic_baseline_rejects_new_or_increased_unallowed_debt() {
+        let identity = no_panic_identity(
+            "crates/example/src/lib.rs",
+            "expect",
+            "method",
+            "expect",
+            "value.expect(\"present\")",
+        );
+        let findings = vec![NoPanicFinding {
+            identity: identity.clone(),
+            count: 2,
+        }];
+
+        let allowlist = NoPanicAllowlist {
             schema_version: "1.0".to_string(),
             allow: Vec::new(),
         };
-        let errors = collect_no_panic_policy_errors(&findings, &strict, true);
+        let exact = NoPanicBaseline {
+            schema_version: "1.0".to_string(),
+            baseline: vec![no_panic_baseline_entry(&identity, 2)],
+        };
+        assert!(collect_no_panic_policy_errors(&findings, &allowlist, Some(&exact)).is_empty());
+
+        let increased = NoPanicBaseline {
+            schema_version: "1.0".to_string(),
+            baseline: vec![no_panic_baseline_entry(&identity, 1)],
+        };
+        let errors = collect_no_panic_policy_errors(&findings, &allowlist, Some(&increased));
+        assert!(
+            errors.iter().any(|error| error.contains("count increased")),
+            "expected baseline count increase, got {errors:?}"
+        );
+
+        let empty = NoPanicBaseline {
+            schema_version: "1.0".to_string(),
+            baseline: Vec::new(),
+        };
+        let errors = collect_no_panic_policy_errors(&findings, &allowlist, Some(&empty));
         assert!(
             errors
                 .iter()
-                .any(|error| error.contains("unlisted panic-family identity")),
-            "expected strict unlisted error, got {errors:?}"
+                .any(|error| error.contains("new unbaselined panic-family identity")),
+            "expected new unbaselined error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn no_panic_baseline_allows_decreased_or_disappeared_debt() {
+        let identity = no_panic_identity(
+            "crates/example/src/lib.rs",
+            "expect",
+            "method",
+            "expect",
+            "value.expect(\"present\")",
+        );
+        let baseline = NoPanicBaseline {
+            schema_version: "1.0".to_string(),
+            baseline: vec![no_panic_baseline_entry(&identity, 2)],
+        };
+        let allowlist = NoPanicAllowlist {
+            schema_version: "1.0".to_string(),
+            allow: Vec::new(),
+        };
+
+        let decreased = vec![NoPanicFinding {
+            identity: identity.clone(),
+            count: 1,
+        }];
+        assert!(collect_no_panic_policy_errors(&decreased, &allowlist, Some(&baseline)).is_empty());
+        assert!(collect_no_panic_policy_errors(&[], &allowlist, Some(&baseline)).is_empty());
+        assert_eq!(
+            count_no_panic_baseline_refresh_candidates(&decreased, &allowlist, &baseline),
+            1
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds policy/no-panic-baseline.toml as the generated no-new-debt panic-family baseline and marks it generated with LF line endings in .gitattributes.
- Extends xtask policy check-no-panic-family to load the baseline and reject new unallowlisted identities or count increases.
- Adds --write-baseline refresh support that drops or decreases disappeared debt but fails before writing if it would absorb new unallowlisted debt.
- Updates no-panic docs, rollout state, and changelog for the active baseline gate.

## Baseline
- 1414 exact panic-family identities
- 2823 callsites
- allowlist covers 0 callsites
- policy check reports 0 unbaselined identities

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p xtask --all-features no_panic
- cargo +1.95.0 test -p xtask --all-features
- cargo +1.95.0 clippy -p xtask --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- policy check-no-panic-family
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- action-check
- cargo +1.95.0 run -p xtask -- public-surface --strict
- cargo +1.95.0 run -p xtask -- arch
- git diff --check