### PR TITLE
refactor: use Rust 1.95 APIs in decision and policy builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   files, executable bits, dependency surfaces, and governed repository files.
 - Routed expensive fuzz and self-dogfood evidence lanes behind explicit labels,
   `main`, schedules, or manual dispatch instead of ordinary unlabeled PRs.
+- Applied targeted Rust 1.95 API cleanup in summary row, decision artifact
+  index, and publishability builders.
 
 ## [0.16.0] - 2026-05-11
 

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -4697,17 +4697,13 @@ fn build_decision_artifact_index(
     let mut compare_receipts = BTreeSet::new();
 
     for component in &scenario.components {
-        if let Some(path) = component
-            .probe_compare_ref
-            .as_ref()
-            .and_then(|reference| reference.path.as_ref())
+        if let Some(reference) = &component.probe_compare_ref
+            && let Some(path) = reference.path.as_ref()
         {
             probe_compares.insert(normalize_artifact_path(path));
         }
-        if let Some(path) = component
-            .compare_ref
-            .as_ref()
-            .and_then(|reference| reference.path.as_ref())
+        if let Some(reference) = &component.compare_ref
+            && let Some(path) = reference.path.as_ref()
         {
             compare_receipts.insert(normalize_artifact_path(path));
         }

--- a/crates/perfgate/src/app/render/summary.rs
+++ b/crates/perfgate/src/app/render/summary.rs
@@ -76,9 +76,6 @@ impl SummaryUseCase {
 
             let benchmark = compare.bench.name.clone();
             let status = format!("{:?}", compare.verdict.status).to_lowercase();
-            if status == "fail" {
-                failed = true;
-            }
             let wall = compare.deltas.get(&Metric::WallMs);
             let (wall_ms, change_pct) = if let Some(d) = wall {
                 (
@@ -89,12 +86,15 @@ impl SummaryUseCase {
                 ("N/A".to_string(), "N/A".to_string())
             };
 
-            rows.push(SummaryRow {
+            let row = rows.push_mut(SummaryRow {
                 benchmark,
                 status,
                 wall_ms,
                 change_pct,
             });
+            if row.status == "fail" {
+                failed = true;
+            }
         }
 
         Ok(SummaryOutcome { rows, failed })

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2578,10 +2578,12 @@ fn rust_code_before_comment(line: &str) -> &str {
 }
 
 fn is_publishable(package: &MetadataPackage) -> bool {
-    match &package.publish {
-        None => true,
-        Some(registries) => !registries.is_empty(),
+    if let Some(registries) = &package.publish
+        && registries.is_empty()
+    {
+        return false;
     }
+    true
 }
 
 fn resolve_manifest_relative_path(manifest_path: &Path, relative_path: &Path) -> PathBuf {


### PR DESCRIPTION
## Summary
- Use Rust 1.95 `Vec::push_mut` in the summary row builder while preserving the failed-row verdict behavior.
- Use Rust 1.95 let-chain guards in decision artifact indexing and publishability classification.
- Add an Unreleased changelog note for the targeted Rust 1.95 cleanup.

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p perfgate --all-features summary`
- `cargo +1.95.0 test -p perfgate-cli --all-features decision`
- `cargo +1.95.0 test -p xtask select_publishable_packages_filters_requested_packages_in_release_order`
- `cargo +1.95.0 clippy -p perfgate -p perfgate-cli -p xtask --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- public-surface --strict`
- `cargo +1.95.0 run -p xtask -- arch`
- `cargo +1.95.0 run -p xtask -- policy check-no-panic-family`
- `git diff --check`