### PR TITLE
release: prepare 0.17.0 for Rust 1.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-12
+
 ### Added
 - Planned the Rust 1.95 and 0.17.0 governance rollout for staged Clippy,
   no-panic, non-Rust file-surface, CI evidence-lane, and release-proof policy.
 
 ### Changed
+- Bumped the workspace and internal crate versions to `0.17.0`.
 - Raised the declared Rust MSRV, local toolchain, and hosted Rust workflow pins
   to Rust 1.95.
 - Enabled the Rust 1.95 compiler lint floor while keeping `unsafe_code` at

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -134,18 +134,18 @@ wiremock = "0.6"
 libc = "0.2.182"
 
 # Internal crates
-perfgate-error = { path = "crates/perfgate-error", version = "0.16.0" }
-perfgate-api = { path = "crates/perfgate-api", version = "0.16.0" }
-perfgate-types = { path = "crates/perfgate-types", version = "0.16.0" }
-perfgate-domain = { path = "crates/perfgate-domain", version = "0.16.0" }
-perfgate-paired = { path = "crates/perfgate-paired", version = "0.16.0" }
-perfgate-render = { path = "crates/perfgate-render", version = "0.16.0" }
-perfgate-export = { path = "crates/perfgate-export", version = "0.16.0" }
-perfgate-sensor = { path = "crates/perfgate-sensor", version = "0.16.0" }
-perfgate-fake = { path = "crates/perfgate-fake", version = "0.16.0" }
-perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.16.0" }
-perfgate-app = { path = "crates/perfgate-app", version = "0.16.0" }
-perfgate-server = { path = "crates/perfgate-server", version = "0.16.0" }
-perfgate-client = { path = "crates/perfgate-client", version = "0.16.0" }
-perfgate-github = { path = "crates/perfgate-github", version = "0.16.0" }
-perfgate = { path = "crates/perfgate", version = "0.16.0" }
+perfgate-error = { path = "crates/perfgate-error", version = "0.17.0" }
+perfgate-api = { path = "crates/perfgate-api", version = "0.17.0" }
+perfgate-types = { path = "crates/perfgate-types", version = "0.17.0" }
+perfgate-domain = { path = "crates/perfgate-domain", version = "0.17.0" }
+perfgate-paired = { path = "crates/perfgate-paired", version = "0.17.0" }
+perfgate-render = { path = "crates/perfgate-render", version = "0.17.0" }
+perfgate-export = { path = "crates/perfgate-export", version = "0.17.0" }
+perfgate-sensor = { path = "crates/perfgate-sensor", version = "0.17.0" }
+perfgate-fake = { path = "crates/perfgate-fake", version = "0.17.0" }
+perfgate-adapters = { path = "crates/perfgate-adapters", version = "0.17.0" }
+perfgate-app = { path = "crates/perfgate-app", version = "0.17.0" }
+perfgate-server = { path = "crates/perfgate-server", version = "0.17.0" }
+perfgate-client = { path = "crates/perfgate-client", version = "0.17.0" }
+perfgate-github = { path = "crates/perfgate-github", version = "0.17.0" }
+perfgate = { path = "crates/perfgate", version = "0.17.0" }

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The generated GitHub workflow uses the repository action:
     upload_artifact: "true"
 ```
 
-Use `@v0.16.0` for an exact patch pin, or `@v0.16` / `@v0` to follow the
+Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
 current compatible action tag.
 
 ## Performance Decisions

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
     required: false
     default: "perfgate-artifacts"
   version:
-    description: "Optional perfgate-cli crate version from crates.io (e.g. 0.16.0); if empty, builds from this action source"
+    description: "Optional perfgate-cli crate version from crates.io (e.g. 0.17.0); if empty, builds from this action source"
     required: false
     default: ""
   comment:
@@ -172,7 +172,7 @@ runs:
       if: steps.install_binary.outputs.installed != 'true'
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: 1.93.0
+        toolchain: 1.95.0
 
     - name: Install perfgate (cargo install fallback)
       if: steps.install_binary.outputs.installed != 'true'

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -1,7 +1,7 @@
 # Getting Started with the Baseline Server
 
 This guide documents the current, shipped baseline-server workflow in
-`perfgate 0.16.0`. Every CLI example below has been validated against the
+`perfgate 0.17.0`. Every CLI example below has been validated against the
 actual binary. It intentionally focuses on commands and flags that exist today.
 
 ## Pick a Mode
@@ -244,7 +244,7 @@ inspect server logs for the full database error.
 ```json
 {
   "status": "healthy",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "storage": {
     "backend": "postgres",
     "status": "healthy"

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.16.0
+        uses: EffortlessMetrics/perfgate@v0.17.0
         with:
           config: perfgate.toml
           all: "true"
@@ -85,8 +85,8 @@ Omit `out_dir` to let the action use `[defaults].out_dir` from
 `perfgate.toml`. Set `out_dir` only when the workflow should override the
 config.
 
-Use `@v0.16.0` when you want an exact patch pin. If you prefer a moving tag,
-the published action aliases `@v0.15` and `@v0` now track the current
+Use `@v0.17.0` when you want an exact patch pin. If you prefer a moving tag,
+the published action aliases `@v0.17` and `@v0` now track the current
 compatible release.
 
 Action outputs are available as:
@@ -109,7 +109,7 @@ comment, opt in to decision mode:
 ```yaml
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.16.0
+        uses: EffortlessMetrics/perfgate@v0.17.0
         with:
           config: perfgate.toml
           all: "true"

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,27 +1,34 @@
 # Release Readiness
 
-Last verified: 2026-05-11 after merging PR #338 (release prep for v0.16.0) and PR #337
-(`publish-check` dry-run matrix repair).
+Last prepared: 2026-05-12 for the v0.17.0 release-candidate branch after the
+Rust 1.95 governance ladder through PR #349.
 
-## Current Main Snapshot
+Latest published release: v0.16.0. Do not call v0.17.0 published until the
+release-proof PR validates the publish matrix, creates the tag, and publishes
+the five allowed crates.
 
-Verified on 2026-05-11 after merging PRs #333 through #337 and #338.
+## Current Release Candidate Snapshot
 
-The `main` branch is published as `v0.16.0` and the 0.16 public crate surface,
-paved first-run workflow, baseline-service operations, and structured performance
-decision workflow are in their intended release shape:
+The release candidate is versioned as `v0.17.0`. It keeps the five-crate public
+surface from v0.16.0, raises the Rust floor to 1.95, and adds the governance
+rails that make the release conveyor explicit:
 
 | Gate | Status | Evidence |
 |------|--------|----------|
+| Rust 1.95 floor | Passing | `Cargo.toml`, `rust-toolchain.toml`, hosted workflow pins, and the composite action fallback toolchain use Rust 1.95 |
+| Rust and Clippy policy | Passing | `clippy.toml`, `policy/clippy-lints.toml`, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` |
+| No-panic governance | Passing | `cargo run -p xtask -- policy check-no-panic-family` and `policy/no-panic-baseline.toml` |
+| Non-Rust file governance | Documented | `policy/non-rust-allowlist.toml`, companion allowlists, `docs/FILE_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md` |
+| CI evidence lane routing | Documented | `docs/ci/test-evidence-lanes.md`, with expensive fuzz, coverage, and self-dogfood lanes routed by label, `main`, schedule, or manual dispatch |
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
 | Architecture boundary enforcement | Passing | `cargo run -p xtask -- arch` |
 | Publish metadata preflight | Passing | `cargo run -p xtask -- publish-check` |
 | Package file-list proof | Passing | `cargo run -p xtask -- publish-check --package-list` |
 | Adoption path docs | Covered | `README.md`, `docs/PERFORMANCE_DECISIONS.md` |
-| Publish dry-run proof | Per-package release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
-| Publish dry-run matrix | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
+| Publish dry-run proof | Release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
+| Publish dry-run matrix | Release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
-| Install smoke proof | Verified | `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force` and `cargo-binstall perfgate-cli --version 0.16.0 --force` |
+| Install smoke proof | Release gate | Before publish: `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force`; after publish: `cargo-binstall perfgate-cli --version 0.17.0 --force` |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |
 | Documentation examples | Passing | `cargo run -p xtask -- docs-check` and `cargo run -p xtask -- doc-test` |
 | Structured decision end-to-end | Verified | `perfgate ingest probes`, `perfgate decision evaluate`, `perfgate decision bundle` on `examples/performance-decision`, plus `perfgate serve --no-open` and `decision upload/history/debt/prune --dry-run` |
@@ -31,7 +38,7 @@ decision workflow are in their intended release shape:
 | Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, and dashboard decision-ledger tests |
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
-| Full repo CI | Passing | Hosted `ci`, `Coverage`, and `perfgate-self` on merge commit `2cda12c`; PR #338 also passed `fuzz` |
+| Full repo CI | Release gate | Hosted `ci` on the release PR, with coverage, fuzz, and self-dogfood evidence routed by policy before tagging |
 
 The only publishable packages allowed by policy are:
 
@@ -43,7 +50,7 @@ perfgate-client
 perfgate-server
 ```
 
-Release proof commands run for v0.16.0 (run without `--allow-dirty`):
+Required release proof commands for v0.17.0 (run without `--allow-dirty`):
 
 ```bash
 cargo run -p xtask -- public-surface --strict
@@ -70,7 +77,7 @@ For PR validation before the branch is committed or while release notes are stil
 being edited, `publish-check` also accepts `--allow-dirty`. Release operators
 should omit it.
 
-The GitHub release workflow (published as v0.16.0) builds platform archives,
+The GitHub release workflow for v0.17.0 builds platform archives,
 unpacks each generated archive, verifies the binary exists, and runs
 `perfgate --version` plus `perfgate doctor --help` on native targets before
 uploading release assets.

--- a/examples/performance-decision/receipts/large-file.compare.json
+++ b/examples/performance-decision/receipts/large-file.compare.json
@@ -2,7 +2,7 @@
   "schema": "perfgate.compare.v1",
   "tool": {
     "name": "perfgate",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "bench": {
     "name": "large-file",

--- a/examples/performance-decision/receipts/small-edit.compare.json
+++ b/examples/performance-decision/receipts/small-edit.compare.json
@@ -2,7 +2,7 @@
   "schema": "perfgate.compare.v1",
   "tool": {
     "name": "perfgate",
-    "version": "0.16.0"
+    "version": "0.17.0"
   },
   "bench": {
     "name": "small-edit",


### PR DESCRIPTION
## Summary
- Bump the workspace and internal crate dependency versions to `0.17.0`.
- Move changelog entries into the `0.17.0` release section and update README/action/getting-started examples to `v0.17.0` / `v0.17`.
- Refresh release-readiness truth for a 0.17.0 release candidate, keeping v0.16.0 as the latest published release until release proof/tag/publish.
- Update the composite action fallback toolchain to Rust 1.95 and refresh performance-decision example receipt versions.

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 check --workspace --all-targets --all-features --locked`
- `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0 test --workspace --all-targets --all-features --locked`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- action-check`
- `cargo +1.95.0 run -p xtask -- public-surface --strict`
- `cargo +1.95.0 run -p xtask -- arch`
- `cargo +1.95.0 run -p xtask -- schema-compat`
- `cargo +1.95.0 run -p xtask -- publish-check`
- `cargo +1.95.0 run -p xtask -- publish-check --package-list`
- `cargo +1.95.0 run -p xtask -- policy check-no-panic-family`
- `git diff --check`