### PR TITLE
release: validate 0.17.0 publish readiness

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,7 +1,7 @@
 # Release Readiness
 
-Last prepared: 2026-05-12 for the v0.17.0 release-candidate branch after the
-Rust 1.95 governance ladder through PR #349.
+Last verified: 2026-05-12 for v0.17.0 publish readiness. See
+[v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md).
 
 Latest published release: v0.16.0. Do not call v0.17.0 published until the
 release-proof PR validates the publish matrix, creates the tag, and publishes
@@ -25,8 +25,8 @@ rails that make the release conveyor explicit:
 | Publish metadata preflight | Passing | `cargo run -p xtask -- publish-check` |
 | Package file-list proof | Passing | `cargo run -p xtask -- publish-check --package-list` |
 | Adoption path docs | Covered | `README.md`, `docs/PERFORMANCE_DECISIONS.md` |
-| Publish dry-run proof | Release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
-| Publish dry-run matrix | Release gate | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
+| Publish dry-run proof | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
+| Publish dry-run matrix | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
 | Install smoke proof | Release gate | Before publish: `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force`; after publish: `cargo-binstall perfgate-cli --version 0.17.0 --force` |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |

--- a/docs/audits/release-0.17.0-publish-readiness.md
+++ b/docs/audits/release-0.17.0-publish-readiness.md
@@ -1,0 +1,48 @@
+# v0.17.0 Publish Readiness Proof
+
+Date: 2026-05-12
+
+Branch: `release/validate-0.17.0-readiness`
+
+Purpose: validate that the v0.17.0 release candidate is ready for the separate
+tag and publish step. This proof does not publish crates, create tags, or create
+GitHub releases.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Target directory | `C:\perfgate-target-msrv` |
+| Version under test | `0.17.0` |
+| Publishable crates | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+
+## Local Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 run -p xtask -- docs-check` | Pass | Documentation drift check reported up to date. |
+| `cargo +1.95.0 run -p xtask -- doc-test` | Pass | Checked 70 CLI examples and 36 structured snippets. |
+| `cargo +1.95.0 run -p xtask -- action-check` | Pass | GitHub Action install, release asset, and failure diagnostic wiring aligned. |
+| `cargo +1.95.0 run -p xtask -- public-surface --strict` | Pass | Public surface remains the five allowed packages. |
+| `cargo +1.95.0 run -p xtask -- arch` | Pass | Architecture dependency rules held. |
+| `cargo +1.95.0 run -p xtask -- schema-compat` | Pass | 18 historical schema fixtures deserialize with current types. |
+| `cargo +1.95.0 run -p xtask -- publish-check --package-list` | Pass | File-list proof passed for all five publishable crates. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types` | Pass | Packaged, verified, and aborted upload because of dry run. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Packaged, verified, and aborted upload because of dry run. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Packaged, verified, and aborted upload because of dry run. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Packaged, verified, and aborted upload because of dry run. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Packaged, verified, and aborted upload because of dry run. |
+
+## Known Gaps
+
+- Crates were not published.
+- No `v0.17.0` tag was created.
+- No GitHub release was created.
+- Post-publish install proof, including `cargo-binstall perfgate-cli --version
+  0.17.0 --force`, remains blocked until the crates and release assets exist.
+
+## Release Boundary
+
+The next irreversible step is tag and publish. Run it only after the release
+proof PR is merged to `main` and the required hosted checks are green.


### PR DESCRIPTION
## Summary
- Add a compact v0.17.0 publish-readiness proof under `docs/audits/`.
- Update `docs/RELEASE_READINESS.md` to point at the proof and mark the dry-run matrix passing.
- Keep release boundaries explicit: no crates published, no tag created, no GitHub release created.

## Validation
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- action-check`
- `cargo +1.95.0 run -p xtask -- public-surface --strict`
- `cargo +1.95.0 run -p xtask -- arch`
- `cargo +1.95.0 run -p xtask -- schema-compat`
- `cargo +1.95.0 run -p xtask -- publish-check --package-list`
- `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types`
- `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate`
- `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client`
- `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server`
- `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli`
- `git diff --check`