### PR TITLE
docs: define source-of-truth model

### DIFF
--- a/.codex/goals/README.md
+++ b/.codex/goals/README.md
@@ -1,0 +1,65 @@
+# Codex Goals
+
+Codex goal manifests record current agent execution state. They are
+machine-readable pointers to the proposal, spec, plan, policy, proof commands,
+allowed files, forbidden files, and completion criteria for the active lane.
+
+Use `.codex/goals/active.toml` for the current goal and `.codex/goals/archive/`
+for completed or superseded manifests.
+
+Do not use `.perfgate/` for Codex goal state. `.perfgate/` is reserved for
+product-generated user artifacts from `perfgate init` and related workflows.
+
+## Boundaries
+
+- Goal TOML may reference a proposal, spec, ADR, plan, policy file, or status
+  doc.
+- Goal TOML may constrain file scope and proof commands for Codex.
+- Goal TOML must not define new product behavior.
+- Goal TOML must not duplicate policy ledgers or release-readiness matrices.
+
+## Suggested Shape
+
+```toml
+id = "perfgate-0-18-spec-driven-governance"
+title = "perfgate 0.18.0 spec-driven governance"
+status = "active"
+owner = "codex"
+created = "2026-05-13"
+
+objective = """
+Make perfgate's product claims, architecture decisions, policy ledgers,
+release proof, and Codex execution state traceable through proposals, specs,
+ADRs, implementation plans, and machine-readable active goals.
+"""
+
+linked_proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
+linked_spec = "docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md"
+linked_plan = "plans/0.18.0/implementation-plan.md"
+
+allowed_files = [
+  "docs/proposals/**",
+  "docs/specs/**",
+  "docs/adr/**",
+  "docs/status/**",
+  "docs/handoffs/**",
+  "plans/0.18.0/**",
+  ".codex/goals/**",
+]
+
+forbidden_files = [
+  "Cargo.toml",
+  "rust-toolchain.toml",
+  ".github/**",
+  "crates/**",
+  "xtask/**",
+  "policy/**",
+  "schemas/**",
+]
+
+proof = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "git diff --check",
+]
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,58 @@
+# perfgate Documentation Source of Truth
+
+perfgate uses a linked documentation stack so contributors and agents can move
+from intent to implementation without rediscovering the architecture each time.
+The stack separates why, what, how, what now, and what proves it.
+
+Existing topic docs remain valid. New governance and spec work should use these
+homes so product claims, policy gates, public surface rules, release proof, and
+Codex execution state stay reviewable.
+
+| Artifact | Owns | Location |
+|----------|------|----------|
+| Proposal | Why a lane exists, who benefits, alternatives, and success criteria | [`proposals/`](proposals/) |
+| Spec | What behavior or proof contract must be true | [`specs/`](specs/) |
+| ADR | Durable architecture decisions | [`adr/`](adr/) |
+| Plan | How work lands PR by PR | [`../plans/`](../plans/) |
+| Goal TOML | Current Codex execution state | [`../.codex/goals/`](../.codex/goals/) |
+| Policy ledger | Machine-readable exceptions, gates, and governed surfaces | [`../policy/`](../policy/) |
+| Status docs | Product claim support tiers and proof map | [`status/`](status/) |
+| Handoff | Closeout notes, remaining work, and operator context | [`handoffs/`](handoffs/) |
+
+## Source-of-truth Rules
+
+- Proposals explain why a lane exists. They do not contain the full PR queue.
+- Specs define behavior, evidence, and proof. They do not duplicate release
+  tables, policy ledgers, or implementation diaries.
+- ADRs record architectural decisions expected to survive individual releases.
+- Plans sequence file changes, proof commands, rollback, blockers, and PR order.
+- Goal TOML files record active agent state. They do not define new behavior.
+- Policy files own concrete exceptions and governed surfaces.
+- Status docs map user-facing claims to support tiers and proof commands.
+- Handoffs record what changed, what remains, and what the next operator needs.
+
+## Existing Anchors
+
+- Public crate surface: [`CRATE_SEAMS.md`](CRATE_SEAMS.md),
+  [`policy/public_crates.txt`](../policy/public_crates.txt), and
+  [`policy/absorbed_crates.txt`](../policy/absorbed_crates.txt)
+- Release proof: [`RELEASE_READINESS.md`](RELEASE_READINESS.md) and
+  [`audits/release-0.17.0-publish-readiness.md`](audits/release-0.17.0-publish-readiness.md)
+- Performance decisions: [`PERFORMANCE_DECISIONS.md`](PERFORMANCE_DECISIONS.md)
+- Architecture: [`ARCHITECTURE.md`](ARCHITECTURE.md) and the existing
+  [`adrs/`](adrs/) archive
+- Policy allowlists: [`POLICY_ALLOWLISTS.md`](POLICY_ALLOWLISTS.md)
+
+## Header Standard
+
+Every proposal, spec, ADR, and plan should start with a short metadata block.
+Each subdirectory README defines the fields for that artifact type.
+
+Status values are intentionally small:
+
+```text
+proposed
+accepted
+implemented
+superseded
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,70 @@
+# Architecture Decision Records
+
+ADRs own durable architectural decisions. Use them for choices that should
+survive individual releases and continue constraining future implementation.
+
+New spec-driven governance ADRs use the `PERFGATE-ADR-000N-*` naming scheme in
+this directory. The existing [`../adrs/`](../adrs/) directory remains the
+historical numbered ADR archive and should be linked when it already records the
+decision context.
+
+## Naming
+
+```text
+PERFGATE-ADR-000N-short-title.md
+```
+
+Example:
+
+```text
+PERFGATE-ADR-0001-public-crates-are-contracts.md
+```
+
+## Required Header
+
+```md
+Status: accepted
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+```
+
+## Template
+
+```md
+# PERFGATE-ADR-000N: Title
+
+Status: accepted
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+
+## Decision
+
+State the durable architecture decision.
+
+## Context
+
+Why this decision exists.
+
+## Consequences
+
+What this enables and constrains.
+
+## Alternatives considered
+
+What was rejected.
+
+## Follow-up specs / plans
+
+What must be implemented or checked.
+```
+
+## Boundaries
+
+- Use proposals for product strategy and motivation.
+- Use specs for behavior and proof contracts.
+- Use plans for PR order, file lists, rollback, and blockers.
+- Do not use ADRs for temporary implementation notes.

--- a/docs/handoffs/README.md
+++ b/docs/handoffs/README.md
@@ -1,0 +1,59 @@
+# Handoffs
+
+Handoffs own closeout and operator context. They capture what changed, what
+was validated, what remains, and which source-of-truth files the next person or
+agent should read.
+
+Use handoffs when a lane, release proof, queue drain, or policy pass needs a
+durable closeout record.
+
+## Naming
+
+```text
+YYYY-MM-DD-short-lane-name.md
+```
+
+Example:
+
+```text
+2026-05-13-spec-driven-governance-scaffold.md
+```
+
+## Suggested Shape
+
+```md
+# Handoff: Title
+
+Status:
+Date:
+Owner:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked policy:
+Support/status impact:
+Proof commands:
+
+## Summary
+
+What changed?
+
+## Evidence
+
+What commands ran, and what passed or failed?
+
+## Remaining work
+
+What is intentionally deferred?
+
+## Next operator notes
+
+What should the next person or agent read first?
+```
+
+## Boundaries
+
+- Do not redefine behavior here; link to specs.
+- Do not redefine policy exceptions here; link to policy ledgers.
+- Do not use handoffs as the only source of release readiness.

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,102 @@
+# Proposals
+
+Proposals own why a lane exists. They describe the problem, the users and
+surfaces affected, rejected alternatives, success criteria, and which specs,
+ADRs, plans, policy ledgers, or status docs the lane should create.
+
+Proposals should be stable enough for future readers to understand the reason
+for the work, but they are not PR checklists.
+
+## Naming
+
+```text
+PERFGATE-PROP-000N-short-title.md
+```
+
+Example:
+
+```text
+PERFGATE-PROP-0001-spec-driven-governance.md
+```
+
+## Required Header
+
+```md
+Status: proposed
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+```
+
+## Template
+
+```md
+# PERFGATE-PROP-000N: Title
+
+Status: proposed
+Owner:
+Created:
+Target milestone:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Support/status impact:
+Policy impact:
+
+## Problem
+
+What risk, user pain, or repo gap exists?
+
+## Users and surfaces
+
+Who benefits? CLI users, action users, server users, maintainers, agents?
+
+## Success criteria
+
+What must be true when complete?
+
+## Proposed shape
+
+What are we doing?
+
+## Alternatives considered
+
+What did we reject and why?
+
+## Specs to create or update
+
+- PERFGATE-SPEC-...
+
+## Architecture decisions needed
+
+- PERFGATE-ADR-...
+
+## Evidence plan
+
+Proof commands, fixtures, policy gates, and status docs.
+
+## Risks
+
+What can go wrong?
+
+## Non-goals
+
+What is explicitly out of scope?
+
+## Exit criteria
+
+When is this proposal done?
+```
+
+## Boundaries
+
+- Link to plans for PR sequencing.
+- Link to specs for behavior contracts.
+- Link to policy files for governed surfaces and exceptions.
+- Link to status docs for product claim support.
+- Do not copy release-readiness matrices or policy ledger entries here.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,123 @@
+# Specs
+
+Specs own what must be true. A spec defines behavior, proof, acceptance
+examples, CI evidence, product surface impact, and implementation ownership.
+
+Specs are product controls. They are not roadmaps, release notes, or diaries.
+When a spec needs concrete exception data, it links to the relevant policy
+ledger instead of copying it.
+
+## Naming
+
+```text
+PERFGATE-SPEC-000N-short-title.md
+```
+
+Example:
+
+```text
+PERFGATE-SPEC-0001-source-of-truth-stack.md
+```
+
+## Required Header
+
+```md
+Status: accepted
+Owner:
+Created:
+Milestone:
+Behavior version:
+Product surface:
+CI surface:
+Schema impact:
+Action impact:
+Server impact:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked policy:
+Support/status impact:
+Proof commands:
+```
+
+## Template
+
+```md
+# PERFGATE-SPEC-000N: Title
+
+Status: accepted
+Owner:
+Created:
+Milestone:
+Behavior version:
+Product surface:
+CI surface:
+Schema impact:
+Action impact:
+Server impact:
+Linked proposal:
+Linked ADRs:
+Linked plan:
+Linked policy:
+Support/status impact:
+Proof commands:
+
+## Problem
+
+What behavior or contract gap exists?
+
+## Behavior
+
+What must be true?
+
+## Non-goals
+
+What is out of scope?
+
+## Required evidence
+
+What proof is required?
+
+## Acceptance examples
+
+Concrete pass/fail examples.
+
+## Test mapping
+
+Which tests, fixtures, or policy checks cover this?
+
+## Implementation mapping
+
+Which crates, modules, docs, or policy files own this?
+
+## CI proof
+
+Which commands and lanes prove it?
+
+## Promotion rule
+
+What moves this from proposed to accepted to implemented?
+```
+
+## Truth Ownership
+
+| Truth | Source |
+|-------|--------|
+| Product claim support | `docs/status/SUPPORT_TIERS.md` and `docs/status/PRODUCT_CLAIMS.md` |
+| Public crate surface | `policy/public_crates.txt` |
+| Absorbed/private crate disposition | `policy/absorbed_crates.txt` |
+| No-panic state | `policy/no-panic-*.toml` |
+| Non-Rust file surface | `policy/*-allowlist.toml` |
+| Active Codex state | `.codex/goals/active.toml` |
+| PR sequencing | `plans/<milestone>/implementation-plan.md` |
+| Why a lane exists | `docs/proposals/` |
+| Behavior contract | `docs/specs/` |
+| Architecture decision | `docs/adr/` and the historical `docs/adrs/` archive |
+
+## Acceptance Rules
+
+- A plan may link to policy files but must not copy policy entries.
+- A spec may define package boundary behavior but must not list every package
+  unless the list itself is the behavior under test.
+- A proposal may describe alternatives but must not become the PR checklist.
+- A goal TOML may reference a spec and plan but must not define new behavior.

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -1,0 +1,52 @@
+# Status Docs
+
+Status docs map product claims to proof. They keep README, release, action, CLI,
+and server claims honest by tying each claim to a support tier, evidence, and
+review cadence.
+
+This directory is the home for:
+
+```text
+SUPPORT_TIERS.md
+PRODUCT_CLAIMS.md
+```
+
+Those files are intentionally introduced after this scaffold so the claim map
+can land as its own reviewable PR.
+
+## Support Tiers
+
+Use these tiers unless a later spec changes the vocabulary:
+
+| Tier | Meaning |
+|------|---------|
+| stable | Public contract with release-grade proof and compatibility expectations |
+| supported | Intended user path with tests, docs, and maintained behavior |
+| advisory | Visible and useful, but not a hard gate or compatibility promise |
+| experimental | Available for trial; behavior may change without migration guarantees |
+| deprecated | Still present, but users should move away from it |
+
+## Product Claim Row
+
+Each claim should record:
+
+```text
+claim id
+claim text
+tier
+surface
+proof commands
+linked tests or policy gates
+artifacts
+review_after
+linked specs
+linked release/readiness notes
+```
+
+## Boundaries
+
+- README and release docs may summarize claims, but the proof map owns the
+  current support tier.
+- Specs define the behavior contract behind a claim.
+- Policy files own machine-readable gates and exceptions.
+- Handoffs record temporary status and remaining work.

--- a/plans/0.18.0/README.md
+++ b/plans/0.18.0/README.md
@@ -1,0 +1,49 @@
+# perfgate 0.18.0 Plans
+
+The 0.18.0 planning lane makes perfgate's product claims, architecture
+decisions, policy ledgers, release proof, and Codex execution state traceable
+through proposals, specs, ADRs, plans, and machine-readable active goals.
+
+This README is the milestone index. The implementation plan and per-work-item
+plans land after the source-of-truth scaffold.
+
+## Initial Lane
+
+```text
+docs: define source-of-truth model
+```
+
+This first PR adds the taxonomy and templates only. It does not change product
+behavior, Rust code, policy ledgers, schemas, workflows, or release state.
+
+## Linked Homes
+
+- Proposals: [`../../docs/proposals/`](../../docs/proposals/)
+- Specs: [`../../docs/specs/`](../../docs/specs/)
+- ADRs: [`../../docs/adr/`](../../docs/adr/)
+- Status docs: [`../../docs/status/`](../../docs/status/)
+- Handoffs: [`../../docs/handoffs/`](../../docs/handoffs/)
+- Active goals: [`../../.codex/goals/`](../../.codex/goals/)
+- Policy ledgers: [`../../policy/`](../../policy/)
+
+## Guardrails For The Scaffold PR
+
+No changes to:
+
+```text
+Cargo.toml
+rust-toolchain.toml
+.github/
+crates/
+xtask/
+policy/
+schemas/
+```
+
+Validation:
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+git diff --check
+```

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,92 @@
+# perfgate Plans
+
+Plans own how work lands. They translate accepted proposals and specs into
+PR-sized work items with scoped file changes, proof commands, blockers,
+rollback, and deferred work.
+
+Plans are operational. They should be easy for Codex and humans to execute
+without searching old chats.
+
+## Layout
+
+```text
+plans/
+  <milestone>/
+    README.md
+    implementation-plan.md
+    <work-item>.md
+```
+
+Example:
+
+```text
+plans/0.18.0/implementation-plan.md
+```
+
+## Required Header
+
+```md
+Status:
+Owner:
+Created:
+Milestone:
+Current PR:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked policy:
+Support/status impact:
+Proof commands:
+Blocks:
+Blocked by:
+Rollback:
+```
+
+## Work Item Template
+
+````md
+## Work item: short-id
+
+Status: ready
+Linked proposal:
+Linked spec:
+Linked ADR:
+Blocks:
+Blocked by:
+
+### Goal
+
+What will this PR-sized item accomplish?
+
+### Production delta
+
+What files or behavior will change?
+
+### Non-goals
+
+What is intentionally out of scope?
+
+### Acceptance
+
+What must be true?
+
+### Proof commands
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+git diff --check
+```
+
+### Rollback
+
+How to revert safely.
+````
+
+## Boundaries
+
+- Link to proposals for why.
+- Link to specs for behavior.
+- Link to ADRs for durable architecture decisions.
+- Link to policy ledgers for governed surfaces and exceptions.
+- Keep PR sequence and file scope here, not in specs.


### PR DESCRIPTION
## Summary
- Add the docs source-of-truth index and artifact ownership rules.
- Add proposal, spec, ADR, status, and handoff README templates.
- Add 0.18.0 plan and Codex goal README scaffolding without product or policy changes.

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check