### PR TITLE
docs(handoff): close spec-driven governance lane

### DIFF
--- a/.codex/goals/archive/perfgate-0-18-spec-driven-governance.toml
+++ b/.codex/goals/archive/perfgate-0-18-spec-driven-governance.toml
@@ -1,11 +1,13 @@
 id = "perfgate-0-18-spec-driven-governance"
 title = "perfgate 0.18.0 spec-driven governance"
-status = "active"
+status = "completed"
 owner = "codex"
 created = "2026-05-13"
+completed = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "implementation-plan-and-active-goal"
-current_pr = "plans(0.18): add spec-driven implementation plan"
+current_work_item = "none"
+current_pr = "complete"
+archive_reason = "The source-of-truth stack, status proof map, implementation plan, active-goal campaign, source docs checker, product claims checker, and closeout handoff all landed."
 
 objective = """
 Make perfgate's product claims, architecture decisions, policy ledgers,
@@ -19,7 +21,7 @@ end_state = [
   "Every behavior contract has a spec with proof commands.",
   "Every durable architecture decision has an ADR.",
   "Every implementation campaign has a PR-sized plan.",
-  "Codex has a machine-readable active goal manifest.",
+  "Codex has a machine-readable goal manifest archived with completion evidence.",
   "README and product claims link to support/status proof instead of free-floating prose.",
   "Policy ledgers remain the concrete source of truth for exceptions and governed surfaces.",
   "Release claims link to release-readiness and audit proof records.",
@@ -27,6 +29,7 @@ end_state = [
 
 linked_proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 linked_plan = "plans/0.18.0/implementation-plan.md"
+linked_handoff = "docs/handoffs/2026-05-13-spec-driven-governance-closeout.md"
 
 linked_specs = [
   "docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md",
@@ -61,33 +64,22 @@ linked_policy = [
   "policy/dependency-surface-allowlist.toml",
 ]
 
-allowed_files = [
-  "plans/0.18.0/implementation-plan.md",
-  ".codex/goals/active.toml",
-]
-
-forbidden_changes = [
-  "Cargo.toml",
-  "rust-toolchain.toml",
-  ".github/**",
-  "crates/**",
-  "xtask/**",
-  "policy/**",
-  "schemas/**",
-]
-
 proof = [
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
   "cargo +1.95.0 run -p xtask -- docs-check",
   "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 clippy -p xtask --all-targets --all-features -- -D warnings",
+  "cargo +1.95.0 test -p xtask --all-features",
   "git diff --check",
 ]
 
 completion_criteria = [
-  "Implementation plan is committed.",
-  "Active goal manifest parses as TOML.",
-  "Plan links current proposal, specs, ADRs, status docs, and policy ledgers.",
-  "Plan identifies remaining checker and closeout work.",
-  "No product, policy, schema, workflow, Cargo, or Rust code files changed.",
+  "Proposal, specs, ADRs, status docs, implementation plan, and handoff are merged.",
+  "Source-of-truth checker validates metadata, IDs, links, and active-goal TOML when present.",
+  "Product-claims checker validates claim IDs, tiers, surfaces, proof commands, linked evidence, and review cadence.",
+  "Active campaign state is archived under .codex/goals/archive/.",
+  "No open spec-governance PR remains for this campaign.",
 ]
 
 [[work_item]]
@@ -139,7 +131,7 @@ commands = [
 
 [[work_item]]
 id = "release-proof-contract"
-status = "in_review"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 commands = [
@@ -154,7 +146,7 @@ commands = [
 
 [[work_item]]
 id = "implementation-plan-and-active-goal"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 spec = "docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md"
 plan = "plans/0.18.0/implementation-plan.md"
@@ -166,7 +158,7 @@ commands = [
 
 [[work_item]]
 id = "docs-source-check"
-status = "ready"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 spec = "docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md"
 commands = [
@@ -177,11 +169,25 @@ commands = [
 
 [[work_item]]
 id = "product-claims-check"
-status = "ready"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 spec = "docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md"
 commands = [
   "cargo +1.95.0 run -p xtask -- product-claims-check",
   "cargo +1.95.0 run -p xtask -- docs-source-check",
   "cargo +1.95.0 run -p xtask -- docs-check",
+]
+
+[[work_item]]
+id = "final-closeout"
+status = "merged"
+proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
+spec = "docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md"
+plan = "plans/0.18.0/implementation-plan.md"
+handoff = "docs/handoffs/2026-05-13-spec-driven-governance-closeout.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
 ]

--- a/docs/handoffs/2026-05-13-spec-driven-governance-closeout.md
+++ b/docs/handoffs/2026-05-13-spec-driven-governance-closeout.md
@@ -1,0 +1,79 @@
+# Handoff: Spec-driven Governance Closeout
+
+Status: complete
+Date: 2026-05-13
+Owner: perfgate maintainers
+Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
+Linked specs: docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md, docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md, docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md, docs/specs/PERFGATE-SPEC-0004-user-devex-paved-road.md, docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Linked ADRs: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md, docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
+Linked plan: plans/0.18.0/implementation-plan.md
+Linked policy: policy/public_crates.txt, policy/absorbed_crates.txt, policy/clippy-*.toml, policy/no-panic-*.toml, policy/*-allowlist.toml
+Support/status impact: docs/status/SUPPORT_TIERS.md, docs/status/PRODUCT_CLAIMS.md
+Proof commands: cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test
+
+## Summary
+
+The 0.18.0 spec-governance lane now has a linked source-of-truth stack:
+
+- proposal for why the lane exists;
+- specs for source-of-truth ownership, package surface, performance decisions,
+  user DevEx, and release proof;
+- ADRs for public-crate contracts and receipts-first decisions;
+- support/status docs that map claims to tiers, evidence, and review cadence;
+- an implementation plan that records the PR-sized sequence;
+- an archived goal manifest at
+  `.codex/goals/archive/perfgate-0-18-spec-driven-governance.toml`;
+- machine checks for source-doc metadata and product-claim proof maps.
+
+The lane did not change product behavior, package policy, schemas, workflows,
+toolchain files, or release state except for the planned xtask enforcement PRs.
+
+## Evidence
+
+Final local proof from merged `main`:
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 clippy -p xtask --all-targets --all-features -- -D warnings
+cargo +1.95.0 test -p xtask --all-features
+```
+
+Hosted proof:
+
+- PRs 365 through 368 were marked ready only after reported checks were green,
+  then merged.
+- PRs 352, 353, and 354 were closed as superseded by PR 355.
+- PR 355 remains the separate canonical RIPR/badge lane and was not combined
+  with this source-of-truth lane.
+
+## Remaining work
+
+- `PERFGATE-SPEC-0006-policy-ledger-contracts` remains a planned follow-up if
+  maintainers want a dedicated policy-ledger behavior contract.
+- Full graph completeness, support-tier coverage enforcement, policy-ledger
+  semantic validation, and every README claim mapping are intentionally not
+  enforced by the first checker.
+- No crates.io publish, tag, GitHub release, or badge/RIPR merge is implied by
+  this closeout.
+
+## Next operator notes
+
+Start with:
+
+- `docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md`
+- `docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md`
+- `plans/0.18.0/implementation-plan.md`
+- `.codex/goals/archive/perfgate-0-18-spec-driven-governance.toml`
+- `docs/status/PRODUCT_CLAIMS.md`
+
+Use these checks before changing the stack:
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+```

--- a/plans/0.18.0/implementation-plan.md
+++ b/plans/0.18.0/implementation-plan.md
@@ -1,19 +1,19 @@
 # perfgate 0.18.0 Spec-driven Governance Implementation Plan
 
-Status: active
+Status: implemented
 Owner: perfgate maintainers
 Created: 2026-05-13
 Milestone: 0.18.0
-Current PR: plans(0.18): add spec-driven implementation plan
+Current PR: complete
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked specs: docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md, docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md, docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md, docs/specs/PERFGATE-SPEC-0004-user-devex-paved-road.md, docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Linked ADRs: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md, docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
 Linked policy: policy/public_crates.txt, policy/absorbed_crates.txt, policy/clippy-*.toml, policy/no-panic-*.toml, policy/*-allowlist.toml
 Support/status impact: docs/status/SUPPORT_TIERS.md, docs/status/PRODUCT_CLAIMS.md
-Proof commands: cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; git diff --check
-Blocks: docs-source-check, product-claims-check, final closeout
+Proof commands: cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test
+Blocks: none
 Blocked by: none
-Rollback: revert this plan and .codex/goals/active.toml; no product behavior changes
+Rollback: revert the closeout handoff, plan status update, and archived goal manifest; no product behavior changes
 
 ## Goal
 
@@ -49,10 +49,11 @@ specs and ADRs.
 | 7 | Performance decision contract spec | merged | `docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md` |
 | 8 | Receipts-first ADR | merged | `docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md` |
 | 9 | User DevEx paved-road spec | merged | `docs/specs/PERFGATE-SPEC-0004-user-devex-paved-road.md` |
-| 10 | Release-proof contract spec | in review | `docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md` |
-| 11 | Implementation plan and active goal | current | `plans/0.18.0/implementation-plan.md`, `.codex/goals/active.toml` |
-| 12 | Source-of-truth docs checker | ready | `xtask`, checker tests, docs |
-| 13 | Product claim proof checker | ready | `xtask`, checker tests, docs |
+| 10 | Release-proof contract spec | merged | `docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md` |
+| 11 | Implementation plan and active goal | merged | `plans/0.18.0/implementation-plan.md`, `.codex/goals/active.toml` |
+| 12 | Source-of-truth docs checker | merged | `xtask`, checker tests, docs |
+| 13 | Product claim proof checker | merged | `xtask`, checker tests, docs |
+| 14 | Final closeout | merged | `docs/handoffs/2026-05-13-spec-driven-governance-closeout.md`, `plans/0.18.0/implementation-plan.md`, `.codex/goals/archive/perfgate-0-18-spec-driven-governance.toml` |
 
 ## Work item: source-of-truth-scaffold
 
@@ -219,7 +220,7 @@ Revert the spec commit. Product behavior remains unchanged.
 
 ## Work item: release-proof-contract
 
-Status: in review
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
@@ -259,7 +260,7 @@ release proof.
 
 ## Work item: implementation-plan-and-active-goal
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md
 Linked ADR:
@@ -292,7 +293,7 @@ remain valid.
 
 ## Work item: docs-source-check
 
-Status: ready
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md
 Linked ADR:
@@ -326,7 +327,7 @@ Revert the checker and its tests. The docs stack remains usable manually.
 
 ## Work item: product-claims-check
 
-Status: ready
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md
 Linked ADR:
@@ -362,7 +363,7 @@ Revert the checker and tests. The status map remains the human-readable source.
 
 ## Work item: final-closeout
 
-Status: planned
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md
 Linked ADR:


### PR DESCRIPTION
## Summary
- Archive the completed spec-governance active goal under .codex/goals/archive/.
- Add the closeout handoff with linked source-of-truth artifacts, evidence, remaining work, and next-operator notes.
- Mark the 0.18 implementation plan as implemented with PR 10-14 statuses complete.

## Scope
- Docs/goal-manifest closeout only.
- No product, policy, schema, workflow, toolchain, Cargo, or Rust code changes.
- RIPR/badge PR #355 remains separate.

## Validation
- archive goal TOML parses
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check