### PR TITLE
release: reconcile 0.17.0 publication state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Reconciled release-readiness docs with the published v0.17.0 state across
+  crates.io packages, GitHub release assets, action alias tags, and public
+  install smoke proof.
+
 ## [0.17.0] - 2026-05-12
 
 ### Added

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,17 +1,31 @@
 # Release Readiness
 
-Last verified: 2026-05-12 for v0.17.0 publish readiness. See
-[v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md).
+Last verified: 2026-05-13 for v0.17.0 publication reconciliation. See
+[v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md)
+and [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md).
 
-Latest published release: v0.16.0. Do not call v0.17.0 published until the
-release-proof PR validates the publish matrix, creates the tag, and publishes
-the five allowed crates.
+Latest published release: v0.17.0. The five allowed crates are published on
+crates.io at `0.17.0`, the GitHub release `v0.17.0` is published with platform
+archives and `sha256sums.txt`, and action alias tags `v0.17` and `v0` point to
+the same release commit as `v0.17.0`.
 
-## Current Release Candidate Snapshot
+## Current Published Release Snapshot
 
-The release candidate is versioned as `v0.17.0`. It keeps the five-crate public
+The current published release is `v0.17.0`. It keeps the five-crate public
 surface from v0.16.0, raises the Rust floor to 1.95, and adds the governance
-rails that make the release conveyor explicit:
+rails that make the release conveyor explicit.
+
+## Current Publication State
+
+| Surface | Status | Evidence |
+|---------|--------|----------|
+| crates.io packages | Published | The crates.io sparse index contains `0.17.0` entries for `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, and `perfgate-cli`. |
+| Exact release tag | Published | GitHub tag `v0.17.0` points to commit `71bdc33117d515d95885deb2d9350d9d67905265`. |
+| Action alias tags | Published | GitHub tags `v0.17` and `v0` also point to commit `71bdc33117d515d95885deb2d9350d9d67905265`. |
+| GitHub release | Published | GitHub release `v0.17.0` was published on 2026-05-12 with platform archives and `sha256sums.txt`. |
+| Public install smoke | Passing | `cargo +1.95.0 install perfgate-cli --version 0.17.0 --locked --root C:/perfgate-smoke/release-reconcile-0170 --force`; installed binary reported `perfgate 0.17.0` and `perfgate doctor --help` printed help. |
+
+## Release Proof Matrix
 
 | Gate | Status | Evidence |
 |------|--------|----------|
@@ -28,7 +42,7 @@ rails that make the release conveyor explicit:
 | Publish dry-run proof | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
 | Publish dry-run matrix | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
-| Install smoke proof | Release gate | Before publish: `cargo install --path crates/perfgate-cli --root C:\\perfgate-smoke\\from --force`; after publish: `cargo-binstall perfgate-cli --version 0.17.0 --force` |
+| Install smoke proof | Passing | Public registry install smoke passed with `cargo +1.95.0 install perfgate-cli --version 0.17.0 --locked --root C:/perfgate-smoke/release-reconcile-0170 --force`; installed binary reported `perfgate 0.17.0` and `perfgate doctor --help` printed help |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |
 | Documentation examples | Passing | `cargo run -p xtask -- docs-check` and `cargo run -p xtask -- doc-test` |
 | Structured decision end-to-end | Verified | `perfgate ingest probes`, `perfgate decision evaluate`, `perfgate decision bundle` on `examples/performance-decision`, plus `perfgate serve --no-open` and `decision upload/history/debt/prune --dry-run` |
@@ -38,7 +52,7 @@ rails that make the release conveyor explicit:
 | Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, and dashboard decision-ledger tests |
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
-| Full repo CI | Release gate | Hosted `ci` on the release PR, with coverage, fuzz, and self-dogfood evidence routed by policy before tagging |
+| Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:
 

--- a/docs/audits/release-0.17.0-publication-closeout.md
+++ b/docs/audits/release-0.17.0-publication-closeout.md
@@ -1,0 +1,103 @@
+# v0.17.0 Publication Closeout
+
+Date: 2026-05-13
+
+Purpose: reconcile the public v0.17.0 release state after the separate
+readiness proof, publish, tag, and GitHub release steps completed.
+
+This closeout records current public state. It does not publish crates, move
+tags, create releases, or modify release assets.
+
+## Public State
+
+| Surface | Verified state |
+| --- | --- |
+| Latest GitHub release | `v0.17.0` |
+| GitHub release URL | `https://github.com/EffortlessMetrics/perfgate/releases/tag/v0.17.0` |
+| GitHub release published at | `2026-05-12T13:07:05Z` |
+| Release commit | `71bdc33117d515d95885deb2d9350d9d67905265` |
+| Exact tag | `v0.17.0` points to `71bdc33117d515d95885deb2d9350d9d67905265` |
+| Action alias tag | `v0.17` points to `71bdc33117d515d95885deb2d9350d9d67905265` |
+| Major action alias tag | `v0` points to `71bdc33117d515d95885deb2d9350d9d67905265` |
+| Release assets | Six platform archives plus `sha256sums.txt` uploaded to the GitHub release |
+| crates.io package set | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+
+## crates.io Verification
+
+The crates.io sparse index contains `0.17.0` entries for every allowed public
+crate:
+
+```bash
+curl https://index.crates.io/pe/rf/perfgate-types
+curl https://index.crates.io/pe/rf/perfgate
+curl https://index.crates.io/pe/rf/perfgate-client
+curl https://index.crates.io/pe/rf/perfgate-server
+curl https://index.crates.io/pe/rf/perfgate-cli
+```
+
+Each response included a line with `"vers":"0.17.0"`.
+
+`cargo +1.95.0 search perfgate-cli --limit 5` also reported:
+
+```text
+perfgate-cli = "0.17.0"
+perfgate-server = "0.17.0"
+```
+
+## GitHub Release Verification
+
+GitHub release metadata was checked with:
+
+```bash
+gh release view v0.17.0 --json tagName,name,isPrerelease,isDraft,publishedAt,targetCommitish,url,assets,body
+gh api repos/EffortlessMetrics/perfgate/git/refs/tags/v0.17.0
+gh api repos/EffortlessMetrics/perfgate/git/refs/tags/v0.17
+gh api repos/EffortlessMetrics/perfgate/git/refs/tags/v0
+```
+
+Observed state:
+
+- `v0.17.0` is not a draft and not a prerelease.
+- `v0.17.0` was published at `2026-05-12T13:07:05Z`.
+- Uploaded release assets include:
+  - `perfgate-aarch64-apple-darwin.tar.gz`
+  - `perfgate-aarch64-unknown-linux-gnu.tar.gz`
+  - `perfgate-x86_64-apple-darwin.tar.gz`
+  - `perfgate-x86_64-pc-windows-msvc.zip`
+  - `perfgate-x86_64-unknown-linux-gnu.tar.gz`
+  - `perfgate-x86_64-unknown-linux-musl.tar.gz`
+  - `sha256sums.txt`
+- `v0.17.0`, `v0.17`, and `v0` resolve to release commit
+  `71bdc33117d515d95885deb2d9350d9d67905265`.
+
+## Public Install Smoke
+
+The public registry install path was tested from an isolated root:
+
+```bash
+cargo +1.95.0 install perfgate-cli --version 0.17.0 --locked --root C:/perfgate-smoke/release-reconcile-0170 --force
+C:/perfgate-smoke/release-reconcile-0170/bin/perfgate.exe --version
+C:/perfgate-smoke/release-reconcile-0170/bin/perfgate.exe doctor --help
+```
+
+Results:
+
+- `cargo install` installed `perfgate-cli v0.17.0` from crates.io.
+- `perfgate --version` printed `perfgate 0.17.0`.
+- `perfgate doctor --help` printed the doctor command help.
+
+## Relationship To Readiness Proof
+
+`docs/audits/release-0.17.0-publish-readiness.md` remains the pre-publish
+readiness record. It intentionally says that the readiness PR did not publish
+crates, create tags, or create a GitHub release.
+
+This closeout records the later public state after those separate release steps
+completed.
+
+## Remaining Work
+
+- Keep future release readiness docs split between pre-publish proof and
+  post-publish closeout evidence.
+- Do not infer future publish, tag, GitHub release, or moving-alias updates from
+  dry-run success alone.

--- a/docs/audits/release-0.17.0-publish-readiness.md
+++ b/docs/audits/release-0.17.0-publish-readiness.md
@@ -8,6 +8,10 @@ Purpose: validate that the v0.17.0 release candidate is ready for the separate
 tag and publish step. This proof does not publish crates, create tags, or create
 GitHub releases.
 
+Publication follow-up: the later public release state is recorded in
+[`release-0.17.0-publication-closeout.md`](release-0.17.0-publication-closeout.md).
+This readiness proof remains the pre-publish record.
+
 ## Environment
 
 | Item | Value |


### PR DESCRIPTION
## Summary
- Update release readiness to say v0.17.0 is the current published release.
- Add a post-publish audit for crates.io, GitHub release assets, exact/action alias tags, and public install smoke.
- Keep the existing publish-readiness audit as the pre-publish proof record and link it to the closeout.
- Record the reconciliation in the Unreleased changelog.

## Verified public state
- crates.io sparse index contains 0.17.0 for perfgate-types, perfgate, perfgate-client, perfgate-server, and perfgate-cli.
- GitHub release v0.17.0 is published and includes platform archives plus sha256sums.txt.
- v0.17.0, v0.17, and v0 point at commit 71bdc33117d515d95885deb2d9350d9d67905265.
- Public install smoke from crates.io installed perfgate-cli v0.17.0 and the binary reported perfgate 0.17.0.

## Validation
- cargo +1.95.0 install perfgate-cli --version 0.17.0 --locked --root C:/perfgate-smoke/release-reconcile-0170 --force
- C:/perfgate-smoke/release-reconcile-0170/bin/perfgate.exe --version
- C:/perfgate-smoke/release-reconcile-0170/bin/perfgate.exe doctor --help
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- git diff --check