### PR TITLE
docs: add first-hour adoption guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reconciled release-readiness docs with the published v0.17.0 state across
   crates.io packages, GitHub release assets, action alias tags, and public
   install smoke proof.
+- Added a first-hour adoption guide for install, init, check, baseline
+  promotion, CI, artifact boundaries, and failure reproduction.
 
 ## [0.17.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ perfgate baseline promote --config perfgate.toml --all
 git add perfgate.toml .github/workflows/perfgate.yml baselines/ .perfgate/
 ```
 
+For a concrete cold-start walkthrough, including expected files, artifacts,
+pass/fail behavior, and what to commit, see
+[`docs/FIRST_HOUR.md`](docs/FIRST_HOUR.md).
+
 `perfgate init --ci github --profile standard` creates:
 
 ```text

--- a/docs/FIRST_HOUR.md
+++ b/docs/FIRST_HOUR.md
@@ -1,0 +1,187 @@
+# First Hour With perfgate
+
+This guide is for a cold user adding perfgate to an existing repository. It
+keeps the path small: install, initialize, run one local check, promote the
+first baseline, commit the durable files, and let CI reproduce the same gate.
+
+You do not need the server, probes, scenarios, or structured decisions for this
+first hour.
+
+## 1. Install
+
+Use the binary installer path first:
+
+```bash
+cargo binstall perfgate-cli
+```
+
+If `cargo-binstall` is not available:
+
+```bash
+cargo install perfgate-cli
+```
+
+Check that the installed binary is usable:
+
+```bash
+perfgate --version
+perfgate doctor --help
+```
+
+## 2. Initialize The Repo
+
+Run this from the repository root:
+
+```bash
+perfgate init --ci github --profile standard
+```
+
+Expected new files:
+
+```text
+perfgate.toml
+.github/workflows/perfgate.yml
+baselines/.gitkeep
+.perfgate/README.md
+```
+
+Open `perfgate.toml` and replace the generated benchmark command with a real
+command for your project. Keep the first benchmark simple and deterministic.
+
+## 3. Check The Setup
+
+Run doctor against the generated config:
+
+```bash
+perfgate doctor --config perfgate.toml
+```
+
+A useful first result is either all pass, or a direct setup failure such as a
+missing benchmark command. Fix setup failures before promoting a baseline.
+
+## 4. Run The First Check
+
+Run the local gate:
+
+```bash
+perfgate check --config perfgate.toml --all
+```
+
+Expected artifact directory:
+
+```text
+artifacts/perfgate/
+```
+
+Expected first-run behavior:
+
+- perfgate runs each configured benchmark command;
+- perfgate writes run receipts under the artifact directory;
+- if no baseline exists yet, perfgate tells you to promote the first trusted
+  local result instead of silently inventing a baseline.
+
+Useful exit-code meanings:
+
+```text
+0  success, or warning without fail-on-warn
+1  tool/runtime error
+2  policy failure
+3  warning treated as failure
+```
+
+## 5. Promote The First Baseline
+
+After one local run looks representative, promote it:
+
+```bash
+perfgate baseline promote --config perfgate.toml --all
+```
+
+Expected durable baseline files:
+
+```text
+baselines/
+```
+
+These files are the comparison point for future local and CI checks.
+
+## 6. Commit The Right Files
+
+Commit the durable setup and baseline:
+
+```bash
+git add perfgate.toml .github/workflows/perfgate.yml baselines/ .perfgate/README.md
+git commit -m "ci: add perfgate performance gate"
+```
+
+Usually commit:
+
+- `perfgate.toml`
+- `.github/workflows/perfgate.yml`
+- `baselines/`
+- `.perfgate/README.md`
+
+Usually do not commit:
+
+- `artifacts/perfgate/`
+- temporary benchmark output
+- local server databases
+- one-off decision bundles unless they are attached to a release, audit, issue,
+  or review record on purpose
+
+## 7. Run CI
+
+Push the branch and let the generated GitHub workflow run. The workflow uses
+the repository action:
+
+```yaml
+- uses: EffortlessMetrics/perfgate@v0
+  with:
+    config: perfgate.toml
+    all: "true"
+    require_baseline: "true"
+    upload_artifact: "true"
+```
+
+Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
+current compatible action tag.
+
+## 8. Understand Pass And Fail
+
+A passing check means the current benchmark receipts are within configured
+budget policy relative to the committed baseline.
+
+A failing check means one of these happened:
+
+- the benchmark command could not run;
+- perfgate could not read config, baselines, or artifact paths;
+- a metric exceeded the configured budget;
+- warning policy was configured to fail the gate.
+
+For local reproduction, run the same command CI ran:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+Then inspect:
+
+```text
+artifacts/perfgate/
+```
+
+If the failure is a real intended performance change, rerun the benchmark
+enough times to trust the new result, then promote the new baseline in a
+separate, reviewable commit.
+
+## 9. Grow Later
+
+After the basic gate is stable:
+
+- add GitHub Action decision mode when CI should explain structured tradeoffs;
+- add probes when you need to show where work moved inside a benchmark;
+- add the server ledger when a team needs shared decision history and debt
+  summaries.
+
+Start with [`PERFORMANCE_DECISIONS.md`](PERFORMANCE_DECISIONS.md) when you are
+ready for structured decisions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ Codex execution state stay reviewable.
   [`audits/release-0.17.0-publish-readiness.md`](audits/release-0.17.0-publish-readiness.md)
 - Verification badges and PR evidence:
   [`VERIFICATION.md`](VERIFICATION.md)
+- First-hour adoption path: [`FIRST_HOUR.md`](FIRST_HOUR.md)
 - Performance decisions: [`PERFORMANCE_DECISIONS.md`](PERFORMANCE_DECISIONS.md)
 - Workspace inventory: [`WORKSPACE.md`](WORKSPACE.md)
 - GitHub Actions setup:


### PR DESCRIPTION
## Summary
- add a first-hour adoption guide for cold users
- link the guide from the README and docs index
- cover install, init, local check, baseline promotion, CI, artifact boundaries, and failure reproduction

## Validation
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `git diff --check`