### PR TITLE
docs: add decision outcome gallery

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "decision-outcome-gallery"
-current_pr = "docs: add decision outcome gallery"
+current_work_item = "first-hour-smoke-proof"
+current_pr = "test: add first-hour adoption smoke fixture"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -102,7 +102,7 @@ commands = [
 
 [[work_item]]
 id = "decision-outcome-gallery"
-status = "ready"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -116,7 +116,7 @@ commands = [
 
 [[work_item]]
 id = "first-hour-smoke-proof"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   promotion, CI, artifact boundaries, and failure reproduction.
 - Added an adoption-level guide that teaches perfgate as local gate, action
   gate, structured decision, and server-ledger workflows.
+- Added a decision outcome gallery for pass, fail, accepted-tradeoff,
+  review-required, missing-evidence, and high-noise review shapes.
 
 ## [0.17.0] - 2026-05-12
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -35,6 +35,10 @@ files, and the local reproduction command.
 `decision.index.json` is the machine-readable artifact manifest for actions,
 servers, dashboards, and agents that need to find the generated evidence set.
 
+For common pass, fail, accepted-tradeoff, review-required, missing-evidence,
+and high-noise shapes, see
+[`examples/decision-outcomes.md`](examples/decision-outcomes.md).
+
 Export a portable JSON bundle when the decision evidence needs to travel with a
 release, issue, audit, or agent handoff:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,8 @@ Codex execution state stay reviewable.
 - First-hour adoption path: [`FIRST_HOUR.md`](FIRST_HOUR.md)
 - Adoption levels: [`ADOPTION_LEVELS.md`](ADOPTION_LEVELS.md)
 - Performance decisions: [`PERFORMANCE_DECISIONS.md`](PERFORMANCE_DECISIONS.md)
+- Decision outcome gallery:
+  [`examples/decision-outcomes.md`](examples/decision-outcomes.md)
 - Workspace inventory: [`WORKSPACE.md`](WORKSPACE.md)
 - GitHub Actions setup:
   [`GETTING_STARTED_GITHUB_ACTIONS.md`](GETTING_STARTED_GITHUB_ACTIONS.md)

--- a/docs/examples/decision-outcomes.md
+++ b/docs/examples/decision-outcomes.md
@@ -1,0 +1,72 @@
+# Decision Outcome Gallery
+
+This gallery helps reviewers recognize the common shapes of a perfgate
+decision. It is not a second spec. The behavior contract lives in
+[`PERFGATE-SPEC-0003`](../specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
+and [`PERFGATE-SPEC-0007`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md).
+
+Use these examples when a CI summary, `decision.md`, or decision bundle looks
+unfamiliar.
+
+## Common Review Packet
+
+Structured decisions are review packets. A complete local packet usually has:
+
+```text
+artifacts/perfgate/
+  compare.json
+  probe-compare.json
+  scenario.json
+  tradeoff.json
+  decision.md
+  decision.index.json
+  decision-bundle.json
+```
+
+The exact paths may be per-benchmark subdirectories when `check --all` runs.
+`decision.index.json` is the machine-readable manifest that tells humans,
+actions, servers, and agents where the supporting receipts live.
+
+## Local Reproduction
+
+For a standard decision-enabled run:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+For the deterministic fixture in this repo:
+
+```bash
+perfgate ingest probes --file examples/performance-decision/probes-baseline.jsonl --out artifacts/perfgate/large-file/probes-baseline.json
+perfgate ingest probes --file examples/performance-decision/probes-current.jsonl --out artifacts/perfgate/large-file/probes-current.json
+perfgate decision evaluate --config examples/performance-decision/perfgate.toml
+```
+
+## Outcome Index
+
+| Outcome | Shape | Reviewer action |
+|---------|-------|-----------------|
+| [Pass](../../examples/performance-decision/outcomes/pass.md) | Workload stays inside policy. | Merge from a performance perspective if other review is clean. |
+| [Fail](../../examples/performance-decision/outcomes/fail.md) | A required metric regresses and no accepted tradeoff applies. | Fix, explain, or intentionally update policy/baseline in a separate review. |
+| [Warn with accepted tradeoff](../../examples/performance-decision/outcomes/warn-accepted-tradeoff.md) | A local regression is accepted because configured compensating evidence passes. | Review the policy rule and evidence, then decide whether the tradeoff is intentional. |
+| [Review required](../../examples/performance-decision/outcomes/review-required.md) | Evidence could support a tradeoff, but policy says a human must inspect it. | Inspect missing/noisy evidence before treating it as accepted. |
+| [Missing evidence](../../examples/performance-decision/outcomes/missing-evidence.md) | A receipt, probe, or metric required by policy is absent. | Reproduce with the missing artifact path fixed or change policy in a separate PR. |
+| [High noise](../../examples/performance-decision/outcomes/high-noise.md) | Evidence exists but is too noisy for automatic acceptance. | Rerun under steadier conditions or require human approval. |
+
+## What A Reviewer Should Check
+
+Before accepting a structured decision:
+
+- read `decision.md` first;
+- follow `decision.index.json` to the receipts when the summary is surprising;
+- check whether the final verdict is `pass`, `warn`, `fail`, or
+  review-required;
+- verify that accepted tradeoffs name a configured rule;
+- inspect probe deltas when the tradeoff depends on a named probe;
+- confirm the local reproduction command is present; and
+- bundle the decision when it needs to travel with a PR, release, issue, audit,
+  or agent handoff.
+

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -43,3 +43,5 @@ The fixture models a memory-for-speed decision:
 slightly. That evidence remains visible in the generated `probe-compare.json`;
 the tradeoff rule accepts the memory regression only because the local
 tokenizer regression stays bounded and the dominant batch-loop probe improves.
+
+For common decision shapes, see the [`outcomes`](outcomes/README.md) gallery.

--- a/examples/performance-decision/outcomes/README.md
+++ b/examples/performance-decision/outcomes/README.md
@@ -1,0 +1,15 @@
+# Performance Decision Outcomes
+
+These examples show the common decision shapes that reviewers see in
+`decision.md`, action summaries, and decision bundles.
+
+They are teaching fixtures, not separate behavior contracts. The contracts live
+in:
+
+- [`docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md`](../../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
+- [`docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md`](../../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
+
+Start with the gallery:
+
+- [`docs/examples/decision-outcomes.md`](../../../docs/examples/decision-outcomes.md)
+

--- a/examples/performance-decision/outcomes/fail.md
+++ b/examples/performance-decision/outcomes/fail.md
@@ -1,0 +1,45 @@
+# Outcome: Fail
+
+## Scenario
+
+A required metric regressed beyond the configured budget and no tradeoff rule
+accepted the change.
+
+## Input Receipts
+
+```text
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.index.json
+```
+
+## decision.md Excerpt
+
+```text
+Decision: fail
+Failed metric: wall_ms
+Reason: weighted workload exceeded configured budget
+Review required: no
+```
+
+## Action Summary Excerpt
+
+```text
+perfgate decision: fail
+Failed metric: wall_ms
+Reproduce: perfgate check --config perfgate.toml --all --require-baseline
+```
+
+## Reviewer Action
+
+Ask for a fix, a separate baseline update with evidence, or a policy change
+that explains why the regression is intentional.
+
+## Local Reproduction
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+```
+

--- a/examples/performance-decision/outcomes/high-noise.md
+++ b/examples/performance-decision/outcomes/high-noise.md
@@ -1,0 +1,45 @@
+# Outcome: High Noise
+
+## Scenario
+
+Evidence exists, but the configured noise policy says it is too noisy for
+automatic acceptance.
+
+## Input Receipts
+
+```text
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/probe-compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.index.json
+```
+
+## decision.md Excerpt
+
+```text
+Decision: warn
+Review required: yes
+Reason: coefficient of variation exceeded policy
+```
+
+## Action Summary Excerpt
+
+```text
+perfgate decision: warn, high noise
+Noise policy: needs review
+Reproduce: perfgate check --config perfgate.toml --all --require-baseline
+```
+
+## Reviewer Action
+
+Rerun under steadier conditions, inspect whether the noise is expected for the
+workload, or require explicit human approval before accepting the tradeoff.
+
+## Local Reproduction
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+```
+

--- a/examples/performance-decision/outcomes/missing-evidence.md
+++ b/examples/performance-decision/outcomes/missing-evidence.md
@@ -1,0 +1,51 @@
+# Outcome: Missing Evidence
+
+## Scenario
+
+The config requires a receipt, probe, or metric that was not present in the
+local artifact set.
+
+## Input Receipts
+
+```text
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.index.json
+```
+
+Missing expected receipt:
+
+```text
+artifacts/perfgate/probe-compare.json
+```
+
+## decision.md Excerpt
+
+```text
+Decision: warn
+Review required: yes
+Reason: required probe evidence is missing
+```
+
+## Action Summary Excerpt
+
+```text
+perfgate decision: warn, missing evidence
+Missing artifact: artifacts/perfgate/probe-compare.json
+Reproduce: perfgate decision evaluate --config perfgate.toml
+```
+
+## Reviewer Action
+
+Fix the artifact path, add the missing probe emission, or change the tradeoff
+policy in a separate review. Do not accept the tradeoff as proven while the
+required evidence is absent.
+
+## Local Reproduction
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+```
+

--- a/examples/performance-decision/outcomes/pass.md
+++ b/examples/performance-decision/outcomes/pass.md
@@ -1,0 +1,43 @@
+# Outcome: Pass
+
+## Scenario
+
+The changed branch stays inside every configured performance budget. No
+tradeoff rule is needed.
+
+## Input Receipts
+
+```text
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.index.json
+```
+
+## decision.md Excerpt
+
+```text
+Decision: pass
+Reason: all weighted scenarios stayed inside policy
+Review required: no
+```
+
+## Action Summary Excerpt
+
+```text
+perfgate decision: pass
+Artifacts: artifacts/perfgate/
+Reproduce: perfgate decision evaluate --config perfgate.toml
+```
+
+## Reviewer Action
+
+Treat the performance decision as clean. Continue normal code review.
+
+## Local Reproduction
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+```
+

--- a/examples/performance-decision/outcomes/review-required.md
+++ b/examples/performance-decision/outcomes/review-required.md
@@ -1,0 +1,46 @@
+# Outcome: Review Required
+
+## Scenario
+
+The available evidence could satisfy a tradeoff, but policy says the evidence
+is not trustworthy enough for automatic acceptance. Common reasons are missing
+noise data, high CV, or incomplete named probe evidence.
+
+## Input Receipts
+
+```text
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/probe-compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.index.json
+```
+
+## decision.md Excerpt
+
+```text
+Decision: warn
+Review required: yes
+Reason: required tradeoff evidence needs human review
+```
+
+## Action Summary Excerpt
+
+```text
+perfgate decision: warn, review required
+Review policy: warn
+Reproduce: perfgate decision evaluate --config perfgate.toml
+```
+
+## Reviewer Action
+
+Inspect the receipt that triggered review. Do not treat review-required as the
+same thing as an accepted automatic tradeoff.
+
+## Local Reproduction
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+perfgate decision evaluate --config perfgate.toml
+```
+

--- a/examples/performance-decision/outcomes/warn-accepted-tradeoff.md
+++ b/examples/performance-decision/outcomes/warn-accepted-tradeoff.md
@@ -1,0 +1,49 @@
+# Outcome: Warn With Accepted Tradeoff
+
+## Scenario
+
+A local metric regressed, but a configured tradeoff rule accepted it because a
+more important workload or probe improved enough.
+
+The deterministic fixture in `examples/performance-decision` uses this shape:
+`max_rss_kb` warns, `parser.batch_loop` improves, and `parser.tokenize` stays
+inside the local regression cap.
+
+## Input Receipts
+
+```text
+artifacts/perfgate/large-file/probe-compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.index.json
+```
+
+## decision.md Excerpt
+
+```text
+Decision: warn
+Accepted tradeoff: memory-for-batch-loop-speed
+Review required: no
+```
+
+## Action Summary Excerpt
+
+```text
+perfgate decision: warn
+Accepted tradeoff: memory-for-batch-loop-speed
+Reproduce: perfgate decision evaluate --config perfgate.toml
+```
+
+## Reviewer Action
+
+Review the accepted rule and the receipts that satisfied it. If the tradeoff is
+intentional, the warning is expected evidence rather than a surprise failure.
+
+## Local Reproduction
+
+```bash
+perfgate ingest probes --file examples/performance-decision/probes-baseline.jsonl --out artifacts/perfgate/large-file/probes-baseline.json
+perfgate ingest probes --file examples/performance-decision/probes-current.jsonl --out artifacts/perfgate/large-file/probes-current.json
+perfgate decision evaluate --config examples/performance-decision/perfgate.toml
+```
+

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -45,8 +45,8 @@ This plan sequences the work. Behavior is owned by
 | 374 | Guided adoption proposal | merged | `docs/proposals/PERFGATE-PROP-0002-guided-adoption.md` |
 | 375 | Guided adoption contract spec | merged | `docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md` |
 | 376 | Guided adoption plan and active goal | current | `plans/0.18.0/guided-adoption.md`, `.codex/goals/active.toml` |
-| 377 | Decision outcome gallery | ready | `docs/examples/decision-outcomes.md`, `examples/performance-decision/outcomes/` |
-| 378 | First-hour adoption smoke fixture | ready | CLI tests and fixtures |
+| 377 | Decision outcome gallery | merged | `docs/examples/decision-outcomes.md`, `examples/performance-decision/outcomes/` |
+| 378 | First-hour adoption smoke fixture | current | CLI tests and fixtures |
 | 379 | Probe instrumentation quickstart | ready | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
 | 380 | Probe-to-decision proof | ready | CLI tests or deterministic fixtures |
 | 381 | GitHub Action failure UX | ready | action output, tests, docs |
@@ -161,7 +161,7 @@ Revert this plan and `.codex/goals/active.toml`.
 
 ## Work item: decision-outcome-gallery
 
-Status: ready
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
@@ -203,7 +203,7 @@ Revert the examples and links.
 
 ## Work item: first-hour-smoke-proof
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:


### PR DESCRIPTION
## Summary
- add a decision outcome gallery for common review shapes
- add example outcome pages for pass, fail, accepted tradeoff, review-required, missing evidence, and high noise
- link the gallery from performance decision docs, the docs index, and the deterministic example
- advance the active guided-adoption goal to first-hour smoke proof

## Validation
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`