### PR TITLE
test: add first-hour adoption smoke proof

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "first-hour-smoke-proof"
-current_pr = "test: add first-hour adoption smoke fixture"
+current_work_item = "probe-quickstart"
+current_pr = "docs: add probe instrumentation quickstart"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -116,7 +116,7 @@ commands = [
 
 [[work_item]]
 id = "first-hour-smoke-proof"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -130,7 +130,7 @@ commands = [
 
 [[work_item]]
 id = "probe-quickstart"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate, structured decision, and server-ledger workflows.
 - Added a decision outcome gallery for pass, fail, accepted-tradeoff,
   review-required, missing-evidence, and high-noise review shapes.
+- Extended first-hour adoption proof to cover baseline status,
+  require-baseline reruns, and compare artifact creation after promotion.
 
 ## [0.17.0] - 2026-05-12
 

--- a/crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs
+++ b/crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs
@@ -54,6 +54,7 @@ fn tune_generated_config_for_fast_fixture(config_path: &Path) {
     let tuned = generated
         .replace("repeat = 7", "repeat = 1")
         .replace("warmup = 1", "warmup = 0")
+        .replace("threshold = 0.20", "threshold = 100.0")
         .replace(
             r#"command = ["cargo", "bench", "--bench", "parser"]"#,
             &format!(r#"command = [{}]"#, command_toml_array(&success_command())),
@@ -101,11 +102,34 @@ fn first_run_paved_road_creates_artifacts_and_baselines() {
 
     perfgate_cmd()
         .current_dir(temp_dir.path())
+        .args(["baseline", "status", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Baseline status"))
+        .stdout(predicate::str::contains("MISSING parser"))
+        .stdout(predicate::str::contains(
+            "perfgate baseline promote --config perfgate.toml --all",
+        ));
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
         .args(["baseline", "promote", "--config", "perfgate.toml", "--all"])
         .assert()
         .success()
         .stderr(predicate::str::contains("Promoted baseline for parser"))
         .stderr(predicate::str::contains("Promoted 1 baseline"));
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args([
+            "check",
+            "--config",
+            "perfgate.toml",
+            "--all",
+            "--require-baseline",
+        ])
+        .assert()
+        .success();
 
     assert!(root.join("perfgate.toml").exists());
     assert!(root.join(".github/workflows/perfgate.yml").exists());
@@ -113,6 +137,7 @@ fn first_run_paved_road_creates_artifacts_and_baselines() {
     assert!(root.join("baselines/.gitkeep").exists());
     assert!(root.join("baselines/parser.json").exists());
     assert!(root.join("artifacts/perfgate/parser/run.json").exists());
+    assert!(root.join("artifacts/perfgate/parser/compare.json").exists());
     assert!(root.join("artifacts/perfgate/parser/report.json").exists());
     assert!(root.join("artifacts/perfgate/parser/comment.md").exists());
 

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -46,8 +46,8 @@ This plan sequences the work. Behavior is owned by
 | 375 | Guided adoption contract spec | merged | `docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md` |
 | 376 | Guided adoption plan and active goal | current | `plans/0.18.0/guided-adoption.md`, `.codex/goals/active.toml` |
 | 377 | Decision outcome gallery | merged | `docs/examples/decision-outcomes.md`, `examples/performance-decision/outcomes/` |
-| 378 | First-hour adoption smoke fixture | current | CLI tests and fixtures |
-| 379 | Probe instrumentation quickstart | ready | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
+| 378 | First-hour adoption smoke fixture | merged | CLI tests and fixtures |
+| 379 | Probe instrumentation quickstart | current | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
 | 380 | Probe-to-decision proof | ready | CLI tests or deterministic fixtures |
 | 381 | GitHub Action failure UX | ready | action output, tests, docs |
 | 382 | Server ledger operations runbook | ready | server docs/runbook |
@@ -127,7 +127,7 @@ Revert the guide and links. Product behavior remains unchanged.
 
 ## Work item: guided-adoption-plan-and-active-goal
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:
@@ -248,7 +248,7 @@ Revert the fixture/test changes.
 
 ## Work item: probe-quickstart
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md


### PR DESCRIPTION
## Summary
- extend the first-hour E2E test through baseline status, baseline promotion, and a require-baseline rerun
- assert the promoted path creates `compare.json` after baseline promotion
- advance the active guided-adoption goal to the probe quickstart work item

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p perfgate-cli --test cli_first_run_e2e_tests --all-features`
- `cargo +1.95.0 test -p perfgate-cli --all-features first_run`
- `cargo +1.95.0 test -p perfgate-cli --all-features baseline`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`