### PR TITLE
docs: add probe instrumentation quickstart

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "probe-quickstart"
-current_pr = "docs: add probe instrumentation quickstart"
+current_work_item = "probe-to-decision-proof"
+current_pr = "test: prove probe helper to decision workflow"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -130,7 +130,7 @@ commands = [
 
 [[work_item]]
 id = "probe-quickstart"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -144,7 +144,7 @@ commands = [
 
 [[work_item]]
 id = "probe-to-decision-proof"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   review-required, missing-evidence, and high-noise review shapes.
 - Extended first-hour adoption proof to cover baseline status,
   require-baseline reruns, and compare artifact creation after promotion.
+- Added a probe instrumentation quickstart covering stable probe names, JSONL
+  emission, Rust helpers, ingest, comparison, and decision wiring.
 
 ## [0.17.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Start with:
 For specific workflows:
 
 - [Performance Decisions](docs/PERFORMANCE_DECISIONS.md)
+- [Probe Instrumentation Quickstart](docs/PROBE_QUICKSTART.md)
 - [Step-by-Step Pipeline](docs/PIPELINE.md)
 - [Baseline Server](docs/GETTING_STARTED_BASELINE_SERVER.md)
 - [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md)

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -140,6 +140,9 @@ prune.
 Named probes explain internal phase movement. Ingest probe observations from any
 language or harness:
 
+For the step-by-step instrumentation path, see
+[`PROBE_QUICKSTART.md`](PROBE_QUICKSTART.md).
+
 ```bash
 perfgate ingest probes --file probes.jsonl --out artifacts/perfgate/probes.json
 ```
@@ -148,7 +151,7 @@ Rust projects can emit the same JSONL with the optional facade helper:
 
 ```toml
 [dependencies]
-perfgate = { version = "0.15", features = ["probe"] }
+perfgate = { version = "0.17", features = ["probe"] }
 ```
 
 ```rust,no_run
@@ -175,7 +178,7 @@ Projects that already use `tracing` can enable the optional span adapter:
 
 ```toml
 [dependencies]
-perfgate = { version = "0.15", features = ["probe-tracing"] }
+perfgate = { version = "0.17", features = ["probe-tracing"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -215,7 +218,7 @@ Criterion samples to also become probe JSONL:
 ```toml
 [dev-dependencies]
 criterion = "0.8"
-perfgate = { version = "0.15", features = ["probe-criterion"] }
+perfgate = { version = "0.17", features = ["probe-criterion"] }
 ```
 
 ```rust,no_run

--- a/docs/PROBE_QUICKSTART.md
+++ b/docs/PROBE_QUICKSTART.md
@@ -1,0 +1,201 @@
+# Probe Instrumentation Quickstart
+
+Probes explain where work moved inside a benchmark. They are useful when the
+normal gate says "this changed" but reviewers need the product answer:
+
+```text
+this got slower here, but faster where it matters
+```
+
+Probes are not a profiler. Start with two or three named phases that already
+matter to reviewers, such as `parser.tokenize`, `parser.ast_build`, and
+`parser.batch_loop`.
+
+## 1. Pick Stable Probe Names
+
+Use names that describe durable work, not temporary function names:
+
+```text
+parser.tokenize
+parser.ast_build
+parser.batch_loop
+```
+
+Good probe names are:
+
+- stable across refactors;
+- specific enough to explain a tradeoff;
+- few enough that reviewers can read the decision.
+
+Avoid emitting one probe for every function, span, or allocation site. perfgate
+needs review evidence, not a trace dump.
+
+## 2. Emit JSONL From Any Language
+
+`perfgate ingest probes` accepts newline-delimited JSON. Each line is one probe
+observation.
+
+```json
+{"probe":"parser.tokenize","scope":"local","wall_ms":12.4,"alloc_bytes":184320,"items":10000}
+{"probe":"parser.batch_loop","scope":"dominant","wall_ms":44.8,"items":10000}
+```
+
+Write that file wherever your benchmark can reach it, for example:
+
+```text
+artifacts/probes-current.jsonl
+```
+
+Then ingest it into a typed perfgate receipt:
+
+```bash
+perfgate ingest probes --file artifacts/probes-current.jsonl --out artifacts/perfgate/probes-current.json
+```
+
+The JSONL file is an input convenience. The receipt is the durable artifact
+that downstream commands consume.
+
+## 3. Use The Rust Helper When Convenient
+
+Rust projects can use the optional helper to write the same JSONL shape without
+hand-building JSON strings.
+
+```toml
+[dependencies]
+perfgate = { version = "0.17", features = ["probe"] }
+```
+
+```rust,no_run
+use perfgate::probe::{ProbeJsonlWriter, probe_event, probe_timer};
+use perfgate::types::ProbeScope;
+
+fn main() -> std::io::Result<()> {
+    let mut probes = ProbeJsonlWriter::create("artifacts/probes-current.jsonl")?;
+
+    probes.record(
+        &probe_event("parser.tokenize")
+            .scope(ProbeScope::Local)
+            .items(10_000)
+            .metric("wall_ms", 12.4, "ms")
+            .metric("alloc_bytes", 184_320.0, "bytes"),
+    )?;
+
+    let timer = probe_timer("parser.batch_loop")
+        .scope(ProbeScope::Dominant)
+        .items(10_000);
+
+    run_batch_loop();
+
+    probes.record(&timer.finish())?;
+    probes.flush()
+}
+
+fn run_batch_loop() {}
+```
+
+The helper is deliberately small: it writes JSONL, and
+`perfgate ingest probes` turns that JSONL into a receipt.
+
+## 4. Keep Baseline And Current Receipts
+
+For decision workflows, compare a baseline probe receipt with a current probe
+receipt.
+
+```bash
+perfgate ingest probes --file baselines/probes.jsonl --out baselines/probes.json
+perfgate ingest probes --file artifacts/probes-current.jsonl --out artifacts/perfgate/probes-current.json
+perfgate probe compare --baseline baselines/probes.json --current artifacts/perfgate/probes-current.json --out artifacts/perfgate/probe-compare.json
+```
+
+Usually commit:
+
+- reviewed baseline probe JSONL or receipt files when they define the accepted
+  comparison point;
+- `perfgate.toml` entries that reference the probe evidence.
+
+Usually do not commit:
+
+- current-run probe JSONL from ordinary local experiments;
+- generated `artifacts/perfgate/` output unless it is attached to a release,
+  audit, issue, or review record on purpose.
+
+## 5. Attach Probes To A Scenario
+
+Add probe paths to the scenario that needs the evidence:
+
+```toml
+[[scenario]]
+name = "large_file_parse"
+bench = "large-file"
+weight = 0.75
+probe_baseline = "baselines/probes.json"
+probe_current = "artifacts/perfgate/probes-current.json"
+probe_compare = "artifacts/perfgate/probe-compare.json"
+```
+
+Then run the normal decision command:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+`decision evaluate` writes the configured `probe-compare.json` before it
+evaluates scenarios and tradeoffs.
+
+## 6. Require A Probe In A Tradeoff
+
+Use a probe-backed requirement when a local regression is acceptable only if a
+named phase improved enough.
+
+```toml
+[[tradeoff]]
+name = "memory-for-batch-loop-speed"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "parser.batch_loop"
+min_improvement_ratio = 1.10
+
+[[tradeoff.allow]]
+metric = "wall_ms"
+probe = "parser.tokenize"
+max_regression = 0.03
+```
+
+This reads as:
+
+```text
+Accept the memory warning only if parser.batch_loop improves by at least 10%,
+and only while parser.tokenize stays within a 3% local regression cap.
+```
+
+If the required probe is missing or too noisy under decision policy, perfgate
+marks the decision as review-required instead of pretending the evidence is
+complete.
+
+## 7. Review The Output
+
+The reviewer-facing artifact is:
+
+```text
+artifacts/perfgate/decision.md
+```
+
+The machine-readable manifest is:
+
+```text
+artifacts/perfgate/decision.index.json
+```
+
+Bundle the evidence when it needs to travel:
+
+```bash
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+For a deterministic fixture that exercises probe ingest, probe compare,
+scenario evaluation, tradeoff evaluation, and decision rendering, see
+[`examples/performance-decision`](../examples/performance-decision/README.md).
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Codex execution state stay reviewable.
 - Performance decisions: [`PERFORMANCE_DECISIONS.md`](PERFORMANCE_DECISIONS.md)
 - Decision outcome gallery:
   [`examples/decision-outcomes.md`](examples/decision-outcomes.md)
+- Probe instrumentation: [`PROBE_QUICKSTART.md`](PROBE_QUICKSTART.md)
 - Workspace inventory: [`WORKSPACE.md`](WORKSPACE.md)
 - GitHub Actions setup:
   [`GETTING_STARTED_GITHUB_ACTIONS.md`](GETTING_STARTED_GITHUB_ACTIONS.md)

--- a/docs/SCHEMAS.md
+++ b/docs/SCHEMAS.md
@@ -70,6 +70,9 @@ cargo run -p xtask -- schema-compat
 `perfgate ingest probes` converts language-agnostic probe JSONL into a
 `perfgate.probe.v1` receipt:
 
+For a first instrumentation path, see
+[`PROBE_QUICKSTART.md`](PROBE_QUICKSTART.md).
+
 ```bash
 perfgate ingest probes --file probes.jsonl --out probe.json
 ```

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -8,6 +8,9 @@ Rust projects can generate compatible probe JSONL with the optional `perfgate`
 `probe` feature, but the fixture keeps the JSONL checked in so the example is
 reproducible in any environment.
 
+For the instrumentation path that produces JSONL from real code, see
+[`docs/PROBE_QUICKSTART.md`](../../docs/PROBE_QUICKSTART.md).
+
 Run from the repository root:
 
 ```bash

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -47,8 +47,8 @@ This plan sequences the work. Behavior is owned by
 | 376 | Guided adoption plan and active goal | current | `plans/0.18.0/guided-adoption.md`, `.codex/goals/active.toml` |
 | 377 | Decision outcome gallery | merged | `docs/examples/decision-outcomes.md`, `examples/performance-decision/outcomes/` |
 | 378 | First-hour adoption smoke fixture | merged | CLI tests and fixtures |
-| 379 | Probe instrumentation quickstart | current | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
-| 380 | Probe-to-decision proof | ready | CLI tests or deterministic fixtures |
+| 379 | Probe instrumentation quickstart | merged | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
+| 380 | Probe-to-decision proof | current | CLI tests or deterministic fixtures |
 | 381 | GitHub Action failure UX | ready | action output, tests, docs |
 | 382 | Server ledger operations runbook | ready | server docs/runbook |
 | 383 | Guided adoption product claims | ready | `docs/status/PRODUCT_CLAIMS.md` |
@@ -203,7 +203,7 @@ Revert the examples and links.
 
 ## Work item: first-hour-smoke-proof
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:
@@ -291,7 +291,7 @@ Revert the quickstart and links.
 
 ## Work item: probe-to-decision-proof
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md


### PR DESCRIPTION
Adds the probe instrumentation quickstart and links it from README, docs, schemas, and the performance-decision example docs. Docs-only plus plan/active-goal advancement. Validation passed locally: cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check.