### PR TITLE
test: prove probe helper to decision workflow

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "probe-to-decision-proof"
-current_pr = "test: prove probe helper to decision workflow"
+current_work_item = "action-failure-copy"
+current_pr = "action: improve failure summary and reproduction copy"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -144,7 +144,7 @@ commands = [
 
 [[work_item]]
 id = "probe-to-decision-proof"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -157,7 +157,7 @@ commands = [
 
 [[work_item]]
 id = "action-failure-copy"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   require-baseline reruns, and compare artifact creation after promotion.
 - Added a probe instrumentation quickstart covering stable probe names, JSONL
   emission, Rust helpers, ingest, comparison, and decision wiring.
+- Proved public Rust probe helper JSONL through ingest, probe compare,
+  scenario, tradeoff, and decision markdown evidence while keeping the CLI
+  decision example as the bundle proof.
 
 ## [0.17.0] - 2026-05-12
 

--- a/crates/perfgate/src/probe.rs
+++ b/crates/perfgate/src/probe.rs
@@ -815,7 +815,19 @@ fn infer_unit(metric: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::render::render_tradeoff_markdown;
+    use crate::app::{
+        ProbeCompareRequest, ProbeCompareUseCase, ScenarioEvaluateInput, ScenarioEvaluateRequest,
+        ScenarioUseCase, TradeoffEvaluateRequest, TradeoffUseCase,
+    };
     use crate::integrations::ingest::{ProbeIngestRequest, ingest_probes_jsonl};
+    use perfgate_types::{
+        BenchMeta, COMPARE_SCHEMA_V1, CompareReceipt, CompareRef, ConfigFile, DecisionPolicyConfig,
+        DefaultsConfig, Delta, Metric, MetricStatistic, MetricStatus, ScenarioConfigFile, ToolInfo,
+        TradeoffAllowance, TradeoffDowngrade, TradeoffRequirement, TradeoffRule, Verdict,
+        VerdictCounts, VerdictStatus,
+    };
+    use std::collections::BTreeMap;
 
     #[test]
     fn probe_event_jsonl_is_ingestible() {
@@ -877,6 +889,230 @@ mod tests {
         assert!(wall_ms.is_finite());
         assert!(wall_ms >= 0.0);
         assert_eq!(event.metrics["wall_ms"].unit.as_deref(), Some("ms"));
+    }
+
+    #[test]
+    fn probe_helper_jsonl_drives_tradeoff_decision_evidence() {
+        let baseline = ingest_probes_jsonl(&ProbeIngestRequest {
+            input: helper_jsonl(&[
+                ("parser.tokenize", ProbeScope::Local, 12.10, 184_320.0),
+                (
+                    "parser.batch_loop",
+                    ProbeScope::Dominant,
+                    100.00,
+                    1_048_576.0,
+                ),
+            ]),
+            bench: Some("parser".to_string()),
+            scenario: Some("large_file_parse".to_string()),
+        })
+        .expect("ingest helper baseline JSONL");
+        let current = ingest_probes_jsonl(&ProbeIngestRequest {
+            input: helper_jsonl(&[
+                ("parser.tokenize", ProbeScope::Local, 12.35, 184_960.0),
+                (
+                    "parser.batch_loop",
+                    ProbeScope::Dominant,
+                    89.60,
+                    1_000_000.0,
+                ),
+            ]),
+            bench: Some("parser".to_string()),
+            scenario: Some("large_file_parse".to_string()),
+        })
+        .expect("ingest helper current JSONL");
+
+        let probe_compare = ProbeCompareUseCase::compare(ProbeCompareRequest {
+            baseline,
+            current,
+            baseline_ref: CompareRef {
+                path: Some("artifacts/perfgate/parser/probes-baseline.json".to_string()),
+                run_id: Some("probe-baseline".to_string()),
+            },
+            current_ref: CompareRef {
+                path: Some("artifacts/perfgate/parser/probes-current.json".to_string()),
+                run_id: Some("probe-current".to_string()),
+            },
+            tool: tool(),
+        })
+        .expect("compare helper probe receipts")
+        .receipt;
+        assert_eq!(probe_compare.verdict.status, VerdictStatus::Warn);
+        assert!(
+            probe_compare.probes.iter().any(
+                |probe| probe.name == "parser.batch_loop" && probe.status == MetricStatus::Pass
+            )
+        );
+        assert!(
+            probe_compare
+                .probes
+                .iter()
+                .any(|probe| probe.name == "parser.tokenize" && probe.status == MetricStatus::Warn)
+        );
+
+        let scenario = ScenarioUseCase::evaluate(ScenarioEvaluateRequest {
+            config: ConfigFile {
+                defaults: DefaultsConfig {
+                    threshold: Some(0.20),
+                    warn_factor: Some(0.50),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            inputs: vec![ScenarioEvaluateInput {
+                config: ScenarioConfigFile {
+                    name: "large_file_parse".to_string(),
+                    weight: 1.0,
+                    bench: "parser".to_string(),
+                    description: None,
+                    compare: Some("artifacts/perfgate/parser/compare.json".to_string()),
+                    probe_compare: Some("artifacts/perfgate/parser/probe-compare.json".to_string()),
+                    probe_baseline: None,
+                    probe_current: None,
+                },
+                compare_ref: CompareRef {
+                    path: Some("artifacts/perfgate/parser/compare.json".to_string()),
+                    run_id: Some("parser-current".to_string()),
+                },
+                compare: compare_receipt(),
+                probe_compare_ref: Some(CompareRef {
+                    path: Some("artifacts/perfgate/parser/probe-compare.json".to_string()),
+                    run_id: Some(probe_compare.run.id.clone()),
+                }),
+                probe_compare: Some(probe_compare.clone()),
+                probe_compare_warning: None,
+            }],
+            workload_name: None,
+            tool: tool(),
+        })
+        .expect("evaluate scenario from probe evidence")
+        .receipt;
+        assert!(
+            scenario.components[0]
+                .probes
+                .iter()
+                .any(|probe| probe == "parser.batch_loop")
+        );
+
+        let tradeoff = TradeoffUseCase::evaluate(TradeoffEvaluateRequest {
+            scenario,
+            probe_compares: vec![probe_compare],
+            rules: vec![TradeoffRule {
+                name: "memory_for_probe_speed".to_string(),
+                if_failed: Metric::MaxRssKb,
+                require: vec![TradeoffRequirement {
+                    metric: Metric::WallMs,
+                    probe: Some("parser.batch_loop".to_string()),
+                    min_improvement_ratio: 1.10,
+                }],
+                allow: vec![TradeoffAllowance {
+                    metric: Metric::WallMs,
+                    probe: "parser.tokenize".to_string(),
+                    max_regression: 0.03,
+                }],
+                downgrade_to: TradeoffDowngrade::Warn,
+            }],
+            decision_policy: DecisionPolicyConfig::default(),
+            tool: tool(),
+        })
+        .expect("evaluate probe-backed tradeoff")
+        .receipt;
+
+        assert!(tradeoff.decision.accepted_tradeoff);
+        assert_eq!(tradeoff.decision.status, MetricStatus::Warn);
+        assert_eq!(
+            tradeoff.rules[0].requirements[0].probe.as_deref(),
+            Some("parser.batch_loop")
+        );
+        assert_eq!(tradeoff.rules[0].allowances[0].probe, "parser.tokenize");
+
+        let decision = render_tradeoff_markdown(&tradeoff);
+        assert!(decision.contains("perfgate tradeoff: warn"));
+        assert!(decision.contains("tradeoff 'memory_for_probe_speed' accepted"));
+        assert!(decision.contains("Probe Evidence"));
+        assert!(decision.contains("parser.batch_loop"));
+        assert!(decision.contains("parser.tokenize"));
+    }
+
+    fn helper_jsonl(probes: &[(&str, ProbeScope, f64, f64)]) -> String {
+        let mut writer = ProbeJsonlWriter::new(Vec::new());
+        for (name, scope, wall_ms, alloc_bytes) in probes {
+            writer
+                .record(
+                    &probe_event(*name)
+                        .scope(*scope)
+                        .items(10_000)
+                        .metric("wall_ms", *wall_ms, "ms")
+                        .metric("alloc_bytes", *alloc_bytes, "bytes"),
+                )
+                .expect("record helper probe event");
+        }
+        writer.flush().expect("flush helper probe JSONL");
+        String::from_utf8(writer.into_inner()).expect("helper JSONL should be utf8")
+    }
+
+    fn compare_receipt() -> CompareReceipt {
+        CompareReceipt {
+            schema: COMPARE_SCHEMA_V1.to_string(),
+            tool: tool(),
+            bench: BenchMeta {
+                name: "parser".to_string(),
+                cwd: None,
+                command: vec!["cargo".to_string(), "bench".to_string()],
+                repeat: 1,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            baseline_ref: CompareRef {
+                path: Some("baselines/parser.json".to_string()),
+                run_id: Some("parser-baseline".to_string()),
+            },
+            current_ref: CompareRef {
+                path: Some("artifacts/perfgate/parser/run.json".to_string()),
+                run_id: Some("parser-current".to_string()),
+            },
+            budgets: BTreeMap::new(),
+            deltas: BTreeMap::from([
+                (Metric::WallMs, delta(100.0, 96.0, 0.0, MetricStatus::Pass)),
+                (
+                    Metric::MaxRssKb,
+                    delta(100.0, 1200.0, 11.0, MetricStatus::Fail),
+                ),
+            ]),
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    pass: 1,
+                    warn: 0,
+                    fail: 1,
+                    skip: 0,
+                },
+                reasons: vec!["max_rss_kb_fail".to_string()],
+            },
+        }
+    }
+
+    fn delta(baseline: f64, current: f64, regression: f64, status: MetricStatus) -> Delta {
+        Delta {
+            baseline,
+            current,
+            ratio: current / baseline,
+            pct: (current - baseline) / baseline,
+            regression,
+            cv: None,
+            noise_threshold: None,
+            statistic: MetricStatistic::Median,
+            significance: None,
+            status,
+        }
+    }
+
+    fn tool() -> ToolInfo {
+        ToolInfo {
+            name: "perfgate".to_string(),
+            version: "0.17.0".to_string(),
+        }
     }
 
     #[cfg(feature = "probe-criterion")]

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -44,12 +44,12 @@ This plan sequences the work. Behavior is owned by
 | 373 | Adoption levels | merged | `docs/ADOPTION_LEVELS.md`, README/docs links |
 | 374 | Guided adoption proposal | merged | `docs/proposals/PERFGATE-PROP-0002-guided-adoption.md` |
 | 375 | Guided adoption contract spec | merged | `docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md` |
-| 376 | Guided adoption plan and active goal | current | `plans/0.18.0/guided-adoption.md`, `.codex/goals/active.toml` |
+| 376 | Guided adoption plan and active goal | merged | `plans/0.18.0/guided-adoption.md`, `.codex/goals/active.toml` |
 | 377 | Decision outcome gallery | merged | `docs/examples/decision-outcomes.md`, `examples/performance-decision/outcomes/` |
 | 378 | First-hour adoption smoke fixture | merged | CLI tests and fixtures |
 | 379 | Probe instrumentation quickstart | merged | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
-| 380 | Probe-to-decision proof | current | CLI tests or deterministic fixtures |
-| 381 | GitHub Action failure UX | ready | action output, tests, docs |
+| 380 | Probe-to-decision proof | merged | CLI tests or deterministic fixtures |
+| 381 | GitHub Action failure UX | current | action output, tests, docs |
 | 382 | Server ledger operations runbook | ready | server docs/runbook |
 | 383 | Guided adoption product claims | ready | `docs/status/PRODUCT_CLAIMS.md` |
 | 384 | Claim/spec freshness checker | ready | `xtask` checker and tests |
@@ -248,7 +248,7 @@ Revert the fixture/test changes.
 
 ## Work item: probe-quickstart
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
@@ -291,7 +291,7 @@ Revert the quickstart and links.
 
 ## Work item: probe-to-decision-proof
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
@@ -332,7 +332,7 @@ Revert the tests/fixtures.
 
 ## Work item: action-failure-copy
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:


### PR DESCRIPTION
Adds an executable probe-feature fixture proving public Rust probe helper JSONL through ingest, probe compare, scenario, tradeoff, and markdown decision evidence. Existing CLI decision tests cover the command-level decision evaluate and bundle path. Also advances the guided-adoption plan and active goal to action failure UX. Validation passed locally with CARGO_TARGET_DIR=C:/perfgate-target/codex-probe-proof: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p perfgate --features probe probe_helper_jsonl_drives_tradeoff_decision_evidence; cargo +1.95.0 test -p perfgate-cli --all-features probe; cargo +1.95.0 test -p perfgate-cli --all-features decision; cargo +1.95.0 clippy -p perfgate --features probe --tests -- -D warnings; cargo +1.95.0 run -p xtask -- schema-compat; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check.