### PR TITLE
action: improve failure summary and reproduction copy

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "action-failure-copy"
-current_pr = "action: improve failure summary and reproduction copy"
+current_work_item = "server-ledger-runbook"
+current_pr = "docs(server): add decision ledger operations runbook"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -157,7 +157,7 @@ commands = [
 
 [[work_item]]
 id = "action-failure-copy"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -169,7 +169,7 @@ commands = [
 
 [[work_item]]
 id = "server-ledger-runbook"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Proved public Rust probe helper JSONL through ingest, probe compare,
   scenario, tradeoff, and decision markdown evidence while keeping the CLI
   decision example as the bundle proof.
+- Improved GitHub Action failure summaries with verdict counts, review-required
+  reasons, missing-baseline promotion hints, uploaded artifact names, and local
+  reproduction commands.
 
 ## [0.17.0] - 2026-05-12
 

--- a/action.yml
+++ b/action.yml
@@ -443,6 +443,14 @@ runs:
         exit_code="${{ steps.run_check.outputs.exit_code }}"
         decision_exit_code="${{ steps.run_decision.outputs.exit_code }}"
         review_exit_code="${{ steps.handle_review_required.outputs.exit_code }}"
+        verdict="${{ steps.run_check.outputs.verdict }}"
+        pass_count="${{ steps.run_check.outputs.pass_count }}"
+        warn_count="${{ steps.run_check.outputs.warn_count }}"
+        fail_count="${{ steps.run_check.outputs.fail_count }}"
+        bench_count="${{ steps.run_check.outputs.bench_count }}"
+        review_required="${{ steps.handle_review_required.outputs.review_required }}"
+        review_reason="${{ steps.handle_review_required.outputs.review_required_reason }}"
+        artifact_name="${{ inputs.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}"
         exit_source="check"
         if [[ "${{ inputs.decision }}" == "true" && -n "${decision_exit_code}" && "${decision_exit_code}" != "0" ]]; then
           exit_code="${decision_exit_code}"
@@ -527,6 +535,14 @@ runs:
           rm -f "${listing}"
         }
 
+        has_no_baseline_reason() {
+          if [[ ! -d "${out}" ]]; then
+            return 1
+          fi
+
+          grep -R -q -e "no_baseline" -e "missing baseline" -e "baseline.*missing" "${out}" 2>/dev/null
+        }
+
         repro_line="$(format_command "${repro[@]}")"
         decision_repro=()
         if [[ "${{ inputs.decision }}" == "true" ]]; then
@@ -537,6 +553,12 @@ runs:
         fi
 
         echo "perfgate ${exit_source} exited with code ${exit_code}"
+        if [[ -n "${verdict}" ]]; then
+          echo "Verdict: ${verdict} (pass=${pass_count:-0}, warn=${warn_count:-0}, fail=${fail_count:-0}, benches=${bench_count:-unknown})"
+        fi
+        if [[ "${{ inputs.decision }}" == "true" && "${review_required}" == "true" ]]; then
+          echo "Review required: ${review_reason}"
+        fi
         echo
         echo "Reproduce locally:"
         echo "  ${repro_line}"
@@ -555,12 +577,29 @@ runs:
           echo
           echo "For cockpit mode, inspect aggregate output plus versioned receipts under ${out}/extras/."
         fi
+        if has_no_baseline_reason; then
+          echo
+          echo "Baseline bootstrap: after reviewing the first trusted run, promote it locally:"
+          echo "  perfgate baseline promote --config ${{ inputs.config }} --all"
+        fi
+        if [[ "${{ inputs.upload_artifact }}" == "true" ]]; then
+          echo
+          echo "Uploaded artifact: ${artifact_name}"
+        fi
 
         if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
           {
             echo "### perfgate local reproduction"
             echo
             echo "perfgate ${exit_source} exited with code \`${exit_code}\`."
+            if [[ -n "${verdict}" ]]; then
+              echo
+              echo "Verdict: \`${verdict}\` (pass=${pass_count:-0}, warn=${warn_count:-0}, fail=${fail_count:-0}, benches=${bench_count:-unknown})."
+            fi
+            if [[ "${{ inputs.decision }}" == "true" && "${review_required}" == "true" ]]; then
+              echo
+              echo "Review required: ${review_reason}"
+            fi
             echo
             echo "```bash"
             echo "${repro_line}"
@@ -581,6 +620,18 @@ runs:
             if [[ "${{ inputs.mode }}" == "cockpit" ]]; then
               echo
               echo "For cockpit mode, inspect aggregate output plus versioned receipts under \`${out}/extras/\`."
+            fi
+            if has_no_baseline_reason; then
+              echo
+              echo "Baseline bootstrap: after reviewing the first trusted run, promote it locally:"
+              echo
+              echo "```bash"
+              echo "perfgate baseline promote --config ${{ inputs.config }} --all"
+              echo "```"
+            fi
+            if [[ "${{ inputs.upload_artifact }}" == "true" ]]; then
+              echo
+              echo "Uploaded artifact: \`${artifact_name}\`."
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
         fi

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -49,8 +49,8 @@ This plan sequences the work. Behavior is owned by
 | 378 | First-hour adoption smoke fixture | merged | CLI tests and fixtures |
 | 379 | Probe instrumentation quickstart | merged | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
 | 380 | Probe-to-decision proof | merged | CLI tests or deterministic fixtures |
-| 381 | GitHub Action failure UX | current | action output, tests, docs |
-| 382 | Server ledger operations runbook | ready | server docs/runbook |
+| 381 | GitHub Action failure UX | merged | action output, tests, docs |
+| 382 | Server ledger operations runbook | current | server docs/runbook |
 | 383 | Guided adoption product claims | ready | `docs/status/PRODUCT_CLAIMS.md` |
 | 384 | Claim/spec freshness checker | ready | `xtask` checker and tests |
 | 385 | Policy ledger contract spec | ready | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
@@ -332,7 +332,7 @@ Revert the tests/fixtures.
 
 ## Work item: action-failure-copy
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:
@@ -374,7 +374,7 @@ Revert action output changes and fixtures.
 
 ## Work item: server-ledger-runbook
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: local server-ledger optionality ADR planned if the lane changes that boundary

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1116,6 +1116,27 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
     }
     if !failure_summary_lines
         .iter()
+        .any(|line| line == "verdict=\"${{ steps.run_check.outputs.verdict }}\"")
+        || !failure_summary_lines.iter().any(|line| {
+            line == "echo \"Verdict: ${verdict} (pass=${pass_count:-0}, warn=${warn_count:-0}, fail=${fail_count:-0}, benches=${bench_count:-unknown})\""
+        })
+    {
+        errors.push(
+            "action.yml failure summary must include verdict counts when available".to_string(),
+        );
+    }
+    if !failure_summary_lines.iter().any(|line| {
+        line == "review_reason=\"${{ steps.handle_review_required.outputs.review_required_reason }}\""
+    }) || !failure_summary_lines
+        .iter()
+        .any(|line| line == "echo \"Review required: ${review_reason}\"")
+    {
+        errors.push(
+            "action.yml failure summary must include review-required reasons".to_string(),
+        );
+    }
+    if !failure_summary_lines
+        .iter()
         .any(|line| line == "repro=(perfgate check --config \"${{ inputs.config }}\")")
         || !failure_summary_lines
             .iter()
@@ -1165,6 +1186,29 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
             "action.yml failure summary must list perfgate receipt and probe evidence files"
                 .to_string(),
         );
+    }
+    if !failure_summary_lines
+        .iter()
+        .any(|line| line == "has_no_baseline_reason() {")
+        || !failure_summary_lines
+            .iter()
+            .any(|line| line.contains("no_baseline"))
+        || !failure_summary_lines.iter().any(|line| {
+            line == "echo \"  perfgate baseline promote --config ${{ inputs.config }} --all\""
+        })
+    {
+        errors.push(
+            "action.yml failure summary must include a baseline promotion hint when no baseline evidence appears"
+                .to_string(),
+        );
+    }
+    if !failure_summary_lines.iter().any(|line| {
+        line == "artifact_name=\"${{ inputs.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}\""
+    }) || !failure_summary_lines
+        .iter()
+        .any(|line| line == "echo \"Uploaded artifact: ${artifact_name}\"")
+    {
+        errors.push("action.yml failure summary must include the uploaded artifact name".to_string());
     }
 
     if !raw_action.contains("out=\"${{ steps.resolve_out_dir.outputs.out_dir }}\"")
@@ -6501,14 +6545,28 @@ runs:
         out="${{ steps.resolve_out_dir.outputs.out_dir }}"
         exit_code="${{ steps.run_check.outputs.exit_code }}"
         review_exit_code="${{ steps.handle_review_required.outputs.exit_code }}"
+        verdict="${{ steps.run_check.outputs.verdict }}"
+        pass_count="${{ steps.run_check.outputs.pass_count }}"
+        warn_count="${{ steps.run_check.outputs.warn_count }}"
+        fail_count="${{ steps.run_check.outputs.fail_count }}"
+        bench_count="${{ steps.run_check.outputs.bench_count }}"
+        review_reason="${{ steps.handle_review_required.outputs.review_required_reason }}"
+        artifact_name="${{ inputs.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}"
         repro=(perfgate check --config "${{ inputs.config }}")
         decision_repro=(perfgate decision evaluate --config "${{ inputs.config }}")
         decision_repro_line="$(format_command "${decision_repro[@]}")"
+        has_no_baseline_reason() {
+          grep -R -q -e "no_baseline" "${out}" 2>/dev/null
+        }
         {
+          echo "Verdict: ${verdict} (pass=${pass_count:-0}, warn=${warn_count:-0}, fail=${fail_count:-0}, benches=${bench_count:-unknown})"
+          echo "Review required: ${review_reason}"
           echo "Reproduce locally:"
           echo "  ${decision_repro_line}"
           echo "### perfgate local reproduction"
           echo "${decision_repro_line}"
+          echo "  perfgate baseline promote --config ${{ inputs.config }} --all"
+          echo "Uploaded artifact: ${artifact_name}"
           find "${out}" -type f \( -name run.json -o -name compare.json -o -name report.json -o -name probe-compare.json -o -name scenario.json -o -name tradeoff.json -o -name decision.md -o -name decision.index.json -o -name comment.md -o -name 'perfgate.*.json' \) | sort
         } >> "${GITHUB_STEP_SUMMARY}"
     - name: Post PR comment


### PR DESCRIPTION
Improves the composite action failure summary with verdict counts, review-required reasons, missing-baseline promotion hints, uploaded artifact names, artifact listings, and local reproduction commands. Updates xtask action-check and its unit fixture so the failure-copy contract stays enforced, then advances the guided-adoption lane to the server ledger runbook. Validation passed locally with CARGO_TARGET_DIR=C:/perfgate-target/codex-action-summary: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 run -p xtask -- action-check; cargo +1.95.0 test -p xtask action_check; cargo +1.95.0 clippy -p xtask --all-targets -- -D warnings; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check.