### PR TITLE
docs(server): add decision ledger operations runbook

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "server-ledger-runbook"
-current_pr = "docs(server): add decision ledger operations runbook"
+current_work_item = "guided-adoption-claims"
+current_pr = "docs(status): add guided adoption product claims"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -169,7 +169,7 @@ commands = [
 
 [[work_item]]
 id = "server-ledger-runbook"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -183,7 +183,7 @@ commands = [
 
 [[work_item]]
 id = "guided-adoption-claims"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved GitHub Action failure summaries with verdict counts, review-required
   reasons, missing-baseline promotion hints, uploaded artifact names, and local
   reproduction commands.
+- Added a decision ledger operations runbook covering storage modes, API key
+  rotation, upload semantics, history, debt, export, prune, backups, CI upload
+  behavior, health, metrics, and recovery paths.
 
 ## [0.17.0] - 2026-05-12
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Use that order to start quickly, then opt into richer tradeoff review and
 auditable governance as teams become ready. See
 [`docs/ADOPTION_LEVELS.md`](docs/ADOPTION_LEVELS.md) for the commands, config,
 artifacts, failure examples, and next step for each level.
+For team ledger operations, see
+[`docs/DECISION_LEDGER_RUNBOOK.md`](docs/DECISION_LEDGER_RUNBOOK.md).
 
 ## Daily Use
 

--- a/docs/ADOPTION_LEVELS.md
+++ b/docs/ADOPTION_LEVELS.md
@@ -251,6 +251,7 @@ merge.
 
 ### Next Level
 
-Once a team relies on the ledger, add an operations runbook for storage,
-backups, API keys, prune policy, and dashboard expectations.
-
+Once a team relies on the ledger, use the
+[decision ledger operations runbook](DECISION_LEDGER_RUNBOOK.md) for storage,
+backups, API keys, prune policy, CI upload behavior, and dashboard
+expectations.

--- a/docs/DECISION_LEDGER_RUNBOOK.md
+++ b/docs/DECISION_LEDGER_RUNBOOK.md
@@ -1,0 +1,184 @@
+# Decision Ledger Operations Runbook
+
+The decision ledger is optional team infrastructure. Local receipts remain the
+source of correctness: `decision.md`, `decision.index.json`,
+`decision-bundle.json`, `scenario.json`, `tradeoff.json`, probe receipts, and
+compare receipts must be useful without a server.
+
+Use the ledger when a team needs retained decision history, debt summaries,
+audit exports, dashboard review, or shared API access.
+
+## Operating Modes
+
+### Local SQLite Mode
+
+Use local mode for evaluation, demos, and small-team shared history on one
+machine.
+
+```bash
+perfgate serve --doctor
+perfgate serve --no-open
+```
+
+`serve --doctor` preflights the SQLite path, WAL setup, and dashboard port. The
+SQLite backend is a single-node service mode; do not mount the same database
+file behind multiple active server processes.
+
+Back up local mode by copying the SQLite database while the service is stopped,
+or by exporting ledger data before maintenance:
+
+```bash
+perfgate decision export --project default --days 90 --out artifacts/perfgate/decision-history.jsonl
+perfgate audit export --project default --format jsonl --out artifacts/perfgate/audit.jsonl
+```
+
+### Team Server Mode
+
+Use `perfgate-server` when CI or multiple users need a shared API endpoint.
+Prefer a stable URL, persistent storage, TLS at the ingress layer, and scoped API
+keys.
+
+```bash
+perfgate-server --storage sqlite --database-path /var/lib/perfgate/perfgate.db
+```
+
+Use PostgreSQL when operational policy requires managed backups, connection
+pooling, or database-level availability controls:
+
+```bash
+perfgate-server --storage postgres --database-url "$DATABASE_URL"
+```
+
+## API Keys
+
+For CLI and CI end-to-end usage, API keys are the supported path.
+
+```bash
+perfgate admin keys create --project my-project --role writer
+perfgate admin keys list --project my-project
+perfgate admin keys rotate --id key_123
+perfgate admin keys revoke --id key_123
+```
+
+Store CI keys as repository or organization secrets. Use writer keys for
+decision upload jobs and read-only keys for dashboards or audit export jobs.
+Rotate keys when maintainers leave, secrets are exposed, or CI ownership
+changes.
+
+## Upload Path
+
+Upload decision receipts after local decision evaluation has produced durable
+artifacts:
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+perfgate decision upload --project my-project --file artifacts/perfgate/tradeoff.json --index artifacts/perfgate/decision.index.json
+```
+
+The upload stores a `perfgate.decision_record.v1` record. It should consume the
+local receipts; it should not become a separate decision model.
+
+## History And Debt
+
+Use history for review and audit lookup:
+
+```bash
+perfgate decision history --project my-project --limit 20
+perfgate decision history --project my-project --accepted true --rule memory_for_probe_speed
+perfgate decision history --project my-project --review-required true
+perfgate decision latest --project my-project
+```
+
+Use debt when accepted tradeoffs need ongoing visibility:
+
+```bash
+perfgate decision debt --project my-project --days 30
+```
+
+Debt output is review input. It should help teams decide whether accepted
+tradeoffs are still cheap, still justified, or ready for follow-up work.
+
+## Export And Backup
+
+Export before releases, migrations, retention pruning, incident review, or
+storage maintenance:
+
+```bash
+perfgate decision export --project my-project --days 90 --format jsonl --out artifacts/perfgate/decision-history.jsonl
+perfgate audit export --project my-project --format jsonl --out artifacts/perfgate/audit.jsonl
+```
+
+For SQLite, combine database backups with JSONL exports. For PostgreSQL, use the
+database platform backup policy and keep JSONL exports for portable audit
+evidence.
+
+## Pruning
+
+Always preview retention changes first:
+
+```bash
+perfgate decision prune --project my-project --older-than 365d --dry-run
+```
+
+Only force prune after the export and audit window is complete:
+
+```bash
+perfgate decision export --project my-project --days 0 --format jsonl --out artifacts/perfgate/decision-history-before-prune.jsonl
+perfgate audit export --project my-project --format jsonl --out artifacts/perfgate/audit-before-prune.jsonl
+perfgate decision prune --project my-project --older-than 365d --force
+```
+
+Treat prune as a retention operation, not a cleanup habit. Keep the dry-run
+output with the change record when pruning production history.
+
+## CI Upload Behavior
+
+CI should make the performance decision from local receipts first. Server upload
+is a persistence step.
+
+If upload fails:
+
+- keep `decision.md`, `decision.index.json`, `tradeoff.json`, and related
+  receipts as CI artifacts;
+- rerun `perfgate decision upload` from the same artifacts after the server or
+  credential issue is fixed;
+- do not rerun benchmarks just to repair ledger persistence unless the receipts
+  are missing or untrusted;
+- fail the job only when the repository policy explicitly requires successful
+  ledger persistence before merge.
+
+For retry jobs, use the same `--file` and `--index` paths that were produced by
+the original decision run.
+
+## Dashboard Expectations
+
+The dashboard is a review surface for retained evidence. Operators should expect
+it to show recent decisions, audit events, debt summaries, and health state. It
+is not the source of correctness for a decision; the linked receipts are.
+
+Check service health and metrics before blaming perfgate verdicts:
+
+```bash
+curl -fsS http://localhost:8080/health
+curl -fsS http://localhost:8080/metrics
+```
+
+## Failure Modes
+
+| Symptom | Likely cause | Recovery |
+|---------|--------------|----------|
+| `401` or `403` from upload | Missing, expired, revoked, or under-scoped API key | Check CI secret, list keys, rotate if needed, rerun upload |
+| SQLite busy or locked | Multiple writers or long-running local process | Stop extra server process, retry, consider Postgres for shared use |
+| Upload fails but `decision.md` exists | Server persistence failed after local decision succeeded | Preserve artifacts and rerun `decision upload` |
+| Prune removed too much | Forced prune without export or wrong retention window | Restore from database backup or JSONL export |
+| Dashboard stale | Server reads old storage or upload failed | Check `/health`, audit events, and latest decision history |
+
+## Proof Commands
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+

--- a/docs/GETTING_STARTED_BASELINE_SERVER.md
+++ b/docs/GETTING_STARTED_BASELINE_SERVER.md
@@ -16,6 +16,9 @@ Use one of these two entry points:
 Use `perfgate serve` for local exploration and `perfgate-server` for a real
 shared baseline service.
 
+For production-style decision ledger operations, see the
+[decision ledger operations runbook](DECISION_LEDGER_RUNBOOK.md).
+
 ## Local Sandbox
 
 Preflight the local SQLite database path and dashboard port:

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,8 @@ Codex execution state stay reviewable.
 - Decision outcome gallery:
   [`examples/decision-outcomes.md`](examples/decision-outcomes.md)
 - Probe instrumentation: [`PROBE_QUICKSTART.md`](PROBE_QUICKSTART.md)
+- Decision ledger operations:
+  [`DECISION_LEDGER_RUNBOOK.md`](DECISION_LEDGER_RUNBOOK.md)
 - Workspace inventory: [`WORKSPACE.md`](WORKSPACE.md)
 - GitHub Actions setup:
   [`GETTING_STARTED_GITHUB_ACTIONS.md`](GETTING_STARTED_GITHUB_ACTIONS.md)

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-13
 Milestone: 0.18.0
-Current PR: plans(0.18): add guided adoption implementation plan
+Current PR: docs(status): add guided adoption product claims
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked specs: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADRs: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md; local server-ledger optionality ADR planned if the lane changes that boundary
@@ -50,8 +50,8 @@ This plan sequences the work. Behavior is owned by
 | 379 | Probe instrumentation quickstart | merged | `docs/PROBE_QUICKSTART.md`, README/docs/example links |
 | 380 | Probe-to-decision proof | merged | CLI tests or deterministic fixtures |
 | 381 | GitHub Action failure UX | merged | action output, tests, docs |
-| 382 | Server ledger operations runbook | current | server docs/runbook |
-| 383 | Guided adoption product claims | ready | `docs/status/PRODUCT_CLAIMS.md` |
+| 382 | Server ledger operations runbook | merged | server docs/runbook |
+| 383 | Guided adoption product claims | current | `docs/status/PRODUCT_CLAIMS.md` |
 | 384 | Claim/spec freshness checker | ready | `xtask` checker and tests |
 | 385 | Policy ledger contract spec | ready | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
 | 386 | Wrapper-crate cleanup plan | ready | crate cleanup plan docs |
@@ -374,7 +374,7 @@ Revert action output changes and fixtures.
 
 ## Work item: server-ledger-runbook
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: local server-ledger optionality ADR planned if the lane changes that boundary
@@ -418,12 +418,12 @@ Revert the runbook and links.
 
 ## Work item: guided-adoption-claims
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:
 Blocks: claim-spec-freshness-check, final closeout
-Blocked by: first-hour-smoke-proof, probe-to-decision-proof, server-ledger-runbook
+Blocked by: first-hour-smoke-proof, probe-to-decision-proof
 
 ### Goal
 
@@ -593,7 +593,7 @@ Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
 Blocks:
-Blocked by: guided-adoption-claims, claim-spec-freshness-check, server-ledger-runbook
+Blocked by: guided-adoption-claims, claim-spec-freshness-check
 
 ### Goal
 


### PR DESCRIPTION
## Summary
- adds a decision ledger operations runbook for optional team ledger mode
- links the runbook from README and adoption/server docs
- advances the guided adoption plan and active goal to product-claim mapping

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check