### PR TITLE
xtask: check product claim spec freshness

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "claim-spec-freshness-check"
-current_pr = "xtask: check product claim spec freshness"
+current_work_item = "policy-ledger-contract-spec"
+current_pr = "docs(spec): add policy ledger contract"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -197,7 +197,7 @@ commands = [
 
 [[work_item]]
 id = "claim-spec-freshness-check"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"
@@ -210,7 +210,7 @@ commands = [
 
 [[work_item]]
 id = "policy-ledger-contract-spec"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 plan = "plans/0.18.0/guided-adoption.md"
 commands = [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added guided adoption product claims for the first-hour path, staged adoption
   levels, probe-backed tradeoff explanation, and optional team ledger
   operations.
+- Tightened the product-claim proof-map checker so stale planned spec links fail
+  once the concrete spec file exists.
 
 ## [0.17.0] - 2026-05-12
 

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-13
 Milestone: 0.18.0
-Current PR: xtask: check product claim spec freshness
+Current PR: docs(spec): add policy ledger contract
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked specs: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADRs: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md; local server-ledger optionality ADR planned if the lane changes that boundary
@@ -52,8 +52,8 @@ This plan sequences the work. Behavior is owned by
 | 381 | GitHub Action failure UX | merged | action output, tests, docs |
 | 382 | Server ledger operations runbook | merged | server docs/runbook |
 | 383 | Guided adoption product claims | merged | `docs/status/PRODUCT_CLAIMS.md` |
-| 384 | Claim/spec freshness checker | current | `xtask` checker and tests |
-| 385 | Policy ledger contract spec | ready | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
+| 384 | Claim/spec freshness checker | merged | `xtask` checker and tests |
+| 385 | Policy ledger contract spec | current | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
 | 386 | Wrapper-crate cleanup plan | ready | crate cleanup plan docs |
 | final | Guided adoption closeout | blocked | handoff and archived active goal |
 
@@ -460,7 +460,7 @@ Revert claim-map entries and any links that rely on them.
 
 ## Work item: claim-spec-freshness-check
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR:
@@ -502,7 +502,7 @@ Revert the checker and tests.
 
 ## Work item: policy-ledger-contract-spec
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: PERFGATE-SPEC-0006-policy-ledger-contracts planned
 Linked ADR:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -4685,6 +4685,22 @@ fn collect_source_docs(root: &Path) -> anyhow::Result<Vec<SourceDoc>> {
     Ok(docs)
 }
 
+fn collect_existing_spec_ids(root: &Path) -> anyhow::Result<BTreeSet<String>> {
+    let id_re =
+        Regex::new(r"^(PERFGATE-SPEC-\d{4})").expect("source doc spec id regex should compile");
+    let mut ids = BTreeSet::new();
+    for path in markdown_files_in(root.join("docs/specs"), false)? {
+        let stem = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .unwrap_or("");
+        if let Some(captures) = id_re.captures(stem) {
+            ids.insert(captures[1].to_string());
+        }
+    }
+    Ok(ids)
+}
+
 fn read_source_doc(kind: SourceDocKind, path: PathBuf) -> anyhow::Result<SourceDoc> {
     let content =
         fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))?;
@@ -4910,7 +4926,8 @@ fn relative_display(root: &Path, path: &Path) -> String {
 fn cmd_product_claims_check(path: &Path) -> anyhow::Result<()> {
     let content =
         fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    let errors = collect_product_claim_errors(&content);
+    let spec_ids = collect_existing_spec_ids(&workspace_root_path())?;
+    let errors = collect_product_claim_errors(&content, &spec_ids);
 
     if !errors.is_empty() {
         println!("Found {} product claim proof-map error(s):", errors.len());
@@ -4936,10 +4953,15 @@ struct ProductClaimSection {
     body: String,
 }
 
-fn collect_product_claim_errors(content: &str) -> Vec<String> {
+fn collect_product_claim_errors(
+    content: &str,
+    concrete_spec_ids: &BTreeSet<String>,
+) -> Vec<String> {
     let mut errors = Vec::new();
     let claims = extract_product_claim_sections(content);
     let mut ids = BTreeSet::new();
+    let planned_spec_re = Regex::new(r"\b(PERFGATE-SPEC-\d{4})\b.*\bplanned\b")
+        .expect("planned spec regex should compile");
 
     if claims.is_empty() {
         errors
@@ -5003,6 +5025,21 @@ fn collect_product_claim_errors(content: &str) -> Vec<String> {
                 "{} line {} must include linked tests, policy, or gates",
                 claim.id, claim.line
             ));
+        }
+
+        for (offset, line) in claim.body.lines().enumerate() {
+            let Some(captures) = planned_spec_re.captures(line) else {
+                continue;
+            };
+            let spec_id = &captures[1];
+            if concrete_spec_ids.contains(spec_id) {
+                errors.push(format!(
+                    "{} line {} references `{}` as planned, but a concrete spec file exists",
+                    claim.id,
+                    claim.line + offset + 1,
+                    spec_id
+                ));
+            }
         }
     }
 
@@ -5991,7 +6028,7 @@ cargo +1.95.0 run -p xtask -- docs-check
 Review after: before-release
 "###;
 
-        let errors = collect_product_claim_errors(content);
+        let errors = collect_product_claim_errors(content, &BTreeSet::new());
         assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     }
 
@@ -6022,7 +6059,7 @@ cargo +1.95.0 run -p xtask -- docs-check
 Review after: before-release
 "###;
 
-        let errors = collect_product_claim_errors(content);
+        let errors = collect_product_claim_errors(content, &BTreeSet::new());
         assert!(
             errors.iter().any(|error| error.contains("unknown tier")),
             "expected tier error, got {errors:?}"
@@ -6056,6 +6093,38 @@ Review after: before-release
                 .iter()
                 .any(|error| error.contains("linked tests, policy, or gates")),
             "expected linked evidence error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn product_claims_check_reports_stale_planned_spec_links() {
+        let content = r###"# Product Claims
+
+## PG-CLAIM-0001: Guided adoption
+
+Tier: supported
+Surface: docs
+Linked specs: `PERFGATE-SPEC-0007-guided-adoption-contract` planned
+Linked gates: docs-check
+Proof commands:
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-check
+```
+
+Review after: before-release
+"###;
+
+        let errors = collect_product_claim_errors(
+            content,
+            &BTreeSet::from(["PERFGATE-SPEC-0007".to_string()]),
+        );
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("references `PERFGATE-SPEC-0007` as planned")),
+            "expected stale planned spec error, got {errors:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- teaches product-claims-check to fail stale PERFGATE-SPEC-XXXX ... planned references once the concrete spec file exists
- adds a focused xtask regression test for the freshness rule
- advances the guided adoption plan and active goal to the policy-ledger contract spec

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p xtask product_claims_check
- cargo +1.95.0 clippy -p xtask --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p xtask --all-features
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check