### PR TITLE
docs(spec): add policy ledger contract

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "policy-ledger-contract-spec"
-current_pr = "docs(spec): add policy ledger contract"
+current_work_item = "wrapper-crate-cleanup-plan"
+current_pr = "docs(crates): plan remaining wrapper absorption"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -210,8 +210,9 @@ commands = [
 
 [[work_item]]
 id = "policy-ledger-contract-spec"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
+spec = "docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md"
 plan = "plans/0.18.0/guided-adoption.md"
 commands = [
   "cargo +1.95.0 run -p xtask -- docs-check",
@@ -223,7 +224,7 @@ commands = [
 
 [[work_item]]
 id = "wrapper-crate-cleanup-plan"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 spec = "docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operations.
 - Tightened the product-claim proof-map checker so stale planned spec links fail
   once the concrete spec file exists.
+- Added the policy-ledger contract spec and linked the policy-ledger product
+  claim to the concrete spec.
+- Refreshed the generated no-panic baseline for the adoption probe proof and
+  product-claim freshness checker callsites.
 
 ## [0.17.0] - 2026-05-12
 

--- a/docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md
+++ b/docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md
@@ -1,0 +1,123 @@
+# PERFGATE-SPEC-0006: Policy ledger contracts
+
+Status: accepted
+Owner: perfgate maintainers
+Created: 2026-05-13
+Milestone: 0.18.0
+Behavior version: policy-ledger-contracts.v1
+Product surface: policy ledgers, public surface, no-panic baseline, non-Rust file governance, product claims
+CI surface: public-surface --strict, arch, policy check-no-panic-family, docs-source-check, product-claims-check
+Schema impact: none
+Action impact: none
+Server impact: none
+Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
+Linked ADRs: PERFGATE-ADR-0001-public-crates-are-contracts, PERFGATE-ADR-0002-receipts-first-performance-decisions
+Linked plan: plans/0.18.0/guided-adoption.md
+Linked policy: policy/public_crates.txt, policy/absorbed_crates.txt, policy/clippy-lints.toml, policy/clippy-debt.toml, policy/clippy-exceptions.toml, policy/no-panic-allowlist.toml, policy/no-panic-baseline.toml, policy/non-rust-allowlist.toml, policy/generated-allowlist.toml, policy/executable-allowlist.toml, policy/workflow-allowlist.toml, policy/dependency-surface-allowlist.toml
+Support/status impact: docs/status/PRODUCT_CLAIMS.md PG-CLAIM-0006 links this spec
+Proof commands: cargo +1.95.0 run -p xtask -- policy check-no-panic-family; cargo +1.95.0 run -p xtask -- public-surface --strict; cargo +1.95.0 run -p xtask -- arch; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check
+
+## Problem
+
+perfgate uses policy files to govern public crates, absorbed crate
+disposition, Clippy debt, panic-family debt, non-Rust files, generated files,
+workflow files, executable bits, and dependency surface exceptions. Those files
+are machine-readable controls, not supporting prose.
+
+Without an explicit contract, future specs and docs can drift by copying policy
+rows, inventing unmanaged exception lists, or making claims that are not backed
+by the ledgers the automation actually reads.
+
+## Behavior
+
+Policy ledgers MUST own concrete reviewed exceptions, governed surfaces, and
+generated baselines. Specs, status docs, plans, README content, and handoffs
+MUST link to ledgers instead of copying their rows.
+
+The following ownership rules apply:
+
+| Truth | Source |
+|-------|--------|
+| Durable public crate surface | `policy/public_crates.txt` |
+| Absorbed or compatibility crate disposition | `policy/absorbed_crates.txt` |
+| Clippy lint policy, debt, and exceptions | `policy/clippy-*.toml` |
+| Panic-family allowance and generated baseline | `policy/no-panic-*.toml` |
+| Non-Rust governed files | `policy/non-rust-allowlist.toml` |
+| Generated file policy | `policy/generated-allowlist.toml` |
+| Executable bit policy | `policy/executable-allowlist.toml` |
+| Workflow file policy | `policy/workflow-allowlist.toml` |
+| Dependency surface policy | `policy/dependency-surface-allowlist.toml` |
+
+Where a policy file records a reviewed exception, it SHOULD include owner,
+reason, and review-after metadata when the ledger format supports those fields.
+Generated baselines MUST be marked as generated or refresh-safe by the owning
+tooling so reviewers can distinguish measured debt from hand-authored policy.
+
+Policy checks MUST be deterministic from repository files. A policy gate MUST
+NOT require chat history or unpublished release context to decide whether an
+exception is allowed.
+
+## Non-goals
+
+- Do not define every policy row in this spec.
+- Do not change policy file formats in this spec-only PR.
+- Do not fail every missing owner/reason/review-after field until the
+  corresponding ledger format and migration plan exist.
+- Do not make advisory policy debt a release blocker unless the relevant
+  policy file or CI gate already says it is blocking.
+
+## Required evidence
+
+The policy-ledger contract is proven by the existing policy and architecture
+gates plus source-doc and claim-map checks:
+
+```bash
+cargo +1.95.0 run -p xtask -- policy check-no-panic-family
+cargo +1.95.0 run -p xtask -- public-surface --strict
+cargo +1.95.0 run -p xtask -- arch
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+git diff --check
+```
+
+## Acceptance examples
+
+| Example | Result |
+|---------|--------|
+| A spec links to `policy/public_crates.txt` for the public crate list instead of copying every row. | Pass |
+| A product claim says policy ledgers govern exceptions and links to this spec plus the policy files. | Pass |
+| A README section lists a copied no-panic allowlist row as product truth. | Fail |
+| A plan proposes a new permanent public crate without updating policy and ADR context. | Fail |
+| A generated no-panic baseline refresh is hand-edited without the owning policy command. | Fail |
+
+## Test mapping
+
+- `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` verifies the
+  panic-family allowlist and generated baseline.
+- `cargo +1.95.0 run -p xtask -- public-surface --strict` verifies the public
+  and absorbed crate ledgers.
+- `cargo +1.95.0 run -p xtask -- arch` verifies crate/module architecture
+  boundaries.
+- `cargo +1.95.0 run -p xtask -- product-claims-check` verifies product claims
+  include support tiers, proof commands, linked evidence, and fresh spec links.
+- `cargo +1.95.0 run -p xtask -- docs-source-check` verifies source-of-truth
+  metadata and linked files.
+
+## Implementation mapping
+
+Policy files under `policy/` own the concrete rows. `xtask` owns machine checks.
+Specs define the behavior contract. Product claims map user-facing support to
+proof. Plans sequence migrations when a ledger needs stronger enforcement.
+
+## CI proof
+
+CI lanes that enforce policy MUST call the relevant `xtask` checks instead of
+reimplementing ledger parsing in workflow YAML. Workflow summaries may describe
+policy failures, but the repository policy files remain the governed source.
+
+## Promotion rule
+
+This spec remains accepted while the ledgers and product claims link to it. It
+becomes implemented when the claim map links this spec and the current policy
+gates pass. Future stricter ledger schema requirements should update this spec
+or create a follow-on spec before enforcement.

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -159,7 +159,7 @@ Review after: next-msrv-change
 Tier: supported
 Surface: policy files, CI, release readiness
 Linked docs: [`POLICY_ALLOWLISTS.md`](../POLICY_ALLOWLISTS.md), [`CLIPPY_POLICY.md`](../CLIPPY_POLICY.md), [`NO_PANIC_POLICY.md`](../NO_PANIC_POLICY.md), [`FILE_POLICY.md`](../FILE_POLICY.md)
-Linked specs: `PERFGATE-SPEC-0006-policy-ledger-contracts` planned
+Linked specs: [`PERFGATE-SPEC-0006-policy-ledger-contracts`](../specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md)
 Linked policy:
 
 - [`policy/clippy-lints.toml`](../../policy/clippy-lints.toml)

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-13
 Milestone: 0.18.0
-Current PR: docs(spec): add policy ledger contract
+Current PR: docs(crates): plan remaining wrapper absorption
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked specs: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADRs: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md; local server-ledger optionality ADR planned if the lane changes that boundary
@@ -53,8 +53,8 @@ This plan sequences the work. Behavior is owned by
 | 382 | Server ledger operations runbook | merged | server docs/runbook |
 | 383 | Guided adoption product claims | merged | `docs/status/PRODUCT_CLAIMS.md` |
 | 384 | Claim/spec freshness checker | merged | `xtask` checker and tests |
-| 385 | Policy ledger contract spec | current | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
-| 386 | Wrapper-crate cleanup plan | ready | crate cleanup plan docs |
+| 385 | Policy ledger contract spec | merged | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
+| 386 | Wrapper-crate cleanup plan | current | crate cleanup plan docs |
 | final | Guided adoption closeout | blocked | handoff and archived active goal |
 
 ## Work item: first-hour-guide
@@ -502,9 +502,9 @@ Revert the checker and tests.
 
 ## Work item: policy-ledger-contract-spec
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
-Linked spec: PERFGATE-SPEC-0006-policy-ledger-contracts planned
+Linked spec: docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md
 Linked ADR:
 Blocks: final closeout
 Blocked by:
@@ -545,7 +545,7 @@ Revert the spec.
 
 ## Work item: wrapper-crate-cleanup-plan
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md
 Linked ADR: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
@@ -593,7 +593,7 @@ Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
 Blocks:
-Blocked by: guided-adoption-claims, claim-spec-freshness-check
+Blocked by: wrapper-crate-cleanup-plan
 
 ### Goal
 

--- a/policy/no-panic-baseline.toml
+++ b/policy/no-panic-baseline.toml
@@ -8710,6 +8710,30 @@ path = "crates/perfgate/src/probe.rs"
 family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
+snippet = ".expect(\"compare helper probe receipts\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"evaluate probe-backed tradeoff\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"evaluate scenario from probe evidence\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
 snippet = ".expect(\"flush criterion probe measurement\");"
 count = 1
 
@@ -8734,7 +8758,31 @@ path = "crates/perfgate/src/probe.rs"
 family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
+snippet = ".expect(\"ingest helper baseline JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"ingest helper current JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
 snippet = ".expect(\"ingest tracing JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"record helper probe event\");"
 count = 1
 
 [[baseline]]
@@ -8774,6 +8822,14 @@ path = "crates/perfgate/src/probe.rs"
 family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
+snippet = "String::from_utf8(writer.into_inner()).expect(\"helper JSONL should be utf8\")"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
 snippet = "layer.flush().expect(\"flush tracing probe layer\");"
 count = 1
 
@@ -8783,6 +8839,14 @@ family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
 snippet = "let output = String::from_utf8(writer.into_inner()).expect(\"utf8 JSONL\");"
+count = 1
+
+[[baseline]]
+path = "crates/perfgate/src/probe.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "writer.flush().expect(\"flush helper probe JSONL\");"
 count = 1
 
 [[baseline]]
@@ -10822,7 +10886,31 @@ path = "xtask/src/main.rs"
 family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
+snippet = ".expect(\"planned spec regex should compile\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
 snippet = ".expect(\"read canonical fixture\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"source doc id regex should compile\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"source doc path regex should compile\")"
 count = 1
 
 [[baseline]]
@@ -10895,6 +10983,30 @@ family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
 snippet = ".expect(\"write source\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = ".expect(\"xtask manifest directory has a workspace parent\")"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "Regex::new(r\"^## (PG-CLAIM-\\d{4})\\b\").expect(\"product claim heading regex should compile\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "Regex::new(r\"^(PERFGATE-SPEC-\\d{4})\").expect(\"source doc spec id regex should compile\");"
 count = 1
 
 [[baseline]]
@@ -11030,6 +11142,14 @@ path = "xtask/src/main.rs"
 family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
+snippet = "fs::create_dir_all(parent).expect(\"create parent dir\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
 snippet = "fs::remove_file(out_dir.join(SCHEMA_FILES[0])).expect(\"remove file\");"
 count = 1
 
@@ -11134,6 +11254,14 @@ path = "xtask/src/main.rs"
 family = "expect"
 selector_kind = "method"
 selector_callee = "expect"
+snippet = "fs::write(path, content).expect(\"write test file\");"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
 snippet = "fs::write(temp_dir.join(\"third_party_report.json\"), valid).expect(\"write fixture\");"
 count = 1
 
@@ -11152,6 +11280,14 @@ selector_kind = "method"
 selector_callee = "expect"
 snippet = "let count = sync_fixtures(&golden, &contracts).expect(\"sync fixtures\");"
 count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "expect"
+selector_kind = "method"
+selector_callee = "expect"
+snippet = "let errors = collect_docs_source_errors(&root).expect(\"collect source errors\");"
+count = 2
 
 [[baseline]]
 path = "xtask/src/main.rs"
@@ -11256,6 +11392,22 @@ selector_kind = "method"
 selector_callee = "unwrap"
 snippet = "path.file_name().unwrap().to_string_lossy()"
 count = 3
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "validate_shields_badge(&badge, Some(\"fixtures\")).unwrap();"
+count = 1
+
+[[baseline]]
+path = "xtask/src/main.rs"
+family = "unwrap"
+selector_kind = "method"
+selector_callee = "unwrap"
+snippet = "validate_shields_badge(&badge, Some(\"ripr+\")).unwrap();"
+count = 1
 
 [[baseline]]
 path = "xtask/tests/xtask_smoke_tests.rs"


### PR DESCRIPTION
## Summary
- adds PERFGATE-SPEC-0006 for policy-ledger ownership and proof contracts
- links PG-CLAIM-0006 to the concrete spec now that the freshness checker exists
- refreshes the generated no-panic baseline for adoption probe proof and xtask freshness-check callsites
- advances the guided adoption plan and active goal to the wrapper-crate cleanup plan

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- policy check-no-panic-family
- cargo +1.95.0 run -p xtask -- public-surface --strict
- cargo +1.95.0 run -p xtask -- arch
- git diff --check