### PR TITLE
docs(crates): plan remaining wrapper absorption

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-13"
 milestone = "0.18.0"
-current_work_item = "wrapper-crate-cleanup-plan"
-current_pr = "docs(crates): plan remaining wrapper absorption"
+current_work_item = "final-closeout"
+current_pr = "docs(handoff): close guided adoption lane"
 
 objective = """
 Make perfgate easy for cold users to install, initialize, run locally,
@@ -224,10 +224,10 @@ commands = [
 
 [[work_item]]
 id = "wrapper-crate-cleanup-plan"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md"
 spec = "docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md"
-plan = "plans/0.18.0/guided-adoption.md"
+plan = "plans/0.18.0/wrapper-crate-cleanup.md"
 commands = [
   "cargo +1.95.0 run -p xtask -- public-surface --strict",
   "cargo +1.95.0 run -p xtask -- arch",
@@ -238,7 +238,7 @@ commands = [
 
 [[work_item]]
 id = "final-closeout"
-status = "blocked"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0002-guided-adoption.md"
 spec = "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md"
 plan = "plans/0.18.0/guided-adoption.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   claim to the concrete spec.
 - Refreshed the generated no-panic baseline for the adoption probe proof and
   product-claim freshness checker callsites.
+- Planned remaining compatibility wrapper absorption batches while preserving
+  the five-crate public surface.
 
 ## [0.17.0] - 2026-05-12
 

--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -154,5 +154,6 @@ absorbed/internal workspace package. It now passes on `main`.
 - [REFACTORING_0_16.md](REFACTORING_0_16.md)
 - [MIGRATION_0_16.md](MIGRATION_0_16.md)
 - [ARCHITECTURE.md](ARCHITECTURE.md)
+- [plans/0.18.0/wrapper-crate-cleanup.md](../plans/0.18.0/wrapper-crate-cleanup.md)
 - [policy/public_crates.txt](../policy/public_crates.txt)
 - [policy/absorbed_crates.txt](../policy/absorbed_crates.txt)

--- a/plans/0.18.0/guided-adoption.md
+++ b/plans/0.18.0/guided-adoption.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-13
 Milestone: 0.18.0
-Current PR: docs(crates): plan remaining wrapper absorption
+Current PR: docs(handoff): close guided adoption lane
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked specs: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADRs: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md; local server-ledger optionality ADR planned if the lane changes that boundary
@@ -54,8 +54,8 @@ This plan sequences the work. Behavior is owned by
 | 383 | Guided adoption product claims | merged | `docs/status/PRODUCT_CLAIMS.md` |
 | 384 | Claim/spec freshness checker | merged | `xtask` checker and tests |
 | 385 | Policy ledger contract spec | merged | `docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md` |
-| 386 | Wrapper-crate cleanup plan | current | crate cleanup plan docs |
-| final | Guided adoption closeout | blocked | handoff and archived active goal |
+| 386 | Wrapper-crate cleanup plan | merged | `plans/0.18.0/wrapper-crate-cleanup.md` |
+| final | Guided adoption closeout | current | handoff and archived active goal |
 
 ## Work item: first-hour-guide
 
@@ -545,7 +545,7 @@ Revert the spec.
 
 ## Work item: wrapper-crate-cleanup-plan
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked spec: docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md
 Linked ADR: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
@@ -588,12 +588,12 @@ Revert the plan.
 
 ## Work item: final-closeout
 
-Status: blocked
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0002-guided-adoption.md
 Linked spec: docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
 Blocks:
-Blocked by: wrapper-crate-cleanup-plan
+Blocked by:
 
 ### Goal
 

--- a/plans/0.18.0/wrapper-crate-cleanup.md
+++ b/plans/0.18.0/wrapper-crate-cleanup.md
@@ -1,0 +1,179 @@
+# perfgate 0.18.0 Wrapper Crate Cleanup Plan
+
+Status: accepted
+Owner: perfgate maintainers
+Created: 2026-05-13
+Milestone: 0.18.0
+Current PR: docs(crates): plan remaining wrapper absorption
+Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
+Linked specs: docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md; docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md
+Linked ADRs: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
+Linked plan: plans/0.18.0/guided-adoption.md
+Linked policy: policy/public_crates.txt; policy/absorbed_crates.txt
+Support/status impact: PG-CLAIM-0004 remains the public-surface claim; no new product claim in this plan PR
+Proof commands: cargo +1.95.0 run -p xtask -- public-surface --strict; cargo +1.95.0 run -p xtask -- arch; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check
+Blocks: wrapper absorption implementation batches
+Blocked by: none
+Rollback: revert this plan and its links; no workspace manifests or crates change in this PR
+
+## Goal
+
+Plan the remaining compatibility wrapper absorption without changing crate
+membership in the planning PR.
+
+The governing rule remains:
+
+```text
+public crates are contracts
+modules are architecture boundaries
+no durable unpublished production crates
+```
+
+## Remaining Wrappers
+
+The public surface remains exactly:
+
+- `perfgate`
+- `perfgate-cli`
+- `perfgate-types`
+- `perfgate-client`
+- `perfgate-server`
+
+The remaining non-public wrappers are transitional and listed in
+[`policy/absorbed_crates.txt`](../../policy/absorbed_crates.txt):
+
+| Wrapper | Owner path | Disposition | Batch |
+|---------|------------|-------------|-------|
+| `perfgate-render` | `perfgate::presentation::render` | delete after docs/import cleanup | presentation |
+| `perfgate-export` | `perfgate::presentation::export` | delete after docs/import cleanup | presentation |
+| `perfgate-sensor` | `perfgate::presentation::sensor` | delete after docs/import cleanup | presentation |
+| `perfgate-adapters` | `perfgate::runtime` | delete after runtime imports use facade paths | runtime/integration |
+| `perfgate-github` | `perfgate::integrations::github` | delete after integration imports use facade paths | runtime/integration |
+| `perfgate-app` | `perfgate::app` | delete after CLI/server imports use facade paths | app/domain |
+| `perfgate-domain` | `perfgate::domain` | delete after examples/docs use facade paths | app/domain |
+| `perfgate-paired` | `perfgate::domain::paired` | delete after examples/docs use facade paths | app/domain |
+| `perfgate-error` | `perfgate_types::error` | delete after all workspace deps use `perfgate-types` | contract-adjacent |
+| `perfgate-api` | `perfgate_types::baseline_service`; `perfgate_server::CredentialSource` | delete after contract-adjacent imports are direct | contract-adjacent |
+
+Private dev/test packages are not wrapper absorption targets in this lane:
+
+- `perfgate-fake`
+- `perfgate-selfbench`
+- root `perfgate-tests`
+- `xtask`
+
+## Batch Sequence
+
+### Batch 1: Presentation Wrappers
+
+Target:
+
+- `perfgate-render`
+- `perfgate-export`
+- `perfgate-sensor`
+
+Required work:
+
+- update any workspace imports to `perfgate::presentation::*`;
+- delete wrapper crates and remove them from workspace members/dependencies;
+- update `docs/WORKSPACE.md`, `docs/CRATE_SEAMS.md`, and
+  `policy/absorbed_crates.txt`;
+- refresh generated no-panic baseline if deleted examples change scan results.
+
+### Batch 2: Runtime And Integration Wrappers
+
+Target:
+
+- `perfgate-adapters`
+- `perfgate-github`
+
+Required work:
+
+- update callers to `perfgate::runtime` and `perfgate::integrations::github`;
+- remove wrapper crates and dependency metadata;
+- keep runtime/platform boundaries covered by `xtask arch`;
+- refresh docs and policy ledgers in the same PR.
+
+### Batch 3: App And Domain Wrappers
+
+Target:
+
+- `perfgate-app`
+- `perfgate-domain`
+- `perfgate-paired`
+
+Required work:
+
+- update CLI, examples, mutation docs, and migration docs to facade paths;
+- keep paired benchmark CLI artifact names unchanged where they are user-facing
+  output names rather than crate references;
+- remove wrapper crates and dependency metadata;
+- refresh generated policy baselines if examples disappear.
+
+### Batch 4: Contract-Adjacent Wrappers
+
+Target:
+
+- `perfgate-error`
+- `perfgate-api`
+
+Required work:
+
+- update internal imports to `perfgate_types::error` and
+  `perfgate_types::baseline_service`;
+- keep `perfgate-client`, `perfgate-server`, and `perfgate-types` as the
+  external contract seams;
+- remove wrapper crates only after `public-surface --strict` and `arch` prove no
+  production dependency still relies on them.
+
+## Non-goals
+
+- Do not remove crates in this planning PR.
+- Do not reduce the five public crates.
+- Do not change release tags, crates.io state, or action aliases.
+- Do not invent a durable unpublished production crate category.
+
+## Acceptance
+
+- The remaining wrapper set is named.
+- Each wrapper has an owner path, disposition, and implementation batch.
+- Dev/test packages are explicitly excluded from wrapper absorption.
+- Proof commands and rollback are documented for future implementation PRs.
+
+## Proof Commands
+
+Each implementation batch must run:
+
+```bash
+cargo +1.95.0 check --workspace --all-targets --all-features --locked
+cargo +1.95.0 test --workspace --all-targets --all-features --locked
+cargo +1.95.0 run -p xtask -- public-surface --strict
+cargo +1.95.0 run -p xtask -- arch
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+git diff --check
+```
+
+If a batch deletes Rust source that changes panic-family scan results, it must
+also run:
+
+```bash
+cargo +1.95.0 run -p xtask -- policy check-no-panic-family
+```
+
+Documentation-only updates to this plan run:
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+git diff --check
+```
+
+## Rollback
+
+Rollback for this planning PR is a straight revert. Rollback for future
+implementation batches is batch-specific: restore the wrapper crate, workspace
+membership, dependency metadata, policy row disposition, docs references, and
+generated baselines changed in that batch.


### PR DESCRIPTION
## Summary
- adds a PR-sized wrapper-crate cleanup plan for the remaining compatibility wrappers
- groups wrapper absorption into presentation, runtime/integration, app/domain, and contract-adjacent batches
- links the plan from crate-surface docs and advances the active goal to final closeout

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- public-surface --strict
- cargo +1.95.0 run -p xtask -- arch
- git diff --check