### PR TITLE
policy: prove final package surface after wrapper absorption

### DIFF
--- a/docs/CRATE_SEAMS.md
+++ b/docs/CRATE_SEAMS.md
@@ -69,7 +69,7 @@ policy files and docs updated in the same change.
 
 `policy/absorbed_crates.txt` is the machine-readable disposition list. The
 public-surface blockers have been resolved; remaining non-public workspace
-packages are private/dev packages or compatibility wrappers:
+packages are private/dev/test/automation packages:
 
 | Package | Disposition |
 |---------|-------------|
@@ -111,9 +111,8 @@ source.
 
 `xtask public-surface` fails if a publishable workspace package is neither listed in
 `policy/public_crates.txt` nor assigned a disposition in
-`policy/absorbed_crates.txt`. Entries marked `[compatibility wrapper]` must also
-stay out of non-dev workspace dependency graphs; internal crates should import
-the owner path directly and leave the wrapper for external compatibility.
+`policy/absorbed_crates.txt`. Deleted absorbed-crate entries record historical
+owner paths; internal code should import the owner path directly.
 
 Run:
 

--- a/docs/handoffs/2026-05-13-guided-adoption-closeout.md
+++ b/docs/handoffs/2026-05-13-guided-adoption-closeout.md
@@ -95,8 +95,8 @@ this handoff to understand the lane without chat history.
 The remaining work is intentionally follow-on, not part of the closed guided
 adoption lane:
 
-- implement wrapper absorption batches from
-  [`plans/0.18.0/wrapper-crate-cleanup.md`](../../plans/0.18.0/wrapper-crate-cleanup.md);
+- wrapper absorption is complete and closed out in
+  [`2026-05-13-wrapper-absorption-closeout.md`](2026-05-13-wrapper-absorption-closeout.md);
 - keep public crates limited to the five-crate surface unless a future ADR and
   policy update justify a change;
 - deepen external/public install smoke as release-candidate automation;

--- a/docs/handoffs/2026-05-13-wrapper-absorption-closeout.md
+++ b/docs/handoffs/2026-05-13-wrapper-absorption-closeout.md
@@ -1,0 +1,84 @@
+# Wrapper Absorption Closeout
+
+Status: implemented
+Owner: perfgate maintainers
+Created: 2026-05-13
+Milestone: 0.18.0
+Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
+Linked specs: docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md; docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md
+Linked ADRs: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
+Linked plan: plans/0.18.0/wrapper-crate-cleanup.md
+Linked policy: policy/public_crates.txt; policy/absorbed_crates.txt; policy/no-panic-baseline.toml
+Support/status impact: docs/status/PRODUCT_CLAIMS.md PG-CLAIM-0004
+Proof commands: cargo +1.95.0 run -p xtask -- public-surface --strict; cargo +1.95.0 run -p xtask -- arch; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; git diff --check
+
+## Summary
+
+The wrapper absorption lane removed the remaining production compatibility
+wrapper crates while preserving the five public crates:
+
+- `perfgate`
+- `perfgate-cli`
+- `perfgate-types`
+- `perfgate-client`
+- `perfgate-server`
+
+The implementation landed in four batches:
+
+- presentation wrappers: `perfgate-render`, `perfgate-export`,
+  `perfgate-sensor`;
+- runtime and integration wrappers: `perfgate-adapters`, `perfgate-github`;
+- app and domain wrappers: `perfgate-app`, `perfgate-domain`,
+  `perfgate-paired`;
+- contract-adjacent wrappers: `perfgate-error`, `perfgate-api`.
+
+The remaining non-public workspace packages are private/dev/test/automation
+packages only: `perfgate-fake`, `perfgate-selfbench`, root `perfgate-tests`,
+and `xtask`.
+
+## Product Surface
+
+The user-facing CLI commands, receipt schemas, default artifact names, and
+server/client/type contract crates were not renamed by this cleanup.
+
+Notably:
+
+- `perfgate paired` remains the paired benchmarking command;
+- the default paired output remains `perfgate-paired.json`;
+- `perfgate-types`, `perfgate-client`, and `perfgate-server` remain external
+  contract seams;
+- mutation aliases such as `perfgate-domain`, `perfgate-app`,
+  `perfgate-paired`, `perfgate-error`, and `perfgate-api` remain available as
+  logical targets where useful, but they no longer name workspace packages.
+
+## Evidence
+
+The implementation batches ran their applicable proof commands. The closeout
+reruns the package-surface and source-of-truth proof:
+
+```bash
+cargo +1.95.0 run -p xtask -- public-surface --strict
+cargo +1.95.0 run -p xtask -- arch
+cargo +1.95.0 run -p xtask -- product-claims-check
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+git diff --check
+```
+
+## Source Of Truth
+
+- `policy/public_crates.txt` owns the five public crates.
+- `policy/absorbed_crates.txt` records the deleted wrapper dispositions.
+- `docs/CRATE_SEAMS.md` explains the final package surface.
+- `docs/WORKSPACE.md` is regenerated from `xtask docs-sync`.
+- `plans/0.18.0/wrapper-crate-cleanup.md` records the implemented batch plan.
+- `docs/status/PRODUCT_CLAIMS.md` maps the public-surface claim to proof.
+
+## Remaining Work
+
+No production compatibility wrapper remains as a durable package category.
+
+Future package-surface changes must start from the package-surface spec, the
+public-crates ADR, and the policy ledgers. They should not reduce or expand the
+five public crates without an explicit proposal/spec/ADR/policy update.

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -108,7 +108,7 @@ Review after: before-0.18.0-release
 
 Tier: stable
 Surface: crates, public API, release policy
-Linked docs: [`CRATE_SEAMS.md`](../CRATE_SEAMS.md), [`ARCHITECTURE.md`](../ARCHITECTURE.md), [`RELEASE_READINESS.md`](../RELEASE_READINESS.md)
+Linked docs: [`CRATE_SEAMS.md`](../CRATE_SEAMS.md), [`ARCHITECTURE.md`](../ARCHITECTURE.md), [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`2026-05-13-wrapper-absorption-closeout.md`](../handoffs/2026-05-13-wrapper-absorption-closeout.md)
 Linked specs: [`PERFGATE-SPEC-0002-package-surface-boundary`](../specs/PERFGATE-SPEC-0002-package-surface-boundary.md)
 Linked policy:
 

--- a/plans/0.18.0/wrapper-crate-cleanup.md
+++ b/plans/0.18.0/wrapper-crate-cleanup.md
@@ -1,25 +1,24 @@
 # perfgate 0.18.0 Wrapper Crate Cleanup Plan
 
-Status: accepted
+Status: implemented
 Owner: perfgate maintainers
 Created: 2026-05-13
 Milestone: 0.18.0
-Current PR: refactor: absorb contract-adjacent wrapper crates
+Current PR: policy: prove final package surface after wrapper absorption
 Linked proposal: docs/proposals/PERFGATE-PROP-0001-spec-driven-governance.md
 Linked specs: docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md; docs/specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md
 Linked ADRs: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
 Linked plan: plans/0.18.0/guided-adoption.md
 Linked policy: policy/public_crates.txt; policy/absorbed_crates.txt
-Support/status impact: PG-CLAIM-0004 remains the public-surface claim; no new product claim in this plan PR
+Support/status impact: PG-CLAIM-0004 remains the public-surface claim and links to the wrapper absorption closeout
 Proof commands: cargo +1.95.0 run -p xtask -- public-surface --strict; cargo +1.95.0 run -p xtask -- arch; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check
-Blocks: wrapper absorption implementation batches
+Blocks: none
 Blocked by: none
 Rollback: revert this plan and its links; no workspace manifests or crates change in this PR
 
 ## Goal
 
-Plan the remaining compatibility wrapper absorption without changing crate
-membership in the planning PR.
+Record the compatibility wrapper absorption sequence and final package surface.
 
 The governing rule remains:
 
@@ -29,7 +28,7 @@ modules are architecture boundaries
 no durable unpublished production crates
 ```
 
-## Remaining Wrappers
+## Wrapper Status
 
 The public surface remains exactly:
 
@@ -39,7 +38,7 @@ The public surface remains exactly:
 - `perfgate-client`
 - `perfgate-server`
 
-The remaining non-public wrappers are transitional and listed in
+The former non-public wrappers are listed in
 [`policy/absorbed_crates.txt`](../../policy/absorbed_crates.txt):
 
 | Wrapper | Owner path | Disposition | Batch |


### PR DESCRIPTION
## Summary
- adds the wrapper absorption closeout handoff
- marks the wrapper cleanup plan implemented and records the final package-surface state
- links PG-CLAIM-0004 to the closeout proof
- updates crate seam wording now that no production compatibility wrappers remain

## Final surface
- public crates remain `perfgate`, `perfgate-cli`, `perfgate-types`, `perfgate-client`, and `perfgate-server`
- remaining non-public workspace packages are private/dev/test/automation only
- deleted wrapper dispositions remain in `policy/absorbed_crates.txt`

## Validation
- `cargo +1.95.0 run -p xtask -- public-surface --strict`
- `cargo +1.95.0 run -p xtask -- arch`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`