### PR TITLE
test: prove structured decision bundle smoke

### DIFF
--- a/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
+++ b/crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs
@@ -373,6 +373,67 @@ fn decision_evaluate_runs_structured_decision_workflow() {
         decision_index.compare_receipts,
         vec!["artifacts/perfgate/parser/compare.json".to_string()]
     );
+
+    perfgate_cmd()
+        .current_dir(root)
+        .args([
+            "decision",
+            "bundle",
+            "--index",
+            "artifacts/perfgate/decision.index.json",
+            "--out",
+            "artifacts/perfgate/decision-bundle.json",
+            "--git-ref",
+            "main",
+            "--git-sha",
+            "abc123",
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Decision bundle written"));
+
+    let bundle: perfgate_types::DecisionBundleReceipt = serde_json::from_str(
+        &fs::read_to_string(root.join("artifacts/perfgate/decision-bundle.json"))
+            .expect("read decision bundle"),
+    )
+    .expect("decision bundle should deserialize");
+    assert_eq!(bundle.schema, "perfgate.decision_bundle.v1");
+    assert_eq!(bundle.metadata.git_ref.as_deref(), Some("main"));
+    assert_eq!(bundle.metadata.git_sha.as_deref(), Some("abc123"));
+    assert_eq!(bundle.index.schema, "perfgate.decision_index.v1");
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind
+                == perfgate_types::DecisionBundleArtifactKind::DecisionIndex)
+    );
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == perfgate_types::DecisionBundleArtifactKind::Scenario)
+    );
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind == perfgate_types::DecisionBundleArtifactKind::Tradeoff)
+    );
+    assert!(
+        bundle.artifacts.iter().any(|artifact| artifact.kind
+            == perfgate_types::DecisionBundleArtifactKind::DecisionMarkdown)
+    );
+    assert!(
+        bundle
+            .artifacts
+            .iter()
+            .any(|artifact| artifact.kind
+                == perfgate_types::DecisionBundleArtifactKind::ProbeCompare)
+    );
+    assert!(bundle.artifacts.iter().any(
+        |artifact| artifact.kind == perfgate_types::DecisionBundleArtifactKind::CompareReceipt
+    ));
 }
 
 fn write_controlled_compare_receipt(path: &Path) {


### PR DESCRIPTION
Summary: extends the structured decision E2E smoke through perfgate decision bundle; asserts the portable bundle embeds the decision index, scenario, tradeoff, markdown, probe compare, and compare receipt artifacts; preserves the local-first decision/probe path. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p perfgate-cli --all-features decision_evaluate_runs_structured_decision_workflow --locked; cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked; cargo +1.95.0 run -p xtask -- schema-compat; git diff --check.