### PR TITLE
test(action): add failure summary golden examples

### DIFF
--- a/docs/examples/action-failure-summaries.md
+++ b/docs/examples/action-failure-summaries.md
@@ -1,0 +1,132 @@
+# Action Failure Summary Examples
+
+These examples show the CI summary shapes reviewers should expect from the
+composite GitHub Action. They are golden examples for the user-facing failure
+copy, not a second behavior spec. The behavior contract lives in
+[`PERFGATE-SPEC-0007`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md),
+and the shell wiring is checked by `cargo +1.95.0 run -p xtask -- action-check`.
+
+The exact artifact paths can vary by configuration. A useful summary must still
+name the verdict, point to receipts, and show a local reproduction command.
+
+## Missing Baseline
+
+Use this when the first CI run has not promoted a baseline yet.
+
+```text
+Verdict: fail (pass=0, warn=0, fail=1, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+Next setup command:
+  perfgate baseline promote --config perfgate.toml --all
+Uploaded artifact: perfgate-artifacts-123456789-1
+artifacts/perfgate/parser/run.json
+artifacts/perfgate/parser/report.json
+```
+
+The reviewer should treat this as setup work unless a baseline was expected to
+exist. Promote intentionally, commit `baselines/`, and rerun CI.
+
+## Policy Failure
+
+Use this when a required benchmark metric exceeded policy and no accepted
+tradeoff applies.
+
+```text
+Verdict: fail (pass=0, warn=0, fail=1, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+Uploaded artifact: perfgate-artifacts-123456789-1
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/parser/report.json
+artifacts/perfgate/parser/comment.md
+```
+
+The reviewer should inspect `compare.json` or `comment.md` first, then decide
+whether the regression must be fixed or intentionally documented in a later
+policy/baseline change.
+
+## Warn With Accepted Tradeoff
+
+Use this when decision mode accepts a local regression because configured
+scenario, probe, and tradeoff evidence support the change.
+
+```text
+Verdict: warn (pass=0, warn=1, fail=0, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+  perfgate decision evaluate --config perfgate.toml
+Uploaded artifact: perfgate-artifacts-123456789-1
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/parser/probe-compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should read `decision.md`, then follow `decision.index.json` to the
+probe and tradeoff receipts if the accepted tradeoff is surprising.
+
+## Review Required
+
+Use this when evidence exists but policy requires a human to inspect it before
+the PR can rely on the decision.
+
+```text
+Verdict: warn (pass=0, warn=1, fail=0, benches=1)
+Review required: tradeoff_review_required
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+  perfgate decision evaluate --config perfgate.toml
+Uploaded artifact: perfgate-artifacts-123456789-1
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should treat this as a performance review request, not as an
+automatic pass. Check the named policy reason before accepting the tradeoff.
+
+## Artifact Upload List
+
+Use this to confirm the summary points to enough receipts for local reproduction
+and asynchronous review.
+
+```text
+Uploaded artifact: perfgate-artifacts-123456789-1
+artifacts/perfgate/parser/run.json
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/parser/report.json
+artifacts/perfgate/parser/comment.md
+artifacts/perfgate/parser/probe-compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should be able to download the artifact and reproduce the same
+decision locally from the listed receipt paths.
+
+## Decision-Enabled Failure
+
+Use this when `perfgate check` reaches a policy failure and decision mode is
+enabled, but structured decision evaluation still rejects the change.
+
+```text
+Verdict: fail (pass=0, warn=0, fail=1, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+  perfgate decision evaluate --config perfgate.toml
+Uploaded artifact: perfgate-artifacts-123456789-1
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should read the structured decision first. A decision-enabled
+failure means the action found or evaluated receipts, but policy still rejects
+the performance change.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -744,7 +744,11 @@ fn cmd_action_check(action: &Path, cli_manifest: &Path) -> anyhow::Result<()> {
         fs::read_to_string(action).with_context(|| format!("reading {}", action.display()))?;
     let manifest_content = fs::read_to_string(cli_manifest)
         .with_context(|| format!("reading {}", cli_manifest.display()))?;
-    let errors = collect_action_check_errors(&action_content, &manifest_content);
+    let summary_examples_path = Path::new("docs/examples/action-failure-summaries.md");
+    let summary_examples = fs::read_to_string(summary_examples_path)
+        .with_context(|| format!("reading {}", summary_examples_path.display()))?;
+    let mut errors = collect_action_check_errors(&action_content, &manifest_content);
+    errors.extend(collect_action_summary_example_errors(&summary_examples));
 
     if !errors.is_empty() {
         println!(
@@ -1244,6 +1248,61 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
             "perfgate-cli binstall metadata must unpack the perfgate binary from the archive"
                 .to_string(),
         );
+    }
+
+    errors
+}
+
+fn collect_action_summary_example_errors(summary_examples: &str) -> Vec<String> {
+    let mut errors = Vec::new();
+    let required_examples = [
+        ("missing baseline", "## Missing Baseline"),
+        ("policy failure", "## Policy Failure"),
+        (
+            "warn with accepted tradeoff",
+            "## Warn With Accepted Tradeoff",
+        ),
+        ("review required", "## Review Required"),
+        ("artifact upload list", "## Artifact Upload List"),
+        ("decision-enabled failure", "## Decision-Enabled Failure"),
+    ];
+    for (name, heading) in required_examples {
+        if !summary_examples.contains(heading) {
+            errors.push(format!(
+                "action failure summary examples must include the {name} golden example"
+            ));
+        }
+    }
+
+    let required_copy = [
+        ("verdict counts", "Verdict:"),
+        (
+            "local check reproduction",
+            "perfgate check --config perfgate.toml",
+        ),
+        (
+            "baseline promotion hint",
+            "perfgate baseline promote --config perfgate.toml --all",
+        ),
+        (
+            "decision reproduction",
+            "perfgate decision evaluate --config perfgate.toml",
+        ),
+        ("review-required reason", "Review required:"),
+        ("uploaded artifact name", "Uploaded artifact:"),
+        ("compare receipt", "compare.json"),
+        ("probe compare receipt", "probe-compare.json"),
+        ("scenario receipt", "scenario.json"),
+        ("tradeoff receipt", "tradeoff.json"),
+        ("decision markdown", "decision.md"),
+        ("decision index", "decision.index.json"),
+    ];
+    for (name, phrase) in required_copy {
+        if !summary_examples.contains(phrase) {
+            errors.push(format!(
+                "action failure summary examples must include {name}: {phrase}"
+            ));
+        }
     }
 
     errors
@@ -6562,6 +6621,30 @@ pkg-fmt = "zip"
         );
 
         assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn action_summary_examples_cover_expected_failure_shapes() {
+        let errors = collect_action_summary_example_errors(include_str!(
+            "../../docs/examples/action-failure-summaries.md"
+        ));
+
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn action_summary_examples_reject_missing_review_required_shape() {
+        let examples = include_str!("../../docs/examples/action-failure-summaries.md")
+            .replace("## Review Required", "## Human Review");
+        let errors = collect_action_summary_example_errors(&examples);
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("review required golden example")),
+            "errors should mention missing review-required example: {:?}",
+            errors
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary: adds checked action failure summary golden examples for missing baseline, policy failure, accepted tradeoff warning, review-required, artifact upload list, and decision-enabled failure; extends xtask action-check to require the golden example surface; adds xtask unit coverage for the action summary example contract. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p xtask action_summary_examples --locked; cargo +1.95.0 run -p xtask -- action-check; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; git diff --check.