### PR TITLE
release: validate 0.18.0 adoption readiness

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,8 +1,11 @@
 # Release Readiness
 
-Last verified: 2026-05-13 for v0.17.0 publication reconciliation. See
-[v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md)
-and [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md).
+Last verified: 2026-05-13 for v0.17.0 publication reconciliation and the
+0.18.0 adoption-readiness snapshot. See
+[v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
+[v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
+and
+[v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md).
 
 Latest published release: v0.17.0. The five allowed crates are published on
 crates.io at `0.17.0`, the GitHub release `v0.17.0` is published with platform
@@ -14,6 +17,11 @@ the same release commit as `v0.17.0`.
 The current published release is `v0.17.0`. It keeps the five-crate public
 surface from v0.16.0, raises the Rust floor to 1.95, and adds the governance
 rails that make the release conveyor explicit.
+
+The 0.18.0 adoption-readiness snapshot is a pre-release proof record, not a
+publication record. It documents wrapper absorption, first-hour smoke proof,
+structured-decision bundle proof, checked action failure examples, and optional
+server-ledger operations smoke after the guided-adoption lane closed out.
 
 ## Current Publication State
 
@@ -52,6 +60,7 @@ rails that make the release conveyor explicit.
 | Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, and dashboard decision-ledger tests |
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
+| 0.18 adoption hardening | Covered | [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md), including wrapper absorption, first-hour smoke, structured decision bundle proof, action summary examples, and server ledger operations smoke |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:

--- a/docs/audits/release-0.18.0-adoption-readiness.md
+++ b/docs/audits/release-0.18.0-adoption-readiness.md
@@ -1,0 +1,99 @@
+# v0.18.0 Adoption Readiness Snapshot
+
+Date: 2026-05-13
+
+Purpose: record the current 0.18.0 adoption-hardening proof after wrapper
+absorption and external adoption smoke work. This is a pre-release readiness
+snapshot. It does not publish crates, move tags, create a GitHub release, or
+change action aliases.
+
+## Scope
+
+This snapshot covers the implementation-hardening lane after guided adoption
+closed out. The lane goal was to make perfgate release-boring and
+adoption-proven:
+
+- a cold user can initialize, check, promote, and rerun with required
+  baselines;
+- a reviewer can follow structured decision receipts through a portable bundle;
+- a GitHub Action failure summary has stable, checked example shapes;
+- a team can exercise optional decision-ledger operations safely; and
+- the public crate surface remains the five intended contract crates after
+  compatibility wrapper absorption.
+
+## Landed Work
+
+| Area | Evidence |
+| --- | --- |
+| Presentation wrapper absorption | PR #389 removed `perfgate-render`, `perfgate-export`, and `perfgate-sensor` as workspace packages and routed callers to owning facade modules. |
+| Runtime/integration wrapper absorption | PR #390 removed `perfgate-adapters` and `perfgate-github` as workspace packages. |
+| App/domain wrapper absorption | PR #391 removed `perfgate-app`, `perfgate-domain`, and `perfgate-paired` as workspace packages while preserving user-facing commands and receipt names. |
+| Contract-adjacent wrapper absorption | PR #392 removed `perfgate-error` and `perfgate-api` as workspace packages while preserving `perfgate-types`, `perfgate-client`, and `perfgate-server` as public seams. |
+| Package-surface closeout | PR #393 added the wrapper absorption handoff and marked the cleanup plan implemented. |
+| First-hour smoke | PR #394 strengthened the generated sample repo path through missing-baseline guidance, baseline promotion, required-baseline rerun, workflow wiring, and commit guidance. |
+| Generated badge refresh | PR #395 refreshed generated badge endpoint data separately from product changes. |
+| Structured decision smoke | PR #396 extended the structured-decision E2E path through `decision bundle` and asserted the portable bundle embeds expected artifacts. |
+| Action summary examples | PR #397 added checked golden examples for common GitHub Action failure summaries and wired them into `action-check`. |
+| Server ledger operations smoke | PR #398 extended the server operations smoke through decision upload with an artifact index, history/latest/debt/export, dry-run prune preservation, and create-audit visibility. |
+
+## Current Product Proof
+
+| User path | Proof surface |
+| --- | --- |
+| First-hour local gate | `cli_first_run_e2e_tests.rs`, `FIRST_HOUR.md`, `ADOPTION_LEVELS.md`, `DEBUGGING_FIRST_CI_RUN.md` |
+| Required-baseline rerun | `first_run_paved_road_creates_artifacts_and_baselines` checks missing-baseline copy, promotion, and `--require-baseline` rerun behavior |
+| Structured decisions | `cli_structured_decision_e2e_tests.rs` covers check, probe compare, scenario, tradeoff, `decision.md`, `decision.index.json`, and `decision-bundle.json` |
+| Action failure UX | `docs/examples/action-failure-summaries.md` and `cargo +1.95.0 run -p xtask -- action-check` |
+| Optional decision ledger | `server_operations_smoke_path_memory` covers upload, history, latest, debt, export, prune dry-run, and audit visibility |
+| Package surface | `cargo +1.95.0 run -p xtask -- public-surface --strict` and `docs/handoffs/2026-05-13-wrapper-absorption-closeout.md` |
+
+## Current Package Surface
+
+The only public contract crates remain:
+
+```text
+perfgate
+perfgate-cli
+perfgate-types
+perfgate-client
+perfgate-server
+```
+
+Former production compatibility wrapper crates are no longer workspace
+packages. Historical absorbed-crate disposition remains documented in
+`policy/absorbed_crates.txt`, `docs/CRATE_SEAMS.md`, and the wrapper absorption
+closeout.
+
+## Snapshot Proof Commands
+
+These commands define the adoption-readiness proof for this snapshot:
+
+```bash
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 check --workspace --all-targets --all-features --locked
+cargo +1.95.0 test -p perfgate-cli --all-features first_run --locked
+cargo +1.95.0 test -p perfgate-cli --all-features decision_evaluate_runs_structured_decision_workflow --locked
+cargo +1.95.0 test -p perfgate-cli --all-features server_operations_smoke_path_memory --locked
+cargo +1.95.0 test -p xtask action_summary_examples --locked
+cargo +1.95.0 run -p xtask -- public-surface --strict
+cargo +1.95.0 run -p xtask -- arch
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+cargo +1.95.0 run -p xtask -- action-check
+cargo +1.95.0 run -p xtask -- schema-compat
+git diff --check
+```
+
+## Release Boundary
+
+This snapshot is not a release PR. Before publishing 0.18.0, run the full
+release proof matrix from `docs/RELEASE_READINESS.md`, including package-list
+and dry-run publish checks for the five public crates.
+
+## Remaining Work
+
+- Run full hosted CI on the eventual 0.18.0 release candidate.
+- Run the publish dry-run matrix immediately before any 0.18.0 publish.
+- Keep generated badge and baseline refresh PRs separate from product strategy.

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -108,7 +108,7 @@ Review after: before-0.18.0-release
 
 Tier: stable
 Surface: crates, public API, release policy
-Linked docs: [`CRATE_SEAMS.md`](../CRATE_SEAMS.md), [`ARCHITECTURE.md`](../ARCHITECTURE.md), [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`2026-05-13-wrapper-absorption-closeout.md`](../handoffs/2026-05-13-wrapper-absorption-closeout.md)
+Linked docs: [`CRATE_SEAMS.md`](../CRATE_SEAMS.md), [`ARCHITECTURE.md`](../ARCHITECTURE.md), [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`2026-05-13-wrapper-absorption-closeout.md`](../handoffs/2026-05-13-wrapper-absorption-closeout.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md)
 Linked specs: [`PERFGATE-SPEC-0002-package-surface-boundary`](../specs/PERFGATE-SPEC-0002-package-surface-boundary.md)
 Linked policy:
 
@@ -229,7 +229,7 @@ Review after: next-release-candidate
 
 Tier: supported
 Surface: CLI, docs, artifacts
-Linked docs: [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`DEBUGGING_FIRST_CI_RUN.md`](../DEBUGGING_FIRST_CI_RUN.md)
+Linked docs: [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`DEBUGGING_FIRST_CI_RUN.md`](../DEBUGGING_FIRST_CI_RUN.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md)
 Linked specs: [`PERFGATE-SPEC-0004-user-devex-paved-road`](../specs/PERFGATE-SPEC-0004-user-devex-paved-road.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
 Proof commands:
 
@@ -259,7 +259,7 @@ Review after: before-0.18.0-release
 
 Tier: supported
 Surface: docs, CLI, GitHub Action, server ledger
-Linked docs: [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`PERFORMANCE_DECISIONS.md`](../PERFORMANCE_DECISIONS.md), [`DECISION_LEDGER_RUNBOOK.md`](../DECISION_LEDGER_RUNBOOK.md)
+Linked docs: [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`PERFORMANCE_DECISIONS.md`](../PERFORMANCE_DECISIONS.md), [`DECISION_LEDGER_RUNBOOK.md`](../DECISION_LEDGER_RUNBOOK.md), [`examples/action-failure-summaries.md`](../examples/action-failure-summaries.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md)
 Linked specs: [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Proof commands:
 
@@ -267,9 +267,10 @@ Proof commands:
 cargo +1.95.0 run -p xtask -- docs-check
 cargo +1.95.0 run -p xtask -- doc-test
 cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- action-check
 ```
 
-Linked gates: docs-check, doc-test, docs-source-check
+Linked gates: docs-check, doc-test, docs-source-check, action-check
 
 Artifacts:
 
@@ -285,7 +286,7 @@ Review after: before-0.18.0-release
 
 Tier: supported
 Surface: CLI, Rust helpers, probe receipts, decision receipts
-Linked docs: [`PROBE_QUICKSTART.md`](../PROBE_QUICKSTART.md), [`PERFORMANCE_DECISIONS.md`](../PERFORMANCE_DECISIONS.md), [`examples/decision-outcomes.md`](../examples/decision-outcomes.md)
+Linked docs: [`PROBE_QUICKSTART.md`](../PROBE_QUICKSTART.md), [`PERFORMANCE_DECISIONS.md`](../PERFORMANCE_DECISIONS.md), [`examples/decision-outcomes.md`](../examples/decision-outcomes.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md)
 Linked specs: [`PERFGATE-SPEC-0003-performance-decision-contract`](../specs/PERFGATE-SPEC-0003-performance-decision-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
 Proof commands:
 
@@ -317,12 +318,13 @@ Review after: next-probe-contract-change
 
 Tier: supported
 Surface: server, CLI, dashboard, audit exports
-Linked docs: [`DECISION_LEDGER_RUNBOOK.md`](../DECISION_LEDGER_RUNBOOK.md), [`BASELINE_SERVICE_DESIGN.md`](../BASELINE_SERVICE_DESIGN.md), [`GETTING_STARTED_BASELINE_SERVER.md`](../GETTING_STARTED_BASELINE_SERVER.md)
+Linked docs: [`DECISION_LEDGER_RUNBOOK.md`](../DECISION_LEDGER_RUNBOOK.md), [`BASELINE_SERVICE_DESIGN.md`](../BASELINE_SERVICE_DESIGN.md), [`GETTING_STARTED_BASELINE_SERVER.md`](../GETTING_STARTED_BASELINE_SERVER.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md)
 Linked specs: [`PERFGATE-SPEC-0003-performance-decision-contract`](../specs/PERFGATE-SPEC-0003-performance-decision-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
 Proof commands:
 
 ```bash
 cargo +1.95.0 test -p perfgate-cli --all-features decision
+cargo +1.95.0 test -p perfgate-cli --all-features server_operations_smoke_path_memory --locked
 cargo +1.95.0 run -p xtask -- docs-check
 cargo +1.95.0 run -p xtask -- doc-test
 ```


### PR DESCRIPTION
Summary: adds the v0.18.0 adoption-readiness snapshot; links the snapshot from release readiness and adoption/package-surface product claims; records wrapper absorption, first-hour smoke, structured decision bundle proof, action summary examples, and optional server ledger operations proof without publishing or moving tags. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; cargo +1.95.0 run -p xtask -- public-surface --strict; cargo +1.95.0 run -p xtask -- arch; cargo +1.95.0 run -p xtask -- action-check; cargo +1.95.0 run -p xtask -- schema-compat; git diff --check.