### PR TITLE
docs(status): add platform metric support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ the contract details.
 | `binary_bytes` | Executable size |
 | `throughput_per_s` | Ops/sec with `--work` |
 
+Metric availability is platform-specific. See
+[`docs/status/PLATFORM_SUPPORT.md`](docs/status/PLATFORM_SUPPORT.md) before
+making non-wall-clock metrics required gates.
+
 perfgate supports local baselines, cloud paths, and the optional baseline
 server, but local in-repo baselines are the default first setup.
 
@@ -260,6 +264,7 @@ For specific workflows:
 - [Probe Instrumentation Quickstart](docs/PROBE_QUICKSTART.md)
 - [Probe Design Patterns](docs/PROBE_DESIGN_PATTERNS.md)
 - [Signal Calibration](docs/SIGNAL_CALIBRATION.md)
+- [Platform Metric Support](docs/status/PLATFORM_SUPPORT.md)
 - [Step-by-Step Pipeline](docs/PIPELINE.md)
 - [Baseline Server](docs/GETTING_STARTED_BASELINE_SERVER.md)
 - [Paired Benchmarking](docs/PAIRED_BENCHMARKING.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,8 @@ Codex execution state stay reviewable.
 - Signal calibration: [`SIGNAL_CALIBRATION.md`](SIGNAL_CALIBRATION.md)
 - Decision ledger operations:
   [`DECISION_LEDGER_RUNBOOK.md`](DECISION_LEDGER_RUNBOOK.md)
+- Platform metric support:
+  [`status/PLATFORM_SUPPORT.md`](status/PLATFORM_SUPPORT.md)
 - Workspace inventory: [`WORKSPACE.md`](WORKSPACE.md)
 - GitHub Actions setup:
   [`GETTING_STARTED_GITHUB_ACTIONS.md`](GETTING_STARTED_GITHUB_ACTIONS.md)

--- a/docs/status/PLATFORM_SUPPORT.md
+++ b/docs/status/PLATFORM_SUPPORT.md
@@ -1,0 +1,73 @@
+# Platform Metric Support
+
+perfgate receipts use optional metric fields. A missing platform metric does
+not invalidate the gate; it means that metric was not available for that run and
+will not be compared unless both baseline and current receipts contain it.
+
+Use this matrix to decide which metrics can be required on a platform and which
+should stay advisory.
+
+## Legend
+
+| Status | Meaning |
+|--------|---------|
+| supported | Populated by the standard runner and suitable for same-platform gates. |
+| advisory | Populated or useful, but semantics are platform-specific or best-effort. |
+| unavailable | Not collected by the standard runner on this platform. |
+
+## Metric Matrix
+
+| Surface | Linux | macOS | Windows | Notes |
+|---------|-------|-------|---------|-------|
+| `wall_ms` | supported | supported | supported | Wall-clock timing is the primary cross-platform metric. |
+| timeout enforcement | supported | supported | supported | Unix and Windows runners poll child process completion and kill on timeout. |
+| `cpu_ms` | supported | supported | unavailable | Unix uses child `rusage`; Windows receipts omit this field. |
+| `max_rss_kb` | supported | supported | supported | Unix uses `rusage`; Windows uses peak working set. Compare within the same host class. |
+| `page_faults` | supported | supported | advisory | Unix records major faults; Windows records total page faults from process memory counters. |
+| `ctx_switches` | supported | supported | unavailable | Unix records voluntary plus involuntary context switches; Windows receipts omit this field. |
+| `io_read_bytes` / `io_write_bytes` | unavailable | unavailable | advisory | Windows uses process IO counters; Unix receipts currently omit these fields. |
+| `binary_bytes` | advisory | advisory | advisory | Best-effort executable path metadata; wrapper scripts and shell commands may omit it. |
+| `energy_uj` | unavailable | unavailable | unavailable | Schema field exists, but the standard runner does not currently collect it. |
+| `network_packets` | unavailable | unavailable | unavailable | Schema field exists, but the standard runner does not currently collect it. |
+
+## Required Gates
+
+For required branch protection:
+
+- prefer `wall_ms` first;
+- use `cpu_ms`, `max_rss_kb`, `page_faults`, or `ctx_switches` only on a host
+  class where the field is consistently present;
+- keep Windows `page_faults`, Windows IO counters, and `binary_bytes`
+  advisory unless the team has reviewed runner-specific behavior;
+- do not compare baselines across materially different host classes;
+- use [`HOST_MISMATCH.md`](../HOST_MISMATCH.md) when CI should warn or fail on
+  different runner fingerprints.
+
+## Missing Metrics
+
+Metric fields are optional in `perfgate.run.v1`. If a field is missing from
+either side of a comparison, perfgate cannot evaluate that metric's budget for
+that comparison.
+
+That means:
+
+- a missing optional metric should not make `wall_ms` unusable;
+- a budget for a platform-unavailable metric will not provide protection on
+  that platform;
+- required metric policies should be paired with a stable runner class and
+  reviewed artifact examples;
+- release claims should say which platform owns the proof.
+
+## Calibration
+
+Use platform support together with signal calibration:
+
+- Linux/macOS CI can gate on `wall_ms`, `cpu_ms`, and selected process metrics
+  when the runner class is stable.
+- Windows CI can gate on `wall_ms` and use memory/page-fault/IO fields as
+  advisory evidence unless the team explicitly calibrates those counters.
+- Cross-platform checks should usually report metrics separately rather than
+  sharing one baseline namespace.
+
+For threshold and noise guidance, see
+[`../SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md).

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -22,6 +22,7 @@ Support tier definitions live in [`SUPPORT_TIERS.md`](SUPPORT_TIERS.md).
 | PG-CLAIM-0010 | perfgate supports staged adoption levels from local gate to team ledger. | supported | docs, CLI, action, server | before-0.18.0-release |
 | PG-CLAIM-0011 | perfgate supports probe-backed tradeoff explanation. | supported | CLI, Rust helpers, receipts | next-probe-contract-change |
 | PG-CLAIM-0012 | perfgate supports optional team decision-ledger operations. | supported | server, CLI, dashboard, docs | next-server-ledger-change |
+| PG-CLAIM-0013 | perfgate documents platform-specific metric availability. | advisory | docs, CLI receipts | next-platform-metric-change |
 
 ## PG-CLAIM-0001: Reviewable performance decisions
 
@@ -343,3 +344,30 @@ Artifacts:
 - `/health` and `/metrics`
 
 Review after: next-server-ledger-change
+
+## PG-CLAIM-0013: Platform metric availability
+
+Tier: advisory
+Surface: docs, CLI receipts, platform runner adapters
+Linked docs: [`PLATFORM_SUPPORT.md`](PLATFORM_SUPPORT.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`HOST_MISMATCH.md`](../HOST_MISMATCH.md)
+Linked specs: [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+
+Linked tests:
+
+- [`runtime.rs`](../../crates/perfgate/src/app/runtime.rs)
+- [`cli_cpu_time_tests.rs`](../../crates/perfgate-cli/tests/cli_cpu_time_tests.rs)
+- [`cli_host_mismatch_tests.rs`](../../crates/perfgate-cli/tests/cli_host_mismatch_tests.rs)
+
+Artifacts:
+
+- `perfgate.run.v1` optional metric fields
+- `perfgate.compare.v1` metric deltas when both sides contain a metric
+- host fingerprints
+
+Review after: next-platform-metric-change

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -9,6 +9,7 @@ This directory is the home for:
 ```text
 SUPPORT_TIERS.md
 PRODUCT_CLAIMS.md
+PLATFORM_SUPPORT.md
 ```
 
 Those files are intentionally introduced after this scaffold so the claim map


### PR DESCRIPTION
## Summary
- adds a platform metric support matrix for wall time, timeouts, CPU, RSS, page faults, context switches, IO, binary size, energy, and network packet fields
- links platform support from README, docs index, and status docs index
- adds an advisory product claim for platform-specific metric availability

## Validation
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`