### PR TITLE
test(action): add failure archaeology examples

### DIFF
--- a/docs/examples/action-failure-summaries.md
+++ b/docs/examples/action-failure-summaries.md
@@ -130,3 +130,137 @@ artifacts/perfgate/decision.index.json
 The reviewer should read the structured decision first. A decision-enabled
 failure means the action found or evaluated receipts, but policy still rejects
 the performance change.
+
+## Missing Benchmark Command
+
+Use this when CI cannot start the configured benchmark command.
+
+```text
+perfgate check exited with code 1
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+Artifacts:
+  artifacts/perfgate/ (no perfgate receipt files found)
+```
+
+The reviewer should inspect `perfgate.toml`, the benchmark command path, and
+the CI runner environment before changing thresholds or promoting a baseline.
+This is setup failure, not performance evidence.
+
+## Wrong Baseline Path
+
+Use this when CI can run the benchmark but cannot find the expected baseline
+namespace or files.
+
+```text
+perfgate check exited with code 2
+Verdict: fail (pass=0, warn=0, fail=1, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+Baseline bootstrap: after reviewing the first trusted run, promote it locally:
+  perfgate baseline promote --config perfgate.toml --all
+Artifacts:
+artifacts/perfgate/parser/run.json
+artifacts/perfgate/parser/report.json
+```
+
+The reviewer should decide whether this is a missing committed baseline,
+wrong `baseline_dir`, wrong `baseline_pattern`, or a host/branch namespace
+mismatch. Do not promote a baseline until the expected baseline source is clear.
+
+## Artifact Upload Disabled
+
+Use this when the action is configured with `upload_artifact: "false"`.
+
+```text
+Verdict: fail (pass=0, warn=0, fail=1, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+Artifacts:
+artifacts/perfgate/parser/compare.json
+artifacts/perfgate/parser/report.json
+```
+
+The reviewer can still use the printed local reproduction command. If the PR
+needs asynchronous review, enable artifact upload or attach the relevant
+receipts intentionally.
+
+## Decision Missing Probe Evidence
+
+Use this when decision mode is enabled but a scenario references missing probe
+receipts.
+
+```text
+Verdict: warn (pass=0, warn=1, fail=0, benches=1)
+Review required: tradeoff_review_required
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+  perfgate decision evaluate --config perfgate.toml
+Artifacts:
+artifacts/perfgate/scenario.json
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should look for `probe evidence missing` in the scenario or
+decision receipts. Missing probes can request review; they should not silently
+accept a tradeoff that depends on named internal movement.
+
+## Server Upload Failed
+
+Use this when a workflow uploads decision receipts to a team ledger after the
+local gate, but that upload fails.
+
+```text
+Verdict: warn (pass=0, warn=1, fail=0, benches=1)
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+  perfgate decision evaluate --config perfgate.toml
+Artifacts:
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should keep local receipts as the correctness contract. Treat a
+server upload failure as an operations problem unless the repository explicitly
+requires ledger persistence before merge.
+
+## Review Required Fail Policy
+
+Use this when `decision: "true"` and `review_required: "fail"` turn a
+needs-review decision into a blocking check.
+
+```text
+perfgate decision review exited with code 2
+Verdict: warn (pass=0, warn=1, fail=0, benches=1)
+Review required: tradeoff_review_required
+Reproduce locally:
+  perfgate check --config perfgate.toml --all --require-baseline
+  perfgate decision evaluate --config perfgate.toml
+Artifacts:
+artifacts/perfgate/tradeoff.json
+artifacts/perfgate/decision.md
+artifacts/perfgate/decision.index.json
+```
+
+The reviewer should inspect the reason before overriding the policy. This is
+not a failed benchmark by itself; it is branch protection enforcing human
+review for incomplete or noisy tradeoff evidence.
+
+## Windows Path Or Shell Quoting
+
+Use this when the reproduction command contains paths with spaces or
+platform-specific separators.
+
+```text
+Reproduce locally:
+  perfgate check --config perfgate.toml --bench parser --out-dir artifacts/perfgate/windows\ path --require-baseline
+Artifacts:
+artifacts/perfgate/windows path/parser/compare.json
+```
+
+The reviewer should copy the command exactly from the action summary. If a
+shell rewrites the path, rerun from the repository root with an explicit
+`--out-dir` and avoid editing receipt paths by hand.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1265,6 +1265,22 @@ fn collect_action_summary_example_errors(summary_examples: &str) -> Vec<String> 
         ("review required", "## Review Required"),
         ("artifact upload list", "## Artifact Upload List"),
         ("decision-enabled failure", "## Decision-Enabled Failure"),
+        ("missing benchmark command", "## Missing Benchmark Command"),
+        ("wrong baseline path", "## Wrong Baseline Path"),
+        ("artifact upload disabled", "## Artifact Upload Disabled"),
+        (
+            "decision missing probe evidence",
+            "## Decision Missing Probe Evidence",
+        ),
+        ("server upload failed", "## Server Upload Failed"),
+        (
+            "review required fail policy",
+            "## Review Required Fail Policy",
+        ),
+        (
+            "windows path or shell quoting",
+            "## Windows Path Or Shell Quoting",
+        ),
     ];
     for (name, heading) in required_examples {
         if !summary_examples.contains(heading) {
@@ -1296,6 +1312,19 @@ fn collect_action_summary_example_errors(summary_examples: &str) -> Vec<String> 
         ("tradeoff receipt", "tradeoff.json"),
         ("decision markdown", "decision.md"),
         ("decision index", "decision.index.json"),
+        (
+            "missing command setup failure",
+            "no perfgate receipt files found",
+        ),
+        ("wrong baseline path guidance", "wrong `baseline_dir`"),
+        (
+            "artifact upload disabled guidance",
+            "upload_artifact: \"false\"",
+        ),
+        ("missing probe evidence", "probe evidence missing"),
+        ("server upload failure", "server upload failure"),
+        ("review-required fail policy", "review_required: \"fail\""),
+        ("windows path guidance", "Windows Path Or Shell Quoting"),
     ];
     for (name, phrase) in required_copy {
         if !summary_examples.contains(phrase) {
@@ -6643,6 +6672,21 @@ pkg-fmt = "zip"
                 .iter()
                 .any(|error| error.contains("review required golden example")),
             "errors should mention missing review-required example: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn action_summary_examples_reject_missing_ugly_failure_shape() {
+        let examples = include_str!("../../docs/examples/action-failure-summaries.md")
+            .replace("## Missing Benchmark Command", "## Missing Command");
+        let errors = collect_action_summary_example_errors(&examples);
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("missing benchmark command golden example")),
+            "errors should mention missing ugly failure example: {:?}",
             errors
         );
     }


### PR DESCRIPTION
## Summary
- adds ugly-case GitHub Action failure examples for missing benchmark commands, wrong baseline paths, disabled artifact uploads, missing probe evidence, server upload failures, review-required fail policy, and Windows/path quoting
- extends `action-check` so those failure archaeology examples are required
- adds a regression test proving the checker rejects a missing ugly-case example

## Validation
- `cargo +1.95.0 fmt --all`
- `cargo +1.95.0 test -p xtask action_summary_examples --locked`
- `cargo +1.95.0 run -p xtask -- action-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`