### PR TITLE
test(server): cover ledger key rotation smoke

### DIFF
--- a/crates/perfgate-cli/tests/cli_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_server_tests.rs
@@ -770,12 +770,26 @@ async fn server_operations_smoke_path_memory() {
         .arg("--description")
         .arg("operations smoke key");
     add_server_auth_flags(&mut create_key, server.url(), &api_key);
-    create_key
+    let create_key_assert = create_key
         .assert()
         .success()
         .stdout(predicate::str::contains(&project))
         .stdout(predicate::str::contains("pg_live_"))
         .stderr(predicate::str::contains("Created API key"));
+    let create_key_stdout =
+        String::from_utf8(create_key_assert.get_output().stdout.clone()).expect("key stdout utf8");
+    let created_key_id = create_key_stdout
+        .lines()
+        .find_map(|line| {
+            let mut columns = line.split('\t');
+            let id = columns.next()?;
+            if id == "id" || id.is_empty() {
+                None
+            } else {
+                Some(id.to_string())
+            }
+        })
+        .expect("created key id should be printed");
 
     let mut list_keys = perfgate_cmd();
     list_keys
@@ -790,6 +804,38 @@ async fn server_operations_smoke_path_memory() {
         .success()
         .stdout(predicate::str::contains("operations smoke key"))
         .stdout(predicate::str::contains(&project));
+
+    let mut rotate_key = perfgate_cmd();
+    rotate_key
+        .arg("admin")
+        .arg("keys")
+        .arg("rotate")
+        .arg(&created_key_id);
+    add_server_auth_flags(&mut rotate_key, server.url(), &api_key);
+    rotate_key
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&created_key_id))
+        .stdout(predicate::str::contains("pg_live_"))
+        .stderr(predicate::str::contains(format!(
+            "Rotated API key {created_key_id}"
+        )));
+
+    let mut list_keys_after_rotate = perfgate_cmd();
+    list_keys_after_rotate
+        .arg("admin")
+        .arg("keys")
+        .arg("list")
+        .arg("--project")
+        .arg(&project)
+        .arg("--include-revoked");
+    add_server_auth_flags(&mut list_keys_after_rotate, server.url(), &api_key);
+    list_keys_after_rotate
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&created_key_id))
+        .stdout(predicate::str::contains("revoked"))
+        .stdout(predicate::str::contains("active"));
 
     let baseline_file = fixtures_dir().join("baseline.json");
     let current_file = fixtures_dir().join("current_pass.json");

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -61,7 +61,7 @@ version, publish, tag, release, action-alias, install-smoke, and closeout steps.
 | First-run paved road | Covered | `crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs` |
 | Baseline bootstrap UX | Covered | `crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs` |
 | Structured decision workflow | Covered | `crates/perfgate-cli/tests/cli_structured_decision_e2e_tests.rs`, `crates/perfgate-cli/tests/cli_performance_decision_example_tests.rs`, `crates/perfgate-cli/tests/cli_release_decision_proof_tests.rs`, and GitHub Action `decision: "true"` |
-| Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, and dashboard decision-ledger tests |
+| Decision ledger and debt | Covered | `decision upload|history|latest|export|prune|debt`, `perfgate.decision_record.v1`, decision upload/prune audit events, admin key create/list/rotate smoke, and dashboard decision-ledger tests |
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
 | 0.18 adoption hardening | Covered | [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md), including wrapper absorption, first-hour smoke, structured decision bundle proof, action summary examples, and server ledger operations smoke |

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -340,6 +340,7 @@ Artifacts:
 
 - `perfgate.decision_record.v1`
 - decision history/latest/export/prune/debt output
+- API key create/list/rotate output for ledger operations
 - audit JSONL exports
 - `/health` and `/metrics`
 


### PR DESCRIPTION
## Summary
- extends the memory server operations smoke to create, list, and rotate admin API keys
- verifies the rotated key appears revoked while a replacement key remains active
- updates release readiness and product-claim proof wording for ledger key rotation

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p perfgate-cli --all-features server_operations_smoke_path_memory --locked`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`