### PR TITLE
init: use neutral zero-benchmark example

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -5216,7 +5216,10 @@ fn execute_init(args: InitArgs) -> anyhow::Result<()> {
         eprintln!("     Example:");
         eprintln!("       [[bench]]");
         eprintln!("       name = \"my-command\"");
-        eprintln!("       command = [\"cargo\", \"run\", \"--\", \"--help\"]");
+        eprintln!("       command = [\"your-benchmark-command\", \"--flag\"]");
+        eprintln!("     Replace the command with what measures this repo, for example:");
+        eprintln!("       command = [\"cargo\", \"bench\", \"--bench\", \"my-bench\"]");
+        eprintln!("       command = [\"node\", \"scripts/bench.js\"]");
         eprintln!(
             "  2. Run: perfgate check --config {} --all",
             args.output.display()

--- a/crates/perfgate-cli/tests/cli_init_tests.rs
+++ b/crates/perfgate-cli/tests/cli_init_tests.rs
@@ -110,6 +110,8 @@ fn init_without_discovered_benchmarks_points_to_bench_entry_first() {
 
     assert!(stderr.contains("No benchmarks discovered"));
     assert!(stderr.contains("Add at least one [[bench]] entry to perfgate.toml."));
+    assert!(stderr.contains("your-benchmark-command"));
+    assert!(stderr.contains("[\"node\", \"scripts/bench.js\"]"));
     assert!(stderr.contains("perfgate check --config perfgate.toml --all"));
 
     let config =
@@ -119,5 +121,7 @@ fn init_without_discovered_benchmarks_points_to_bench_entry_first() {
     let onboarding = fs::read_to_string(temp_dir.path().join(".perfgate/README.md"))
         .expect("read onboarding README");
     assert!(onboarding.contains("Add at least one `[[bench]]` entry"));
+    assert!(onboarding.contains("your-benchmark-command"));
+    assert!(onboarding.contains("[\"node\", \"scripts/bench.js\"]"));
     assert!(onboarding.contains("perfgate check --config perfgate.toml --all"));
 }

--- a/crates/perfgate/src/app/init.rs
+++ b/crates/perfgate/src/app/init.rs
@@ -523,6 +523,15 @@ pub fn render_onboarding_readme(
     } else {
         format!(
             r#"1. Add at least one `[[bench]]` entry to `{config}`.
+   Example:
+   ```toml
+   [[bench]]
+   name = "my-command"
+   command = ["your-benchmark-command", "--flag"]
+   ```
+   Replace the command with what measures this repo, such as
+   `["cargo", "bench", "--bench", "my-bench"]` for Rust or
+   `["node", "scripts/bench.js"]` for Node.
 2. Run `perfgate check --config {config} --all`.
 3. Promote trusted first runs with `perfgate baseline promote --config {config} --all`.
 4. Commit `{config}`, {ci_commit}`baselines/.gitkeep`, and this directory.
@@ -948,6 +957,8 @@ harness = false
         let content = render_onboarding_readme(Path::new("perfgate.toml"), None, false);
 
         assert!(content.contains("Add at least one `[[bench]]` entry"));
+        assert!(content.contains("your-benchmark-command"));
+        assert!(content.contains("[\"node\", \"scripts/bench.js\"]"));
         assert!(content.contains("perfgate check --config perfgate.toml --all"));
         assert!(content.contains("perfgate baseline promote --config perfgate.toml --all"));
     }


### PR DESCRIPTION
## Summary
- replaces the zero-benchmark `init` example with a language-neutral placeholder
- shows Rust and Node examples so non-Rust repos are not pointed at Cargo-only setup
- covers both CLI stderr and generated `.perfgate/README.md` copy with tests

## Validation
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p perfgate-cli --all-features init_without_discovered_benchmarks_points_to_bench_entry_first --locked`
- `cargo +1.95.0 test -p perfgate --all-features onboarding_readme_mentions_bench_entry_when_none_discovered --locked`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`