### PR TITLE
plans(0.18): add release cutover plan

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -1,0 +1,252 @@
+id = "perfgate-0-18-release-cutover"
+title = "perfgate 0.18.0 release cutover and public install proof"
+status = "active"
+owner = "codex"
+created = "2026-05-14"
+milestone = "0.18.0"
+current_work_item = "release-cutover-plan"
+current_pr = "plans(0.18): add release cutover plan"
+
+objective = """
+Cut or explicitly defer perfgate 0.18.0 with no ambiguity. The repo must
+answer from files alone what version is public, which crates were published,
+which tags and action aliases moved, what public install smoke passed, what
+external canaries proved, what remains unproven, and what should happen next.
+"""
+
+end_state = [
+  "0.18.0 is either publicly released with publication proof or explicitly deferred with honest docs.",
+  "Version prep and release notes match actual merged source-of-truth, guided-adoption, wrapper-absorption, external-trust, and proof work.",
+  "Publish dry-runs pass for the five public crates in dependency order.",
+  "Release artifact smoke proves the staged install path before publication.",
+  "Public docs distinguish ready-to-release from released until crates, tags, and aliases actually move.",
+  "If publishing happens, public install smoke proves install, doctor, init, check, promote, require-baseline, and action workflow generation from public artifacts.",
+  "Product claims link release proof, canary evidence, tests, and support boundaries without overstating hosted external CI coverage.",
+  "The lane closes with a publication or deferral audit and an archived goal manifest.",
+]
+
+linked_proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+linked_spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+linked_plan = "plans/0.18.0/release-cutover.md"
+
+linked_specs = [
+  "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md",
+  "docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md",
+  "docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md",
+  "docs/specs/PERFGATE-SPEC-0002-package-surface-boundary.md",
+]
+
+linked_adrs = [
+  "docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md",
+  "docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md",
+]
+
+linked_status = [
+  "docs/status/PRODUCT_CLAIMS.md",
+  "docs/RELEASE_READINESS.md",
+]
+
+allowed_files = [
+  "Cargo.toml",
+  "Cargo.lock",
+  "crates/**/Cargo.toml",
+  "CHANGELOG.md",
+  "README.md",
+  "docs/**",
+  "plans/0.18.0/**",
+  ".codex/goals/**",
+  "policy/**",
+  "xtask/**",
+  "action.yml",
+  ".github/workflows/**",
+]
+
+forbidden_without_explicit_release_approval = [
+  "cargo publish",
+  "cargo owner",
+  "git tag v0.18.0",
+  "git tag -f v0.18",
+  "git tag -f v0",
+  "gh release create",
+  "gh release upload",
+  "git push origin v0.18.0",
+  "git push origin v0.18",
+  "git push origin v0",
+]
+
+proof = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "cargo +1.95.0 run -p xtask -- public-surface --strict",
+  "cargo +1.95.0 run -p xtask -- arch",
+  "cargo +1.95.0 run -p xtask -- action-check",
+  "cargo +1.95.0 run -p xtask -- schema-compat",
+  "cargo +1.95.0 run -p xtask -- publish-check --package-list",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli",
+  "git diff --check",
+]
+
+completion_criteria = [
+  "Release cutover proposal and plan are merged.",
+  "Version prep and release notes are merged or the release is explicitly deferred.",
+  "Publish dry-run proof is recorded for all five public crates.",
+  "Release artifact smoke is recorded before publication.",
+  "Public documentation reflects the actual release state.",
+  "Crates, tags, GitHub release, and action aliases move only with explicit release approval.",
+  "Public install smoke is recorded if publication happens.",
+  "Publication or deferral closeout records public state and non-inferences.",
+  "This active goal is archived with status completed.",
+]
+
+[[work_item]]
+id = "release-cutover-proposal"
+status = "merged"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-cutover-plan"
+status = "current"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "version-prep"
+status = "ready"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 check --workspace --all-targets --all-features --locked",
+  "cargo +1.95.0 test --workspace --all-targets --all-features --locked",
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "cargo +1.95.0 run -p xtask -- public-surface --strict",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "publish-dry-run-matrix"
+status = "ready"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- publish-check --package-list",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-artifact-smoke"
+status = "ready"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "public-docs-cutover"
+status = "ready"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "publish-crates"
+status = "blocked"
+blocked_by = "explicit release-operator approval"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo publish -p perfgate-types",
+  "cargo publish -p perfgate",
+  "cargo publish -p perfgate-client",
+  "cargo publish -p perfgate-server",
+  "cargo publish -p perfgate-cli",
+]
+
+[[work_item]]
+id = "tag-release-aliases"
+status = "blocked"
+blocked_by = "explicit release-operator approval and publish-crates"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "git tag v0.18.0",
+  "gh release create v0.18.0",
+  "git tag -f v0.18",
+  "git tag -f v0",
+]
+
+[[work_item]]
+id = "public-install-smoke"
+status = "blocked"
+blocked_by = "publish-crates and tag-release-aliases"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo binstall perfgate-cli",
+  "perfgate --version",
+  "perfgate doctor",
+  "perfgate init --ci github --profile standard",
+  "perfgate check --config perfgate.toml --all",
+  "perfgate baseline promote --config perfgate.toml --all",
+  "perfgate check --config perfgate.toml --all --require-baseline",
+]
+
+[[work_item]]
+id = "publication-closeout"
+status = "blocked"
+blocked_by = "public-install-smoke or explicit deferral decision"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "git diff --check",
+]

--- a/docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+++ b/docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
@@ -6,7 +6,7 @@ Created: 2026-05-14
 Target milestone: 0.18.0
 Linked specs: PERFGATE-SPEC-0005-release-proof-contract, PERFGATE-SPEC-0007-guided-adoption-contract, PERFGATE-SPEC-0003-performance-decision-contract
 Linked ADRs: PERFGATE-ADR-0001-public-crates-are-contracts, PERFGATE-ADR-0002-receipts-first-performance-decisions
-Linked plan:
+Linked plan: plans/0.18.0/release-cutover.md
 Support/status impact: docs/status/PRODUCT_CLAIMS.md must distinguish public release proof from pre-release readiness and external canary evidence
 Policy impact: no new policy rows by default; release must keep the five-crate public surface and existing policy ledgers authoritative
 

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -1,0 +1,314 @@
+# perfgate 0.18.0 Release Cutover Plan
+
+Status: active
+Owner: perfgate maintainers
+Created: 2026-05-14
+Milestone: 0.18.0
+Current PR: release cutover plan and active goal
+Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../../docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../../docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
+Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../../docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
+Linked policy: [`public_crates.txt`](../../policy/public_crates.txt), [`absorbed_crates.txt`](../../policy/absorbed_crates.txt)
+Support/status impact: [`PRODUCT_CLAIMS.md`](../../docs/status/PRODUCT_CLAIMS.md) and [`RELEASE_READINESS.md`](../../docs/RELEASE_READINESS.md) must match the public release state
+Proof commands: docs-check; doc-test; docs-source-check; product-claims-check; public-surface --strict; arch; action-check; schema-compat; publish-check dry-runs; public install smoke after publication
+Blocks: 0.18 publication closeout
+Blocked by: explicit release-operator approval for crates.io publish, tags, GitHub release, and action alias movement
+Rollback: before publication, revert the release-prep PRs; after publication, forward-fix crates/docs/tags and record repair notes because crates.io versions cannot be unpublished as a normal rollback
+
+## Goal
+
+Cut or explicitly defer `0.18.0` with no ambiguity. A release operator should
+be able to answer from repo artifacts:
+
+```text
+what version is public
+which crates were published
+which tags and action aliases moved
+what public install smoke passed
+what external canaries proved
+what remains unproven
+what should happen next
+```
+
+This plan sequences the release work. It does not authorize publishing crates,
+moving tags, creating a GitHub release, or moving action aliases by itself.
+
+## Operating Rules
+
+- Keep one release semantic per PR: plan, version prep, dry-run proof, artifact
+  smoke, docs cutover, publication, alias movement, public smoke, closeout.
+- Do not publish crates from planning, docs, version-prep, or dry-run PRs.
+- Do not create or move `v0.18.0`, `v0.18`, or `v0` from planning, docs,
+  version-prep, or dry-run PRs.
+- Move `v0` only after public install smoke proves 0.18.0 is the intended
+  default action release.
+- Preserve the five public crates:
+  `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`,
+  `perfgate-cli`.
+- Keep local receipts as the correctness contract and server ledger mode as
+  optional team history.
+- Keep docs honest: readiness proof is not publication proof.
+
+## PR Sequence
+
+| PR | Work item | Status | Files / surface |
+| --- | --- | --- | --- |
+| 415 | Release cutover proposal | merged | `docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md` |
+| next | Release cutover plan and active goal | current | `plans/0.18.0/release-cutover.md`, `.codex/goals/active.toml` |
+| next | Version prep | ready | workspace/package versions, changelog, release notes draft, docs references if needed |
+| next | Publish dry-run matrix | ready | `docs/audits/release-0.18.0-publish-readiness.md` |
+| next | Release artifact smoke | ready | staged archive or local release-artifact smoke audit |
+| next | Public documentation cutover | ready | README, first-hour/adoption docs, release readiness, product claims |
+| gated | Publish crates | blocked | crates.io publication in dependency order |
+| gated | Tag, GitHub release, action aliases | blocked | `v0.18.0`, `v0.18`, `v0` if intended, release assets |
+| gated | Public install smoke | blocked | public install path and first-hour smoke from published artifacts |
+| final | Publication or deferral closeout | blocked | release closeout audit, product claims, archived goal |
+
+## Work Item: version-prep
+
+Status: ready
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Linked ADR: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
+Blocks: publish-dry-run-matrix
+Blocked by:
+
+### Goal
+
+Prepare version and release-note state for 0.18.0 without publishing.
+
+### Production delta
+
+Expected files:
+
+```text
+Cargo.toml
+crates/*/Cargo.toml if package versions are not inherited
+CHANGELOG.md
+docs/audits/release-0.18.0-notes.md or equivalent release notes draft
+README.md or docs references only when they mention concrete versions
+```
+
+### Acceptance
+
+- Workspace/package versions consistently point to 0.18.0.
+- Release notes summarize actual merged changes: source-of-truth governance,
+  guided adoption, wrapper absorption, external canaries, signal/probe/platform
+  guidance, action failure examples, server-ledger key rotation smoke, and
+  release deferral/cutover state.
+- Docs do not claim 0.18.0 is published.
+
+### Proof commands
+
+```bash
+cargo +1.95.0 check --workspace --all-targets --all-features --locked
+cargo +1.95.0 test --workspace --all-targets --all-features --locked
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- product-claims-check
+cargo +1.95.0 run -p xtask -- public-surface --strict
+git diff --check
+```
+
+### Rollback
+
+Revert the version-prep PR before any crates are published.
+
+## Work Item: publish-dry-run-matrix
+
+Status: ready
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Blocks: release-artifact-smoke, publish-crates
+Blocked by: version-prep
+
+### Goal
+
+Prove the publish graph without publishing.
+
+### Acceptance
+
+- Package list resolves to the five public crates.
+- Per-package dry-runs pass in dependency order.
+- The audit records command outputs, package order, commit, and any warnings.
+
+### Proof commands
+
+```bash
+cargo +1.95.0 run -p xtask -- publish-check --package-list
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli
+git diff --check
+```
+
+### Rollback
+
+Revert the audit PR. No public state changes in this work item.
+
+## Work Item: release-artifact-smoke
+
+Status: ready
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Blocks: public-documentation-cutover, publish-crates
+Blocked by: version-prep
+
+### Goal
+
+Prove the staged release artifact path before crates.io publication.
+
+### Acceptance
+
+- A release-like binary or archive reports `perfgate 0.18.0`.
+- The staged artifact runs `doctor`, `init`, zero-benchmark guidance, manual
+  benchmark check, baseline promotion, and required-baseline rerun.
+- The audit clearly says the smoke was staged and not public install proof.
+
+### Rollback
+
+Revert the audit PR. No public state changes in this work item.
+
+## Work Item: public-documentation-cutover
+
+Status: ready
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
+Blocks: public-install-smoke, publication-closeout
+Blocked by: publish-dry-run-matrix, release-artifact-smoke
+
+### Goal
+
+Prepare public docs for release while distinguishing ready-to-release from
+released.
+
+### Acceptance
+
+- README and user docs do not claim public 0.18.0 availability before publish.
+- `RELEASE_READINESS.md` states the latest published release and the latest
+  readiness proof.
+- `PRODUCT_CLAIMS.md` links canary and release proof without overstating
+  hosted external CI coverage.
+
+### Rollback
+
+Revert the docs PR before publication. After publication, forward-fix docs.
+
+## Work Item: publish-crates
+
+Status: blocked
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Blocks: tag-release-aliases
+Blocked by: explicit release-operator approval, publish-dry-run-matrix
+
+### Goal
+
+Publish the 0.18.0 crates in dependency order.
+
+### Order
+
+```text
+perfgate-types
+perfgate
+perfgate-client
+perfgate-server
+perfgate-cli
+```
+
+### Acceptance
+
+- Each crate exists on crates.io at 0.18.0.
+- The publication audit records package URLs, timestamps, and operator notes.
+
+### Rollback
+
+Crates.io publication is effectively forward-fix only. Repair with a patch
+release and document the issue.
+
+## Work Item: tag-release-aliases
+
+Status: blocked
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Blocks: public-install-smoke
+Blocked by: explicit release-operator approval, publish-crates
+
+### Goal
+
+Create the GitHub release and intentional action alias state.
+
+### Acceptance
+
+- `v0.18.0` points to the intended release commit.
+- `v0.18` points to the intended release commit.
+- `v0` moves only when 0.18.0 is intended as the default action release.
+- GitHub release assets exist and checksums are recorded.
+- Any alias-triggered release workflows are expected, cancelled, or recorded.
+
+### Rollback
+
+Move tags only with explicit operator approval and record repair notes. If `v0`
+was moved incorrectly, move it back only under explicit approval.
+
+## Work Item: public-install-smoke
+
+Status: blocked
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
+Blocks: publication-closeout
+Blocked by: publish-crates, tag-release-aliases
+
+### Goal
+
+Prove a cold user can install and run the public 0.18.0 release.
+
+### Acceptance
+
+- Install uses public artifacts, not the workspace-built binary.
+- Smoke covers `--version`, `doctor`, `init`, zero-benchmark guidance, manual
+  benchmark, `check`, `baseline promote`, and `check --require-baseline`.
+- Generated action workflow references the intended public action alias.
+
+### Proof commands
+
+```bash
+cargo binstall perfgate-cli
+perfgate --version
+perfgate doctor
+perfgate init --ci github --profile standard
+perfgate check --config perfgate.toml --all
+perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+### Rollback
+
+If public install fails, do not hide it. Record failure, repair with a patch
+release or docs correction, and update the publication closeout.
+
+## Work Item: publication-closeout
+
+Status: blocked
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
+Blocks:
+Blocked by: public-install-smoke or explicit deferral decision
+
+### Goal
+
+Close the lane with a durable public-state audit.
+
+### Acceptance
+
+- The closeout says what was published or deferred.
+- It records crate URLs, tags, action aliases, GitHub release assets, public
+  install smoke, canary evidence, product-claim updates, and non-inferences.
+- `.codex/goals/active.toml` is archived with status `completed`.
+
+### Rollback
+
+Closeout audits should be superseded by a repair audit rather than edited to
+erase prior public state.


### PR DESCRIPTION
## Summary
- adds `plans/0.18.0/release-cutover.md` with the 0.18 release sequence, guardrails, proof commands, rollback notes, and gated operator steps
- adds `.codex/goals/active.toml` for the release cutover lane
- links the release cutover proposal to the new plan

## Validation
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`

## Notes
- No versions, tags, release assets, crates, workflows, or action aliases changed.
- Publish/tag/alias steps remain blocked on explicit release-operator approval.