### PR TITLE
release: prepare 0.18.0 versions

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-14"
 milestone = "0.18.0"
-current_work_item = "release-cutover-plan"
-current_pr = "plans(0.18): add release cutover plan"
+current_work_item = "version-prep"
+current_pr = "release: prepare 0.18.0 versions"
 
 objective = """
 Cut or explicitly defer perfgate 0.18.0 with no ambiguity. The repo must
@@ -120,7 +120,7 @@ commands = [
 
 [[work_item]]
 id = "release-cutover-plan"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -134,7 +134,7 @@ commands = [
 
 [[work_item]]
 id = "version-prep"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+No unreleased changes.
+
+## [0.18.0] - 2026-05-14
+
 ### Changed
 - Reconciled release-readiness docs with the published v0.17.0 state across
   crates.io packages, GitHub release assets, action alias tags, and public
@@ -39,10 +43,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   claim to the concrete spec.
 - Refreshed the generated no-panic baseline for the adoption probe proof and
   product-claim freshness checker callsites.
-- Planned remaining compatibility wrapper absorption batches while preserving
-  the five-crate public surface.
+- Absorbed remaining production compatibility wrappers while preserving the
+  five-crate public surface.
+- Added external adoption canary receipts for a small Rust CLI, a larger Rust
+  workspace, and a non-Rust command benchmark.
+- Added signal/noise calibration guidance, probe design patterns, platform
+  metric support boundaries, and action failure archaeology examples.
+- Extended server-ledger operations proof with API key create/list/rotate smoke
+  while keeping ledger mode optional.
+- Added the 0.18.0 release cutover proposal and plan so publication, tags,
+  action aliases, public install smoke, and closeout have explicit gates.
 - Closed the guided adoption lane with a handoff and archived active-goal
   manifest.
+- Closed the external trust lane with a handoff and explicit non-inferences
+  for hosted external CI, 0.18 publication, server correctness, and
+  probe-backed external canaries.
 
 ## [0.17.0] - 2026-05-12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -122,8 +122,8 @@ wiremock = "0.6"
 libc = "0.2.182"
 
 # Internal crates
-perfgate-types = { path = "crates/perfgate-types", version = "0.17.0" }
-perfgate-fake = { path = "crates/perfgate-fake", version = "0.17.0" }
-perfgate-server = { path = "crates/perfgate-server", version = "0.17.0" }
-perfgate-client = { path = "crates/perfgate-client", version = "0.17.0" }
-perfgate = { path = "crates/perfgate", version = "0.17.0" }
+perfgate-types = { path = "crates/perfgate-types", version = "0.18.0" }
+perfgate-fake = { path = "crates/perfgate-fake", version = "0.18.0" }
+perfgate-server = { path = "crates/perfgate-server", version = "0.18.0" }
+perfgate-client = { path = "crates/perfgate-client", version = "0.18.0" }
+perfgate = { path = "crates/perfgate", version = "0.18.0" }

--- a/docs/audits/release-0.18.0-release-notes-draft.md
+++ b/docs/audits/release-0.18.0-release-notes-draft.md
@@ -1,0 +1,65 @@
+# v0.18.0 Release Notes Draft
+
+Date: 2026-05-14
+
+Status: draft, unpublished
+
+Linked proposal: [`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Purpose: prepare release notes for the 0.18.0 release candidate. This document
+does not mean 0.18.0 has been published, tagged, released, or made the default
+GitHub Action alias.
+
+## Public State
+
+As of this draft:
+
+- latest published release remains `v0.17.0`;
+- crates.io latest remains `0.17.0`;
+- no `v0.18.0`, `v0.18`, or `v0` alias movement is performed by this PR;
+- the workspace version is prepared for `0.18.0` release validation.
+
+## Highlights
+
+- Added the source-of-truth governance stack for proposals, specs, ADRs, plans,
+  active goals, product claims, policy ledgers, and handoffs.
+- Added guided adoption docs and proof for first-hour setup, adoption levels,
+  decision outcome examples, probe quickstart, action failure copy, and server
+  ledger operations.
+- Absorbed production compatibility wrappers while preserving the five public
+  crates as the durable public surface.
+- Added product-claim and source-doc checkers to keep release claims and linked
+  source-of-truth artifacts reviewable.
+- Added external canary receipts for a small Rust CLI, a larger Rust workspace,
+  and a non-Rust command benchmark.
+- Improved zero-benchmark `perfgate init` guidance, including a
+  language-neutral benchmark example for non-Rust repositories.
+- Added signal/noise calibration guidance, probe design patterns, platform
+  metric support boundaries, and action failure archaeology examples.
+- Extended server-ledger operations proof with API key create/list/rotate smoke
+  while keeping the server optional for correctness.
+- Added a release cutover proposal and plan so publishing, tags, GitHub release
+  assets, action aliases, public install smoke, and closeout stay explicit.
+
+## Release Proof Still Required
+
+Before this draft can become a publication closeout, the release lane must
+still record:
+
+- publish dry-runs for all five public crates;
+- release artifact smoke before publication;
+- public documentation cutover that distinguishes ready from released;
+- explicit release-operator approval before crates.io publish;
+- tag, GitHub release, and action alias proof if publication happens;
+- public install smoke from public artifacts;
+- publication or deferral closeout.
+
+## Non-Inferences
+
+- This draft does not publish crates.
+- This draft does not create or move tags.
+- This draft does not create a GitHub release.
+- This draft does not move `v0`, `v0.18`, or `v0.18.0`.
+- This draft does not claim hosted external canary CI has run.


### PR DESCRIPTION
## Summary
- bump workspace and internal workspace dependency versions to 0.18.0 for release validation
- promote the accumulated changelog entries into a 0.18.0 section
- add a draft 0.18.0 release-notes audit that is explicitly unpublished
- advance the active release cutover goal to the version-prep work item

## Guardrails
- no crates.io publication
- no tags or GitHub release
- no v0, v0.18, or v0.18.0 alias movement
- no action/workflow behavior changes

## Validation
- cargo +1.95.0 metadata --format-version 1 --no-deps
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 check --workspace --all-targets --all-features --locked
- cargo +1.95.0 test --workspace --all-targets --all-features --locked
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- public-surface --strict
- cargo +1.95.0 run -p xtask -- arch
- git diff --check