### PR TITLE
release: prove 0.18.0 archive install smoke

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-14"
 milestone = "0.18.0"
-current_work_item = "publish-dry-run-matrix"
-current_pr = "release: prove 0.18.0 publish dry-run"
+current_work_item = "release-artifact-smoke"
+current_pr = "release: prove 0.18.0 archive install smoke"
 
 objective = """
 Cut or explicitly defer perfgate 0.18.0 with no ambiguity. The repo must
@@ -150,7 +150,7 @@ commands = [
 
 [[work_item]]
 id = "publish-dry-run-matrix"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -166,7 +166,7 @@ commands = [
 
 [[work_item]]
 id = "release-artifact-smoke"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"

--- a/docs/audits/release-0.18.0-artifact-smoke.md
+++ b/docs/audits/release-0.18.0-artifact-smoke.md
@@ -1,0 +1,61 @@
+# v0.18.0 Staged Release Artifact Smoke
+
+Date: 2026-05-14
+
+Branch: `release/0-18-artifact-smoke`
+
+Purpose: prove a release-like archive and first-hour flow before crates.io
+publication. This is staged artifact proof only. It does not publish crates,
+create tags, create a GitHub release, move action aliases, or prove public
+install from crates.io or GitHub release assets.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Version under test | `0.18.0` |
+| Target | `x86_64-pc-windows-msvc` |
+| Staged archive | `%TEMP%\perfgate-0.18.0-artifact-smoke\perfgate-x86_64-pc-windows-msvc.zip` |
+| Archive size | `11098367` bytes |
+| Archive SHA256 | `9a3d1ebd8772f812da8c0dcc201cf327d70fa39b46f4eafb4382159d6a73d86d` |
+
+## Build And Package Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 build --release --locked --target x86_64-pc-windows-msvc -p perfgate-cli` | Pass | Built the release `perfgate.exe` binary for the Windows release target. |
+| Staged archive creation with `Compress-Archive` | Pass | Created `perfgate-x86_64-pc-windows-msvc.zip` containing `perfgate.exe`, matching the release workflow archive shape for Windows. |
+| Archive unpack smoke | Pass | Expanded the staged archive, found `perfgate.exe`, verified `perfgate --version` reported `perfgate 0.18.0`, and verified `perfgate doctor --help` exited successfully. |
+
+## First-Hour Smoke From Staged Binary
+
+The unpacked staged binary was used for both smoke paths below.
+
+| Path | Result | Evidence summary |
+| --- | --- | --- |
+| Zero-benchmark repository | Pass | `perfgate init --ci github --profile standard` created `perfgate.toml`, `.github/workflows/perfgate.yml`, and `.perfgate/README.md`; stderr reported no discovered benchmarks and showed the `your-benchmark-command` manual benchmark guidance. |
+| Manual benchmark repository | Pass | Added a language-neutral PowerShell benchmark command after `init`, then ran `doctor`, `check --all`, missing-baseline `check --require-baseline`, `baseline status`, `baseline promote --all`, and final `check --require-baseline`. |
+| Artifact assertions | Pass | Verified `baselines/manual-bench.json`, `artifacts/perfgate/manual-bench/run.json`, `compare.json`, `report.json`, and `comment.md` existed after promotion and rerun. |
+
+## Non-Inferences
+
+- This is not public install smoke.
+- This does not prove crates.io `cargo install` or `cargo binstall` from public
+  release assets.
+- This does not prove Linux, macOS, or cross-target release archives.
+- This does not create or move `v0.18.0`, `v0.18`, or `v0`.
+- This does not create a GitHub release.
+- This does not authorize publication.
+
+## Follow-Up Boundary
+
+The next non-irreversible release step is public documentation cutover that
+continues to distinguish `0.18.0` readiness proof from public release state.
+Public install smoke remains blocked until public crates and release assets
+exist.

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-14
 Milestone: 0.18.0
-Current PR: release cutover plan and active goal
+Current PR: release artifact smoke
 Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../../docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../../docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../../docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -54,10 +54,10 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | PR | Work item | Status | Files / surface |
 | --- | --- | --- | --- |
 | 415 | Release cutover proposal | merged | `docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md` |
-| next | Release cutover plan and active goal | current | `plans/0.18.0/release-cutover.md`, `.codex/goals/active.toml` |
-| next | Version prep | ready | workspace/package versions, changelog, release notes draft, docs references if needed |
-| next | Publish dry-run matrix | ready | `docs/audits/release-0.18.0-publish-readiness.md` |
-| next | Release artifact smoke | ready | staged archive or local release-artifact smoke audit |
+| 416 | Release cutover plan and active goal | merged | `plans/0.18.0/release-cutover.md`, `.codex/goals/active.toml` |
+| 417 | Version prep | merged | workspace/package versions, changelog, release notes draft |
+| 418 | Publish dry-run matrix | merged | `docs/audits/release-0.18.0-publish-readiness.md` |
+| next | Release artifact smoke | current | staged archive or local release-artifact smoke audit |
 | next | Public documentation cutover | ready | README, first-hour/adoption docs, release readiness, product claims |
 | gated | Publish crates | blocked | crates.io publication in dependency order |
 | gated | Tag, GitHub release, action aliases | blocked | `v0.18.0`, `v0.18`, `v0` if intended, release assets |
@@ -66,7 +66,7 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 
 ## Work Item: version-prep
 
-Status: ready
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md
@@ -116,7 +116,7 @@ Revert the version-prep PR before any crates are published.
 
 ## Work Item: publish-dry-run-matrix
 
-Status: ready
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: release-artifact-smoke, publish-crates
@@ -150,7 +150,7 @@ Revert the audit PR. No public state changes in this work item.
 
 ## Work Item: release-artifact-smoke
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: public-documentation-cutover, publish-crates


### PR DESCRIPTION
## Summary
- record a staged Windows release archive smoke for 0.18.0
- prove the unpacked archive binary reports 0.18.0 and runs doctor help
- prove zero-benchmark guidance and manual-benchmark check/promote/require-baseline from the unpacked binary
- advance the release cutover plan and active goal to the artifact-smoke work item

## Guardrails
- staged artifact proof only, not public install smoke
- no crates.io publication
- no tags or GitHub release
- no v0, v0.18, or v0.18.0 alias movement

## Validation
- cargo +1.95.0 build --release --locked --target x86_64-pc-windows-msvc -p perfgate-cli
- staged archive creation and unpack smoke from perfgate-x86_64-pc-windows-msvc.zip
- staged binary: perfgate --version
- staged binary: perfgate doctor --help
- staged binary: perfgate init --ci github --profile standard in a zero-benchmark repo
- staged binary: doctor/check/require-baseline/baseline status/baseline promote/final require-baseline in a manual-benchmark repo
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check