### PR TITLE
docs: prepare 0.18 public release docs

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-14"
 milestone = "0.18.0"
-current_work_item = "release-artifact-smoke"
-current_pr = "release: prove 0.18.0 archive install smoke"
+current_work_item = "public-docs-cutover"
+current_pr = "docs: prepare 0.18 public release docs"
 
 objective = """
 Cut or explicitly defer perfgate 0.18.0 with no ambiguity. The repo must
@@ -166,7 +166,7 @@ commands = [
 
 [[work_item]]
 id = "release-artifact-smoke"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -178,7 +178,7 @@ commands = [
 
 [[work_item]]
 id = "public-docs-cutover"
-status = "ready"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ perfgate --version
 perfgate doctor --help
 ```
 
+Current public release: `v0.17.0`. The `0.18.0` source tree has release-candidate
+proof in progress, but it is not public until crates, tags, release assets,
+action aliases, and public install smoke are recorded in the release closeout.
+
 ## Start Here
 
 From a repository with benchmark commands:
@@ -102,7 +106,8 @@ The generated GitHub workflow uses the repository action:
 ```
 
 Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
-current compatible action tag.
+current compatible action tag until the `0.18.0` publication closeout moves
+the release aliases.
 
 ## Performance Decisions
 

--- a/docs/ADOPTION_LEVELS.md
+++ b/docs/ADOPTION_LEVELS.md
@@ -109,7 +109,8 @@ The generated workflow calls the repository action:
 ```
 
 Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
-current compatible action tag.
+current compatible action tag until the `0.18.0` publication closeout moves
+the release aliases.
 
 ### Artifacts
 

--- a/docs/FIRST_HOUR.md
+++ b/docs/FIRST_HOUR.md
@@ -144,7 +144,8 @@ the repository action:
 ```
 
 Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
-current compatible action tag.
+current compatible action tag until the `0.18.0` publication closeout moves
+the release aliases.
 
 ## 8. Understand Pass And Fail
 

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,11 +1,13 @@
 # Release Readiness
 
-Last verified: 2026-05-13 for v0.17.0 publication reconciliation and the
-0.18.0 adoption-readiness snapshot. See
+Last verified: 2026-05-14 for v0.17.0 publication reconciliation and the
+0.18.0 release-candidate cutover proof. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
+[v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
+[v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md),
 and
-[v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md).
+[v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
 The current 0.18 cutover decision is recorded in
 [v0.18.0 Cutover Decision](audits/release-0.18.0-cutover-decision.md).
 
@@ -20,12 +22,12 @@ The current published release is `v0.17.0`. It keeps the five-crate public
 surface from v0.16.0, raises the Rust floor to 1.95, and adds the governance
 rails that make the release conveyor explicit.
 
-The 0.18.0 adoption-readiness snapshot is a pre-release proof record, not a
-publication record. It documents wrapper absorption, first-hour smoke proof,
-structured-decision bundle proof, checked action failure examples, and optional
-server-ledger operations smoke after the guided-adoption lane closed out.
-The 0.18.0 cutover remains deferred until an explicit release PR starts the
-version, publish, tag, release, action-alias, install-smoke, and closeout steps.
+The 0.18.0 release-candidate proof records are pre-release records, not
+publication records. They document wrapper absorption, first-hour smoke proof,
+structured-decision bundle proof, checked action failure examples, optional
+server-ledger operations smoke, external canaries, publish dry-runs for all five
+public crates, and staged Windows archive smoke. No public `0.18.0` crates,
+tags, GitHub release, action aliases, or public install smoke exist yet.
 
 ## Current Publication State
 
@@ -65,6 +67,8 @@ version, publish, tag, release, action-alias, install-smoke, and closeout steps.
 | Signal-trust features | Covered | flakiness history, `baseline flaky`, inverse-variance aggregation, adaptive paired retries, local-regression caps, and noise-aware tradeoff review |
 | Server operations visibility | Covered | `perfgate serve --doctor`, `/health`, `/metrics`, `audit list`, dashboard audit view tests, and dashboard decision-ledger tests |
 | 0.18 adoption hardening | Covered | [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md), including wrapper absorption, first-hour smoke, structured decision bundle proof, action summary examples, and server ledger operations smoke |
+| 0.18 publish dry-run matrix | Passing | [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md) packaged and verified `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, and `perfgate-cli` at `0.18.0` without uploading. |
+| 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:
@@ -77,7 +81,8 @@ perfgate-client
 perfgate-server
 ```
 
-Required release proof commands for v0.17.0 (run without `--allow-dirty`):
+Required release proof commands for the current 0.18.0 release candidate (run
+without `--allow-dirty`):
 
 ```bash
 cargo run -p xtask -- public-surface --strict
@@ -104,7 +109,7 @@ For PR validation before the branch is committed or while release notes are stil
 being edited, `publish-check` also accepts `--allow-dirty`. Release operators
 should omit it.
 
-The GitHub release workflow for v0.17.0 builds platform archives,
+The GitHub release workflow builds platform archives,
 unpacks each generated archive, verifies the binary exists, and runs
 `perfgate --version` plus `perfgate doctor --help` on native targets before
 uploading release assets.

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -210,7 +210,7 @@ Review after: next-decision-contract-change
 
 Tier: supported
 Surface: release, crates, CI
-Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md)
+Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md)
 Linked gates: publish-check --package-list and per-package publish dry-runs
 Proof commands:
@@ -230,7 +230,7 @@ Review after: next-release-candidate
 
 Tier: supported
 Surface: CLI, docs, artifacts
-Linked docs: [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`DEBUGGING_FIRST_CI_RUN.md`](../DEBUGGING_FIRST_CI_RUN.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md), [`2026-05-13-external-canary-diffguard-small-rust-cli.md`](../audits/2026-05-13-external-canary-diffguard-small-rust-cli.md), [`2026-05-13-external-canary-shipper-large-rust-workspace.md`](../audits/2026-05-13-external-canary-shipper-large-rust-workspace.md), [`2026-05-13-external-canary-droid-action-non-rust-command.md`](../audits/2026-05-13-external-canary-droid-action-non-rust-command.md)
+Linked docs: [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`DEBUGGING_FIRST_CI_RUN.md`](../DEBUGGING_FIRST_CI_RUN.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md), [`release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`2026-05-13-external-canary-diffguard-small-rust-cli.md`](../audits/2026-05-13-external-canary-diffguard-small-rust-cli.md), [`2026-05-13-external-canary-shipper-large-rust-workspace.md`](../audits/2026-05-13-external-canary-shipper-large-rust-workspace.md), [`2026-05-13-external-canary-droid-action-non-rust-command.md`](../audits/2026-05-13-external-canary-droid-action-non-rust-command.md)
 Linked specs: [`PERFGATE-SPEC-0004-user-devex-paved-road`](../specs/PERFGATE-SPEC-0004-user-devex-paved-road.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
 Proof commands:
 
@@ -260,7 +260,7 @@ Review after: before-0.18.0-release
 
 Tier: supported
 Surface: docs, CLI, GitHub Action, server ledger
-Linked docs: [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`PERFORMANCE_DECISIONS.md`](../PERFORMANCE_DECISIONS.md), [`DECISION_LEDGER_RUNBOOK.md`](../DECISION_LEDGER_RUNBOOK.md), [`examples/action-failure-summaries.md`](../examples/action-failure-summaries.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md), [`2026-05-13-external-canary-shipper-large-rust-workspace.md`](../audits/2026-05-13-external-canary-shipper-large-rust-workspace.md), [`2026-05-13-external-canary-droid-action-non-rust-command.md`](../audits/2026-05-13-external-canary-droid-action-non-rust-command.md)
+Linked docs: [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`PERFORMANCE_DECISIONS.md`](../PERFORMANCE_DECISIONS.md), [`DECISION_LEDGER_RUNBOOK.md`](../DECISION_LEDGER_RUNBOOK.md), [`examples/action-failure-summaries.md`](../examples/action-failure-summaries.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md), [`release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`2026-05-13-external-canary-shipper-large-rust-workspace.md`](../audits/2026-05-13-external-canary-shipper-large-rust-workspace.md), [`2026-05-13-external-canary-droid-action-non-rust-command.md`](../audits/2026-05-13-external-canary-droid-action-non-rust-command.md)
 Linked specs: [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Proof commands:
 

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-14
 Milestone: 0.18.0
-Current PR: release artifact smoke
+Current PR: public documentation cutover
 Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../../docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../../docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../../docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -57,8 +57,8 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 416 | Release cutover plan and active goal | merged | `plans/0.18.0/release-cutover.md`, `.codex/goals/active.toml` |
 | 417 | Version prep | merged | workspace/package versions, changelog, release notes draft |
 | 418 | Publish dry-run matrix | merged | `docs/audits/release-0.18.0-publish-readiness.md` |
-| next | Release artifact smoke | current | staged archive or local release-artifact smoke audit |
-| next | Public documentation cutover | ready | README, first-hour/adoption docs, release readiness, product claims |
+| 419 | Release artifact smoke | merged | `docs/audits/release-0.18.0-artifact-smoke.md` |
+| next | Public documentation cutover | current | README, first-hour/adoption docs, release readiness, product claims |
 | gated | Publish crates | blocked | crates.io publication in dependency order |
 | gated | Tag, GitHub release, action aliases | blocked | `v0.18.0`, `v0.18`, `v0` if intended, release assets |
 | gated | Public install smoke | blocked | public install path and first-hour smoke from published artifacts |
@@ -150,7 +150,7 @@ Revert the audit PR. No public state changes in this work item.
 
 ## Work Item: release-artifact-smoke
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: public-documentation-cutover, publish-crates
@@ -173,7 +173,7 @@ Revert the audit PR. No public state changes in this work item.
 
 ## Work Item: public-documentation-cutover
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Blocks: public-install-smoke, publication-closeout


### PR DESCRIPTION
## Summary
- update README and first-hour/action docs to keep public pins on v0.17.0 until the 0.18 closeout moves aliases
- refresh release readiness with 0.18 publish dry-run and staged artifact smoke proof while preserving the current public release as v0.17.0
- link product claims to the new 0.18 release-candidate proof without claiming publication
- advance the release cutover plan and active goal to public-docs-cutover

## Guardrails
- no crates.io publication
- no tags or GitHub release
- no v0, v0.18, or v0.18.0 alias movement
- no claim that 0.18.0 public install smoke has passed

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check