### PR TITLE
release: close 0.18.0 deferral

### DIFF
--- a/.codex/goals/archive/perfgate-0-18-release-cutover.toml
+++ b/.codex/goals/archive/perfgate-0-18-release-cutover.toml
@@ -1,11 +1,13 @@
 id = "perfgate-0-18-release-cutover"
 title = "perfgate 0.18.0 release cutover and public install proof"
-status = "active"
+status = "completed"
 owner = "codex"
 created = "2026-05-14"
+completed = "2026-05-14"
 milestone = "0.18.0"
-current_work_item = "public-docs-cutover"
-current_pr = "docs: prepare 0.18 public release docs"
+current_work_item = "none"
+current_pr = "complete"
+archive_reason = "The 0.18 release cutover lane landed proposal, plan, version prep, publish dry-run proof, staged archive smoke, public docs cutover, and an explicit deferral closeout. Crates, tags, GitHub release, action aliases, and public install smoke remain blocked until explicit release-operator approval."
 
 objective = """
 Cut or explicitly defer perfgate 0.18.0 with no ambiguity. The repo must
@@ -45,6 +47,8 @@ linked_status = [
   "docs/status/PRODUCT_CLAIMS.md",
   "docs/RELEASE_READINESS.md",
 ]
+
+linked_closeout = "docs/audits/release-0.18.0-deferral-closeout.md"
 
 allowed_files = [
   "Cargo.toml",
@@ -178,7 +182,7 @@ commands = [
 
 [[work_item]]
 id = "public-docs-cutover"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -238,8 +242,8 @@ commands = [
 
 [[work_item]]
 id = "publication-closeout"
-status = "blocked"
-blocked_by = "public-install-smoke or explicit deferral decision"
+status = "completed"
+blocked_by = "explicit deferral decision recorded"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -8,8 +8,9 @@ Last verified: 2026-05-14 for v0.17.0 publication reconciliation and the
 [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
-The current 0.18 cutover decision is recorded in
-[v0.18.0 Cutover Decision](audits/release-0.18.0-cutover-decision.md).
+The current 0.18 cutover decision and closeout are recorded in
+[v0.18.0 Cutover Decision](audits/release-0.18.0-cutover-decision.md) and
+[v0.18.0 Deferral Closeout](audits/release-0.18.0-deferral-closeout.md).
 
 Latest published release: v0.17.0. The five allowed crates are published on
 crates.io at `0.17.0`, the GitHub release `v0.17.0` is published with platform
@@ -27,7 +28,9 @@ publication records. They document wrapper absorption, first-hour smoke proof,
 structured-decision bundle proof, checked action failure examples, optional
 server-ledger operations smoke, external canaries, publish dry-runs for all five
 public crates, and staged Windows archive smoke. No public `0.18.0` crates,
-tags, GitHub release, action aliases, or public install smoke exist yet.
+tags, GitHub release, action aliases, or public install smoke exist yet. The
+deferral closeout records that boundary until a release operator explicitly
+approves publication.
 
 ## Current Publication State
 

--- a/docs/audits/release-0.18.0-deferral-closeout.md
+++ b/docs/audits/release-0.18.0-deferral-closeout.md
@@ -1,0 +1,99 @@
+# v0.18.0 Deferral Closeout
+
+Date: 2026-05-14
+
+Status: deferred
+
+Purpose: close the 0.18 release cutover lane without ambiguity. The repository
+has release-candidate proof for 0.18.0, but this closeout deliberately stops
+before crates.io publication, tags, GitHub release assets, action alias
+movement, and public install smoke because those steps require explicit
+release-operator approval.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Linked goal archive:
+[`perfgate-0-18-release-cutover.toml`](../../.codex/goals/archive/perfgate-0-18-release-cutover.toml)
+
+## Public State Verified
+
+| Surface | State | Evidence |
+| --- | --- | --- |
+| crates.io | Latest public `perfgate-cli` is `0.17.0` | `cargo search perfgate-cli --limit 3` reported `perfgate-cli = "0.17.0"`. |
+| GitHub release | Latest release is `v0.17.0` | `gh release list --limit 5` reported `v0.17.0` as latest, published 2026-05-12. |
+| Exact 0.18 tags | Not present | `git ls-remote --tags origin "v0*"` listed no `v0.18` or `v0.18.0` refs. |
+| Action aliases | Still on 0.17 release line | Remote `v0`, `v0.17`, and `v0.17.0` tags peel to `71bdc33117d515d95885deb2d9350d9d67905265`. |
+| Workspace source | Prepared for 0.18.0 validation | `Cargo.toml` workspace version is `0.18.0`; this is source/release-candidate state, not public publication state. |
+
+## Landed Cutover Work
+
+| Area | Evidence |
+| --- | --- |
+| Release cutover proposal | PR #415 added the proposal and release criteria. |
+| Release cutover plan | PR #416 added the implementation plan and active goal. |
+| Version prep | PR #417 set workspace source to `0.18.0`, updated changelog state, and added the release notes draft. |
+| Publish dry-run matrix | PR #418 recorded package-list and per-package dry-run proof for the five public crates. |
+| Staged artifact smoke | PR #419 recorded Windows archive smoke, zero-benchmark guidance, manual benchmark check, baseline promotion, and required-baseline rerun from the unpacked binary. |
+| Public docs cutover | PR #420 kept public install/action guidance on `v0.17.0` while linking 0.18 readiness proof and stating that 0.18 is not public. |
+
+## Proof Commands
+
+The lane recorded these proof commands:
+
+```bash
+cargo +1.95.0 check --workspace --all-targets --all-features --locked
+cargo +1.95.0 test --workspace --all-targets --all-features --locked
+cargo +1.95.0 run -p xtask -- publish-check --package-list
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server
+cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli
+cargo +1.95.0 build --release --locked --target x86_64-pc-windows-msvc -p perfgate-cli
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+cargo +1.95.0 run -p xtask -- public-surface --strict
+cargo +1.95.0 run -p xtask -- arch
+git diff --check
+```
+
+The staged artifact smoke also ran `perfgate --version`, `perfgate doctor
+--help`, `perfgate init --ci github --profile standard`, `perfgate doctor
+--config perfgate.toml`, `perfgate check --config perfgate.toml --all`,
+`perfgate baseline status --config perfgate.toml`, `perfgate baseline promote
+--config perfgate.toml --all`, and `perfgate check --config perfgate.toml --all
+--require-baseline` from the unpacked staged binary.
+
+## Non-Actions
+
+This closeout did not:
+
+- publish crates;
+- create `v0.18.0`;
+- create or move `v0.18`;
+- move `v0`;
+- create a GitHub release;
+- upload release assets;
+- run public install smoke from crates.io or GitHub release assets;
+- claim hosted external canary CI for 0.18.0.
+
+## What To Do Next
+
+When a release operator explicitly approves publication, start a new release
+operator PR or release run from this proof trail:
+
+1. re-run the publish dry-run matrix from
+   [`release-0.18.0-publish-readiness.md`](release-0.18.0-publish-readiness.md);
+2. publish in dependency order: `perfgate-types`, `perfgate`,
+   `perfgate-client`, `perfgate-server`, `perfgate-cli`;
+3. create `v0.18.0` and the GitHub release with assets;
+4. move `v0.18`, and move `v0` only if 0.18.0 is intended as the default
+   action release;
+5. run public install smoke from public artifacts;
+6. add a publication closeout that records crate URLs, tags, action aliases,
+   release assets, public install smoke, and remaining non-inferences.

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -210,7 +210,7 @@ Review after: next-decision-contract-change
 
 Tier: supported
 Surface: release, crates, CI
-Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md)
+Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`audits/release-0.18.0-deferral-closeout.md`](../audits/release-0.18.0-deferral-closeout.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md)
 Linked gates: publish-check --package-list and per-package publish dry-runs
 Proof commands:

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -1,10 +1,10 @@
 # perfgate 0.18.0 Release Cutover Plan
 
-Status: active
+Status: implemented
 Owner: perfgate maintainers
 Created: 2026-05-14
 Milestone: 0.18.0
-Current PR: public documentation cutover
+Current PR: complete
 Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../../docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../../docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../../docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -58,11 +58,11 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 417 | Version prep | merged | workspace/package versions, changelog, release notes draft |
 | 418 | Publish dry-run matrix | merged | `docs/audits/release-0.18.0-publish-readiness.md` |
 | 419 | Release artifact smoke | merged | `docs/audits/release-0.18.0-artifact-smoke.md` |
-| next | Public documentation cutover | current | README, first-hour/adoption docs, release readiness, product claims |
+| 420 | Public documentation cutover | merged | README, first-hour/adoption docs, release readiness, product claims |
 | gated | Publish crates | blocked | crates.io publication in dependency order |
 | gated | Tag, GitHub release, action aliases | blocked | `v0.18.0`, `v0.18`, `v0` if intended, release assets |
 | gated | Public install smoke | blocked | public install path and first-hour smoke from published artifacts |
-| final | Publication or deferral closeout | blocked | release closeout audit, product claims, archived goal |
+| final | Publication or deferral closeout | implemented | `docs/audits/release-0.18.0-deferral-closeout.md`, `.codex/goals/archive/perfgate-0-18-release-cutover.toml` |
 
 ## Work Item: version-prep
 
@@ -173,7 +173,7 @@ Revert the audit PR. No public state changes in this work item.
 
 ## Work Item: public-documentation-cutover
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Blocks: public-install-smoke, publication-closeout
@@ -291,11 +291,11 @@ release or docs correction, and update the publication closeout.
 
 ## Work Item: publication-closeout
 
-Status: blocked
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Blocks:
-Blocked by: public-install-smoke or explicit deferral decision
+Blocked by:
 
 ### Goal
 


### PR DESCRIPTION
## Summary
- close the 0.18 release cutover lane as explicitly deferred because publish/tag/release/alias steps require release-operator approval
- record verified public state: crates.io and GitHub release remain v0.17.0, no v0.18 tags exist, and v0/v0.17 still peel to the v0.17.0 release commit
- archive the active goal manifest and remove the active goal file
- link the deferral closeout from release readiness and product claims

## Guardrails
- no crates.io publication
- no tags or GitHub release
- no v0, v0.18, or v0.18.0 alias movement
- no public install smoke claim for 0.18.0

## Validation
- cargo search perfgate-cli --limit 3
- gh release list --limit 5
- git ls-remote --tags origin "v0*"
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check