### PR TITLE
release: reopen 0.18.0 cutover lane

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -1,30 +1,28 @@
 id = "perfgate-0-18-release-cutover"
 title = "perfgate 0.18.0 release cutover and public install proof"
-status = "completed"
+status = "active"
 owner = "codex"
 created = "2026-05-14"
-completed = "2026-05-14"
 milestone = "0.18.0"
-current_work_item = "none"
-current_pr = "complete"
-archive_reason = "The 0.18 release cutover lane landed proposal, plan, version prep, publish dry-run proof, staged archive smoke, public docs cutover, and an explicit deferral closeout. Crates, tags, GitHub release, action aliases, and public install smoke remain blocked until explicit release-operator approval."
+current_work_item = "release-operator-gated-publication"
+current_pr = "release: refresh 0.18.0 pre-publish proof"
 
 objective = """
-Cut or explicitly defer perfgate 0.18.0 with no ambiguity. The repo must
+Cut perfgate 0.18.0 with no ambiguity. The repo must
 answer from files alone what version is public, which crates were published,
 which tags and action aliases moved, what public install smoke passed, what
 external canaries proved, what remains unproven, and what should happen next.
 """
 
 end_state = [
-  "0.18.0 is either publicly released with publication proof or explicitly deferred with honest docs.",
+  "0.18.0 is publicly released with publication proof.",
   "Version prep and release notes match actual merged source-of-truth, guided-adoption, wrapper-absorption, external-trust, and proof work.",
   "Publish dry-runs pass for the five public crates in dependency order.",
   "Release artifact smoke proves the staged install path before publication.",
   "Public docs distinguish ready-to-release from released until crates, tags, and aliases actually move.",
   "If publishing happens, public install smoke proves install, doctor, init, check, promote, require-baseline, and action workflow generation from public artifacts.",
   "Product claims link release proof, canary evidence, tests, and support boundaries without overstating hosted external CI coverage.",
-  "The lane closes with a publication or deferral audit and an archived goal manifest.",
+  "The lane closes with a publication audit and an archived goal manifest.",
 ]
 
 linked_proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
@@ -47,8 +45,6 @@ linked_status = [
   "docs/status/PRODUCT_CLAIMS.md",
   "docs/RELEASE_READINESS.md",
 ]
-
-linked_closeout = "docs/audits/release-0.18.0-deferral-closeout.md"
 
 allowed_files = [
   "Cargo.toml",
@@ -98,13 +94,13 @@ proof = [
 
 completion_criteria = [
   "Release cutover proposal and plan are merged.",
-  "Version prep and release notes are merged or the release is explicitly deferred.",
+  "Version prep and release notes are merged.",
   "Publish dry-run proof is recorded for all five public crates.",
   "Release artifact smoke is recorded before publication.",
   "Public documentation reflects the actual release state.",
   "Crates, tags, GitHub release, and action aliases move only with explicit release approval.",
   "Public install smoke is recorded if publication happens.",
-  "Publication or deferral closeout records public state and non-inferences.",
+  "Publication closeout records public state and non-inferences.",
   "This active goal is archived with status completed.",
 ]
 
@@ -195,9 +191,56 @@ commands = [
 ]
 
 [[work_item]]
+id = "final-prepublish-proof"
+status = "ready"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo +1.95.0 fmt --all -- --check",
+  "cargo +1.95.0 check --workspace --all-targets --all-features --locked",
+  "cargo +1.95.0 test --workspace --all-targets --all-features --locked",
+  "cargo +1.95.0 run -p xtask -- docs-check",
+  "cargo +1.95.0 run -p xtask -- doc-test",
+  "cargo +1.95.0 run -p xtask -- docs-source-check",
+  "cargo +1.95.0 run -p xtask -- product-claims-check",
+  "cargo +1.95.0 run -p xtask -- public-surface --strict",
+  "cargo +1.95.0 run -p xtask -- arch",
+  "cargo +1.95.0 run -p xtask -- action-check",
+  "cargo +1.95.0 run -p xtask -- schema-compat",
+  "cargo +1.95.0 run -p xtask -- publish-check --package-list",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server",
+  "cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli",
+  "git diff --check",
+]
+
+[[work_item]]
+id = "release-operator-gated-publication"
+status = "current"
+blocked_by = "final-prepublish-proof and explicit release-operator approval"
+proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
+spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
+plan = "plans/0.18.0/release-cutover.md"
+commands = [
+  "cargo publish -p perfgate-types",
+  "cargo publish -p perfgate",
+  "cargo publish -p perfgate-client",
+  "cargo publish -p perfgate-server",
+  "cargo publish -p perfgate-cli",
+  "git tag v0.18.0",
+  "gh release create v0.18.0",
+  "git tag -f v0.18",
+  "git tag -f v0",
+  "cargo binstall perfgate-cli --version 0.18.0",
+]
+
+[[work_item]]
 id = "publish-crates"
 status = "blocked"
-blocked_by = "explicit release-operator approval"
+blocked_by = "final-prepublish-proof and explicit release-operator approval"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -242,8 +285,8 @@ commands = [
 
 [[work_item]]
 id = "publication-closeout"
-status = "completed"
-blocked_by = "explicit deferral decision recorded"
+status = "blocked"
+blocked_by = "public-install-smoke"
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -8,9 +8,11 @@ Last verified: 2026-05-14 for v0.17.0 publication reconciliation and the
 [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
-The current 0.18 cutover decision and closeout are recorded in
-[v0.18.0 Cutover Decision](audits/release-0.18.0-cutover-decision.md) and
-[v0.18.0 Deferral Closeout](audits/release-0.18.0-deferral-closeout.md).
+The current 0.18 cutover lane remains active. The earlier
+[v0.18.0 Deferral Closeout](audits/release-0.18.0-deferral-closeout.md)
+is superseded because it correctly verified public state but incorrectly
+archived the lane before publication. The earlier cutover decision is recorded
+in [v0.18.0 Cutover Decision](audits/release-0.18.0-cutover-decision.md).
 
 Latest published release: v0.17.0. The five allowed crates are published on
 crates.io at `0.17.0`, the GitHub release `v0.17.0` is published with platform
@@ -29,8 +31,8 @@ structured-decision bundle proof, checked action failure examples, optional
 server-ledger operations smoke, external canaries, publish dry-runs for all five
 public crates, and staged Windows archive smoke. No public `0.18.0` crates,
 tags, GitHub release, action aliases, or public install smoke exist yet. The
-deferral closeout records that boundary until a release operator explicitly
-approves publication.
+active release cutover lane is waiting at final pre-publish proof and
+release-operator-gated publication.
 
 ## Current Publication State
 

--- a/docs/audits/release-0.18.0-deferral-closeout.md
+++ b/docs/audits/release-0.18.0-deferral-closeout.md
@@ -1,22 +1,26 @@
-# v0.18.0 Deferral Closeout
+# v0.18.0 Deferral Closeout (Superseded)
 
 Date: 2026-05-14
 
-Status: deferred
+Status: superseded
 
-Purpose: close the 0.18 release cutover lane without ambiguity. The repository
-has release-candidate proof for 0.18.0, but this closeout deliberately stops
-before crates.io publication, tags, GitHub release assets, action alias
-movement, and public install smoke because those steps require explicit
-release-operator approval.
+Superseded by: the corrective `release: reopen 0.18.0 cutover lane` PR.
+
+Correction: this audit accurately recorded that `0.18.0` was not yet public,
+but it drew the wrong operational conclusion by closing the release cutover lane
+as deferred. The correct lane state is active: versions, dry-runs, staged
+archive smoke, and public docs prep are complete; publish, tag, release asset,
+action alias, public install smoke, and publication closeout work remain.
+
+Purpose: historical audit of the premature #421 closeout. Keep this file as a
+superseded record of the public-state verification, not as release-lane closure.
 
 Linked proposal:
 [`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 
 Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
 
-Linked goal archive:
-[`perfgate-0-18-release-cutover.toml`](../../.codex/goals/archive/perfgate-0-18-release-cutover.toml)
+Linked active goal: [`active.toml`](../../.codex/goals/active.toml)
 
 ## Public State Verified
 
@@ -71,7 +75,7 @@ The staged artifact smoke also ran `perfgate --version`, `perfgate doctor
 
 ## Non-Actions
 
-This closeout did not:
+This superseded audit did not:
 
 - publish crates;
 - create `v0.18.0`;
@@ -84,12 +88,11 @@ This closeout did not:
 
 ## What To Do Next
 
-When a release operator explicitly approves publication, start a new release
-operator PR or release run from this proof trail:
+Continue the active release lane from this proof trail:
 
-1. re-run the publish dry-run matrix from
-   [`release-0.18.0-publish-readiness.md`](release-0.18.0-publish-readiness.md);
-2. publish in dependency order: `perfgate-types`, `perfgate`,
+1. re-run final pre-publish proof from current `main`;
+2. publish in dependency order after explicit release-operator approval:
+   `perfgate-types`, `perfgate`,
    `perfgate-client`, `perfgate-server`, `perfgate-cli`;
 3. create `v0.18.0` and the GitHub release with assets;
 4. move `v0.18`, and move `v0` only if 0.18.0 is intended as the default

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -210,7 +210,7 @@ Review after: next-decision-contract-change
 
 Tier: supported
 Surface: release, crates, CI
-Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`audits/release-0.18.0-deferral-closeout.md`](../audits/release-0.18.0-deferral-closeout.md)
+Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md)
 Linked gates: publish-check --package-list and per-package publish dry-runs
 Proof commands:

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -1,10 +1,10 @@
 # perfgate 0.18.0 Release Cutover Plan
 
-Status: implemented
+Status: active
 Owner: perfgate maintainers
 Created: 2026-05-14
 Milestone: 0.18.0
-Current PR: complete
+Current PR: release-operator-gated publication
 Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../../docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../../docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../../docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -17,7 +17,7 @@ Rollback: before publication, revert the release-prep PRs; after publication, fo
 
 ## Goal
 
-Cut or explicitly defer `0.18.0` with no ambiguity. A release operator should
+Cut `0.18.0` with no ambiguity. A release operator should
 be able to answer from repo artifacts:
 
 ```text
@@ -59,10 +59,13 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 418 | Publish dry-run matrix | merged | `docs/audits/release-0.18.0-publish-readiness.md` |
 | 419 | Release artifact smoke | merged | `docs/audits/release-0.18.0-artifact-smoke.md` |
 | 420 | Public documentation cutover | merged | README, first-hour/adoption docs, release readiness, product claims |
+| 421 | Premature deferral closeout | superseded | verified public state but incorrectly archived the lane |
+| next | Reopen release lane | current | `.codex/goals/active.toml`, release readiness, product claims, plan, superseded audit |
+| next | Final pre-publish proof | ready | `docs/audits/release-0.18.0-final-prepublish-proof.md` |
 | gated | Publish crates | blocked | crates.io publication in dependency order |
 | gated | Tag, GitHub release, action aliases | blocked | `v0.18.0`, `v0.18`, `v0` if intended, release assets |
 | gated | Public install smoke | blocked | public install path and first-hour smoke from published artifacts |
-| final | Publication or deferral closeout | implemented | `docs/audits/release-0.18.0-deferral-closeout.md`, `.codex/goals/archive/perfgate-0-18-release-cutover.toml` |
+| final | Publication closeout | blocked | release closeout audit, product claims, archived goal |
 
 ## Work Item: version-prep
 
@@ -95,7 +98,7 @@ README.md or docs references only when they mention concrete versions
 - Release notes summarize actual merged changes: source-of-truth governance,
   guided adoption, wrapper absorption, external canaries, signal/probe/platform
   guidance, action failure examples, server-ledger key rotation smoke, and
-  release deferral/cutover state.
+  release cutover state.
 - Docs do not claim 0.18.0 is published.
 
 ### Proof commands
@@ -196,6 +199,59 @@ released.
 
 Revert the docs PR before publication. After publication, forward-fix docs.
 
+## Work Item: final-prepublish-proof
+
+Status: ready
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Blocks: publish-crates
+Blocked by: release lane reopen
+
+### Goal
+
+Refresh the full pre-publish proof from current `main` after the premature
+deferral closeout is superseded.
+
+### Acceptance
+
+- Full workspace fmt, check, test, docs, source-doc, product-claim,
+  public-surface, arch, action, schema, package-list, and per-crate dry-run
+  gates pass from current `main`.
+- `docs/audits/release-0.18.0-final-prepublish-proof.md` records the command
+  set and non-inferences.
+
+### Rollback
+
+Revert the audit PR. No public state changes in this work item.
+
+## Work Item: release-operator-gated-publication
+
+Status: current
+Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
+Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
+Blocks: publish-crates, tag-release-aliases, public-install-smoke, publication-closeout
+Blocked by: final-prepublish-proof and explicit release-operator approval
+
+### Goal
+
+Keep the lane active at the release-operator boundary. The next irreversible
+steps are publishing crates, creating tags/releases/assets, moving action
+aliases, and running public install smoke.
+
+### Acceptance
+
+- Prep remains recorded: 0.18.0 versions, publish dry-runs, staged artifact
+  smoke, and public docs cutover.
+- Latest public release remains `v0.17.0` until crates, tags, release assets,
+  aliases, and public install smoke actually move.
+- The lane is not archived until public install smoke and publication closeout
+  are complete.
+
+### Rollback
+
+Before publication, revert only corrective or proof PRs as needed. After
+publication, forward-fix public state and record repair notes.
+
 ## Work Item: publish-crates
 
 Status: blocked
@@ -291,11 +347,11 @@ release or docs correction, and update the publication closeout.
 
 ## Work Item: publication-closeout
 
-Status: implemented
+Status: blocked
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Blocks:
-Blocked by:
+Blocked by: public-install-smoke
 
 ### Goal
 
@@ -303,7 +359,7 @@ Close the lane with a durable public-state audit.
 
 ### Acceptance
 
-- The closeout says what was published or deferred.
+- The closeout says what was published.
 - It records crate URLs, tags, action aliases, GitHub release assets, public
   install smoke, canary evidence, product-claim updates, and non-inferences.
 - `.codex/goals/active.toml` is archived with status `completed`.


### PR DESCRIPTION
## Summary
- restore `.codex/goals/active.toml` and remove the premature release-cutover archive from #421
- mark the #421 deferral closeout as superseded rather than authoritative lane closure
- return the release cutover plan to active state with current work at release-operator-gated publication
- preserve factual public state: latest public release remains v0.17.0 and 0.18.0 is not public yet
- preserve completed prep: versions, dry-run matrix, staged archive smoke, and public docs cutover remain recorded

## Guardrails
- no crates.io publication
- no tags or GitHub release
- no v0, v0.18, or v0.18.0 alias movement
- no claim that 0.18.0 is publicly installable

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check