### PR TITLE
init: suggest benchmark templates by repo shape

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1625,6 +1625,32 @@ pub enum InitCiPlatform {
     Circleci,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum BenchmarkSuggestionProfile {
+    /// Infer a conservative suggestion profile from nearby repo files.
+    Auto,
+    /// Rust command-line app suggestions.
+    RustCli,
+    /// Rust workspace suggestions.
+    RustWorkspace,
+    /// Node.js benchmark command suggestions.
+    Node,
+    /// Language-neutral command benchmark suggestions.
+    GenericCommand,
+}
+
+impl BenchmarkSuggestionProfile {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::RustCli => "rust-cli",
+            Self::RustWorkspace => "rust-workspace",
+            Self::Node => "node",
+            Self::GenericCommand => "generic-command",
+        }
+    }
+}
+
 #[derive(Debug, Args)]
 pub struct InitArgs {
     /// Directory to scan for benchmarks (default: current directory).
@@ -1642,6 +1668,10 @@ pub struct InitArgs {
     /// Also generate a CI workflow file.
     #[arg(long)]
     pub ci: Option<InitCiPlatform>,
+
+    /// Append commented benchmark templates to the generated config.
+    #[arg(long, value_enum, num_args = 0..=1, default_missing_value = "auto")]
+    pub suggest_benches: Option<BenchmarkSuggestionProfile>,
 
     /// Accept defaults without prompting.
     #[arg(long, default_value_t = false)]
@@ -5296,6 +5326,97 @@ fn execute_cargo_bench(args: CargoBenchArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn resolve_benchmark_suggestion_profile(
+    requested: BenchmarkSuggestionProfile,
+    scan_dir: &Path,
+) -> BenchmarkSuggestionProfile {
+    if requested != BenchmarkSuggestionProfile::Auto {
+        return requested;
+    }
+
+    if scan_dir.join("package.json").exists() {
+        return BenchmarkSuggestionProfile::Node;
+    }
+
+    let cargo_toml = scan_dir.join("Cargo.toml");
+    if let Ok(content) = fs::read_to_string(cargo_toml) {
+        if content.contains("[workspace]") {
+            return BenchmarkSuggestionProfile::RustWorkspace;
+        }
+        return BenchmarkSuggestionProfile::RustCli;
+    }
+
+    BenchmarkSuggestionProfile::GenericCommand
+}
+
+fn render_benchmark_suggestions(profile: BenchmarkSuggestionProfile) -> String {
+    match profile {
+        BenchmarkSuggestionProfile::Auto => {
+            render_benchmark_suggestions(BenchmarkSuggestionProfile::GenericCommand)
+        }
+        BenchmarkSuggestionProfile::RustCli => r#"
+# Benchmark suggestions (rust-cli)
+# Review and edit before committing. These are candidates, not policy.
+#
+# Fast first-hour check: low setup cost and useful for smoke gating.
+# [[bench]]
+# name = "cli-help"
+# command = ["cargo", "run", "-q", "--", "--help"]
+#
+# Heavier check: keep advisory until calibrated.
+# [[bench]]
+# name = "cli-release-help"
+# command = ["cargo", "run", "--release", "--", "--help"]
+"#
+        .to_string(),
+        BenchmarkSuggestionProfile::RustWorkspace => r#"
+# Benchmark suggestions (rust-workspace)
+# Review and edit before committing. These are candidates, not policy.
+#
+# Fast first-hour check: choose one small package or command with low setup cost.
+# [[bench]]
+# name = "workspace-smoke"
+# command = ["cargo", "test", "-p", "your-package", "--no-fail-fast"]
+#
+# Heavier check: compile-heavy workspace tests should stay advisory until calibrated.
+# [[bench]]
+# name = "workspace-test"
+# command = ["cargo", "test", "--workspace", "--no-fail-fast"]
+"#
+        .to_string(),
+        BenchmarkSuggestionProfile::Node => r#"
+# Benchmark suggestions (node)
+# Review and edit before committing. These are candidates, not policy.
+#
+# Fast first-hour check: a dedicated benchmark script with stable input.
+# [[bench]]
+# name = "node-bench"
+# command = ["node", "scripts/bench.js"]
+#
+# Package-manager path: useful when `npm run bench` already exists.
+# [[bench]]
+# name = "npm-bench"
+# command = ["npm", "run", "bench"]
+"#
+        .to_string(),
+        BenchmarkSuggestionProfile::GenericCommand => r#"
+# Benchmark suggestions (generic-command)
+# Review and edit before committing. These are candidates, not policy.
+#
+# Fast first-hour check: a stable command that measures the workload directly.
+# [[bench]]
+# name = "command-smoke"
+# command = ["./scripts/bench.sh"]
+#
+# Language-neutral example: replace this with your real benchmark command.
+# [[bench]]
+# name = "my-command"
+# command = ["your-benchmark-command", "--flag"]
+"#
+        .to_string(),
+    }
+}
+
 /// Execute the `init` subcommand.
 fn execute_init(args: InitArgs) -> anyhow::Result<()> {
     let preset = match args.preset {
@@ -5339,11 +5460,25 @@ fn execute_init(args: InitArgs) -> anyhow::Result<()> {
     }
 
     let config = generate_config(&benchmarks, preset);
-    let toml_content = render_config_toml(&config);
+    let mut toml_content = render_config_toml(&config);
+    let suggestion_profile = args
+        .suggest_benches
+        .map(|profile| resolve_benchmark_suggestion_profile(profile, &scan_dir));
+    if let Some(profile) = suggestion_profile {
+        toml_content.push_str(&render_benchmark_suggestions(profile));
+    }
 
     fs::write(&args.output, &toml_content)
         .with_context(|| format!("write {}", args.output.display()))?;
     eprintln!("Wrote {}", args.output.display());
+    if let Some(profile) = suggestion_profile {
+        eprintln!(
+            "Appended reviewable benchmark suggestions ({}) to {}.",
+            profile.as_str(),
+            args.output.display()
+        );
+        eprintln!("Review and edit suggestions before committing baselines.");
+    }
 
     let baseline_dir = config
         .defaults

--- a/crates/perfgate-cli/tests/cli_init_tests.rs
+++ b/crates/perfgate-cli/tests/cli_init_tests.rs
@@ -125,3 +125,84 @@ fn init_without_discovered_benchmarks_points_to_bench_entry_first() {
     assert!(onboarding.contains("[\"node\", \"scripts/bench.js\"]"));
     assert!(onboarding.contains("perfgate check --config perfgate.toml --all"));
 }
+
+#[test]
+fn init_suggest_benches_generates_language_neutral_commented_candidates() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+
+    let output = perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args([
+            "init",
+            "--ci",
+            "github",
+            "--profile",
+            "standard",
+            "--suggest-benches",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(output).expect("stderr is utf8");
+
+    let config =
+        fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
+    assert!(config.contains("# Benchmark suggestions (generic-command)"));
+    assert!(config.contains("# Review and edit before committing."));
+    assert!(config.contains("# [[bench]]"));
+    assert!(config.contains("# name = \"command-smoke\""));
+    assert!(config.contains("# command = [\"./scripts/bench.sh\"]"));
+    assert!(config.contains("# command = [\"your-benchmark-command\", \"--flag\"]"));
+    assert!(
+        !config.contains("\n[[bench]]"),
+        "suggestions must stay commented until reviewed"
+    );
+
+    assert!(stderr.contains("Appended reviewable benchmark suggestions (generic-command)"));
+    assert!(stderr.contains("Review and edit suggestions before committing baselines."));
+}
+
+#[test]
+fn init_suggest_benches_accepts_explicit_rust_cli_profile() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args(["init", "--suggest-benches", "rust-cli"])
+        .assert()
+        .success();
+
+    let config =
+        fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
+    assert!(config.contains("# Benchmark suggestions (rust-cli)"));
+    assert!(config.contains("# name = \"cli-help\""));
+    assert!(config.contains("# command = [\"cargo\", \"run\", \"-q\", \"--\", \"--help\"]"));
+    assert!(
+        !config.contains("\n[[bench]]"),
+        "explicit suggestions must stay commented until reviewed"
+    );
+}
+
+#[test]
+fn init_suggest_benches_auto_detects_node_repo() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    fs::write(
+        temp_dir.path().join("package.json"),
+        r#"{"scripts":{"bench":"node scripts/bench.js"}}"#,
+    )
+    .expect("write package.json");
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args(["init", "--suggest-benches"])
+        .assert()
+        .success();
+
+    let config =
+        fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
+    assert!(config.contains("# Benchmark suggestions (node)"));
+    assert!(config.contains("# command = [\"node\", \"scripts/bench.js\"]"));
+    assert!(config.contains("# command = [\"npm\", \"run\", \"bench\"]"));
+}


### PR DESCRIPTION
## Summary
- adds explicit `perfgate init --suggest-benches [profile]`
- supports auto, rust-cli, rust-workspace, node, and generic-command suggestion profiles
- appends commented benchmark candidates to `perfgate.toml` so users review/edit before committing policy
- adds focused init tests for generic suggestions, explicit rust-cli suggestions, and auto-detected Node suggestions

## Validation
- `cargo +1.95.0 fmt --all -- --check` passed
- `cargo +1.95.0 test -p perfgate-cli --all-features init` passed
- `cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked` passed
- `cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings` passed
- `cargo +1.95.0 run -p xtask -- docs-check` passed
- `cargo +1.95.0 run -p xtask -- doc-test` passed
- `cargo +1.95.0 run -p xtask -- docs-source-check` passed
- `cargo +1.95.0 run -p xtask -- product-claims-check` passed
- `git diff --check` passed

## Boundaries
- suggestions remain commented and are not active `[[bench]]` entries
- no automatic baseline promotion or policy mutation
- no release publication, tags, GitHub release, or action alias changes
- does not touch #414 nightly baseline/trend refresh