### PR TITLE
cli: add artifact explanation command

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -398,11 +398,14 @@ enum Command {
         action: FleetAction,
     },
 
-    /// Provide AI-ready prompts and automated playbooks for diagnosing performance regressions.
+    /// Provide AI-ready prompts, artifact explanations, and automated playbooks.
     Explain {
+        #[command(subcommand)]
+        action: Option<ExplainAction>,
+
         /// Path to a compare receipt
         #[arg(long)]
-        compare: PathBuf,
+        compare: Option<PathBuf>,
 
         /// Path to baseline Cargo.lock for binary blame analysis
         #[arg(long)]
@@ -1290,6 +1293,19 @@ pub enum IngestCommand {
 pub enum ProbeAction {
     /// Compare two perfgate.probe.v1 receipts into a perfgate.probe_compare.v1 receipt.
     Compare(ProbeCompareArgs),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ExplainAction {
+    /// Explain known perfgate artifacts in a receipt directory.
+    Artifacts(ExplainArtifactsArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ExplainArtifactsArgs {
+    /// Artifact directory to explain.
+    #[arg(long, default_value = DEFAULT_ARTIFACT_DIR)]
+    pub out_dir: PathBuf,
 }
 
 #[derive(Debug, Subcommand)]
@@ -3560,10 +3576,19 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
         Command::Blame(args) => execute_blame(*args),
 
         Command::Explain {
+            action,
             compare,
             baseline_lock,
             current_lock,
         } => {
+            if let Some(action) = action {
+                return execute_explain_action(action);
+            }
+            let Some(compare) = compare else {
+                anyhow::bail!(
+                    "use `perfgate explain --compare <compare.json>` or `perfgate explain artifacts --out-dir <dir>`"
+                );
+            };
             let usecase = ExplainUseCase;
             let outcome = usecase.execute(ExplainRequest {
                 compare,
@@ -5324,6 +5349,158 @@ fn execute_cargo_bench(args: CargoBenchArgs) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn execute_explain_action(action: ExplainAction) -> anyhow::Result<()> {
+    match action {
+        ExplainAction::Artifacts(args) => execute_explain_artifacts(args),
+    }
+}
+
+fn execute_explain_artifacts(args: ExplainArtifactsArgs) -> anyhow::Result<()> {
+    let mut known = Vec::new();
+    let mut unknown = Vec::new();
+    collect_artifact_files(&args.out_dir, &args.out_dir, &mut known, &mut unknown)?;
+
+    println!("perfgate artifact explanation");
+    println!();
+
+    if !args.out_dir.exists() {
+        println!("Status: no_artifacts");
+        println!(
+            "Meaning: {} does not exist yet; run a check or decision command first.",
+            args.out_dir.display()
+        );
+        println!("Artifacts:");
+        println!("  none");
+        println!("Next:");
+        println!("  perfgate check --config perfgate.toml --all");
+        println!("Do not:");
+        println!("  commit generated artifact directories before reviewing repo policy");
+        return Ok(());
+    }
+
+    if known.is_empty() {
+        println!("Status: no_known_artifacts");
+        println!(
+            "Meaning: {} exists, but no known perfgate receipt files were found.",
+            args.out_dir.display()
+        );
+        println!("Artifacts:");
+        if unknown.is_empty() {
+            println!("  none");
+        } else {
+            for path in &unknown {
+                println!("  {}  unrecognized file", path.display());
+            }
+        }
+        println!("Next:");
+        println!("  perfgate check --config perfgate.toml --all");
+        println!("Do not:");
+        println!("  infer a verdict from unknown files alone");
+        return Ok(());
+    }
+
+    println!("Status: artifacts_found");
+    println!("Meaning: known perfgate receipts or review artifacts are present.");
+    println!("Artifacts:");
+    for (path, role) in &known {
+        println!("  {:<32} {}", path.display(), role);
+    }
+    if !unknown.is_empty() {
+        println!("  unknown:");
+        for path in &unknown {
+            println!("    {}  unrecognized file", path.display());
+        }
+    }
+    println!("Next:");
+    for command in artifact_next_commands(&known) {
+        println!("  {command}");
+    }
+    println!("Do not:");
+    println!("  treat artifacts as durable baselines unless promoted intentionally");
+
+    Ok(())
+}
+
+fn collect_artifact_files(
+    root: &Path,
+    dir: &Path,
+    known: &mut Vec<(PathBuf, &'static str)>,
+    unknown: &mut Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_artifact_files(root, &path, known, unknown)?;
+            continue;
+        }
+
+        let relative = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            unknown.push(relative);
+            continue;
+        };
+
+        if let Some(role) = known_artifact_role(name) {
+            known.push((relative, role));
+        } else {
+            unknown.push(relative);
+        }
+    }
+
+    known.sort_by(|left, right| left.0.cmp(&right.0));
+    unknown.sort();
+    Ok(())
+}
+
+fn known_artifact_role(file_name: &str) -> Option<&'static str> {
+    match file_name {
+        RUN_RECEIPT_FILE => Some("raw measurement receipt"),
+        COMPARE_RECEIPT_FILE => Some("baseline/current comparison receipt"),
+        "report.json" => Some("machine-readable verdict summary"),
+        "comment.md" => Some("PR-ready human summary"),
+        "repair_context.json" => Some("local reproduction and repair hints"),
+        "decision.md" => Some("human-readable performance decision"),
+        "decision.index.json" => Some("index of decision evidence artifacts"),
+        "decision-bundle.json" => Some("portable decision evidence bundle"),
+        "probe-compare.json" => Some("named probe baseline/current comparison"),
+        "scenario.json" => Some("weighted workload scenario receipt"),
+        "tradeoff.json" => Some("tradeoff policy evaluation receipt"),
+        _ => None,
+    }
+}
+
+fn artifact_next_commands(known: &[(PathBuf, &'static str)]) -> Vec<String> {
+    let has = |name: &str| {
+        known
+            .iter()
+            .any(|(path, _)| path.file_name().and_then(|file| file.to_str()) == Some(name))
+    };
+
+    let mut commands = Vec::new();
+    if has("comment.md") {
+        commands.push("inspect artifacts/perfgate/comment.md or the per-bench comment.md".into());
+    }
+    if has("repair_context.json") {
+        commands.push("inspect repair_context.json for local reproduction and repair hints".into());
+    }
+    if has("decision.index.json") {
+        commands
+            .push("perfgate decision bundle --index artifacts/perfgate/decision.index.json".into());
+    }
+    if has(COMPARE_RECEIPT_FILE) {
+        commands.push("perfgate check --config perfgate.toml --all --require-baseline".into());
+    }
+    if commands.is_empty() {
+        commands.push("perfgate check --config perfgate.toml --all".into());
+    }
+    commands
 }
 
 fn resolve_benchmark_suggestion_profile(

--- a/crates/perfgate-cli/tests/cli_explain_tests.rs
+++ b/crates/perfgate-cli/tests/cli_explain_tests.rs
@@ -1,0 +1,84 @@
+//! Integration tests for `perfgate explain`.
+
+use predicates::prelude::*;
+use std::fs;
+
+mod common;
+use common::{fixtures_dir, generate_compare_receipt, perfgate_cmd};
+
+#[test]
+fn explain_compare_legacy_path_still_works() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let compare = temp_dir.path().join("compare.json");
+    generate_compare_receipt(
+        &fixtures_dir().join("baseline.json"),
+        &fixtures_dir().join("current_fail.json"),
+        &compare,
+    )
+    .expect("generate compare receipt");
+
+    perfgate_cmd()
+        .args(["explain", "--compare"])
+        .arg(&compare)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Performance Analysis"))
+        .stdout(predicate::str::contains("Performance Regressions Detected"));
+}
+
+#[test]
+fn explain_artifacts_identifies_known_receipts_and_next_steps() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let out_dir = temp_dir.path().join("artifacts/perfgate");
+    let bench_dir = out_dir.join("parser");
+    fs::create_dir_all(&bench_dir).expect("create artifact dir");
+    fs::write(bench_dir.join("run.json"), "{}").expect("write run");
+    fs::write(bench_dir.join("compare.json"), "{}").expect("write compare");
+    fs::write(bench_dir.join("report.json"), "{}").expect("write report");
+    fs::write(bench_dir.join("comment.md"), "# comment").expect("write comment");
+    fs::write(bench_dir.join("repair_context.json"), "{}").expect("write repair context");
+    fs::write(out_dir.join("decision.index.json"), "{}").expect("write decision index");
+
+    perfgate_cmd()
+        .args(["explain", "artifacts", "--out-dir"])
+        .arg(&out_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Status: artifacts_found"))
+        .stdout(predicate::str::contains("parser"))
+        .stdout(predicate::str::contains("run.json"))
+        .stdout(predicate::str::contains("raw measurement receipt"))
+        .stdout(predicate::str::contains("compare.json"))
+        .stdout(predicate::str::contains(
+            "baseline/current comparison receipt",
+        ))
+        .stdout(predicate::str::contains("repair_context.json"))
+        .stdout(predicate::str::contains(
+            "local reproduction and repair hints",
+        ))
+        .stdout(predicate::str::contains(
+            "perfgate decision bundle --index artifacts/perfgate/decision.index.json",
+        ))
+        .stdout(predicate::str::contains(
+            "perfgate check --config perfgate.toml --all --require-baseline",
+        ));
+}
+
+#[test]
+fn explain_artifacts_handles_missing_directory_as_setup_state() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let out_dir = temp_dir.path().join("missing-artifacts");
+
+    perfgate_cmd()
+        .args(["explain", "artifacts", "--out-dir"])
+        .arg(&out_dir)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Status: no_artifacts"))
+        .stdout(predicate::str::contains(
+            "run a check or decision command first",
+        ))
+        .stdout(predicate::str::contains(
+            "perfgate check --config perfgate.toml --all",
+        ));
+}


### PR DESCRIPTION
## Summary
- adds `perfgate explain artifacts --out-dir <dir>`
- recognizes local gate, repair, probe, scenario, tradeoff, decision, and bundle artifact filenames
- prints Status / Meaning / Artifacts / Next / Do not guidance for present, missing, and unknown artifact directories
- keeps the existing `perfgate explain --compare <compare.json>` path working and covered by a test

## Validation
- `cargo +1.95.0 fmt --all -- --check` passed
- `cargo +1.95.0 test -p perfgate-cli --all-features explain` passed
- `cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked` passed
- `cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings` passed
- `cargo +1.95.0 run -p xtask -- docs-check` passed
- `cargo +1.95.0 run -p xtask -- doc-test` passed
- `cargo +1.95.0 run -p xtask -- docs-source-check` passed
- `cargo +1.95.0 run -p xtask -- product-claims-check` passed
- `git diff --check` passed

## Boundaries
- no schema validation behavior added to `explain artifacts`
- no changes to decision receipt generation or bundle behavior
- no release publication, tags, GitHub release, or action alias changes
- does not touch #414 nightly baseline/trend refresh or #429 badge refresh