### PR TITLE
cli: standardize failure classes and repair guidance

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -45,7 +45,7 @@ use perfgate_domain::{DependencyChangeType, SignificancePolicy};
 use perfgate_types::config::{
     apply_ratchet_toml_changes, load_config_file, preview_ratchet_toml_changes,
 };
-use perfgate_types::error::{ConfigValidationError, IoError, PerfgateError};
+use perfgate_types::error::{AdapterError, ConfigValidationError, IoError, PerfgateError};
 use perfgate_types::fingerprint::sha256_hex;
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
@@ -7586,6 +7586,373 @@ fn is_regression(status: VerdictStatus) -> bool {
     matches!(status, VerdictStatus::Warn | VerdictStatus::Fail)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailureClass {
+    SetupMissingConfig,
+    SetupMissingBench,
+    SetupCommandFailed,
+    MissingBaseline,
+    PerformanceRegression,
+    HighNoise,
+    UnsupportedMetric,
+    HostMismatch,
+    ReviewRequired,
+    ServerUploadFailed,
+}
+
+impl FailureClass {
+    fn status(self) -> &'static str {
+        match self {
+            Self::SetupMissingConfig => "setup_missing_config",
+            Self::SetupMissingBench => "setup_missing_bench",
+            Self::SetupCommandFailed => "setup_command_failed",
+            Self::MissingBaseline => "missing_baseline",
+            Self::PerformanceRegression => "performance_regression",
+            Self::HighNoise => "high_noise",
+            Self::UnsupportedMetric => "unsupported_metric",
+            Self::HostMismatch => "host_mismatch",
+            Self::ReviewRequired => "review_required",
+            Self::ServerUploadFailed => "server_upload_failed",
+        }
+    }
+
+    fn meaning(self) -> &'static str {
+        match self {
+            Self::SetupMissingConfig => {
+                "perfgate could not read the config, so no performance decision was made."
+            }
+            Self::SetupMissingBench => {
+                "The requested benchmark is missing or no runnable benchmarks are configured yet."
+            }
+            Self::SetupCommandFailed => {
+                "The benchmark command failed before perfgate could make a performance decision."
+            }
+            Self::MissingBaseline => "Setup is incomplete; this is not a performance regression.",
+            Self::PerformanceRegression => {
+                "A configured benchmark exceeded its performance budget or warning threshold."
+            }
+            Self::HighNoise => {
+                "The run is noisy enough that the result may need paired mode or calibration."
+            }
+            Self::UnsupportedMetric => "A requested metric is not available on this platform.",
+            Self::HostMismatch => {
+                "The baseline and current run were captured on different host fingerprints."
+            }
+            Self::ReviewRequired => {
+                "The evidence needs human review before this result should be accepted."
+            }
+            Self::ServerUploadFailed => {
+                "The optional server ledger upload failed; local receipts still record the result."
+            }
+        }
+    }
+
+    fn do_not(self) -> &'static str {
+        match self {
+            Self::SetupMissingConfig => "do not copy another repo's baselines to bypass setup",
+            Self::SetupMissingBench => {
+                "do not promote a baseline until the benchmark command is reviewed"
+            }
+            Self::SetupCommandFailed => {
+                "do not loosen thresholds to fix a command that does not run"
+            }
+            Self::MissingBaseline => "do not loosen thresholds to fix a missing baseline",
+            Self::PerformanceRegression => {
+                "do not promote the current run as a baseline until the regression is understood"
+            }
+            Self::HighNoise => "do not treat noisy single-run evidence as release proof",
+            Self::UnsupportedMetric => {
+                "do not assume a missing platform metric invalidates every gate"
+            }
+            Self::HostMismatch => {
+                "do not accept host-mismatched evidence without checking whether the hosts are comparable"
+            }
+            Self::ReviewRequired => "do not bypass required review by changing local thresholds",
+            Self::ServerUploadFailed => {
+                "do not rerun the benchmark just to repair an optional ledger upload"
+            }
+        }
+    }
+
+    fn artifacts(self, out_dir: Option<&Path>, compare_path: Option<&Path>) -> Vec<String> {
+        let Some(out_dir) = out_dir else {
+            return vec![
+                "artifacts unavailable because setup failed before receipts were written"
+                    .to_string(),
+            ];
+        };
+
+        let mut artifacts = match self {
+            Self::MissingBaseline => vec![
+                out_dir.join(RUN_RECEIPT_FILE).display().to_string(),
+                out_dir.join(REPORT_RECEIPT_FILE).display().to_string(),
+                out_dir.join(COMMENT_MARKDOWN_FILE).display().to_string(),
+                out_dir.join("repair_context.json").display().to_string(),
+            ],
+            Self::PerformanceRegression
+            | Self::HighNoise
+            | Self::HostMismatch
+            | Self::ReviewRequired => vec![
+                out_dir.join(RUN_RECEIPT_FILE).display().to_string(),
+                compare_path
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| out_dir.join(COMPARE_RECEIPT_FILE).display().to_string()),
+                out_dir.join(REPORT_RECEIPT_FILE).display().to_string(),
+                out_dir.join(COMMENT_MARKDOWN_FILE).display().to_string(),
+                out_dir.join("repair_context.json").display().to_string(),
+            ],
+            Self::ServerUploadFailed => vec![
+                out_dir.join(RUN_RECEIPT_FILE).display().to_string(),
+                out_dir.join(REPORT_RECEIPT_FILE).display().to_string(),
+            ],
+            Self::SetupMissingConfig
+            | Self::SetupMissingBench
+            | Self::SetupCommandFailed
+            | Self::UnsupportedMetric => {
+                vec!["artifacts unavailable or incomplete because setup failed".to_string()]
+            }
+        };
+        artifacts.sort();
+        artifacts.dedup();
+        artifacts
+    }
+
+    fn next_commands(
+        self,
+        config_path: &Path,
+        bench_name: Option<&str>,
+        compare_path: Option<&Path>,
+    ) -> Vec<String> {
+        let config = shell_path(config_path);
+        let check = check_command(config_path, bench_name, false);
+        let check_required = check_command(config_path, bench_name, true);
+        match self {
+            Self::SetupMissingConfig => vec![
+                "perfgate init --ci github --profile standard --suggest-benches".to_string(),
+                format!("perfgate doctor --config {config}"),
+            ],
+            Self::SetupMissingBench => vec![
+                format!("edit {config} and add a reviewed [[bench]] command"),
+                format!("perfgate doctor --config {config}"),
+            ],
+            Self::SetupCommandFailed => vec![check],
+            Self::MissingBaseline => vec![check, baseline_promote_command(config_path, bench_name)],
+            Self::PerformanceRegression => {
+                let mut commands = vec![check_required];
+                if let Some(compare_path) = compare_path {
+                    commands.push(format!(
+                        "perfgate explain --compare {}",
+                        shell_path(compare_path)
+                    ));
+                }
+                commands
+            }
+            Self::HighNoise => vec![
+                paired_command(bench_name),
+                format!("review noise guidance before tightening {config}"),
+            ],
+            Self::UnsupportedMetric => vec![
+                format!("review platform metric support before changing {config}"),
+                check,
+            ],
+            Self::HostMismatch => vec![
+                check_required,
+                "rerun on the same runner class as the baseline".to_string(),
+            ],
+            Self::ReviewRequired => vec![
+                "review artifacts/perfgate/decision.md or the Action summary".to_string(),
+                "perfgate decision bundle --index artifacts/perfgate/decision.index.json"
+                    .to_string(),
+            ],
+            Self::ServerUploadFailed => vec![
+                "inspect server URL/API key/project settings".to_string(),
+                "perfgate decision history".to_string(),
+            ],
+        }
+    }
+}
+
+const REPORT_RECEIPT_FILE: &str = "report.json";
+const COMMENT_MARKDOWN_FILE: &str = "comment.md";
+
+fn shell_path(path: &Path) -> String {
+    let value = path.display().to_string();
+    if value.contains(' ') {
+        format!("\"{}\"", value.replace('"', "\\\""))
+    } else {
+        value
+    }
+}
+
+fn check_command(config_path: &Path, bench_name: Option<&str>, require_baseline: bool) -> String {
+    let mut command = if let Some(bench_name) = bench_name {
+        format!(
+            "perfgate check --config {} --bench {}",
+            shell_path(config_path),
+            bench_name
+        )
+    } else {
+        format!("perfgate check --config {} --all", shell_path(config_path))
+    };
+    if require_baseline {
+        command.push_str(" --require-baseline");
+    }
+    command
+}
+
+fn baseline_promote_command(config_path: &Path, bench_name: Option<&str>) -> String {
+    if let Some(bench_name) = bench_name {
+        format!(
+            "perfgate baseline promote --config {} --bench {}",
+            shell_path(config_path),
+            bench_name
+        )
+    } else {
+        format!(
+            "perfgate baseline promote --config {} --all",
+            shell_path(config_path)
+        )
+    }
+}
+
+fn paired_command(bench_name: Option<&str>) -> String {
+    let name = bench_name.unwrap_or("<bench>");
+    format!(
+        "perfgate paired --name {name} --baseline-cmd \"<baseline-cmd>\" --current-cmd \"<current-cmd>\" --repeat 10 --out artifacts/perfgate/{name}/paired.json"
+    )
+}
+
+fn print_check_failure_guidance(
+    class: FailureClass,
+    config_path: &Path,
+    bench_name: Option<&str>,
+    out_dir: Option<&Path>,
+    compare_path: Option<&Path>,
+) {
+    eprintln!();
+    eprintln!("Status: {}", class.status());
+    eprintln!("Meaning: {}", class.meaning());
+    eprintln!("Artifacts:");
+    for artifact in class.artifacts(out_dir, compare_path) {
+        eprintln!("  {artifact}");
+    }
+    eprintln!("Next:");
+    for command in class.next_commands(config_path, bench_name, compare_path) {
+        eprintln!("  {command}");
+    }
+    eprintln!("Do not:");
+    eprintln!("  {}", class.do_not());
+}
+
+fn classify_check_error(error: &anyhow::Error) -> FailureClass {
+    if let Some(err) = error.downcast_ref::<PerfgateError>() {
+        return match err {
+            PerfgateError::Config(ConfigValidationError::BenchName(_)) => {
+                FailureClass::SetupMissingBench
+            }
+            PerfgateError::Io(IoError::BaselineNotFound { .. }) => FailureClass::MissingBaseline,
+            PerfgateError::Io(IoError::RunCommand { .. })
+            | PerfgateError::Adapter(AdapterError::RunCommand { .. })
+            | PerfgateError::Adapter(AdapterError::EmptyArgv)
+            | PerfgateError::Adapter(AdapterError::Timeout) => FailureClass::SetupCommandFailed,
+            PerfgateError::Adapter(AdapterError::TimeoutUnsupported) => {
+                FailureClass::UnsupportedMetric
+            }
+            _ => FailureClass::SetupCommandFailed,
+        };
+    }
+
+    let message = error.to_string().to_ascii_lowercase();
+    if message.contains("no benchmarks")
+        || message.contains("not found in config")
+        || message.contains("either --bench or --all")
+    {
+        FailureClass::SetupMissingBench
+    } else if message.contains("baseline") {
+        FailureClass::MissingBaseline
+    } else if message.contains("host mismatch") {
+        FailureClass::HostMismatch
+    } else if message.contains("not found") || message.contains("read ") {
+        FailureClass::SetupMissingConfig
+    } else {
+        FailureClass::SetupCommandFailed
+    }
+}
+
+fn emit_check_outcome_guidance(
+    req: &CheckConfig,
+    bench_name: &str,
+    bench_out_dir: &Path,
+    outcome: &CheckOutcome,
+) {
+    if outcome.compare_receipt.is_none() {
+        print_check_failure_guidance(
+            FailureClass::MissingBaseline,
+            &req.config_path,
+            Some(bench_name),
+            Some(bench_out_dir),
+            None,
+        );
+    }
+
+    if let Some(compare) = &outcome.compare_receipt
+        && is_regression(compare.verdict.status)
+    {
+        print_check_failure_guidance(
+            FailureClass::PerformanceRegression,
+            &req.config_path,
+            Some(bench_name),
+            Some(bench_out_dir),
+            outcome.compare_path.as_deref(),
+        );
+    }
+
+    if outcome.suggest_paired
+        || outcome
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("high noise"))
+    {
+        print_check_failure_guidance(
+            FailureClass::HighNoise,
+            &req.config_path,
+            Some(bench_name),
+            Some(bench_out_dir),
+            outcome.compare_path.as_deref(),
+        );
+    }
+
+    if outcome
+        .warnings
+        .iter()
+        .any(|warning| warning.contains("host mismatch"))
+    {
+        print_check_failure_guidance(
+            FailureClass::HostMismatch,
+            &req.config_path,
+            Some(bench_name),
+            Some(bench_out_dir),
+            outcome.compare_path.as_deref(),
+        );
+    }
+
+    if outcome
+        .report
+        .verdict
+        .reasons
+        .iter()
+        .any(|reason| reason.contains("review_required") || reason.contains("review required"))
+    {
+        print_check_failure_guidance(
+            FailureClass::ReviewRequired,
+            &req.config_path,
+            Some(bench_name),
+            Some(bench_out_dir),
+            outcome.compare_path.as_deref(),
+        );
+    }
+}
+
 /// Attempt to capture a flamegraph for a regressing benchmark.
 ///
 /// This is a best-effort operation: failures are reported to stderr
@@ -7670,6 +8037,15 @@ fn submit_verdict_if_possible(
 fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
     // Load config file
     let config_content = fs::read_to_string(&req.config_path)
+        .inspect_err(|_| {
+            print_check_failure_guidance(
+                FailureClass::SetupMissingConfig,
+                &req.config_path,
+                req.bench.as_deref(),
+                None,
+                None,
+            );
+        })
         .with_context(|| format!("read {}", req.config_path.display()))?;
 
     let config_file: ConfigFile = if req
@@ -7695,10 +8071,19 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
         req.bench.as_deref(),
         req.all,
         req.bench_regex.as_deref(),
-    )?;
+    )
+    .inspect_err(|error| {
+        print_check_failure_guidance(
+            classify_check_error(error),
+            &req.config_path,
+            req.bench.as_deref(),
+            None,
+            None,
+        );
+    })?;
     let bench_count = bench_names.len() as u32;
 
-    let markdown_template_path = req.md_template.or_else(|| {
+    let markdown_template_path = req.md_template.clone().or_else(|| {
         config_file
             .defaults
             .markdown_template
@@ -7744,7 +8129,7 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
         let clock = SystemClock;
         let usecase = CheckUseCase::new(runner, host_probe, clock);
 
-        let outcome = usecase.execute(CheckRequest {
+        let outcome = match usecase.execute(CheckRequest {
             config: config_file.clone(),
             bench_name: bench_name.clone(),
             out_dir: bench_out_dir.clone(),
@@ -7762,7 +8147,19 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
             significance_alpha: req.significance_alpha,
             significance_min_samples: req.significance_min_samples,
             require_significance: req.require_significance,
-        })?;
+        }) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                print_check_failure_guidance(
+                    classify_check_error(&error),
+                    &req.config_path,
+                    Some(bench_name),
+                    Some(&bench_out_dir),
+                    None,
+                );
+                return Err(error);
+            }
+        };
 
         // Submit verdict to server if configured
         if let Some(compare) = &outcome.compare_receipt {
@@ -7774,6 +8171,13 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
             && let Err(e) = upload_to_local_db(bench_name, &outcome.run_receipt)
         {
             eprintln!("warning: local-db upload failed: {:#}", e);
+            print_check_failure_guidance(
+                FailureClass::ServerUploadFailed,
+                &req.config_path,
+                Some(bench_name),
+                Some(&bench_out_dir),
+                outcome.compare_path.as_deref(),
+            );
         }
 
         // Write artifacts
@@ -7821,6 +8225,8 @@ fn run_check_standard(req: CheckConfig) -> anyhow::Result<()> {
                 all_warnings.push(warning.clone());
             }
         }
+
+        emit_check_outcome_guidance(&req, bench_name, &bench_out_dir, &outcome);
 
         total_pass += outcome.report.summary.pass_count;
         total_warn += outcome.report.summary.warn_count;

--- a/crates/perfgate-cli/tests/cli_check_tests.rs
+++ b/crates/perfgate-cli/tests/cli_check_tests.rs
@@ -404,13 +404,14 @@ fn test_check_missing_baseline_warns() {
         .arg(&out_dir);
 
     let output = cmd.output().expect("failed to execute check");
+    let stderr = String::from_utf8_lossy(&output.stderr);
 
     // Should succeed (warning only)
     assert!(
         output.status.success(),
         "check without baseline should succeed with warning: {:?}, stderr: {}",
         output.status.code(),
-        String::from_utf8_lossy(&output.stderr)
+        stderr
     );
 
     // run.json should exist, but not compare.json
@@ -492,6 +493,27 @@ fn test_check_missing_baseline_warns() {
     assert!(
         md_content.contains("no baseline"),
         "comment.md should mention no baseline"
+    );
+
+    assert!(
+        stderr.contains("Status: missing_baseline"),
+        "stderr should classify missing baseline: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("setup is incomplete") || stderr.contains("Setup is incomplete"),
+        "stderr should explain setup vs regression: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("perfgate baseline promote --config"),
+        "stderr should include baseline promotion guidance: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("do not loosen thresholds"),
+        "stderr should include do-not guidance: {}",
+        stderr
     );
 }
 
@@ -600,6 +622,16 @@ fn test_check_require_baseline_fails() {
     assert!(
         stderr.contains("baseline required") || stderr.contains("baseline"),
         "stderr should mention baseline: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("Status: missing_baseline"),
+        "stderr should classify missing baseline: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("perfgate baseline promote --config"),
+        "stderr should include baseline promotion guidance: {}",
         stderr
     );
 }
@@ -982,6 +1014,22 @@ command = [{}]
         Some(2),
         "check should exit 2 on fail: stderr {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Status: performance_regression"),
+        "stderr should classify the regression: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("perfgate explain --compare"),
+        "stderr should point reviewers to compare explanation: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("do not promote the current run"),
+        "stderr should include do-not guidance: {}",
+        stderr
     );
 
     let content = fs::read_to_string(&github_output).expect("read GITHUB_OUTPUT");


### PR DESCRIPTION
## Summary
- adds perfgate check failure guidance with Status, Meaning, Artifacts, Next, and Do not sections
- classifies missing config/bench, command failure, missing baseline, regression, high noise, host mismatch, review-required, unsupported metric, and optional server upload failure surfaces
- covers missing-baseline and regression output in CLI integration tests

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --all-features check
- cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check