### PR TITLE
calibrate: suggest thresholds and noise policy

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -52,10 +52,11 @@ use perfgate_types::{
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_BUNDLE_SCHEMA_V1,
     DECISION_INDEX_SCHEMA_V1, DecisionArtifactIndex, DecisionBundleArtifact,
     DecisionBundleArtifactContent, DecisionBundleArtifactKind, DecisionBundleMetadata,
-    DecisionBundleReceipt, FailIfNOfM, HostMismatchPolicy, MetricStatus, OtelSpanIdentifiers,
-    PerfgateReport, ProbeCompareReceipt, ProbeReceipt, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
-    RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
-    ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt, VerdictStatus,
+    DecisionBundleReceipt, FailIfNOfM, HostMismatchPolicy, Metric, MetricStatus,
+    OtelSpanIdentifiers, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
+    REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairGitMetadata,
+    RepairMetricBreach, RunReceipt, ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus,
+    ToolInfo, TradeoffReceipt, VerdictStatus,
 };
 use regex::Regex;
 use serde_json::Value as JsonValue;
@@ -259,6 +260,9 @@ enum Command {
     /// - 2: fail (budget violated)
     /// - 3: warn treated as failure (with --fail-on-warn)
     Check(Box<CheckArgs>),
+
+    /// Suggest advisory thresholds and noise policy from existing receipts.
+    Calibrate(Box<CalibrateArgs>),
 
     /// Diagnose local setup, config, baselines, artifacts, CI, and server reachability.
     Doctor(Box<DoctorArgs>),
@@ -1139,6 +1143,29 @@ pub struct CheckArgs {
     /// Warning and failing checks already emit it automatically.
     #[arg(long, default_value_t = false)]
     pub emit_repair_context: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct CalibrateArgs {
+    /// Path to the config file (TOML or JSON)
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Name of the benchmark to calibrate (must match a [[bench]] in config)
+    #[arg(long)]
+    pub bench: String,
+
+    /// Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate.
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Explicit recent run receipt. Defaults to <out-dir>/<bench>/run.json, then <out-dir>/run.json.
+    #[arg(long)]
+    pub run: Option<PathBuf>,
+
+    /// Explicit baseline receipt. Defaults to the configured baseline path.
+    #[arg(long)]
+    pub baseline: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -2477,6 +2504,214 @@ fn local_baselines_ready(config: &ConfigFile, server_flags: &ServerFlags) -> boo
     (local == 0 && remote > 0) || (local > 0 && found == local)
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CalibrationSuggestion {
+    fail_threshold: f64,
+    warn_factor: f64,
+    noise_threshold: f64,
+    noise_policy: perfgate_types::NoisePolicy,
+    recommended_repeat: usize,
+    suggest_paired: bool,
+}
+
+fn execute_calibrate(args: CalibrateArgs) -> anyhow::Result<()> {
+    let config = load_config_file(&args.config)?;
+    config
+        .validate()
+        .map_err(ConfigValidationError::ConfigFile)?;
+    let bench = config
+        .benches
+        .iter()
+        .find(|bench| bench.name == args.bench)
+        .ok_or_else(|| {
+            ConfigValidationError::BenchName(format!("bench '{}' not found in config", args.bench))
+        })?;
+
+    let out_dir = resolve_configured_out_dir(args.out_dir.as_ref(), Some(&config));
+    let run_path = args
+        .run
+        .clone()
+        .or_else(|| find_calibration_run_path(&out_dir, &args.bench));
+    let run_receipt = run_path
+        .as_ref()
+        .filter(|path| path.exists())
+        .map(|path| read_json::<RunReceipt>(path))
+        .transpose()?;
+
+    let baseline_path = resolve_baseline_path(&args.baseline, &args.bench, &config);
+    let baseline_receipt = load_optional_baseline_receipt(&baseline_path)?;
+    let evidence_receipt = run_receipt.as_ref().or(baseline_receipt.as_ref());
+    let cv = run_receipt
+        .as_ref()
+        .and_then(|receipt| receipt.stats.wall_ms.cv())
+        .or_else(|| {
+            baseline_receipt
+                .as_ref()
+                .and_then(|receipt| receipt.stats.wall_ms.cv())
+        });
+    let sample_count = evidence_receipt
+        .map(measured_sample_count)
+        .unwrap_or_default();
+    let configured_threshold = configured_wall_threshold(&config, bench);
+    let suggestion = suggest_calibration(cv, sample_count, configured_threshold);
+
+    println!("perfgate calibrate");
+    println!();
+    println!("Bench: {}", args.bench);
+    if sample_count == 0 {
+        println!("Samples: unavailable");
+    } else {
+        println!(
+            "Samples: {sample_count} measured sample{}",
+            plural(sample_count)
+        );
+    }
+    println!(
+        "CV: {}",
+        cv.map(format_percent)
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+    println!(
+        "Host class: {}",
+        evidence_receipt
+            .map(host_class)
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!();
+    println!("Evidence:");
+    if let Some(path) = run_path.as_ref().filter(|path| path.exists()) {
+        println!("  run: {}", path.display());
+    } else if let Some(path) = run_path.as_ref() {
+        println!("  run: missing ({})", path.display());
+    } else {
+        println!(
+            "  run: missing (expected {})",
+            out_dir.join(RUN_RECEIPT_FILE).display()
+        );
+    }
+    if baseline_receipt.is_some() {
+        println!("  baseline: {}", baseline_path.display());
+    } else {
+        println!("  baseline: missing ({})", baseline_path.display());
+    }
+    println!();
+    println!(
+        "Suggested fail threshold: {}",
+        format_percent(suggestion.fail_threshold)
+    );
+    println!(
+        "Suggested warn threshold: {}",
+        format_percent(suggestion.fail_threshold * suggestion.warn_factor)
+    );
+    println!(
+        "Suggested noise threshold: {}",
+        format_percent(suggestion.noise_threshold)
+    );
+    println!(
+        "Suggested noise policy: {}",
+        suggestion.noise_policy.as_str()
+    );
+    println!(
+        "Repeat guidance: collect at least {} measured samples before tightening.",
+        suggestion.recommended_repeat
+    );
+    if suggestion.suggest_paired {
+        println!("Paired mode: recommended before making this gate blocking.");
+    } else {
+        println!("Paired mode: not required yet; use it if reviewers see inconsistent results.");
+    }
+    println!();
+    println!("Suggested config patch:");
+    println!("  threshold = {:.2}", suggestion.fail_threshold);
+    println!("  warn_factor = {:.2}", suggestion.warn_factor);
+    println!("  noise_threshold = {:.2}", suggestion.noise_threshold);
+    println!("  noise_policy = \"{}\"", suggestion.noise_policy.as_str());
+    println!();
+    println!("Next:");
+    if run_receipt.is_none() {
+        println!(
+            "  {}",
+            check_command(&args.config, Some(&args.bench), false)
+        );
+    }
+    println!("  {}", check_command(&args.config, Some(&args.bench), true));
+    if suggestion.suggest_paired {
+        println!("  {}", paired_command(Some(&args.bench)));
+    }
+    println!("Do not:");
+    println!("  do not auto-edit thresholds from this advisory output; review the benchmark first");
+    println!();
+    println!("Advisory only: no config was written.");
+
+    Ok(())
+}
+
+fn find_calibration_run_path(out_dir: &Path, bench_name: &str) -> Option<PathBuf> {
+    [
+        out_dir.join(bench_name).join(RUN_RECEIPT_FILE),
+        out_dir.join(RUN_RECEIPT_FILE),
+    ]
+    .into_iter()
+    .find(|path| path.exists())
+}
+
+fn configured_wall_threshold(config: &ConfigFile, bench: &perfgate_types::BenchConfigFile) -> f64 {
+    bench
+        .budgets
+        .as_ref()
+        .and_then(|budgets| budgets.get(&Metric::WallMs))
+        .and_then(|budget| budget.threshold)
+        .or(config.defaults.threshold)
+        .unwrap_or(0.20)
+}
+
+fn suggest_calibration(
+    cv: Option<f64>,
+    sample_count: usize,
+    configured_threshold: f64,
+) -> CalibrationSuggestion {
+    let fail_threshold = cv
+        .map(|cv| {
+            if cv <= 0.02 {
+                0.05
+            } else if cv <= 0.05 {
+                0.10
+            } else if cv <= 0.10 {
+                0.15
+            } else if cv <= 0.20 {
+                0.20
+            } else {
+                configured_threshold.max(0.30)
+            }
+        })
+        .unwrap_or(configured_threshold.max(0.20));
+    let noise_threshold = cv.map(|cv| (cv * 2.0).clamp(0.05, 0.30)).unwrap_or(0.08);
+    CalibrationSuggestion {
+        fail_threshold,
+        warn_factor: 0.50,
+        noise_threshold,
+        noise_policy: perfgate_types::NoisePolicy::Warn,
+        recommended_repeat: sample_count.max(10),
+        suggest_paired: cv.is_some_and(|cv| cv > 0.10),
+    }
+}
+
+fn measured_sample_count(receipt: &RunReceipt) -> usize {
+    receipt
+        .samples
+        .iter()
+        .filter(|sample| !sample.warmup)
+        .count()
+}
+
+fn host_class(receipt: &RunReceipt) -> String {
+    format!("{}-{}", receipt.run.host.os, receipt.run.host.arch)
+}
+
+fn format_percent(value: f64) -> String {
+    format!("{:.1}%", value * 100.0)
+}
+
 fn execute_doctor(args: DoctorArgs, server_flags: ServerFlags) -> anyhow::Result<()> {
     let mut checks = Vec::new();
     checks.push(DoctorCheck::ok(
@@ -3402,6 +3637,8 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 OutputMode::Cockpit => run_check_cockpit(req),
             }
         }
+
+        Command::Calibrate(args) => execute_calibrate(*args),
 
         Command::Doctor(args) => execute_doctor(*args, server_flags),
 

--- a/crates/perfgate-cli/tests/cli_calibrate_tests.rs
+++ b/crates/perfgate-cli/tests/cli_calibrate_tests.rs
@@ -1,0 +1,161 @@
+//! Integration tests for `perfgate calibrate`.
+
+use std::fs;
+use tempfile::tempdir;
+
+mod common;
+use common::perfgate_cmd;
+
+fn write_config(root: &std::path::Path) -> std::path::PathBuf {
+    let config_path = root.join("perfgate.toml");
+    fs::write(
+        &config_path,
+        r#"
+[defaults]
+repeat = 5
+warmup = 0
+threshold = 0.20
+out_dir = "artifacts/perfgate"
+
+[[bench]]
+name = "parser"
+command = ["echo", "parser"]
+"#,
+    )
+    .expect("write config");
+    config_path
+}
+
+fn write_run_receipt(path: &std::path::Path, bench_name: &str, mean: f64, stddev: f64) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create receipt parent");
+    }
+    let receipt = serde_json::json!({
+        "schema": "perfgate.run.v1",
+        "tool": {
+            "name": "perfgate",
+            "version": "0.18.0"
+        },
+        "run": {
+            "id": "run-id",
+            "started_at": "2026-01-01T00:00:00Z",
+            "ended_at": "2026-01-01T00:00:01Z",
+            "host": {
+                "os": "linux",
+                "arch": "x86_64"
+            }
+        },
+        "bench": {
+            "name": bench_name,
+            "command": ["echo", "parser"],
+            "repeat": 3,
+            "warmup": 0
+        },
+        "samples": [
+            {"wall_ms": 100, "exit_code": 0, "warmup": false, "timed_out": false},
+            {"wall_ms": 104, "exit_code": 0, "warmup": false, "timed_out": false},
+            {"wall_ms": 96, "exit_code": 0, "warmup": false, "timed_out": false}
+        ],
+        "stats": {
+            "wall_ms": {
+                "median": 100,
+                "min": 96,
+                "max": 104,
+                "mean": mean,
+                "stddev": stddev
+            }
+        }
+    });
+    fs::write(path, serde_json::to_string_pretty(&receipt).unwrap()).expect("write receipt");
+}
+
+#[test]
+fn calibrate_suggests_thresholds_from_existing_run_receipt() {
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_config(temp_dir.path());
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    let run_path = out_dir.join("parser").join("run.json");
+    write_run_receipt(&run_path, "parser", 100.0, 4.0);
+    write_run_receipt(
+        &temp_dir.path().join("baselines").join("parser.json"),
+        "parser",
+        100.0,
+        4.0,
+    );
+    let original_config = fs::read_to_string(&config_path).expect("read config");
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("calibrate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--bench")
+        .arg("parser");
+
+    let output = cmd.output().expect("run calibrate");
+    assert!(
+        output.status.success(),
+        "calibrate should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Bench: parser"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Samples: 3 measured samples"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("CV: 4.0%"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Suggested fail threshold: 10.0%"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Suggested warn threshold: 5.0%"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("noise_policy = \"warn\""),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Advisory only: no config was written."),
+        "stdout: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(&config_path).expect("read config after calibrate"),
+        original_config,
+        "calibrate must not edit config in the advisory-only version"
+    );
+}
+
+#[test]
+fn calibrate_handles_missing_run_receipt_with_next_check_command() {
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_config(temp_dir.path());
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("calibrate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--bench")
+        .arg("parser");
+
+    let output = cmd.output().expect("run calibrate");
+    assert!(
+        output.status.success(),
+        "calibrate should succeed without receipts: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Samples: unavailable"), "stdout: {stdout}");
+    assert!(stdout.contains("CV: unavailable"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("perfgate check --config"),
+        "stdout should include the next check command: {stdout}"
+    );
+    assert!(
+        stdout.contains("Advisory only: no config was written."),
+        "stdout: {stdout}"
+    );
+}

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -16,6 +16,7 @@ Commands:
   ratchet Preview or apply conservative budget ratcheting from compare evidence
   report Generate a cockpit-compatible report from a compare receipt
   check Config-driven one-command workflow
+  calibrate Suggest advisory thresholds and noise policy from existing receipts
   doctor Diagnose local setup, config, baselines, artifacts, CI, and server reachability
   paired Run paired benchmark: interleave baseline and current commands for reduced noise
   baseline Inspect local baselines and manage baselines on the baseline server
@@ -31,7 +32,7 @@ Commands:
   cargo-bench Wrap `cargo bench` and produce perfgate run receipts
   blame Analyze changes in Cargo.lock to identify dependency updates causing binary size regressions
   fleet Fleet-wide dependency regression analysis across projects
-  explain Provide AI-ready prompts and automated playbooks for diagnosing performance regressions
+  explain Provide AI-ready prompts, artifact explanations, and automated playbooks
   ingest Import benchmark results from external frameworks into perfgate format
   badge Generate an embeddable SVG status badge from a report or compare receipt
   discover Auto-detect benchmarks in a repository without manual configuration


### PR DESCRIPTION
## Summary
- adds advisory perfgate calibrate --config <path> --bench <name> output from existing run/baseline receipts
- reports samples, CV, host class, evidence paths, suggested fail/warn/noise thresholds, repeat guidance, and paired-mode guidance
- keeps the first version read-only: no config writes and no --write mode
- adds focused CLI coverage and updates the top-level help snapshot

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --all-features calibrate
- cargo +1.95.0 test -p perfgate-cli --all-features snapshot_help_main
- cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check