### PR TITLE
decision: add readiness suggestions

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1349,6 +1349,8 @@ pub enum TradeoffAction {
 
 #[derive(Debug, Subcommand)]
 pub enum DecisionAction {
+    /// Suggest whether structured decisions are useful for the current evidence.
+    Suggest(DecisionSuggestArgs),
     /// Evaluate configured scenarios and tradeoffs, then render decision markdown.
     Evaluate(DecisionEvaluateArgs),
     /// Export indexed decision evidence as one portable JSON bundle.
@@ -1411,6 +1413,17 @@ pub struct TradeoffEvaluateArgs {
     /// Pretty-print JSON.
     #[arg(long, default_value_t = false)]
     pub pretty: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DecisionSuggestArgs {
+    /// Path to perfgate.toml.
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Override artifact directory used for compare lookup.
+    #[arg(long)]
+    pub out_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -4325,6 +4338,7 @@ fn execute_decision_action(
     server_flags: &ServerFlags,
 ) -> anyhow::Result<()> {
     match action {
+        DecisionAction::Suggest(args) => execute_decision_suggest(args),
         DecisionAction::Evaluate(args) => execute_decision_evaluate(args),
         DecisionAction::Bundle(args) => execute_decision_bundle(args),
         DecisionAction::Upload(args) => execute_decision_upload(args, server_flags),
@@ -4333,6 +4347,284 @@ fn execute_decision_action(
         DecisionAction::Debt(args) => execute_decision_debt(args, server_flags),
         DecisionAction::Export(args) => execute_decision_export(args, server_flags),
         DecisionAction::Prune(args) => execute_decision_prune(args, server_flags),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DecisionReadiness {
+    RunLocalGateFirst,
+    SimpleGateEnough,
+    PairedModeRecommended,
+    StructuredDecisionCandidate,
+    StructuredDecisionReady,
+    ReadyToBundle,
+}
+
+impl DecisionReadiness {
+    fn status(self) -> &'static str {
+        match self {
+            Self::RunLocalGateFirst => "run_local_gate_first",
+            Self::SimpleGateEnough => "simple_gate_enough",
+            Self::PairedModeRecommended => "paired_mode_recommended",
+            Self::StructuredDecisionCandidate => "structured_decision_candidate",
+            Self::StructuredDecisionReady => "structured_decision_ready",
+            Self::ReadyToBundle => "ready_to_bundle",
+        }
+    }
+
+    fn meaning(self) -> &'static str {
+        match self {
+            Self::RunLocalGateFirst => {
+                "No compare receipts were found yet; run the local gate before making a decision."
+            }
+            Self::SimpleGateEnough => {
+                "The current evidence does not require structured decision ceremony."
+            }
+            Self::PairedModeRecommended => {
+                "The current evidence looks noisy; paired mode is a better next step than decision policy."
+            }
+            Self::StructuredDecisionCandidate => {
+                "Structured decisions may help, but scenario/tradeoff/probe evidence is not ready yet."
+            }
+            Self::StructuredDecisionReady => {
+                "Scenario and tradeoff policy are configured; decision evaluation is useful now."
+            }
+            Self::ReadyToBundle => {
+                "A decision index already exists; the evidence can be exported as a portable bundle."
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DecisionReadinessEvidence {
+    compare_found: usize,
+    compare_missing: usize,
+    has_regression: bool,
+    has_improvement: bool,
+    high_noise: bool,
+    has_probe_config: bool,
+    probe_receipts_found: usize,
+    decision_index_exists: bool,
+}
+
+fn execute_decision_suggest(args: DecisionSuggestArgs) -> anyhow::Result<()> {
+    let config = load_validated_config(&args.config)?;
+    let out_dir = args
+        .out_dir
+        .clone()
+        .unwrap_or_else(|| resolve_configured_out_dir(None, Some(&config)));
+    let evidence = collect_decision_readiness_evidence(&config, &out_dir)?;
+    let readiness = classify_decision_readiness(&config, &evidence);
+    let gaps = decision_readiness_gaps(&config, &evidence);
+
+    println!("perfgate decision suggest");
+    println!();
+    println!("Status: {}", readiness.status());
+    println!("Meaning: {}", readiness.meaning());
+    println!();
+    println!("Evidence:");
+    println!("  benches: {}", config.benches.len());
+    println!("  compare receipts found: {}", evidence.compare_found);
+    println!("  compare receipts missing: {}", evidence.compare_missing);
+    println!("  scenarios: {}", config.scenarios.len());
+    println!("  tradeoff rules: {}", config.tradeoffs.len());
+    println!(
+        "  probe evidence: {}",
+        if evidence.has_probe_config {
+            format!(
+                "configured, {} receipt{}",
+                evidence.probe_receipts_found,
+                plural(evidence.probe_receipts_found)
+            )
+        } else {
+            "not configured".to_string()
+        }
+    );
+    println!(
+        "  decision index: {}",
+        if evidence.decision_index_exists {
+            out_dir.join("decision.index.json").display().to_string()
+        } else {
+            "missing".to_string()
+        }
+    );
+    println!();
+    println!("Structured decisions may help if:");
+    println!("  - one benchmark regressed while another improved");
+    println!("  - reviewers need to accept a bounded tradeoff");
+    println!("  - probe or scenario evidence explains where work moved");
+    if !gaps.is_empty() {
+        println!();
+        println!("Not ready yet:");
+        for gap in &gaps {
+            println!("  - {gap}");
+        }
+    }
+    println!();
+    println!("Next:");
+    for command in decision_readiness_next_commands(readiness, &args.config, &out_dir) {
+        println!("  {command}");
+    }
+    println!("Do not:");
+    println!("  do not make structured decisions mandatory for simple local gates");
+
+    Ok(())
+}
+
+fn collect_decision_readiness_evidence(
+    config: &ConfigFile,
+    out_dir: &Path,
+) -> anyhow::Result<DecisionReadinessEvidence> {
+    let mut compare_found = 0usize;
+    let mut compare_missing = 0usize;
+    let mut has_regression = false;
+    let mut has_improvement = false;
+    let mut high_noise = false;
+
+    for (bench_name, path) in decision_compare_paths(config, out_dir) {
+        if !path.exists() {
+            compare_missing += 1;
+            continue;
+        }
+        compare_found += 1;
+        let compare: CompareReceipt = read_json(&path).with_context(|| {
+            format!("read compare receipt for {bench_name}: {}", path.display())
+        })?;
+        has_regression |= is_regression(compare.verdict.status);
+        has_improvement |= compare.deltas.values().any(|delta| delta.pct < 0.0);
+        high_noise |= compare
+            .deltas
+            .values()
+            .any(|delta| delta.cv.is_some_and(|cv| cv > 0.10));
+    }
+
+    let probe_paths = configured_decision_probe_paths(config);
+    let has_probe_config = !probe_paths.is_empty();
+    let probe_receipts_found = probe_paths.iter().filter(|path| path.exists()).count();
+
+    Ok(DecisionReadinessEvidence {
+        compare_found,
+        compare_missing,
+        has_regression,
+        has_improvement,
+        high_noise,
+        has_probe_config,
+        probe_receipts_found,
+        decision_index_exists: out_dir.join("decision.index.json").exists(),
+    })
+}
+
+fn decision_compare_paths(config: &ConfigFile, out_dir: &Path) -> Vec<(String, PathBuf)> {
+    let single_compare = out_dir.join(COMPARE_RECEIPT_FILE);
+    config
+        .benches
+        .iter()
+        .map(|bench| {
+            let per_bench = out_dir.join(&bench.name).join(COMPARE_RECEIPT_FILE);
+            let path = if config.benches.len() == 1 && single_compare.exists() {
+                single_compare.clone()
+            } else {
+                per_bench
+            };
+            (bench.name.clone(), path)
+        })
+        .collect()
+}
+
+fn configured_decision_probe_paths(config: &ConfigFile) -> Vec<PathBuf> {
+    config
+        .scenarios
+        .iter()
+        .flat_map(|scenario| {
+            [
+                scenario.probe_baseline.as_deref(),
+                scenario.probe_current.as_deref(),
+                scenario.probe_compare.as_deref(),
+            ]
+        })
+        .flatten()
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn classify_decision_readiness(
+    config: &ConfigFile,
+    evidence: &DecisionReadinessEvidence,
+) -> DecisionReadiness {
+    if evidence.decision_index_exists {
+        return DecisionReadiness::ReadyToBundle;
+    }
+    if evidence.compare_found == 0 {
+        return DecisionReadiness::RunLocalGateFirst;
+    }
+    if evidence.high_noise {
+        return DecisionReadiness::PairedModeRecommended;
+    }
+    if !config.scenarios.is_empty() && !config.tradeoffs.is_empty() {
+        return DecisionReadiness::StructuredDecisionReady;
+    }
+    if evidence.has_regression || evidence.has_improvement {
+        return DecisionReadiness::StructuredDecisionCandidate;
+    }
+    DecisionReadiness::SimpleGateEnough
+}
+
+fn decision_readiness_gaps(
+    config: &ConfigFile,
+    evidence: &DecisionReadinessEvidence,
+) -> Vec<&'static str> {
+    let mut gaps = Vec::new();
+    if evidence.compare_found == 0 {
+        gaps.push("no compare receipts found; run `perfgate check` first");
+    }
+    if config.scenarios.is_empty() {
+        gaps.push("no scenario weights configured");
+    }
+    if config.tradeoffs.is_empty() {
+        gaps.push("no tradeoff rules configured");
+    }
+    if !evidence.has_probe_config {
+        gaps.push("no probe evidence configured");
+    } else if evidence.probe_receipts_found == 0 {
+        gaps.push("configured probe evidence was not found on disk");
+    }
+    gaps
+}
+
+fn decision_readiness_next_commands(
+    readiness: DecisionReadiness,
+    config_path: &Path,
+    out_dir: &Path,
+) -> Vec<String> {
+    match readiness {
+        DecisionReadiness::RunLocalGateFirst => vec![format!(
+            "perfgate check --config {} --all --require-baseline",
+            shell_path(config_path)
+        )],
+        DecisionReadiness::SimpleGateEnough => vec![format!(
+            "perfgate check --config {} --all --require-baseline",
+            shell_path(config_path)
+        )],
+        DecisionReadiness::PairedModeRecommended => vec![
+            "perfgate paired --name <bench> --baseline-cmd \"<baseline-cmd>\" --current-cmd \"<current-cmd>\" --repeat 10 --out artifacts/perfgate/<bench>/paired.json".to_string(),
+            format!("perfgate calibrate --config {} --bench <bench>", shell_path(config_path)),
+        ],
+        DecisionReadiness::StructuredDecisionCandidate => vec![
+            "add scenario weights and tradeoff rules for the review question".to_string(),
+            "add probe evidence only if reviewers need to know where work moved".to_string(),
+        ],
+        DecisionReadiness::StructuredDecisionReady => vec![
+            format!("perfgate decision evaluate --config {}", shell_path(config_path)),
+            format!(
+                "perfgate decision bundle --index {}",
+                out_dir.join("decision.index.json").display()
+            ),
+        ],
+        DecisionReadiness::ReadyToBundle => vec![format!(
+            "perfgate decision bundle --index {}",
+            out_dir.join("decision.index.json").display()
+        )],
     }
 }
 

--- a/crates/perfgate-cli/tests/cli_decision_suggest_tests.rs
+++ b/crates/perfgate-cli/tests/cli_decision_suggest_tests.rs
@@ -1,0 +1,184 @@
+//! Integration tests for `perfgate decision suggest`.
+
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+mod common;
+use common::perfgate_cmd;
+
+fn write_basic_config(root: &Path) -> std::path::PathBuf {
+    let config_path = root.join("perfgate.toml");
+    fs::write(
+        &config_path,
+        r#"
+[defaults]
+out_dir = "artifacts/perfgate"
+
+[[bench]]
+name = "parser"
+command = ["echo", "parser"]
+"#,
+    )
+    .expect("write config");
+    config_path
+}
+
+fn write_decision_ready_config(root: &Path) -> std::path::PathBuf {
+    let config_path = root.join("perfgate.toml");
+    fs::write(
+        &config_path,
+        r#"
+[defaults]
+out_dir = "artifacts/perfgate"
+
+[[bench]]
+name = "parser"
+command = ["echo", "parser"]
+
+[[scenario]]
+name = "release"
+bench = "parser"
+weight = 1.0
+compare = "artifacts/perfgate/parser/compare.json"
+probe_baseline = "artifacts/perfgate/parser/probes-baseline.json"
+probe_current = "artifacts/perfgate/parser/probes-current.json"
+probe_compare = "artifacts/perfgate/parser/probe-compare.json"
+
+[[tradeoff]]
+name = "parser tradeoff"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+min_improvement_ratio = 1.05
+
+[[tradeoff.allow]]
+probe = "parser.tokenize"
+metric = "wall_ms"
+max_regression = 0.03
+"#,
+    )
+    .expect("write config");
+    config_path
+}
+
+fn write_compare_receipt(path: &Path, status: &str, baseline: f64, current: f64) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create compare parent");
+    }
+    let fail = u32::from(status == "fail");
+    let warn = u32::from(status == "warn");
+    let pass = u32::from(status == "pass");
+    let regression = if current > baseline {
+        (current - baseline) / baseline
+    } else {
+        0.0
+    };
+    let receipt = serde_json::json!({
+        "schema": "perfgate.compare.v1",
+        "tool": {"name": "perfgate", "version": "0.18.0"},
+        "bench": {
+            "name": "parser",
+            "command": ["echo", "parser"],
+            "repeat": 1,
+            "warmup": 0
+        },
+        "baseline_ref": {"path": "baselines/parser.json", "run_id": "baseline"},
+        "current_ref": {"path": "artifacts/perfgate/parser/run.json", "run_id": "current"},
+        "budgets": {},
+        "deltas": {
+            "wall_ms": {
+                "baseline": baseline,
+                "current": current,
+                "ratio": current / baseline,
+                "pct": (current - baseline) / baseline,
+                "regression": regression,
+                "status": status
+            }
+        },
+        "verdict": {
+            "status": status,
+            "counts": {"pass": pass, "warn": warn, "fail": fail, "skip": 0},
+            "reasons": []
+        }
+    });
+    fs::write(path, serde_json::to_string_pretty(&receipt).unwrap()).expect("write compare");
+}
+
+#[test]
+fn decision_suggest_tells_user_to_run_local_gate_first_without_compares() {
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_basic_config(temp_dir.path());
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("decision")
+        .arg("suggest")
+        .arg("--config")
+        .arg(&config_path);
+
+    let output = cmd.output().expect("run decision suggest");
+    assert!(
+        output.status.success(),
+        "decision suggest should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Status: run_local_gate_first"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("no compare receipts found"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("perfgate check --config"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn decision_suggest_reports_structured_decision_ready_when_policy_and_evidence_exist() {
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_decision_ready_config(temp_dir.path());
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    write_compare_receipt(
+        &out_dir.join("parser").join("compare.json"),
+        "fail",
+        100.0,
+        115.0,
+    );
+    fs::write(out_dir.join("parser").join("probes-baseline.json"), "{}").expect("write probe");
+    fs::write(out_dir.join("parser").join("probes-current.json"), "{}").expect("write probe");
+    fs::write(out_dir.join("parser").join("probe-compare.json"), "{}").expect("write probe");
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("decision")
+        .arg("suggest")
+        .arg("--config")
+        .arg(&config_path);
+
+    let output = cmd.output().expect("run decision suggest");
+    assert!(
+        output.status.success(),
+        "decision suggest should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Status: structured_decision_ready"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("perfgate decision evaluate --config"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("probe evidence: configured, 3 receipts"),
+        "stdout: {stdout}"
+    );
+}

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_decision.snap
@@ -8,6 +8,7 @@ Evaluate scenario and tradeoff evidence into a review-ready decision summary
 Usage: perfgate decision [OPTIONS] <COMMAND>
 
 Commands:
+  suggest Suggest whether structured decisions are useful for the current evidence
   evaluate Evaluate configured scenarios and tradeoffs, then render decision markdown
   bundle Export indexed decision evidence as one portable JSON bundle
   upload Upload a perfgate.tradeoff.v1 receipt to the baseline server decision ledger


### PR DESCRIPTION
## Summary
- adds read-only perfgate decision suggest --config <path> readiness output
- classifies whether to run the local gate first, stay with a simple gate, use paired mode, move into structured decisions, or bundle existing evidence
- reports compare/scenario/tradeoff/probe/decision-index evidence and concrete next commands
- adds focused CLI tests and updates the decision help snapshot

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --all-features decision_suggest
- cargo +1.95.0 test -p perfgate-cli --all-features snapshot_help_decision
- cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check