### PR TITLE
probes: add starter templates

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1318,8 +1318,33 @@ pub enum IngestCommand {
 
 #[derive(Debug, Subcommand)]
 pub enum ProbeAction {
+    /// Generate reviewable probe JSONL and policy starter templates.
+    Init(ProbeInitArgs),
     /// Compare two perfgate.probe.v1 receipts into a perfgate.probe_compare.v1 receipt.
     Compare(ProbeCompareArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct ProbeInitArgs {
+    /// Starter template to generate.
+    #[arg(long, value_enum)]
+    pub template: ProbeTemplate,
+
+    /// Directory for generated probe starter files.
+    #[arg(long, default_value = "perfgate-probes")]
+    pub out_dir: PathBuf,
+
+    /// Overwrite existing generated files.
+    #[arg(long, default_value_t = false)]
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProbeTemplate {
+    Parser,
+    Batch,
+    Cli,
+    Server,
 }
 
 #[derive(Debug, Subcommand)]
@@ -3989,8 +4014,242 @@ fn execute_ingest_probes(args: IngestProbesArgs) -> anyhow::Result<()> {
 
 fn execute_probe_action(action: ProbeAction) -> anyhow::Result<()> {
     match action {
+        ProbeAction::Init(args) => execute_probe_init(args),
         ProbeAction::Compare(args) => execute_probe_compare(args),
     }
+}
+
+fn execute_probe_init(args: ProbeInitArgs) -> anyhow::Result<()> {
+    let template = probe_template(args.template);
+    fs::create_dir_all(&args.out_dir)
+        .with_context(|| format!("create probe template directory {}", args.out_dir.display()))?;
+
+    write_probe_template_file(
+        &args.out_dir.join("README.md"),
+        &render_probe_template_readme(&template, &args.out_dir),
+        args.force,
+    )?;
+    write_probe_template_file(
+        &args.out_dir.join("probes-baseline.jsonl"),
+        &format!("{}\n", template.baseline_jsonl.join("\n")),
+        args.force,
+    )?;
+    write_probe_template_file(
+        &args.out_dir.join("probes-current.jsonl"),
+        &format!("{}\n", template.current_jsonl.join("\n")),
+        args.force,
+    )?;
+    write_probe_template_file(
+        &args.out_dir.join("scenario.toml"),
+        &render_probe_template_scenario(&template),
+        args.force,
+    )?;
+    write_probe_template_file(
+        &args.out_dir.join("tradeoff.toml"),
+        &render_probe_template_tradeoff(&template),
+        args.force,
+    )?;
+
+    eprintln!(
+        "Probe starter template '{}' written to {}",
+        template.slug,
+        args.out_dir.display()
+    );
+    eprintln!("Review the generated snippets before adding them to perfgate.toml.");
+    eprintln!(
+        "Next: perfgate ingest probes --file {}/probes-current.jsonl --out artifacts/perfgate/probes-current.json",
+        args.out_dir.display()
+    );
+    Ok(())
+}
+
+fn write_probe_template_file(path: &Path, content: &str, force: bool) -> anyhow::Result<()> {
+    if path.exists() && !force {
+        anyhow::bail!(
+            "{} already exists; pass --force to overwrite generated probe starter files",
+            path.display()
+        );
+    }
+
+    fs::write(path, content).with_context(|| format!("write probe template {}", path.display()))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ProbeStarterTemplate {
+    slug: &'static str,
+    title: &'static str,
+    bench: &'static str,
+    scenario: &'static str,
+    workload: &'static str,
+    dominant_probe: &'static str,
+    local_probe: &'static str,
+    support_probe: &'static str,
+    baseline_jsonl: &'static [&'static str],
+    current_jsonl: &'static [&'static str],
+}
+
+fn probe_template(template: ProbeTemplate) -> ProbeStarterTemplate {
+    match template {
+        ProbeTemplate::Parser => ProbeStarterTemplate {
+            slug: "parser",
+            title: "Parser pipeline probes",
+            bench: "parser",
+            scenario: "large_file_parse",
+            workload: "large-file parser throughput",
+            dominant_probe: "parser.batch_loop",
+            local_probe: "parser.tokenize",
+            support_probe: "parser.ast_build",
+            baseline_jsonl: &[
+                r#"{"probe":"parser.tokenize","scope":"local","wall_ms":12.4,"items":10000}"#,
+                r#"{"probe":"parser.ast_build","scope":"local","wall_ms":28.2,"items":10000}"#,
+                r#"{"probe":"parser.batch_loop","scope":"dominant","wall_ms":44.8,"items":10000}"#,
+            ],
+            current_jsonl: &[
+                r#"{"probe":"parser.tokenize","scope":"local","wall_ms":12.8,"items":10000}"#,
+                r#"{"probe":"parser.ast_build","scope":"local","wall_ms":27.5,"items":10000}"#,
+                r#"{"probe":"parser.batch_loop","scope":"dominant","wall_ms":39.6,"items":10000}"#,
+            ],
+        },
+        ProbeTemplate::Batch => ProbeStarterTemplate {
+            slug: "batch",
+            title: "Batch processing probes",
+            bench: "batch",
+            scenario: "batch_transform",
+            workload: "batch transform throughput",
+            dominant_probe: "batch.transform",
+            local_probe: "batch.read_inputs",
+            support_probe: "batch.write_outputs",
+            baseline_jsonl: &[
+                r#"{"probe":"batch.read_inputs","scope":"local","wall_ms":18.0,"items":5000}"#,
+                r#"{"probe":"batch.transform","scope":"dominant","wall_ms":92.0,"items":5000}"#,
+                r#"{"probe":"batch.write_outputs","scope":"local","wall_ms":26.0,"items":5000}"#,
+            ],
+            current_jsonl: &[
+                r#"{"probe":"batch.read_inputs","scope":"local","wall_ms":18.4,"items":5000}"#,
+                r#"{"probe":"batch.transform","scope":"dominant","wall_ms":82.0,"items":5000}"#,
+                r#"{"probe":"batch.write_outputs","scope":"local","wall_ms":25.2,"items":5000}"#,
+            ],
+        },
+        ProbeTemplate::Cli => ProbeStarterTemplate {
+            slug: "cli",
+            title: "CLI workflow probes",
+            bench: "cli-command",
+            scenario: "cli_user_path",
+            workload: "CLI command response path",
+            dominant_probe: "cli.execute",
+            local_probe: "cli.parse_args",
+            support_probe: "cli.render_output",
+            baseline_jsonl: &[
+                r#"{"probe":"cli.parse_args","scope":"local","wall_ms":3.2,"items":1}"#,
+                r#"{"probe":"cli.execute","scope":"dominant","wall_ms":42.0,"items":1}"#,
+                r#"{"probe":"cli.render_output","scope":"local","wall_ms":5.8,"items":1}"#,
+            ],
+            current_jsonl: &[
+                r#"{"probe":"cli.parse_args","scope":"local","wall_ms":3.3,"items":1}"#,
+                r#"{"probe":"cli.execute","scope":"dominant","wall_ms":37.8,"items":1}"#,
+                r#"{"probe":"cli.render_output","scope":"local","wall_ms":5.9,"items":1}"#,
+            ],
+        },
+        ProbeTemplate::Server => ProbeStarterTemplate {
+            slug: "server",
+            title: "Server request probes",
+            bench: "server-request",
+            scenario: "server_local_request",
+            workload: "controlled local server request path",
+            dominant_probe: "server.handle_request",
+            local_probe: "server.decode_request",
+            support_probe: "server.encode_response",
+            baseline_jsonl: &[
+                r#"{"probe":"server.decode_request","scope":"local","wall_ms":4.4,"items":100}"#,
+                r#"{"probe":"server.handle_request","scope":"dominant","wall_ms":31.0,"items":100}"#,
+                r#"{"probe":"server.encode_response","scope":"local","wall_ms":6.5,"items":100}"#,
+            ],
+            current_jsonl: &[
+                r#"{"probe":"server.decode_request","scope":"local","wall_ms":4.5,"items":100}"#,
+                r#"{"probe":"server.handle_request","scope":"dominant","wall_ms":27.0,"items":100}"#,
+                r#"{"probe":"server.encode_response","scope":"local","wall_ms":6.7,"items":100}"#,
+            ],
+        },
+    }
+}
+
+fn render_probe_template_readme(template: &ProbeStarterTemplate, out_dir: &Path) -> String {
+    let out_dir = out_dir.display();
+    format!(
+        r#"# {title}
+
+This starter shows a small probe set for {workload}. Review and edit the probe
+names before using them in durable decision policy.
+
+Generated files:
+
+- `probes-baseline.jsonl`: reviewed baseline probe events
+- `probes-current.jsonl`: current-run probe events for local experimentation
+- `scenario.toml`: scenario snippet to copy into `perfgate.toml`
+- `tradeoff.toml`: tradeoff snippet to copy into `perfgate.toml`
+
+Next:
+
+```bash
+perfgate ingest probes --file {out_dir}/probes-baseline.jsonl --out baselines/probes.json
+perfgate ingest probes --file {out_dir}/probes-current.jsonl --out artifacts/perfgate/probes-current.json
+perfgate probe compare --baseline baselines/probes.json --current artifacts/perfgate/probes-current.json --out artifacts/perfgate/probe-compare.json
+perfgate decision suggest --config perfgate.toml
+```
+
+Do not:
+
+- keep probes that no reviewer can act on;
+- use generated sample values as release proof;
+- turn a temporary debugging span into a durable probe id.
+"#,
+        title = template.title,
+        workload = template.workload,
+        out_dir = out_dir
+    )
+}
+
+fn render_probe_template_scenario(template: &ProbeStarterTemplate) -> String {
+    format!(
+        r#"# Copy into perfgate.toml after reviewing paths and names.
+[[scenario]]
+name = "{scenario}"
+bench = "{bench}"
+weight = 1.0
+probe_baseline = "baselines/probes.json"
+probe_current = "artifacts/perfgate/probes-current.json"
+probe_compare = "artifacts/perfgate/probe-compare.json"
+"#,
+        scenario = template.scenario,
+        bench = template.bench
+    )
+}
+
+fn render_probe_template_tradeoff(template: &ProbeStarterTemplate) -> String {
+    format!(
+        r#"# Copy into perfgate.toml only when reviewers need a bounded tradeoff.
+[[tradeoff]]
+name = "{slug}-dominant-probe-improvement"
+if_failed = "wall_ms"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+probe = "{dominant_probe}"
+min_improvement_ratio = 1.10
+
+[[tradeoff.allow]]
+metric = "wall_ms"
+probe = "{local_probe}"
+max_regression = 0.03
+
+# Supporting probe to keep visible in reviews: {support_probe}
+"#,
+        slug = template.slug,
+        dominant_probe = template.dominant_probe,
+        local_probe = template.local_probe,
+        support_probe = template.support_probe
+    )
 }
 
 fn execute_probe_compare(args: ProbeCompareArgs) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -391,7 +391,22 @@ fn cli_help_probe() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Compare named probe receipts"))
+        .stdout(predicate::str::contains("init"))
         .stdout(predicate::str::contains("compare"));
+}
+
+#[test]
+fn cli_help_probe_init() {
+    perfgate_cmd()
+        .args(["probe", "init", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Generate reviewable probe JSONL and policy starter templates",
+        ))
+        .stdout(predicate::str::contains("--template"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--force"));
 }
 
 #[test]
@@ -583,6 +598,11 @@ fn snapshot_help_decision_bundle() {
 #[test]
 fn snapshot_help_probe() {
     insta::assert_snapshot!("help_probe", help_output(&["probe", "--help"]));
+}
+
+#[test]
+fn snapshot_help_probe_init() {
+    insta::assert_snapshot!("help_probe_init", help_output(&["probe", "init", "--help"]));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_probe_tests.rs
+++ b/crates/perfgate-cli/tests/cli_probe_tests.rs
@@ -10,6 +10,81 @@ use std::path::Path;
 use tempfile::tempdir;
 
 #[test]
+fn test_probe_init_writes_starter_template_files() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let out_dir = temp_dir.path().join("probe-starter");
+
+    perfgate_cmd()
+        .arg("probe")
+        .arg("init")
+        .arg("--template")
+        .arg("parser")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Probe starter template 'parser' written",
+        ))
+        .stderr(predicate::str::contains("Review the generated snippets"));
+
+    let readme = fs::read_to_string(out_dir.join("README.md")).expect("read template readme");
+    let baseline =
+        fs::read_to_string(out_dir.join("probes-baseline.jsonl")).expect("read baseline jsonl");
+    let current =
+        fs::read_to_string(out_dir.join("probes-current.jsonl")).expect("read current jsonl");
+    let scenario = fs::read_to_string(out_dir.join("scenario.toml")).expect("read scenario toml");
+    let tradeoff = fs::read_to_string(out_dir.join("tradeoff.toml")).expect("read tradeoff toml");
+
+    assert!(readme.contains("perfgate ingest probes"));
+    assert!(baseline.contains("\"probe\":\"parser.tokenize\""));
+    assert!(current.contains("\"probe\":\"parser.batch_loop\""));
+    assert!(scenario.contains("name = \"large_file_parse\""));
+    assert!(scenario.contains("probe_compare = \"artifacts/perfgate/probe-compare.json\""));
+    assert!(tradeoff.contains("probe = \"parser.batch_loop\""));
+    assert!(tradeoff.contains("max_regression = 0.03"));
+}
+
+#[test]
+fn test_probe_init_refuses_to_overwrite_without_force() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let out_dir = temp_dir.path().join("probe-starter");
+
+    perfgate_cmd()
+        .arg("probe")
+        .arg("init")
+        .arg("--template")
+        .arg("batch")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .assert()
+        .success();
+
+    perfgate_cmd()
+        .arg("probe")
+        .arg("init")
+        .arg("--template")
+        .arg("batch")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"))
+        .stderr(predicate::str::contains("--force"));
+
+    perfgate_cmd()
+        .arg("probe")
+        .arg("init")
+        .arg("--template")
+        .arg("batch")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--force")
+        .assert()
+        .success();
+}
+
+#[test]
 fn test_probe_compare_writes_probe_compare_receipt() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let baseline_path = temp_dir.path().join("baseline-probes.json");

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_probe_init.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_probe_init.snap
@@ -1,18 +1,16 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 600
-expression: "help_output(&[\"probe\", \"--help\"])"
+assertion_line: 605
+expression: "help_output(&[\"probe\", \"init\", \"--help\"])"
 ---
-Compare named probe receipts and emit probe-level deltas
+Generate reviewable probe JSONL and policy starter templates
 
-Usage: perfgate probe [OPTIONS] <COMMAND>
-
-Commands:
-  init Generate reviewable probe JSONL and policy starter templates
-  compare Compare two perfgate.probe.v1 receipts into a perfgate.probe_compare.v1 receipt
-  help Print this message or the help of the given subcommand(s)
+Usage: perfgate probe init [OPTIONS] --template <TEMPLATE>
 
 Options:
+      --template <TEMPLATE> Starter template to generate [possible values: parser, batch, cli, server]
+      --out-dir <OUT_DIR> Directory for generated probe starter files [default: perfgate-probes]
+      --force Overwrite existing generated files
   -h, --help Print help
 
 Global Options:

--- a/docs/PROBE_QUICKSTART.md
+++ b/docs/PROBE_QUICKSTART.md
@@ -15,6 +15,15 @@ For guidance on where to put those first probes, stable naming, and bad probe
 shapes to avoid, see
 [`PROBE_DESIGN_PATTERNS.md`](PROBE_DESIGN_PATTERNS.md).
 
+If you want starter files instead of a blank page, generate a reviewed template:
+
+```bash
+perfgate probe init --template parser --out-dir perfgate-probes
+```
+
+Templates are examples, not policy. Review the generated probe names, JSONL,
+scenario snippet, and tradeoff snippet before committing them.
+
 ## 1. Pick Stable Probe Names
 
 Use names that describe durable work, not temporary function names:


### PR DESCRIPTION
## Summary
- add perfgate probe init --template parser|batch|cli|server starter generation under the existing singular probe namespace
- generate reviewed JSONL, scenario, tradeoff, and README starter files without auto-editing config
- document the starter path in the probe quickstart and cover help snapshots/overwrite behavior

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --test cli_probe_tests --all-features probe_init
- cargo +1.95.0 test -p perfgate-cli --all-features snapshot_help_probe
- cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

## Notes
- Uses perfgate probe init instead of a new top-level probes command to preserve the existing CLI namespace.
- The first doc-test attempt timed out while competing for Cargo locks during parallel validation; the serial rerun passed.