### PR TITLE
ledger: add optional readiness doctor

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -486,6 +486,12 @@ enum Command {
     /// dashboard in the default browser unless --no-open is passed.
     Serve(Box<ServeArgs>),
 
+    /// Inspect optional decision-ledger readiness without making it required.
+    Ledger {
+        #[command(subcommand)]
+        action: LedgerAction,
+    },
+
     /// Validate computational complexity (scaling behavior) of a benchmark.
     ///
     /// Runs a command at multiple input sizes, fits complexity models (O(1)
@@ -714,6 +720,27 @@ pub struct ServeArgs {
     /// Do not open the browser automatically
     #[arg(long, default_value_t = false)]
     pub no_open: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LedgerAction {
+    /// Report optional server-ledger readiness and next actions.
+    Doctor(LedgerDoctorArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LedgerDoctorArgs {
+    /// Path to perfgate.toml.
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Artifact directory used to verify local receipt readiness.
+    #[arg(long, default_value = DEFAULT_ARTIFACT_DIR)]
+    pub out_dir: PathBuf,
+
+    /// Report configured state without contacting the server.
+    #[arg(long, default_value_t = false)]
+    pub offline: bool,
 }
 
 #[derive(Debug, Args)]
@@ -3830,6 +3857,7 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
         }
 
         Command::Decision { action } => execute_decision_action(action, &server_flags),
+        Command::Ledger { action } => execute_ledger_action(action, &server_flags),
         Command::Probe { action } => execute_probe_action(action),
         Command::Scenario { action } => execute_scenario_action(action),
         Command::Tradeoff { action } => execute_tradeoff_action(action),
@@ -4607,6 +4635,225 @@ fn execute_decision_action(
         DecisionAction::Export(args) => execute_decision_export(args, server_flags),
         DecisionAction::Prune(args) => execute_decision_prune(args, server_flags),
     }
+}
+
+fn execute_ledger_action(action: LedgerAction, server_flags: &ServerFlags) -> anyhow::Result<()> {
+    match action {
+        LedgerAction::Doctor(args) => execute_ledger_doctor(args, server_flags),
+    }
+}
+
+fn execute_ledger_doctor(args: LedgerDoctorArgs, server_flags: &ServerFlags) -> anyhow::Result<()> {
+    let config = if args.config.exists() {
+        load_config_file(&args.config)
+            .with_context(|| format!("load ledger doctor config {}", args.config.display()))?
+    } else {
+        ConfigFile::default()
+    };
+    let server_config = server_flags.resolve(&config.baseline_server);
+
+    println!("perfgate ledger doctor");
+    print_ledger_readiness_line(
+        "Local receipts",
+        match ensure_artifact_dir_writable(&args.out_dir) {
+            Ok(()) => format!("ready ({} writable)", args.out_dir.display()),
+            Err(error) => format!(
+                "not ready ({} not writable: {error})",
+                args.out_dir.display()
+            ),
+        },
+    );
+
+    if !server_config.is_configured() {
+        print_ledger_readiness_line("Server URL", "missing");
+        print_ledger_readiness_line("API key", "not configured");
+        print_ledger_readiness_line("Project", "not configured");
+        print_ledger_readiness_line(
+            "Upload mode",
+            "local receipts only; server ledger is optional team history",
+        );
+        print_ledger_readiness_line("History", "not checked; no server URL configured");
+        print_ledger_readiness_line("Export", "not checked; no server URL configured");
+        print_ledger_readiness_line("Prune dry-run", "not checked; no server URL configured");
+        print_ledger_next(&[
+            "You do not need server mode yet.",
+            "Use `perfgate decision bundle` when decision evidence needs to travel.",
+        ]);
+        print_ledger_do_not();
+        return Ok(());
+    }
+
+    let url = server_config
+        .url
+        .as_deref()
+        .expect("checked by is_configured");
+    print_ledger_readiness_line("Server URL", format!("configured ({url})"));
+    print_ledger_readiness_line(
+        "API key",
+        if server_config.api_key.is_some() {
+            "present"
+        } else {
+            "missing; okay only for local unauthenticated server mode"
+        },
+    );
+    let project = server_config.project.as_deref();
+    print_ledger_readiness_line("Project", project.unwrap_or("missing"));
+    print_ledger_readiness_line(
+        "Upload mode",
+        if server_config.fallback_to_local {
+            "advisory (fallback_to_local = true); local receipts remain primary"
+        } else {
+            "server operations are explicit; local receipts remain primary"
+        },
+    );
+
+    if args.offline {
+        print_ledger_readiness_line("Health", "not checked (--offline)");
+        print_ledger_readiness_line("History", "not checked (--offline)");
+        print_ledger_readiness_line("Export", "not checked (--offline)");
+        print_ledger_readiness_line("Prune dry-run", "not checked (--offline)");
+        print_ledger_next(&["Run without `--offline` when you want reachability checks."]);
+        print_ledger_do_not();
+        return Ok(());
+    }
+
+    let client = match ledger_doctor_client(&server_config) {
+        Ok(client) => client,
+        Err(error) => {
+            print_ledger_readiness_line("Health", format!("not checkable: {error:#}"));
+            print_ledger_readiness_line("History", "not checked; client setup failed");
+            print_ledger_readiness_line("Export", "not checked; client setup failed");
+            print_ledger_readiness_line("Prune dry-run", "not checked; client setup failed");
+            print_ledger_next(&["Fix the server URL or use local receipts only."]);
+            print_ledger_do_not();
+            return Ok(());
+        }
+    };
+
+    match with_tokio_runtime(async { client.health_check().await.map_err(anyhow::Error::from) }) {
+        Ok(health) if health.status == "healthy" => {
+            print_ledger_readiness_line("Health", "reachable");
+        }
+        Ok(health) => {
+            print_ledger_readiness_line(
+                "Health",
+                format!("unhealthy response ({})", health.status),
+            );
+        }
+        Err(error) => {
+            print_ledger_readiness_line("Health", format!("unreachable: {error:#}"));
+            print_ledger_readiness_line("History", "not checked; health failed");
+            print_ledger_readiness_line("Export", "not checked; health failed");
+            print_ledger_readiness_line("Prune dry-run", "not checked; health failed");
+            print_ledger_next(&[
+                "Keep local receipts and retry ledger checks after the server is healthy.",
+            ]);
+            print_ledger_do_not();
+            return Ok(());
+        }
+    }
+
+    let Some(project) = project else {
+        print_ledger_readiness_line("History", "not checked; project missing");
+        print_ledger_readiness_line("Export", "not checked; project missing");
+        print_ledger_readiness_line("Prune dry-run", "not checked; project missing");
+        print_ledger_next(&[
+            "Set `--project`, `PERFGATE_PROJECT`, or `[baseline_server].project`.",
+        ]);
+        print_ledger_do_not();
+        return Ok(());
+    };
+
+    let history_result = with_tokio_runtime(async {
+        client
+            .list_decisions(project, &ListDecisionsQuery::new().with_limit(1))
+            .await
+            .map_err(anyhow::Error::from)
+    });
+    match history_result {
+        Ok(response) => {
+            print_ledger_readiness_line(
+                "History",
+                format!(
+                    "reachable ({} decision record(s) visible)",
+                    response.pagination.total
+                ),
+            );
+            print_ledger_readiness_line("Export", "available through decision export");
+        }
+        Err(error) => {
+            print_ledger_readiness_line("History", format!("not reachable: {error:#}"));
+            print_ledger_readiness_line("Export", "not available until history is reachable");
+        }
+    }
+
+    let prune_result = with_tokio_runtime(async {
+        client
+            .prune_decisions(
+                project,
+                &PruneDecisionsRequest {
+                    older_than: chrono::Utc::now(),
+                    dry_run: true,
+                },
+            )
+            .await
+            .map_err(anyhow::Error::from)
+    });
+    match prune_result {
+        Ok(response) => {
+            print_ledger_readiness_line(
+                "Prune dry-run",
+                format!(
+                    "available ({} record(s) matched; dry-run deleted {})",
+                    response.matched, response.deleted
+                ),
+            );
+        }
+        Err(error) => {
+            print_ledger_readiness_line("Prune dry-run", format!("not available: {error:#}"));
+        }
+    }
+
+    print_ledger_next(&[
+        "Use `perfgate decision upload` only after local decision receipts are reviewed.",
+        "Use `perfgate decision history`, `export`, and `prune --dry-run` for team operations.",
+    ]);
+    print_ledger_do_not();
+    Ok(())
+}
+
+fn ledger_doctor_client(server_config: &ResolvedServerConfig) -> anyhow::Result<BaselineClient> {
+    let url = server_config
+        .url
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!(BASELINE_SERVER_NOT_CONFIGURED))?;
+    let mut client_config = ClientConfig::new(url)
+        .with_timeout(Duration::from_secs(2))
+        .with_retry(RetryConfig::new().with_max_retries(0));
+    if let Some(api_key) = &server_config.api_key {
+        client_config = client_config.with_api_key(api_key);
+    }
+    BaselineClient::new(client_config)
+        .with_context(|| format!("create ledger doctor client for {url}"))
+}
+
+fn print_ledger_readiness_line(label: &str, value: impl AsRef<str>) {
+    println!("{label}: {}", value.as_ref());
+}
+
+fn print_ledger_next(lines: &[&str]) {
+    println!();
+    println!("Next:");
+    for line in lines {
+        println!("  {line}");
+    }
+}
+
+fn print_ledger_do_not() {
+    println!();
+    println!("Do not:");
+    println!("  make the server ledger part of local correctness.");
+    println!("  rerun benchmarks only to repair optional ledger uploads.");
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -22,6 +22,7 @@ fn cli_help_main() {
         .stdout(predicate::str::contains("compare"))
         .stdout(predicate::str::contains("check"))
         .stdout(predicate::str::contains("doctor"))
+        .stdout(predicate::str::contains("ledger"))
         .stdout(predicate::str::contains("paired"))
         .stdout(predicate::str::contains("audit"))
         .stdout(predicate::str::contains("probe"))
@@ -385,6 +386,32 @@ fn cli_help_decision_bundle() {
 }
 
 #[test]
+fn cli_help_ledger() {
+    perfgate_cmd()
+        .args(["ledger", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Inspect optional decision-ledger readiness",
+        ))
+        .stdout(predicate::str::contains("doctor"));
+}
+
+#[test]
+fn cli_help_ledger_doctor() {
+    perfgate_cmd()
+        .args(["ledger", "doctor", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Report optional server-ledger readiness",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--offline"));
+}
+
+#[test]
 fn cli_help_probe() {
     perfgate_cmd()
         .args(["probe", "--help"])
@@ -592,6 +619,19 @@ fn snapshot_help_decision_bundle() {
     insta::assert_snapshot!(
         "help_decision_bundle",
         help_output(&["decision", "bundle", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_ledger() {
+    insta::assert_snapshot!("help_ledger", help_output(&["ledger", "--help"]));
+}
+
+#[test]
+fn snapshot_help_ledger_doctor() {
+    insta::assert_snapshot!(
+        "help_ledger_doctor",
+        help_output(&["ledger", "doctor", "--help"])
     );
 }
 

--- a/crates/perfgate-cli/tests/cli_server_tests.rs
+++ b/crates/perfgate-cli/tests/cli_server_tests.rs
@@ -197,6 +197,55 @@ fn assert_root_health_is_healthy(root_url: &str) {
     );
 }
 
+#[test]
+fn test_ledger_doctor_says_server_mode_is_optional_without_config() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path()).arg("ledger").arg("doctor");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("perfgate ledger doctor"))
+        .stdout(predicate::str::contains("Local receipts: ready"))
+        .stdout(predicate::str::contains("Server URL: missing"))
+        .stdout(predicate::str::contains("You do not need server mode yet."))
+        .stdout(predicate::str::contains(
+            "make the server ledger part of local correctness",
+        ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_ledger_doctor_reports_configured_server_readiness() {
+    let temp_dir = TempDir::new().expect("failed to create temp dir");
+    let project = unique_project("ledger-doctor");
+    let api_key = admin_key();
+    let config = ServerConfig::new()
+        .storage_backend(StorageBackend::Memory)
+        .scoped_api_key(&api_key, Role::Admin, &project, None);
+    let server = RunningTestServer::spawn(config).await;
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("--baseline-server")
+        .arg(server.url())
+        .arg("--api-key")
+        .arg(&api_key)
+        .arg("--project")
+        .arg(&project)
+        .arg("ledger")
+        .arg("doctor");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Server URL: configured"))
+        .stdout(predicate::str::contains("API key: present"))
+        .stdout(predicate::str::contains(format!("Project: {project}")))
+        .stdout(predicate::str::contains("Health: reachable"))
+        .stdout(predicate::str::contains("History: reachable"))
+        .stdout(predicate::str::contains("Export: available"))
+        .stdout(predicate::str::contains("Prune dry-run: available"))
+        .stdout(predicate::str::contains("local receipts remain primary"));
+}
+
 /// Test that `--upload` fails without `--baseline-server` configured.
 #[test]
 fn test_upload_requires_baseline_server() {

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_ledger.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_ledger.snap
@@ -1,0 +1,20 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 627
+expression: "help_output(&[\"ledger\", \"--help\"])"
+---
+Inspect optional decision-ledger readiness without making it required
+
+Usage: perfgate ledger [OPTIONS] <COMMAND>
+
+Commands:
+  doctor Report optional server-ledger readiness and next actions
+  help Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_ledger_doctor.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_ledger_doctor.snap
@@ -1,0 +1,19 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 632
+expression: "help_output(&[\"ledger\", \"doctor\", \"--help\"])"
+---
+Report optional server-ledger readiness and next actions
+
+Usage: perfgate ledger doctor [OPTIONS]
+
+Options:
+      --config <CONFIG> Path to perfgate.toml [default: perfgate.toml]
+      --out-dir <OUT_DIR> Artifact directory used to verify local receipt readiness [default: artifacts/perfgate]
+      --offline Report configured state without contacting the server
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_main.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 542
 expression: "help_output(&[\"--help\"])"
 ---
 Perf budgets and baseline diffs for CI / PR bots
@@ -40,6 +41,7 @@ Commands:
   init Scan a repository and generate a perfgate.toml config file
   watch Watch for file changes and re-run benchmarks with live terminal output
   serve Start a local dashboard server backed by SQLite
+  ledger Inspect optional decision-ledger readiness without making it required
   scale Validate computational complexity (scaling behavior) of a benchmark
   comment Post or update a performance report comment on a GitHub pull request
   trend Analyze metric trends and predict budget threshold breaches

--- a/docs/DECISION_LEDGER_RUNBOOK.md
+++ b/docs/DECISION_LEDGER_RUNBOOK.md
@@ -24,6 +24,16 @@ perfgate serve --no-open
 SQLite backend is a single-node service mode; do not mount the same database
 file behind multiple active server processes.
 
+Check whether the current repo is ready to use the optional decision ledger:
+
+```bash
+perfgate ledger doctor
+```
+
+For most first-hour users, `ledger doctor` should say that server mode is not
+needed yet. Local receipts and decision bundles remain the correctness
+contract; the ledger is team history.
+
 Back up local mode by copying the SQLite database while the service is stopped,
 or by exporting ledger data before maintenance:
 
@@ -181,4 +191,3 @@ cargo +1.95.0 run -p xtask -- doc-test
 cargo +1.95.0 run -p xtask -- docs-source-check
 cargo +1.95.0 run -p xtask -- product-claims-check
 ```
-


### PR DESCRIPTION
## Summary
- add perfgate ledger doctor to report optional decision-ledger readiness without making server mode required
- check local receipt writability, server configuration, health, history/export reachability, and non-mutating prune dry-run when configured
- add ledger help snapshots, server-backed readiness tests, and runbook guidance

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --test cli_server_tests --all-features ledger_doctor
- cargo +1.95.0 test -p perfgate-cli --all-features snapshot_help_ledger
- cargo +1.95.0 test -p perfgate-cli --all-features snapshot_help_main
- cargo +1.95.0 check -p perfgate-cli --all-targets --all-features --locked
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

## Notes
- Server ledger remains optional team history; local receipts remain the correctness contract.
- The command exits successfully for unconfigured users and tells them they do not need server mode yet.