### PR TITLE
decision: detect improvements on higher-is-better metrics

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -52,7 +52,7 @@ use perfgate_types::{
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_BUNDLE_SCHEMA_V1,
     DECISION_INDEX_SCHEMA_V1, DecisionArtifactIndex, DecisionBundleArtifact,
     DecisionBundleArtifactContent, DecisionBundleArtifactKind, DecisionBundleMetadata,
-    DecisionBundleReceipt, FailIfNOfM, HostMismatchPolicy, Metric, MetricStatus,
+    DecisionBundleReceipt, Direction, FailIfNOfM, HostMismatchPolicy, Metric, MetricStatus,
     OtelSpanIdentifiers, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
     REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairGitMetadata,
     RepairMetricBreach, RunReceipt, ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus,
@@ -4751,7 +4751,14 @@ fn collect_decision_readiness_evidence(
             format!("read compare receipt for {bench_name}: {}", path.display())
         })?;
         has_regression |= is_regression(compare.verdict.status);
-        has_improvement |= compare.deltas.values().any(|delta| delta.pct < 0.0);
+        has_improvement |=
+            compare
+                .deltas
+                .iter()
+                .any(|(metric, delta)| match metric.default_direction() {
+                    Direction::Lower => delta.pct < 0.0,
+                    Direction::Higher => delta.pct > 0.0,
+                });
         high_noise |= compare
             .deltas
             .values()

--- a/crates/perfgate-cli/tests/cli_decision_suggest_tests.rs
+++ b/crates/perfgate-cli/tests/cli_decision_suggest_tests.rs
@@ -65,17 +65,28 @@ max_regression = 0.03
 }
 
 fn write_compare_receipt(path: &Path, status: &str, baseline: f64, current: f64) {
+    let regression = if current > baseline {
+        (current - baseline) / baseline
+    } else {
+        0.0
+    };
+    write_compare_receipt_for_metric(path, "wall_ms", status, baseline, current, regression);
+}
+
+fn write_compare_receipt_for_metric(
+    path: &Path,
+    metric: &str,
+    status: &str,
+    baseline: f64,
+    current: f64,
+    regression: f64,
+) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).expect("create compare parent");
     }
     let fail = u32::from(status == "fail");
     let warn = u32::from(status == "warn");
     let pass = u32::from(status == "pass");
-    let regression = if current > baseline {
-        (current - baseline) / baseline
-    } else {
-        0.0
-    };
     let receipt = serde_json::json!({
         "schema": "perfgate.compare.v1",
         "tool": {"name": "perfgate", "version": "0.18.0"},
@@ -89,7 +100,7 @@ fn write_compare_receipt(path: &Path, status: &str, baseline: f64, current: f64)
         "current_ref": {"path": "artifacts/perfgate/parser/run.json", "run_id": "current"},
         "budgets": {},
         "deltas": {
-            "wall_ms": {
+            metric: {
                 "baseline": baseline,
                 "current": current,
                 "ratio": current / baseline,
@@ -180,5 +191,44 @@ fn decision_suggest_reports_structured_decision_ready_when_policy_and_evidence_e
     assert!(
         stdout.contains("probe evidence: configured, 3 receipts"),
         "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn decision_suggest_detects_throughput_improvement_as_structured_candidate() {
+    // Regression test: improvements on Direction::Higher metrics (e.g. throughput_per_s)
+    // must be detected as improvements. A passing compare with throughput up should
+    // classify as structured_decision_candidate, not simple_gate_enough.
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_basic_config(temp_dir.path());
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    // throughput went from 100/s baseline to 120/s current — an improvement.
+    // regression is 0 because higher throughput is better.
+    write_compare_receipt_for_metric(
+        &out_dir.join("parser").join("compare.json"),
+        "throughput_per_s",
+        "pass",
+        100.0,
+        120.0,
+        0.0,
+    );
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("decision")
+        .arg("suggest")
+        .arg("--config")
+        .arg(&config_path);
+
+    let output = cmd.output().expect("run decision suggest");
+    assert!(
+        output.status.success(),
+        "decision suggest should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Status: structured_decision_candidate"),
+        "expected throughput improvement to flag structured_decision_candidate, stdout: {stdout}"
     );
 }


### PR DESCRIPTION
## Summary

`perfgate decision suggest` (added in #434) flagged a compare receipt as containing an improvement only when any delta had `pct < 0.0`. That is the right sign for `Direction::Lower` metrics (`wall_ms`, `max_rss_kb`, …), but `Direction::Higher` metrics like `throughput_per_s` are the opposite — an improvement is `pct > 0.0`, while `pct < 0.0` is a regression.

Net effect on `classify_decision_readiness`:
- A clean-passing compare whose only signal was higher throughput got `simple_gate_enough` instead of `structured_decision_candidate`.
- A throughput regression also contributed a false `has_improvement` signal (harmless in practice because `has_regression` short-circuits the same branch, but still wrong).

This switches to a direction-aware check via `Metric::default_direction()` and adds a regression test that exercises the throughput-improvement path. With the production change reverted the new test fails; with the fix in place all three `decision suggest` tests pass.

Found in `crates/perfgate-cli/src/main.rs:4754` (now line 4754–4761 after the edit).

## Test plan

- [x] `cargo test -p perfgate-cli --test cli_decision_suggest_tests`
- [x] `cargo test -p perfgate-cli` (all CLI integration tests)
- [x] `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Verified the new test fails when the production fix is reverted, then passes once restored


---
_Generated by [Claude Code](https://claude.ai/code/session_01MXKzUjEUaVuZqg9RHDswp4)_