### PR TITLE
dogfood: record hosted external action canary

### DIFF
--- a/docs/audits/2026-05-15-hosted-external-action-canary-droid-action.md
+++ b/docs/audits/2026-05-15-hosted-external-action-canary-droid-action.md
@@ -1,0 +1,195 @@
+# Hosted External Action Canary: droid-action
+
+Date: 2026-05-15
+
+Status: observed
+
+Linked proposal: [`PERFGATE-PROP-0005`](../proposals/PERFGATE-PROP-0005-first-use-intelligence.md)
+
+Linked specs: [`PERFGATE-SPEC-0008`](../specs/PERFGATE-SPEC-0008-first-use-ux-contract.md)
+
+Linked plan: [`first-use-intelligence.md`](../../plans/0.19.0/first-use-intelligence.md)
+
+Support/status impact: this canary supports the hosted external action proof
+path, but product-claim promotion waits for the action step-summary shell fix
+recorded below.
+
+Purpose: record a hosted external GitHub Action canary against a non-perfgate
+repository. Earlier external canaries proved local adoption in external repos;
+this canary proves a PR workflow can run the perfgate Action in a hosted
+external repository, upload artifacts, and print a copyable local reproduction
+command.
+
+## Canary Target
+
+| Field | Value |
+| --- | --- |
+| External repository | `EffortlessSteven/droid-action` |
+| External PR | `https://github.com/EffortlessSteven/droid-action/pull/7` |
+| Canary branch | `sz/perfgate-hosted-action-canary-20260515` |
+| Base branch | `dev` |
+| Workflow | `.github/workflows/perfgate.yml` |
+| Action ref | `EffortlessMetrics/perfgate@main` |
+| Action commit | `a172a37b3e7f59351aaea402907b924f42c55320` |
+| Runner | GitHub-hosted `ubuntu-24.04` |
+| Config | `perfgate.toml` |
+| Bench | `droid-node-version` |
+
+The external PR added:
+
+```text
+.github/workflows/perfgate.yml
+.perfgate/README.md
+perfgate.toml
+baselines/droid-node-version.json
+```
+
+The workflow used `require_baseline: true`, `fail_on_warn: true`, and
+`upload_artifact: true`.
+
+## Local Preflight
+
+The canary first verified the external repo locally with the workspace-built
+perfgate binary:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+After the baseline was adjusted to force a hosted failure path, the local
+preflight used:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline --fail-on-warn
+```
+
+Result: the CLI failed as expected and printed the first-use failure taxonomy
+for `performance_regression` and `high_noise`, including next commands and
+guardrail guidance.
+
+## Hosted Run: Passing Setup
+
+| Field | Value |
+| --- | --- |
+| Run | `25941466798` |
+| URL | `https://github.com/EffortlessSteven/droid-action/actions/runs/25941466798` |
+| Result | success |
+| Artifact | `perfgate-artifacts-25941466798-1` |
+| Artifact ID | `7026601760` |
+
+Downloaded artifact contents:
+
+```text
+droid-node-version/comment.md
+droid-node-version/compare.json
+droid-node-version/report.json
+droid-node-version/run.json
+```
+
+The PR-ready comment reported a pass. `wall_ms` compared a `46 ms` baseline to
+a `27 ms` current run.
+
+## Hosted Run: Forced Failure
+
+| Field | Value |
+| --- | --- |
+| Run | `25941883937` |
+| URL | `https://github.com/EffortlessSteven/droid-action/actions/runs/25941883937` |
+| Job URL | `https://github.com/EffortlessSteven/droid-action/actions/runs/25941883937/job/76261230315` |
+| Result | failure, expected by canary setup |
+| Artifact | `perfgate-artifacts-25941883937-1` |
+| Artifact ID | `7026765094` |
+| Artifact digest | `184253bd75c3a316b6506949f429fb9d173752b1fa63f094ca319a1f2b5be727` |
+
+Downloaded artifact contents:
+
+```text
+droid-node-version/comment.md
+droid-node-version/compare.json
+droid-node-version/repair_context.json
+droid-node-version/report.json
+droid-node-version/run.json
+```
+
+The action log printed:
+
+```text
+perfgate check exited with code 2
+Verdict: fail (pass=3, warn=0, fail=1, benches=1)
+Reproduce locally: perfgate check --config perfgate.toml --all --fail-on-warn --require-baseline
+Uploaded artifact: perfgate-artifacts-25941883937-1
+```
+
+The artifact list in the action output named:
+
+```text
+artifacts/perfgate/droid-node-version/comment.md
+artifacts/perfgate/droid-node-version/compare.json
+artifacts/perfgate/droid-node-version/report.json
+artifacts/perfgate/droid-node-version/run.json
+```
+
+The PR-ready comment reported:
+
+```text
+wall_ms baseline 1 ms, current 27 ms, delta +2600%, budget 20%, fail
+```
+
+`repair_context.json` recorded a failing status and recommended local follow-up
+commands, including:
+
+```text
+rerun current command: node -e console.log(process.version)
+perfgate explain --compare artifacts/perfgate/droid-node-version/compare.json
+perfgate paired --name droid-node-version --baseline-cmd "<baseline-cmd>" --current-cmd "<current-cmd>" --repeat 10 --out artifacts/perfgate/droid-node-version/paired.json
+perfgate compare --baseline baselines/droid-node-version.json --current artifacts/perfgate/droid-node-version/run.json --out artifacts/perfgate/droid-node-version/recompare.json
+perfgate bisect --good <good-ref> --bad HEAD --executable <bench-binary>
+```
+
+## Finding
+
+The hosted failure run exposed a shell bug in the action step-summary path:
+
+```text
+decision_repro_line: unbound variable
+$'text\n    print_artifacts\n    echo ': command not found
+```
+
+The action still uploaded artifacts and printed enough console output to
+reproduce the failure locally. The finding blocks product-claim promotion and
+lane closeout until the action summary shell is fixed and the hosted canary is
+rerun or otherwise revalidated.
+
+Required follow-up:
+
+```text
+action: fix failure summary step-summary guard
+```
+
+## What This Canary Proves
+
+- A hosted external PR can run the perfgate GitHub Action from a non-perfgate
+  repository.
+- A committed baseline plus `require_baseline` works in an external hosted PR
+  workflow.
+- The action uploads perfgate artifacts on both pass and fail paths.
+- The forced failure path prints a copyable local reproduction command.
+- The forced failure path creates `repair_context.json` with local next
+  commands.
+
+## What This Canary Does Not Prove
+
+- It does not prove the public `0.18.0` release, `v0.18`, or `v0` action
+  aliases. The canary used `EffortlessMetrics/perfgate@main`.
+- It does not prove every external repository shape or hosted runner.
+- It does not prove server-ledger correctness.
+- It does not prove a probe-backed external canary.
+- It does not prove full external CI health for the target repository. The
+  unrelated `Droid Auto Review` workflow failed separately and is not perfgate
+  evidence.
+
+## Cleanup
+
+The canary used a temporary local worktree and downloaded artifact directories
+under `C:\perfgate-canaries`. Those local files are evidence caches only; the
+durable evidence is this audit plus the external PR and workflow run URLs.

--- a/plans/0.19.0/first-use-intelligence.md
+++ b/plans/0.19.0/first-use-intelligence.md
@@ -64,23 +64,24 @@ machine-readable active goal remains the release cutover.
 |----|-----------|--------|-----------------|
 | 425 | First-use intelligence proposal | merged | `docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md` |
 | 426 | First-use UX contract spec | merged | `docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md` |
-| 427 | First-use implementation plan | current | `plans/0.19.0/first-use-intelligence.md` |
-| 428 | Adoption-state doctor | ready | `crates/perfgate-cli`, `perfgate::app`, CLI tests |
-| 429 | Benchmark suggestion templates | ready | `init` behavior, templates, CLI tests |
-| 430 | Artifact explanation command | ready | `perfgate explain artifacts`, CLI tests |
-| 431 | Failure taxonomy and repair copy | ready | shared CLI/action wording helpers, tests |
-| 432 | Calibration suggestions | ready | `perfgate calibrate`, CLI tests |
-| 433 | Mandatory action reproduction block | ready | action summaries, `xtask action-check` fixtures |
-| 434 | Decision readiness suggestions | ready | `perfgate decision suggest`, CLI tests |
-| 435 | Probe starter templates | ready | `perfgate probes init`, examples, CLI tests |
-| 436 | Ledger readiness doctor | ready | `perfgate ledger doctor`, CLI/server tests |
-| 437 | Hosted external action canary | ready | audit note and any required docs/tooling fixes |
+| 427 | First-use implementation plan | merged | `plans/0.19.0/first-use-intelligence.md` |
+| 428 | Adoption-state doctor | merged | `crates/perfgate-cli`, `perfgate::app`, CLI tests |
+| 429 | Benchmark suggestion templates | merged | `init` behavior, templates, CLI tests |
+| 430 | Artifact explanation command | merged | `perfgate explain artifacts`, CLI tests |
+| 431 | Failure taxonomy and repair copy | merged | shared CLI/action wording helpers, tests |
+| 432 | Calibration suggestions | merged | `perfgate calibrate`, CLI tests |
+| 433 | Mandatory action reproduction block | merged | action summaries, `xtask action-check` fixtures |
+| 434 | Decision readiness suggestions | merged | `perfgate decision suggest`, CLI tests |
+| 435 | Probe starter templates | merged | `perfgate probes init`, examples, CLI tests |
+| 436 | Ledger readiness doctor | merged | `perfgate ledger doctor`, CLI/server tests |
+| 437 | Hosted external action canary | current | audit note and hosted finding |
+| 437a | Action step-summary shell fix | ready | `action.yml`, action proof |
 | 438 | Product claim updates | ready | `docs/status/PRODUCT_CLAIMS.md` |
 | 439 | First-use intelligence closeout | ready | handoff and, if active by then, archived goal |
 
 ## Work item: adoption-state-doctor
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -133,7 +134,7 @@ Revert the doctor classifier, output changes, and tests.
 
 ## Work item: benchmark-suggestions
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -183,7 +184,7 @@ Revert suggestion templates, init wiring, docs, and tests.
 
 ## Work item: artifact-explanation
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
@@ -230,7 +231,7 @@ Revert the command, parser wiring, docs, and tests.
 
 ## Work item: failure-taxonomy
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -284,7 +285,7 @@ Revert shared wording/helpers and fixture updates.
 
 ## Work item: calibration-suggestions
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -329,7 +330,7 @@ Revert command wiring, docs, and tests.
 
 ## Work item: action-reproduction-block
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -371,7 +372,7 @@ Revert action summary changes and fixture expectations.
 
 ## Work item: decision-readiness
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
@@ -418,7 +419,7 @@ Revert command wiring, docs, and tests.
 
 ## Work item: probe-starter-templates
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR: docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md
@@ -467,7 +468,7 @@ Revert template files, command wiring, docs, and tests.
 
 ## Work item: ledger-readiness-doctor
 
-Status: ready
+Status: implemented
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -515,7 +516,7 @@ Revert command wiring, docs, and tests.
 
 ## Work item: hosted-action-canary
 
-Status: ready
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
 Linked ADR:
@@ -542,6 +543,8 @@ was fixed.
 
 - The canary audit distinguishes what it proves from what remains unproven.
 - Any required docs/tooling fixes are separately scoped and validated.
+- The hosted step-summary shell bug found by the canary is fixed before
+  product-claim promotion or lane closeout.
 
 ### Proof commands
 
@@ -556,6 +559,52 @@ git diff --check
 ### Rollback
 
 Revert the canary audit and any canary-only docs links.
+
+## Work item: action-step-summary-shell-fix
+
+Status: ready
+Linked proposal: docs/proposals/PERFGATE-PROP-0005-first-use-intelligence.md
+Linked spec: docs/specs/PERFGATE-SPEC-0008-first-use-ux-contract.md
+Linked ADR:
+Blocks: first-use product claims, final closeout
+Blocked by: hosted-action-canary
+
+### Goal
+
+Fix the hosted action failure-summary shell issue found by the external canary.
+
+### Production delta
+
+Guard optional summary variables and make Markdown code fences shell-safe in
+`action.yml` so hosted failure summaries can render without Bash command
+substitution or unbound-variable errors.
+
+### Non-goals
+
+- Do not move action aliases.
+- Do not change verdict semantics.
+- Do not require server mode.
+
+### Acceptance
+
+- The action failure summary still prints verdict, artifacts, and local
+  reproduction.
+- Optional decision guidance is omitted safely when decision mode is disabled.
+- Hosted shell execution no longer reports `decision_repro_line: unbound
+  variable` or attempts to execute Markdown fence text.
+
+### Proof commands
+
+```bash
+cargo +1.95.0 run -p xtask -- action-check
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+git diff --check
+```
+
+### Rollback
+
+Revert the action summary shell changes and any fixture updates.
 
 ## Work item: first-use-product-claims
 


### PR DESCRIPTION
## Summary
- records the hosted external Action canary against EffortlessSteven/droid-action PR #7
- captures the passing and forced-failure hosted runs, uploaded artifacts, and local reproduction output
- updates the 0.19 first-use plan to mark completed work, keep the canary current, and add the step-summary shell fix blocker

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

## Notes
This does not promote product claims or close the lane. The canary found an Action step-summary shell bug that should be fixed before claim promotion.