### PR TITLE
Refactor CLI support code into SRP modules

### DIFF
--- a/crates/perfgate-cli/src/artifact_io.rs
+++ b/crates/perfgate-cli/src/artifact_io.rs
@@ -1,0 +1,174 @@
+//! Receipt I/O helpers for local files and object-store-backed remote paths.
+
+use anyhow::Context;
+use object_store::{ObjectStore, path::Path as ObjectPath};
+use perfgate::app as perfgate_app;
+use perfgate_types::RunReceipt;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use url::Url;
+
+use perfgate_app::baseline_resolve::is_remote_storage_uri;
+
+struct RemoteLocation {
+    store: Arc<dyn ObjectStore>,
+    object_path: ObjectPath,
+}
+
+fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
+    let uri = path.to_string_lossy().to_string();
+    if !is_remote_storage_uri(&uri) {
+        return Ok(None);
+    }
+
+    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
+    let (store, object_path) =
+        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
+
+    Ok(Some(RemoteLocation {
+        store: store.into(),
+        object_path,
+    }))
+}
+
+pub(crate) fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("initialize async runtime")?;
+    rt.block_on(f)
+}
+
+fn is_object_not_found(err: &object_store::Error) -> bool {
+    matches!(err, object_store::Error::NotFound { .. })
+        || err.to_string().to_ascii_lowercase().contains("not found")
+}
+
+pub(crate) fn location_exists(path: &Path) -> anyhow::Result<bool> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let head = with_tokio_runtime(async move {
+            remote
+                .store
+                .head(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)
+        });
+        return match head {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if err
+                    .downcast_ref::<object_store::Error>()
+                    .is_some_and(is_object_not_found)
+                {
+                    Ok(false)
+                } else {
+                    Err(err).with_context(|| format!("check existence {}", path.display()))
+                }
+            }
+        };
+    }
+    Ok(path.exists())
+}
+
+pub(crate) fn read_json_from_location<T: serde::de::DeserializeOwned>(
+    path: &Path,
+) -> anyhow::Result<T> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = with_tokio_runtime(async move {
+            let result = remote
+                .store
+                .get(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)?;
+            result.bytes().await.map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("read {}", path.display()))?;
+
+        return serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse json {}", path.display()));
+    }
+
+    read_json(path)
+}
+
+pub(crate) fn write_json_to_location<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = if pretty {
+            serde_json::to_vec_pretty(value)?
+        } else {
+            serde_json::to_vec(value)?
+        };
+
+        with_tokio_runtime(async move {
+            remote
+                .store
+                .put(&remote.object_path, bytes.into())
+                .await
+                .map(|_| ())
+                .map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("write {}", path.display()))?;
+        return Ok(());
+    }
+
+    write_json(path, value, pretty)
+}
+
+pub(crate) fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
+    if location_exists(path)? {
+        Ok(Some(read_json_from_location(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
+    Ok(perfgate_types::read_json_file(path)?)
+}
+
+pub(crate) fn write_json<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+
+    let bytes = if pretty {
+        serde_json::to_vec_pretty(value)?
+    } else {
+        serde_json::to_vec(value)?
+    };
+
+    atomic_write(path, &bytes)
+}
+
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = parent.to_path_buf();
+    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+
+    {
+        let mut f =
+            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("write temp {}", tmp.display()))?;
+        f.sync_all().ok();
+    }
+
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}

--- a/crates/perfgate-cli/src/git_context.rs
+++ b/crates/perfgate-cli/src/git_context.rs
@@ -1,0 +1,93 @@
+//! Git and tracing context collected for repair diagnostics.
+
+use perfgate_types::{ChangedFilesSummary, OtelSpanIdentifiers, RepairGitMetadata};
+use std::collections::BTreeMap;
+use std::process::Command as ProcessCommand;
+
+pub(crate) fn otel_span_from_env() -> Option<OtelSpanIdentifiers> {
+    let trace_id = std::env::var("OTEL_TRACE_ID").ok();
+    let span_id = std::env::var("OTEL_SPAN_ID").ok();
+    if trace_id.is_none() && span_id.is_none() {
+        None
+    } else {
+        Some(OtelSpanIdentifiers { trace_id, span_id })
+    }
+}
+
+pub(crate) fn git_metadata() -> Option<RepairGitMetadata> {
+    let branch = run_git_capture(&["rev-parse", "--abbrev-ref", "HEAD"]);
+    let sha = run_git_capture(&["rev-parse", "HEAD"]);
+    if branch.is_none() && sha.is_none() {
+        None
+    } else {
+        Some(RepairGitMetadata { branch, sha })
+    }
+}
+
+pub(crate) fn changed_files_summary() -> Option<ChangedFilesSummary> {
+    let output = run_git_capture_bytes(&["status", "--porcelain", "-z"])?;
+    Some(parse_changed_files_summary(&output))
+}
+
+pub(crate) fn parse_changed_files_summary(output: &[u8]) -> ChangedFilesSummary {
+    let mut files = Vec::new();
+    let mut by_top = BTreeMap::new();
+
+    let mut entries = output
+        .split(|byte| *byte == b'\0')
+        .filter(|entry| !entry.is_empty());
+    while let Some(entry) = entries.next() {
+        if entry.len() <= 3 {
+            continue;
+        }
+
+        let status = &entry[..2];
+        let current_path = if status.iter().any(|code| matches!(code, b'R' | b'C')) {
+            entries.next().unwrap_or(&[])
+        } else {
+            &entry[3..]
+        };
+
+        if current_path.is_empty() {
+            continue;
+        }
+
+        let path = String::from_utf8_lossy(current_path).into_owned();
+        files.push(path.clone());
+        let top = path
+            .split(['/', '\\'])
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(".")
+            .to_string();
+        *by_top.entry(top).or_insert(0) += 1;
+    }
+
+    ChangedFilesSummary {
+        file_count: files.len() as u32,
+        files,
+        file_count_by_top_level: by_top,
+    }
+}
+
+pub(crate) fn run_git_capture(args: &[&str]) -> Option<String> {
+    let output = ProcessCommand::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let trimmed = text.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn run_git_capture_bytes(args: &[&str]) -> Option<Vec<u8>> {
+    let output = ProcessCommand::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(output.stdout)
+}

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -3,7 +3,6 @@
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use glob::glob;
-use object_store::{ObjectStore, path::Path as ObjectPath};
 use perfgate::app as perfgate_app;
 use perfgate::domain as perfgate_domain;
 use perfgate::integrations::github::{self, CommentOptions, GitHubClient};
@@ -49,14 +48,13 @@ use perfgate_types::error::{AdapterError, ConfigValidationError, IoError, Perfga
 use perfgate_types::fingerprint::sha256_hex;
 use perfgate_types::{
     AggregateWeightMode, AggregationPolicy, BASELINE_REASON_NO_BASELINE, BaselineServerConfig,
-    ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_BUNDLE_SCHEMA_V1,
-    DECISION_INDEX_SCHEMA_V1, DecisionArtifactIndex, DecisionBundleArtifact,
-    DecisionBundleArtifactContent, DecisionBundleArtifactKind, DecisionBundleMetadata,
-    DecisionBundleReceipt, FailIfNOfM, HostMismatchPolicy, Metric, MetricStatus,
-    OtelSpanIdentifiers, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
-    REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairGitMetadata,
-    RepairMetricBreach, RunReceipt, ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus,
-    ToolInfo, TradeoffReceipt, VerdictStatus,
+    CompareReceipt, CompareRef, ConfigFile, DECISION_BUNDLE_SCHEMA_V1, DECISION_INDEX_SCHEMA_V1,
+    DecisionArtifactIndex, DecisionBundleArtifact, DecisionBundleArtifactContent,
+    DecisionBundleArtifactKind, DecisionBundleMetadata, DecisionBundleReceipt, FailIfNOfM,
+    HostMismatchPolicy, Metric, MetricStatus, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
+    REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairMetricBreach, RunReceipt,
+    ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt,
+    VerdictStatus,
 };
 use regex::Regex;
 use serde_json::Value as JsonValue;
@@ -67,7 +65,17 @@ use std::process::Command as ProcessCommand;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use url::Url;
+
+mod artifact_io;
+mod git_context;
+
+use artifact_io::{
+    atomic_write, load_optional_baseline_receipt, location_exists, read_json,
+    read_json_from_location, with_tokio_runtime, write_json, write_json_to_location,
+};
+#[cfg(test)]
+use git_context::parse_changed_files_summary;
+use git_context::{changed_files_summary, git_metadata, otel_span_from_env, run_git_capture};
 
 const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured; set `--baseline-server`, `PERFGATE_SERVER_URL`, or `[baseline_server].url` in `perfgate.toml`";
 const DEFAULT_FALLBACK_BASELINE_DIR: &str = "baselines";
@@ -7033,8 +7041,6 @@ fn open_browser(url: &str) {
 }
 
 fn execute_scale(args: ScaleArgs) -> anyhow::Result<()> {
-    use std::process::Command as ProcessCommand;
-
     let ScaleArgs {
         name,
         command,
@@ -10143,94 +10149,6 @@ fn recommended_next_commands(outcome: &CheckOutcome, baseline_path: Option<&Path
     cmds
 }
 
-fn otel_span_from_env() -> Option<OtelSpanIdentifiers> {
-    let trace_id = std::env::var("OTEL_TRACE_ID").ok();
-    let span_id = std::env::var("OTEL_SPAN_ID").ok();
-    if trace_id.is_none() && span_id.is_none() {
-        None
-    } else {
-        Some(OtelSpanIdentifiers { trace_id, span_id })
-    }
-}
-
-fn git_metadata() -> Option<RepairGitMetadata> {
-    let branch = run_git_capture(&["rev-parse", "--abbrev-ref", "HEAD"]);
-    let sha = run_git_capture(&["rev-parse", "HEAD"]);
-    if branch.is_none() && sha.is_none() {
-        None
-    } else {
-        Some(RepairGitMetadata { branch, sha })
-    }
-}
-
-fn changed_files_summary() -> Option<ChangedFilesSummary> {
-    let output = run_git_capture_bytes(&["status", "--porcelain", "-z"])?;
-    Some(parse_changed_files_summary(&output))
-}
-
-fn parse_changed_files_summary(output: &[u8]) -> ChangedFilesSummary {
-    let mut files = Vec::new();
-    let mut by_top = BTreeMap::new();
-
-    let mut entries = output
-        .split(|byte| *byte == b'\0')
-        .filter(|entry| !entry.is_empty());
-    while let Some(entry) = entries.next() {
-        if entry.len() <= 3 {
-            continue;
-        }
-
-        let status = &entry[..2];
-        let current_path = if status.iter().any(|code| matches!(code, b'R' | b'C')) {
-            entries.next().unwrap_or(&[])
-        } else {
-            &entry[3..]
-        };
-
-        if current_path.is_empty() {
-            continue;
-        }
-
-        let path = String::from_utf8_lossy(current_path).into_owned();
-        files.push(path.clone());
-        let top = path
-            .split(['/', '\\'])
-            .next()
-            .filter(|s| !s.is_empty())
-            .unwrap_or(".")
-            .to_string();
-        *by_top.entry(top).or_insert(0) += 1;
-    }
-
-    ChangedFilesSummary {
-        file_count: files.len() as u32,
-        files,
-        file_count_by_top_level: by_top,
-    }
-}
-
-fn run_git_capture(args: &[&str]) -> Option<String> {
-    let output = ProcessCommand::new("git").args(args).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let text = String::from_utf8(output.stdout).ok()?;
-    let trimmed = text.trim().to_string();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed)
-    }
-}
-
-fn run_git_capture_bytes(args: &[&str]) -> Option<Vec<u8>> {
-    let output = ProcessCommand::new("git").args(args).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    Some(output.stdout)
-}
-
 fn execute_export(
     run: Option<PathBuf>,
     compare: Option<PathBuf>,
@@ -10485,162 +10403,6 @@ fn normalize_paired_cli_command(args: Vec<String>, flag_name: &str) -> anyhow::R
     }
 
     Ok(args)
-}
-
-struct RemoteLocation {
-    store: Arc<dyn ObjectStore>,
-    object_path: ObjectPath,
-}
-
-fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
-    let uri = path.to_string_lossy().to_string();
-    if !is_remote_storage_uri(&uri) {
-        return Ok(None);
-    }
-
-    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
-    let (store, object_path) =
-        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
-
-    Ok(Some(RemoteLocation {
-        store: store.into(),
-        object_path,
-    }))
-}
-
-fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
-where
-    F: std::future::Future<Output = anyhow::Result<T>>,
-{
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("initialize async runtime")?;
-    rt.block_on(f)
-}
-
-fn is_object_not_found(err: &object_store::Error) -> bool {
-    matches!(err, object_store::Error::NotFound { .. })
-        || err.to_string().to_ascii_lowercase().contains("not found")
-}
-
-fn location_exists(path: &Path) -> anyhow::Result<bool> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let head = with_tokio_runtime(async move {
-            remote
-                .store
-                .head(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)
-        });
-        return match head {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                if err
-                    .downcast_ref::<object_store::Error>()
-                    .is_some_and(is_object_not_found)
-                {
-                    Ok(false)
-                } else {
-                    Err(err).with_context(|| format!("check existence {}", path.display()))
-                }
-            }
-        };
-    }
-    Ok(path.exists())
-}
-
-fn read_json_from_location<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = with_tokio_runtime(async move {
-            let result = remote
-                .store
-                .get(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)?;
-            result.bytes().await.map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("read {}", path.display()))?;
-
-        return serde_json::from_slice(&bytes)
-            .with_context(|| format!("parse json {}", path.display()));
-    }
-
-    read_json(path)
-}
-
-fn write_json_to_location<T: serde::Serialize>(
-    path: &Path,
-    value: &T,
-    pretty: bool,
-) -> anyhow::Result<()> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = if pretty {
-            serde_json::to_vec_pretty(value)?
-        } else {
-            serde_json::to_vec(value)?
-        };
-
-        with_tokio_runtime(async move {
-            remote
-                .store
-                .put(&remote.object_path, bytes.into())
-                .await
-                .map(|_| ())
-                .map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("write {}", path.display()))?;
-        return Ok(());
-    }
-
-    write_json(path, value, pretty)
-}
-
-fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
-    if location_exists(path)? {
-        Ok(Some(read_json_from_location(path)?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    Ok(perfgate_types::read_json_file(path)?)
-}
-
-fn write_json<T: serde::Serialize>(path: &Path, value: &T, pretty: bool) -> anyhow::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new(""));
-    if !parent.as_os_str().is_empty() {
-        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
-    }
-
-    let bytes = if pretty {
-        serde_json::to_vec_pretty(value)?
-    } else {
-        serde_json::to_vec(value)?
-    };
-
-    atomic_write(path, &bytes)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    use std::io::Write;
-
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = parent.to_path_buf();
-    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
-
-    {
-        let mut f =
-            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
-        f.write_all(bytes)
-            .with_context(|| format!("write temp {}", tmp.display()))?;
-        f.sync_all().ok();
-    }
-
-    fs::rename(&tmp, path)
-        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibilities of the `perfgate` CLI entrypoint by extracting non-CLI business logic into focused submodules. 
- Isolate artifact/receipt I/O and object-store interactions from `main.rs` so they can be reasoned about and tested independently. 
- Encapsulate git and tracing repair-context collection to follow single-responsibility principles and make diagnostics code reusable.

### Description
- Added `crates/perfgate-cli/src/artifact_io.rs` containing receipt I/O and storage helpers including `parse_remote_location`, `with_tokio_runtime`, `location_exists`, `read_json_from_location`, `write_json_to_location`, `load_optional_baseline_receipt`, `read_json`, `write_json`, and `atomic_write` as `pub(crate)` helpers. 
- Added `crates/perfgate-cli/src/git_context.rs` containing diagnostics helpers including `otel_span_from_env`, `git_metadata`, `changed_files_summary`, `parse_changed_files_summary`, and `run_git_capture` as `pub(crate)` helpers. 
- Updated `crates/perfgate-cli/src/main.rs` to `mod` the new modules and import only the narrow helper APIs (`atomic_write`, `load_optional_baseline_receipt`, `location_exists`, `read_json`, `read_json_from_location`, `with_tokio_runtime`, `write_json`, `write_json_to_location`, `changed_files_summary`, `git_metadata`, `otel_span_from_env`, and `run_git_capture`), removing duplicated support code from `main.rs`.

### Testing
- Ran `cargo fmt --all` with no changes required (success). 
- Ran `cargo test -p perfgate-cli --bin perfgate` and unit tests passed (`34 passed; 0 failed`). 
- Ran `cargo clippy -p perfgate-cli --bin perfgate -- -D warnings` with no warnings (success). 
- A broader `cargo test -p perfgate-cli` run was started but intentionally interrupted when an integration test spawned a nested release `cargo bench` to avoid long-running builds in this environment (interrupted, not failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd9969c4833380ff1c423c8a4bf3)