### PR TITLE
Refactor CLI helpers into SRP modules

### DIFF
--- a/crates/perfgate-cli/src/cli_parsers.rs
+++ b/crates/perfgate-cli/src/cli_parsers.rs
@@ -1,0 +1,227 @@
+//! CLI value parsers and option validators.
+//!
+//! Keeping these parsing-only helpers out of `main.rs` makes the command
+//! dispatcher focus on orchestration while this module owns clap-compatible
+//! parsing and cross-option validation.
+
+use anyhow::Context;
+use perfgate_types::{
+    AggregateWeightMode, AggregationPolicy, FailIfNOfM, HostMismatchPolicy, MetricStatus,
+    VerdictStatus,
+};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+pub(crate) fn parse_duration(s: &str) -> anyhow::Result<Duration> {
+    let d = humantime::parse_duration(s).with_context(|| format!("invalid duration: {s}"))?;
+    Ok(d)
+}
+
+pub(crate) fn parse_key_val_string(s: &str) -> Result<(String, String), String> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| "expected KEY=VALUE".to_string())?;
+    Ok((k.to_string(), v.to_string()))
+}
+
+pub(crate) fn parse_key_val_f64(s: &str) -> Result<(String, f64), String> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| "expected KEY=VALUE".to_string())?;
+    let f: f64 = v.parse().map_err(|_| format!("invalid float value: {v}"))?;
+    Ok((k.to_string(), f))
+}
+
+pub(crate) fn parse_noise_policy(s: &str) -> Result<perfgate_types::NoisePolicy, String> {
+    match s.to_lowercase().as_str() {
+        "warn" => Ok(perfgate_types::NoisePolicy::Warn),
+        "skip" => Ok(perfgate_types::NoisePolicy::Skip),
+        "ignore" => Ok(perfgate_types::NoisePolicy::Ignore),
+        _ => Err(format!(
+            "invalid noise policy: {s} (expected warn|skip|ignore)"
+        )),
+    }
+}
+
+pub(crate) fn parse_flakiness_score(s: &str) -> Result<f64, String> {
+    let score: f64 = s
+        .parse()
+        .map_err(|_| "flakiness score must be a number".to_string())?;
+    if !score.is_finite() || !(0.0..=1.0).contains(&score) {
+        return Err("flakiness score must be between 0.0 and 1.0".to_string());
+    }
+    Ok(score)
+}
+
+pub(crate) fn parse_verdict_status(s: &str) -> Result<VerdictStatus, String> {
+    match s.to_lowercase().as_str() {
+        "pass" => Ok(VerdictStatus::Pass),
+        "warn" => Ok(VerdictStatus::Warn),
+        "fail" => Ok(VerdictStatus::Fail),
+        "skip" => Ok(VerdictStatus::Skip),
+        _ => Err(format!(
+            "invalid verdict status: {s} (expected pass|warn|fail|skip)"
+        )),
+    }
+}
+
+pub(crate) fn parse_metric_status(s: &str) -> Result<MetricStatus, String> {
+    match s.to_lowercase().as_str() {
+        "pass" => Ok(MetricStatus::Pass),
+        "warn" => Ok(MetricStatus::Warn),
+        "fail" => Ok(MetricStatus::Fail),
+        "skip" => Ok(MetricStatus::Skip),
+        _ => Err(format!(
+            "invalid metric status: {s} (expected pass|warn|fail|skip)"
+        )),
+    }
+}
+
+pub(crate) fn parse_host_mismatch_policy(s: &str) -> Result<HostMismatchPolicy, String> {
+    match s {
+        "warn" => Ok(HostMismatchPolicy::Warn),
+        "error" | "fail" => Ok(HostMismatchPolicy::Error),
+        "ignore" => Ok(HostMismatchPolicy::Ignore),
+        _ => Err(format!(
+            "invalid host mismatch policy: {} (expected warn, error, or ignore)",
+            s
+        )),
+    }
+}
+
+pub(crate) fn parse_aggregation_policy(s: &str) -> Result<AggregationPolicy, String> {
+    match s {
+        "all" => Ok(AggregationPolicy::All),
+        "majority" => Ok(AggregationPolicy::Majority),
+        "weighted" => Ok(AggregationPolicy::Weighted),
+        "quorum" => Ok(AggregationPolicy::Quorum),
+        "fail_if_n_of_m" => Ok(AggregationPolicy::FailIfNOfM),
+        _ => Err(format!(
+            "invalid aggregation policy: {s} (expected all|majority|weighted|quorum|fail_if_n_of_m)"
+        )),
+    }
+}
+
+pub(crate) fn parse_aggregate_weight_mode(s: &str) -> Result<AggregateWeightMode, String> {
+    match s {
+        "configured" => Ok(AggregateWeightMode::Configured),
+        "inverse_variance" => Ok(AggregateWeightMode::InverseVariance),
+        _ => Err(format!(
+            "invalid aggregate weight mode: {s} (expected configured|inverse_variance)"
+        )),
+    }
+}
+
+pub(crate) fn parse_weight_map(weights: &[String]) -> anyhow::Result<BTreeMap<String, f64>> {
+    let mut map = BTreeMap::new();
+    for raw in weights {
+        let (label, weight_raw) = raw
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("invalid --weight '{raw}', expected label=value"))?;
+        if label.trim().is_empty() {
+            anyhow::bail!("invalid --weight '{raw}': label cannot be empty");
+        }
+        let weight: f64 = weight_raw
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid --weight '{raw}': weight must be a number"))?;
+        if !weight.is_finite() || weight < 0.0 {
+            anyhow::bail!("invalid --weight '{raw}': weight must be a non-negative finite number");
+        }
+        map.insert(label.trim().to_string(), weight);
+    }
+    Ok(map)
+}
+
+pub(crate) fn validate_aggregate_options(
+    policy: AggregationPolicy,
+    weight_mode: AggregateWeightMode,
+    quorum: Option<f64>,
+    fail_n: Option<u32>,
+    fail_m: Option<u32>,
+    variance_floor: Option<f64>,
+) -> anyhow::Result<(Option<f64>, Option<FailIfNOfM>, Option<f64>)> {
+    if let Some(quorum) = quorum {
+        if !quorum.is_finite() || !(0.0..=1.0).contains(&quorum) {
+            anyhow::bail!("--quorum must be between 0.0 and 1.0, got {quorum}");
+        }
+        if !matches!(
+            policy,
+            AggregationPolicy::Weighted | AggregationPolicy::Quorum
+        ) {
+            anyhow::bail!("--quorum requires --policy weighted or quorum");
+        }
+    }
+
+    if matches!(weight_mode, AggregateWeightMode::InverseVariance)
+        && !matches!(policy, AggregationPolicy::Weighted)
+    {
+        anyhow::bail!("--weight-mode inverse_variance requires --policy weighted");
+    }
+
+    if let Some(variance_floor) = variance_floor {
+        if !variance_floor.is_finite() || variance_floor <= 0.0 {
+            anyhow::bail!(
+                "--variance-floor must be a positive finite number, got {variance_floor}"
+            );
+        }
+        if !matches!(weight_mode, AggregateWeightMode::InverseVariance) {
+            anyhow::bail!("--variance-floor requires --weight-mode inverse_variance");
+        }
+    }
+
+    match policy {
+        AggregationPolicy::FailIfNOfM => {
+            let n = fail_n
+                .ok_or_else(|| anyhow::anyhow!("--policy fail_if_n_of_m requires --fail-n"))?;
+            if n == 0 {
+                anyhow::bail!("--fail-n must be at least 1");
+            }
+            if let Some(m) = fail_m {
+                if m == 0 {
+                    anyhow::bail!("--fail-m must be at least 1");
+                }
+                if m < n {
+                    anyhow::bail!("--fail-m must be greater than or equal to --fail-n");
+                }
+            }
+            Ok((quorum, Some(FailIfNOfM { n, m: fail_m }), variance_floor))
+        }
+        _ => {
+            if fail_n.is_some() || fail_m.is_some() {
+                anyhow::bail!("--fail-n and --fail-m require --policy fail_if_n_of_m");
+            }
+            Ok((quorum, None, variance_floor))
+        }
+    }
+}
+
+pub(crate) fn parse_significance_alpha(s: &str) -> Result<f64, String> {
+    let alpha: f64 = s.parse().map_err(|_| format!("invalid float value: {s}"))?;
+    if !(0.0..=1.0).contains(&alpha) {
+        return Err(format!(
+            "significance alpha must be between 0.0 and 1.0, got {alpha}"
+        ));
+    }
+    Ok(alpha)
+}
+
+pub(crate) fn normalize_paired_cli_command(
+    args: Vec<String>,
+    flag_name: &str,
+) -> anyhow::Result<Vec<String>> {
+    if args.is_empty() {
+        anyhow::bail!("{} requires at least one argument", flag_name);
+    }
+
+    if args.len() == 1 && args[0].chars().any(char::is_whitespace) {
+        let raw = &args[0];
+        let parsed = shell_words::split(raw)
+            .with_context(|| format!("failed to parse {} shell string: {}", flag_name, raw))?;
+        if parsed.is_empty() {
+            anyhow::bail!("{} parsed to an empty command", flag_name);
+        }
+        return Ok(parsed);
+    }
+
+    Ok(args)
+}

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1,9 +1,12 @@
 //! perfgate CLI - entry point for all workflows.
 
+mod cli_parsers;
+mod storage;
+
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use cli_parsers::*;
 use glob::glob;
-use object_store::{ObjectStore, path::Path as ObjectPath};
 use perfgate::app as perfgate_app;
 use perfgate::domain as perfgate_domain;
 use perfgate::integrations::github::{self, CommentOptions, GitHubClient};
@@ -52,11 +55,10 @@ use perfgate_types::{
     ChangedFilesSummary, CompareReceipt, CompareRef, ConfigFile, DECISION_BUNDLE_SCHEMA_V1,
     DECISION_INDEX_SCHEMA_V1, DecisionArtifactIndex, DecisionBundleArtifact,
     DecisionBundleArtifactContent, DecisionBundleArtifactKind, DecisionBundleMetadata,
-    DecisionBundleReceipt, FailIfNOfM, HostMismatchPolicy, Metric, MetricStatus,
-    OtelSpanIdentifiers, PerfgateReport, ProbeCompareReceipt, ProbeReceipt,
-    REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig, RepairContextReceipt, RepairGitMetadata,
-    RepairMetricBreach, RunReceipt, ScenarioConfigFile, ScenarioReceipt, SensorVerdictStatus,
-    ToolInfo, TradeoffReceipt, VerdictStatus,
+    DecisionBundleReceipt, HostMismatchPolicy, Metric, MetricStatus, OtelSpanIdentifiers,
+    PerfgateReport, ProbeCompareReceipt, ProbeReceipt, REPAIR_CONTEXT_SCHEMA_V1, RatchetConfig,
+    RepairContextReceipt, RepairGitMetadata, RepairMetricBreach, RunReceipt, ScenarioConfigFile,
+    ScenarioReceipt, SensorVerdictStatus, ToolInfo, TradeoffReceipt, VerdictStatus,
 };
 use regex::Regex;
 use serde_json::Value as JsonValue;
@@ -65,9 +67,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::process::ExitCode;
-use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use url::Url;
+use storage::*;
 
 const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured; set `--baseline-server`, `PERFGATE_SERVER_URL`, or `[baseline_server].url` in `perfgate.toml`";
 const DEFAULT_FALLBACK_BASELINE_DIR: &str = "baselines";
@@ -9751,6 +9752,7 @@ fn rename_extras_to_versioned(extras_dir: &Path) -> anyhow::Result<()> {
 /// Run the watch command: monitor filesystem and re-run benchmarks on changes.
 fn run_watch(args: WatchArgs) -> anyhow::Result<()> {
     use notify::{EventKind, RecursiveMode, Watcher};
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc;
 
@@ -10274,373 +10276,6 @@ fn tool_info() -> ToolInfo {
 
 fn map_domain_err(err: anyhow::Error) -> anyhow::Error {
     err
-}
-
-fn parse_duration(s: &str) -> anyhow::Result<Duration> {
-    let d = humantime::parse_duration(s).with_context(|| format!("invalid duration: {s}"))?;
-    Ok(d)
-}
-
-fn parse_key_val_string(s: &str) -> Result<(String, String), String> {
-    let (k, v) = s
-        .split_once('=')
-        .ok_or_else(|| "expected KEY=VALUE".to_string())?;
-    Ok((k.to_string(), v.to_string()))
-}
-
-fn parse_key_val_f64(s: &str) -> Result<(String, f64), String> {
-    let (k, v) = s
-        .split_once('=')
-        .ok_or_else(|| "expected KEY=VALUE".to_string())?;
-    let f: f64 = v.parse().map_err(|_| format!("invalid float value: {v}"))?;
-    Ok((k.to_string(), f))
-}
-
-fn parse_noise_policy(s: &str) -> Result<perfgate_types::NoisePolicy, String> {
-    match s.to_lowercase().as_str() {
-        "warn" => Ok(perfgate_types::NoisePolicy::Warn),
-        "skip" => Ok(perfgate_types::NoisePolicy::Skip),
-        "ignore" => Ok(perfgate_types::NoisePolicy::Ignore),
-        _ => Err(format!(
-            "invalid noise policy: {s} (expected warn|skip|ignore)"
-        )),
-    }
-}
-
-fn parse_flakiness_score(s: &str) -> Result<f64, String> {
-    let score: f64 = s
-        .parse()
-        .map_err(|_| "flakiness score must be a number".to_string())?;
-    if !score.is_finite() || !(0.0..=1.0).contains(&score) {
-        return Err("flakiness score must be between 0.0 and 1.0".to_string());
-    }
-    Ok(score)
-}
-
-fn parse_verdict_status(s: &str) -> Result<VerdictStatus, String> {
-    match s.to_lowercase().as_str() {
-        "pass" => Ok(VerdictStatus::Pass),
-        "warn" => Ok(VerdictStatus::Warn),
-        "fail" => Ok(VerdictStatus::Fail),
-        "skip" => Ok(VerdictStatus::Skip),
-        _ => Err(format!(
-            "invalid verdict status: {s} (expected pass|warn|fail|skip)"
-        )),
-    }
-}
-
-fn parse_metric_status(s: &str) -> Result<MetricStatus, String> {
-    match s.to_lowercase().as_str() {
-        "pass" => Ok(MetricStatus::Pass),
-        "warn" => Ok(MetricStatus::Warn),
-        "fail" => Ok(MetricStatus::Fail),
-        "skip" => Ok(MetricStatus::Skip),
-        _ => Err(format!(
-            "invalid metric status: {s} (expected pass|warn|fail|skip)"
-        )),
-    }
-}
-
-fn parse_host_mismatch_policy(s: &str) -> Result<HostMismatchPolicy, String> {
-    match s {
-        "warn" => Ok(HostMismatchPolicy::Warn),
-        "error" | "fail" => Ok(HostMismatchPolicy::Error),
-        "ignore" => Ok(HostMismatchPolicy::Ignore),
-        _ => Err(format!(
-            "invalid host mismatch policy: {} (expected warn, error, or ignore)",
-            s
-        )),
-    }
-}
-
-fn parse_aggregation_policy(s: &str) -> Result<AggregationPolicy, String> {
-    match s {
-        "all" => Ok(AggregationPolicy::All),
-        "majority" => Ok(AggregationPolicy::Majority),
-        "weighted" => Ok(AggregationPolicy::Weighted),
-        "quorum" => Ok(AggregationPolicy::Quorum),
-        "fail_if_n_of_m" => Ok(AggregationPolicy::FailIfNOfM),
-        _ => Err(format!(
-            "invalid aggregation policy: {s} (expected all|majority|weighted|quorum|fail_if_n_of_m)"
-        )),
-    }
-}
-
-fn parse_aggregate_weight_mode(s: &str) -> Result<AggregateWeightMode, String> {
-    match s {
-        "configured" => Ok(AggregateWeightMode::Configured),
-        "inverse_variance" => Ok(AggregateWeightMode::InverseVariance),
-        _ => Err(format!(
-            "invalid aggregate weight mode: {s} (expected configured|inverse_variance)"
-        )),
-    }
-}
-
-fn parse_weight_map(weights: &[String]) -> anyhow::Result<BTreeMap<String, f64>> {
-    let mut map = BTreeMap::new();
-    for raw in weights {
-        let (label, weight_raw) = raw
-            .split_once('=')
-            .ok_or_else(|| anyhow::anyhow!("invalid --weight '{raw}', expected label=value"))?;
-        if label.trim().is_empty() {
-            anyhow::bail!("invalid --weight '{raw}': label cannot be empty");
-        }
-        let weight: f64 = weight_raw
-            .parse()
-            .map_err(|_| anyhow::anyhow!("invalid --weight '{raw}': weight must be a number"))?;
-        if !weight.is_finite() || weight < 0.0 {
-            anyhow::bail!("invalid --weight '{raw}': weight must be a non-negative finite number");
-        }
-        map.insert(label.trim().to_string(), weight);
-    }
-    Ok(map)
-}
-
-fn validate_aggregate_options(
-    policy: AggregationPolicy,
-    weight_mode: AggregateWeightMode,
-    quorum: Option<f64>,
-    fail_n: Option<u32>,
-    fail_m: Option<u32>,
-    variance_floor: Option<f64>,
-) -> anyhow::Result<(Option<f64>, Option<FailIfNOfM>, Option<f64>)> {
-    if let Some(quorum) = quorum {
-        if !quorum.is_finite() || !(0.0..=1.0).contains(&quorum) {
-            anyhow::bail!("--quorum must be between 0.0 and 1.0, got {quorum}");
-        }
-        if !matches!(
-            policy,
-            AggregationPolicy::Weighted | AggregationPolicy::Quorum
-        ) {
-            anyhow::bail!("--quorum requires --policy weighted or quorum");
-        }
-    }
-
-    if matches!(weight_mode, AggregateWeightMode::InverseVariance)
-        && !matches!(policy, AggregationPolicy::Weighted)
-    {
-        anyhow::bail!("--weight-mode inverse_variance requires --policy weighted");
-    }
-
-    if let Some(variance_floor) = variance_floor {
-        if !variance_floor.is_finite() || variance_floor <= 0.0 {
-            anyhow::bail!(
-                "--variance-floor must be a positive finite number, got {variance_floor}"
-            );
-        }
-        if !matches!(weight_mode, AggregateWeightMode::InverseVariance) {
-            anyhow::bail!("--variance-floor requires --weight-mode inverse_variance");
-        }
-    }
-
-    match policy {
-        AggregationPolicy::FailIfNOfM => {
-            let n = fail_n
-                .ok_or_else(|| anyhow::anyhow!("--policy fail_if_n_of_m requires --fail-n"))?;
-            if n == 0 {
-                anyhow::bail!("--fail-n must be at least 1");
-            }
-            if let Some(m) = fail_m {
-                if m == 0 {
-                    anyhow::bail!("--fail-m must be at least 1");
-                }
-                if m < n {
-                    anyhow::bail!("--fail-m must be greater than or equal to --fail-n");
-                }
-            }
-            Ok((quorum, Some(FailIfNOfM { n, m: fail_m }), variance_floor))
-        }
-        _ => {
-            if fail_n.is_some() || fail_m.is_some() {
-                anyhow::bail!("--fail-n and --fail-m require --policy fail_if_n_of_m");
-            }
-            Ok((quorum, None, variance_floor))
-        }
-    }
-}
-
-fn parse_significance_alpha(s: &str) -> Result<f64, String> {
-    let alpha: f64 = s.parse().map_err(|_| format!("invalid float value: {s}"))?;
-    if !(0.0..=1.0).contains(&alpha) {
-        return Err(format!(
-            "significance alpha must be between 0.0 and 1.0, got {alpha}"
-        ));
-    }
-    Ok(alpha)
-}
-
-fn normalize_paired_cli_command(args: Vec<String>, flag_name: &str) -> anyhow::Result<Vec<String>> {
-    if args.is_empty() {
-        anyhow::bail!("{} requires at least one argument", flag_name);
-    }
-
-    if args.len() == 1 && args[0].chars().any(char::is_whitespace) {
-        let raw = &args[0];
-        let parsed = shell_words::split(raw)
-            .with_context(|| format!("failed to parse {} shell string: {}", flag_name, raw))?;
-        if parsed.is_empty() {
-            anyhow::bail!("{} parsed to an empty command", flag_name);
-        }
-        return Ok(parsed);
-    }
-
-    Ok(args)
-}
-
-struct RemoteLocation {
-    store: Arc<dyn ObjectStore>,
-    object_path: ObjectPath,
-}
-
-fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
-    let uri = path.to_string_lossy().to_string();
-    if !is_remote_storage_uri(&uri) {
-        return Ok(None);
-    }
-
-    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
-    let (store, object_path) =
-        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
-
-    Ok(Some(RemoteLocation {
-        store: store.into(),
-        object_path,
-    }))
-}
-
-fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
-where
-    F: std::future::Future<Output = anyhow::Result<T>>,
-{
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("initialize async runtime")?;
-    rt.block_on(f)
-}
-
-fn is_object_not_found(err: &object_store::Error) -> bool {
-    matches!(err, object_store::Error::NotFound { .. })
-        || err.to_string().to_ascii_lowercase().contains("not found")
-}
-
-fn location_exists(path: &Path) -> anyhow::Result<bool> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let head = with_tokio_runtime(async move {
-            remote
-                .store
-                .head(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)
-        });
-        return match head {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                if err
-                    .downcast_ref::<object_store::Error>()
-                    .is_some_and(is_object_not_found)
-                {
-                    Ok(false)
-                } else {
-                    Err(err).with_context(|| format!("check existence {}", path.display()))
-                }
-            }
-        };
-    }
-    Ok(path.exists())
-}
-
-fn read_json_from_location<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = with_tokio_runtime(async move {
-            let result = remote
-                .store
-                .get(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)?;
-            result.bytes().await.map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("read {}", path.display()))?;
-
-        return serde_json::from_slice(&bytes)
-            .with_context(|| format!("parse json {}", path.display()));
-    }
-
-    read_json(path)
-}
-
-fn write_json_to_location<T: serde::Serialize>(
-    path: &Path,
-    value: &T,
-    pretty: bool,
-) -> anyhow::Result<()> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = if pretty {
-            serde_json::to_vec_pretty(value)?
-        } else {
-            serde_json::to_vec(value)?
-        };
-
-        with_tokio_runtime(async move {
-            remote
-                .store
-                .put(&remote.object_path, bytes.into())
-                .await
-                .map(|_| ())
-                .map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("write {}", path.display()))?;
-        return Ok(());
-    }
-
-    write_json(path, value, pretty)
-}
-
-fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
-    if location_exists(path)? {
-        Ok(Some(read_json_from_location(path)?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    Ok(perfgate_types::read_json_file(path)?)
-}
-
-fn write_json<T: serde::Serialize>(path: &Path, value: &T, pretty: bool) -> anyhow::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new(""));
-    if !parent.as_os_str().is_empty() {
-        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
-    }
-
-    let bytes = if pretty {
-        serde_json::to_vec_pretty(value)?
-    } else {
-        serde_json::to_vec(value)?
-    };
-
-    atomic_write(path, &bytes)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    use std::io::Write;
-
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = parent.to_path_buf();
-    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
-
-    {
-        let mut f =
-            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
-        f.write_all(bytes)
-            .with_context(|| format!("write temp {}", tmp.display()))?;
-        f.sync_all().ok();
-    }
-
-    fs::rename(&tmp, path)
-        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/perfgate-cli/src/storage.rs
+++ b/crates/perfgate-cli/src/storage.rs
@@ -1,0 +1,175 @@
+//! JSON persistence helpers for local files and remote object-store URIs.
+//!
+//! This module owns the storage boundary for CLI commands so command handlers
+//! can work with receipt paths without mixing orchestration and I/O details.
+
+use anyhow::Context;
+use object_store::{ObjectStore, path::Path as ObjectPath};
+use perfgate::app::baseline_resolve::is_remote_storage_uri;
+use perfgate_types::RunReceipt;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use url::Url;
+
+struct RemoteLocation {
+    store: Arc<dyn ObjectStore>,
+    object_path: ObjectPath,
+}
+
+fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
+    let uri = path.to_string_lossy().to_string();
+    if !is_remote_storage_uri(&uri) {
+        return Ok(None);
+    }
+
+    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
+    let (store, object_path) =
+        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
+
+    Ok(Some(RemoteLocation {
+        store: store.into(),
+        object_path,
+    }))
+}
+
+pub(crate) fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("initialize async runtime")?;
+    rt.block_on(f)
+}
+
+fn is_object_not_found(err: &object_store::Error) -> bool {
+    matches!(err, object_store::Error::NotFound { .. })
+        || err.to_string().to_ascii_lowercase().contains("not found")
+}
+
+pub(crate) fn location_exists(path: &Path) -> anyhow::Result<bool> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let head = with_tokio_runtime(async move {
+            remote
+                .store
+                .head(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)
+        });
+        return match head {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if err
+                    .downcast_ref::<object_store::Error>()
+                    .is_some_and(is_object_not_found)
+                {
+                    Ok(false)
+                } else {
+                    Err(err).with_context(|| format!("check existence {}", path.display()))
+                }
+            }
+        };
+    }
+    Ok(path.exists())
+}
+
+pub(crate) fn read_json_from_location<T: serde::de::DeserializeOwned>(
+    path: &Path,
+) -> anyhow::Result<T> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = with_tokio_runtime(async move {
+            let result = remote
+                .store
+                .get(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)?;
+            result.bytes().await.map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("read {}", path.display()))?;
+
+        return serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse json {}", path.display()));
+    }
+
+    read_json(path)
+}
+
+pub(crate) fn write_json_to_location<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = if pretty {
+            serde_json::to_vec_pretty(value)?
+        } else {
+            serde_json::to_vec(value)?
+        };
+
+        with_tokio_runtime(async move {
+            remote
+                .store
+                .put(&remote.object_path, bytes.into())
+                .await
+                .map(|_| ())
+                .map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("write {}", path.display()))?;
+        return Ok(());
+    }
+
+    write_json(path, value, pretty)
+}
+
+pub(crate) fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
+    if location_exists(path)? {
+        Ok(Some(read_json_from_location(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
+    Ok(perfgate_types::read_json_file(path)?)
+}
+
+pub(crate) fn write_json<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+
+    let bytes = if pretty {
+        serde_json::to_vec_pretty(value)?
+    } else {
+        serde_json::to_vec(value)?
+    };
+
+    atomic_write(path, &bytes)
+}
+
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = parent.to_path_buf();
+    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+
+    {
+        let mut f =
+            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("write temp {}", tmp.display()))?;
+        f.sync_all().ok();
+    }
+
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibility of `crates/perfgate-cli/src/main.rs` by moving parsing and storage logic into focused modules so the CLI entrypoint only handles orchestration. 
- Improve single-responsibility, testability, and readability by grouping clap value parsers and option validators separately from I/O and object-store plumbing. 

### Description
- Extracted clap-compatible value parsers, option validators, and related helpers into `crates/perfgate-cli/src/cli_parsers.rs` and made them `pub(crate)` for use by the CLI. 
- Extracted local/remote JSON persistence, object-store URI parsing, async runtime bridging (`with_tokio_runtime`), and `atomic_write` into `crates/perfgate-cli/src/storage.rs` as `pub(crate)` storage helpers. 
- Updated `crates/perfgate-cli/src/main.rs` to `mod cli_parsers; mod storage;` and import `use cli_parsers::*; use storage::*;` while removing the moved helper implementations from `main.rs`. 
- Adjusted imports and small call sites so the command dispatchers use the new modules without changing external behavior or public CLI surface. 

### Testing
- Ran `cargo test -p perfgate-cli --no-run` (build check) which completed successfully. 
- Ran `cargo test -p perfgate-cli --bin perfgate` which executed the unit tests and reported `34 passed; 0 failed`. 
- Ran `cargo clippy -p perfgate-cli --all-targets -- -D warnings` which succeeded (no lints at `warning` level). 
- Ran `git diff --check` to ensure no whitespace/merge artifacts, which returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd9969c4833380ff1c423c8a4bf3)