### PR TITLE
refactor(cli): split IO helpers into SRP module

### DIFF
--- a/crates/perfgate-cli/src/io.rs
+++ b/crates/perfgate-cli/src/io.rs
@@ -1,0 +1,176 @@
+//! CLI I/O helpers for local files and object-store-backed locations.
+//!
+//! This module keeps path resolution and JSON persistence concerns out of the
+//! command dispatcher in `main.rs`. The CLI can ask for typed reads/writes
+//! without knowing whether a path is local or a remote object-store URI.
+
+use anyhow::Context;
+use object_store::{ObjectStore, path::Path as ObjectPath};
+use perfgate::app::baseline_resolve::is_remote_storage_uri;
+use perfgate_types::RunReceipt;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use url::Url;
+
+struct RemoteLocation {
+    store: Arc<dyn ObjectStore>,
+    object_path: ObjectPath,
+}
+
+fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
+    let uri = path.to_string_lossy().to_string();
+    if !is_remote_storage_uri(&uri) {
+        return Ok(None);
+    }
+
+    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
+    let (store, object_path) =
+        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
+
+    Ok(Some(RemoteLocation {
+        store: store.into(),
+        object_path,
+    }))
+}
+
+pub(crate) fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("initialize async runtime")?;
+    rt.block_on(f)
+}
+
+fn is_object_not_found(err: &object_store::Error) -> bool {
+    matches!(err, object_store::Error::NotFound { .. })
+        || err.to_string().to_ascii_lowercase().contains("not found")
+}
+
+pub(crate) fn location_exists(path: &Path) -> anyhow::Result<bool> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let head = with_tokio_runtime(async move {
+            remote
+                .store
+                .head(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)
+        });
+        return match head {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if err
+                    .downcast_ref::<object_store::Error>()
+                    .is_some_and(is_object_not_found)
+                {
+                    Ok(false)
+                } else {
+                    Err(err).with_context(|| format!("check existence {}", path.display()))
+                }
+            }
+        };
+    }
+    Ok(path.exists())
+}
+
+pub(crate) fn read_json_from_location<T: serde::de::DeserializeOwned>(
+    path: &Path,
+) -> anyhow::Result<T> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = with_tokio_runtime(async move {
+            let result = remote
+                .store
+                .get(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)?;
+            result.bytes().await.map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("read {}", path.display()))?;
+
+        return serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse json {}", path.display()));
+    }
+
+    read_json(path)
+}
+
+pub(crate) fn write_json_to_location<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = if pretty {
+            serde_json::to_vec_pretty(value)?
+        } else {
+            serde_json::to_vec(value)?
+        };
+
+        with_tokio_runtime(async move {
+            remote
+                .store
+                .put(&remote.object_path, bytes.into())
+                .await
+                .map(|_| ())
+                .map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("write {}", path.display()))?;
+        return Ok(());
+    }
+
+    write_json(path, value, pretty)
+}
+
+pub(crate) fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
+    if location_exists(path)? {
+        Ok(Some(read_json_from_location(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
+    Ok(perfgate_types::read_json_file(path)?)
+}
+
+pub(crate) fn write_json<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+
+    let bytes = if pretty {
+        serde_json::to_vec_pretty(value)?
+    } else {
+        serde_json::to_vec(value)?
+    };
+
+    atomic_write(path, &bytes)
+}
+
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = parent.to_path_buf();
+    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+
+    {
+        let mut f =
+            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("write temp {}", tmp.display()))?;
+        f.sync_all().ok();
+    }
+
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1,9 +1,14 @@
 //! perfgate CLI - entry point for all workflows.
 
+mod io;
+
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use glob::glob;
-use object_store::{ObjectStore, path::Path as ObjectPath};
+use io::{
+    atomic_write, load_optional_baseline_receipt, location_exists, read_json,
+    read_json_from_location, with_tokio_runtime, write_json, write_json_to_location,
+};
 use perfgate::app as perfgate_app;
 use perfgate::domain as perfgate_domain;
 use perfgate::integrations::github::{self, CommentOptions, GitHubClient};
@@ -67,7 +72,6 @@ use std::process::Command as ProcessCommand;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use url::Url;
 
 const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured; set `--baseline-server`, `PERFGATE_SERVER_URL`, or `[baseline_server].url` in `perfgate.toml`";
 const DEFAULT_FALLBACK_BASELINE_DIR: &str = "baselines";
@@ -10485,162 +10489,6 @@ fn normalize_paired_cli_command(args: Vec<String>, flag_name: &str) -> anyhow::R
     }
 
     Ok(args)
-}
-
-struct RemoteLocation {
-    store: Arc<dyn ObjectStore>,
-    object_path: ObjectPath,
-}
-
-fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
-    let uri = path.to_string_lossy().to_string();
-    if !is_remote_storage_uri(&uri) {
-        return Ok(None);
-    }
-
-    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
-    let (store, object_path) =
-        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
-
-    Ok(Some(RemoteLocation {
-        store: store.into(),
-        object_path,
-    }))
-}
-
-fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
-where
-    F: std::future::Future<Output = anyhow::Result<T>>,
-{
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("initialize async runtime")?;
-    rt.block_on(f)
-}
-
-fn is_object_not_found(err: &object_store::Error) -> bool {
-    matches!(err, object_store::Error::NotFound { .. })
-        || err.to_string().to_ascii_lowercase().contains("not found")
-}
-
-fn location_exists(path: &Path) -> anyhow::Result<bool> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let head = with_tokio_runtime(async move {
-            remote
-                .store
-                .head(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)
-        });
-        return match head {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                if err
-                    .downcast_ref::<object_store::Error>()
-                    .is_some_and(is_object_not_found)
-                {
-                    Ok(false)
-                } else {
-                    Err(err).with_context(|| format!("check existence {}", path.display()))
-                }
-            }
-        };
-    }
-    Ok(path.exists())
-}
-
-fn read_json_from_location<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = with_tokio_runtime(async move {
-            let result = remote
-                .store
-                .get(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)?;
-            result.bytes().await.map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("read {}", path.display()))?;
-
-        return serde_json::from_slice(&bytes)
-            .with_context(|| format!("parse json {}", path.display()));
-    }
-
-    read_json(path)
-}
-
-fn write_json_to_location<T: serde::Serialize>(
-    path: &Path,
-    value: &T,
-    pretty: bool,
-) -> anyhow::Result<()> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = if pretty {
-            serde_json::to_vec_pretty(value)?
-        } else {
-            serde_json::to_vec(value)?
-        };
-
-        with_tokio_runtime(async move {
-            remote
-                .store
-                .put(&remote.object_path, bytes.into())
-                .await
-                .map(|_| ())
-                .map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("write {}", path.display()))?;
-        return Ok(());
-    }
-
-    write_json(path, value, pretty)
-}
-
-fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
-    if location_exists(path)? {
-        Ok(Some(read_json_from_location(path)?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    Ok(perfgate_types::read_json_file(path)?)
-}
-
-fn write_json<T: serde::Serialize>(path: &Path, value: &T, pretty: bool) -> anyhow::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new(""));
-    if !parent.as_os_str().is_empty() {
-        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
-    }
-
-    let bytes = if pretty {
-        serde_json::to_vec_pretty(value)?
-    } else {
-        serde_json::to_vec(value)?
-    };
-
-    atomic_write(path, &bytes)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    use std::io::Write;
-
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = parent.to_path_buf();
-    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
-
-    {
-        let mut f =
-            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
-        f.write_all(bytes)
-            .with_context(|| format!("write temp {}", tmp.display()))?;
-        f.sync_all().ok();
-    }
-
-    fs::rename(&tmp, path)
-        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Reduce complexity in the large `perfgate` CLI entrypoint by isolating filesystem and remote-object-store JSON persistence into a single-responsibility submodule.
- Make the command-dispatch code in `crates/perfgate-cli/src/main.rs` focus on workflow logic rather than I/O details.

### Description
- Add new module `crates/perfgate-cli/src/io.rs` that contains remote URI parsing, Tokio runtime bridging, object-store head/get/put helpers, JSON read/write helpers, optional baseline loading, and atomic file write logic (`parse_remote_location`, `with_tokio_runtime`, `location_exists`, `read_json_from_location`, `write_json_to_location`, `load_optional_baseline_receipt`, `read_json`, `write_json`, `atomic_write`).
- Update `crates/perfgate-cli/src/main.rs` to `mod io;` and to import the focused helper surface (`atomic_write`, `load_optional_baseline_receipt`, `location_exists`, `read_json`, `read_json_from_location`, `with_tokio_runtime`, `write_json`, `write_json_to_location`) instead of owning persistence implementations inline.
- Keep visibility `pub(crate)` for helper functions to constrain the API to the CLI crate.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Built and prepared tests with `cargo test -p perfgate-cli --no-run` which compiled the crate successfully.
- Executed the CLI unit tests with `cargo test -p perfgate-cli --bin perfgate` where the test binary ran and reported `34 passed; 0 failed`.
- Ran lints with `cargo clippy -p perfgate-cli --all-targets -- -D warnings` which completed without warnings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd9969c4833380ff1c423c8a4bf3)