### PR TITLE
Refactor export renderers into SRP modules

### DIFF
--- a/crates/perfgate/src/app/export.rs
+++ b/crates/perfgate/src/app/export.rs
@@ -54,9 +54,16 @@
 //! assert!(csv.contains("bench"));
 //! ```
 
-use std::fmt::Write;
-
 use perfgate_types::{CompareReceipt, Metric, MetricStatus, RunReceipt};
+
+mod csv;
+mod escape;
+mod html;
+mod jsonl;
+mod junit;
+mod prometheus;
+
+pub use escape::csv_escape;
 
 /// Supported export formats.
 ///
@@ -257,33 +264,12 @@ impl ExportUseCase {
         let row = Self::run_to_row(receipt);
 
         match format {
-            ExportFormat::Csv => Self::run_row_to_csv(&row),
-            ExportFormat::Jsonl => Self::run_row_to_jsonl(&row),
-            ExportFormat::Html => Self::run_row_to_html(&row),
-            ExportFormat::Prometheus => Self::run_row_to_prometheus(&row),
-            ExportFormat::JUnit => Self::run_row_to_junit_run(receipt, &row),
+            ExportFormat::Csv => csv::run_row_to_csv(&row),
+            ExportFormat::Jsonl => jsonl::run_row_to_jsonl(&row),
+            ExportFormat::Html => html::run_row_to_html(&row),
+            ExportFormat::Prometheus => prometheus::run_row_to_prometheus(&row),
+            ExportFormat::JUnit => junit::run_row_to_junit_run(receipt, &row),
         }
-    }
-
-    fn run_row_to_junit_run(receipt: &RunReceipt, _row: &RunExportRow) -> anyhow::Result<String> {
-        let mut out = String::new();
-        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        out.push_str("<testsuites name=\"perfgate\">\n");
-        writeln!(
-            out,
-            "  <testsuite name=\"{}\" tests=\"1\" failures=\"0\" errors=\"0\">",
-            html_escape(&receipt.bench.name)
-        )?;
-        writeln!(
-            out,
-            "    <testcase name=\"execution\" classname=\"perfgate.{}\" time=\"{}\">",
-            html_escape(&receipt.bench.name),
-            receipt.stats.wall_ms.median as f64 / 1000.0
-        )?;
-        out.push_str("    </testcase>\n");
-        out.push_str("  </testsuite>\n");
-        out.push_str("</testsuites>\n");
-        Ok(out)
     }
 
     /// Export a [`CompareReceipt`] to the specified format.
@@ -325,11 +311,11 @@ impl ExportUseCase {
         let rows = Self::compare_to_rows(receipt);
 
         match format {
-            ExportFormat::Csv => Self::compare_rows_to_csv(&rows),
-            ExportFormat::Jsonl => Self::compare_rows_to_jsonl(&rows),
-            ExportFormat::Html => Self::compare_rows_to_html(&rows),
-            ExportFormat::Prometheus => Self::compare_rows_to_prometheus(&rows),
-            ExportFormat::JUnit => Self::compare_rows_to_junit(receipt, &rows),
+            ExportFormat::Csv => csv::compare_rows_to_csv(&rows),
+            ExportFormat::Jsonl => jsonl::compare_rows_to_jsonl(&rows),
+            ExportFormat::Html => html::compare_rows_to_html(&rows),
+            ExportFormat::Prometheus => prometheus::compare_rows_to_prometheus(&rows),
+            ExportFormat::JUnit => junit::compare_rows_to_junit(receipt, &rows),
         }
     }
 
@@ -385,365 +371,6 @@ impl ExportUseCase {
         rows.sort_by(|a, b| a.metric.cmp(&b.metric));
         rows
     }
-
-    fn run_row_to_csv(row: &RunExportRow) -> anyhow::Result<String> {
-        let mut output = String::new();
-
-        output.push_str("bench_name,wall_ms_median,wall_ms_min,wall_ms_max,binary_bytes_median,cpu_ms_median,ctx_switches_median,max_rss_kb_median,page_faults_median,io_read_bytes_median,io_write_bytes_median,network_packets_median,energy_uj_median,throughput_median,sample_count,timestamp\n");
-
-        output.push_str(&csv_escape(&row.bench_name));
-        write!(
-            output,
-            ",{},{},{},",
-            row.wall_ms_median, row.wall_ms_min, row.wall_ms_max
-        )?;
-        write_opt_u64(&mut output, row.binary_bytes_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.cpu_ms_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.ctx_switches_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.max_rss_kb_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.page_faults_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.io_read_bytes_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.io_write_bytes_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.network_packets_median);
-        output.push(',');
-        write_opt_u64(&mut output, row.energy_uj_median);
-        output.push(',');
-        if let Some(v) = row.throughput_median {
-            write!(output, "{:.6}", v)?;
-        }
-        write!(output, ",{},", row.sample_count)?;
-        output.push_str(&csv_escape(&row.timestamp));
-        output.push('\n');
-
-        Ok(output)
-    }
-
-    /// Format RunExportRow as JSONL.
-    fn run_row_to_jsonl(row: &RunExportRow) -> anyhow::Result<String> {
-        let json = serde_json::to_string(row)?;
-        let mut out = json;
-        out.push('\n');
-        Ok(out)
-    }
-
-    /// Format CompareExportRows as CSV (RFC 4180).
-    fn compare_rows_to_csv(rows: &[CompareExportRow]) -> anyhow::Result<String> {
-        let mut output = String::new();
-
-        output.push_str(
-            "bench_name,metric,baseline_value,current_value,regression_pct,status,threshold\n",
-        );
-
-        for row in rows {
-            output.push_str(&csv_escape(&row.bench_name));
-            output.push(',');
-            output.push_str(&csv_escape(&row.metric));
-            write!(
-                output,
-                ",{:.6},{:.6},{:.6},",
-                row.baseline_value, row.current_value, row.regression_pct
-            )?;
-            output.push_str(&csv_escape(&row.status));
-            writeln!(output, ",{:.6}", row.threshold)?;
-        }
-
-        Ok(output)
-    }
-
-    /// Format CompareExportRows as JSONL.
-    fn compare_rows_to_jsonl(rows: &[CompareExportRow]) -> anyhow::Result<String> {
-        let mut output = String::new();
-
-        for row in rows {
-            let json = serde_json::to_string(row)?;
-            writeln!(output, "{}", json)?;
-        }
-
-        Ok(output)
-    }
-
-    fn run_row_to_html(row: &RunExportRow) -> anyhow::Result<String> {
-        let html = format!(
-            "<!doctype html><html><head><meta charset=\"utf-8\"><title>perfgate run export</title></head><body>\
-             <h1>perfgate run export</h1>\
-             <table border=\"1\">\
-             <thead><tr><th>bench_name</th><th>wall_ms_median</th><th>wall_ms_min</th><th>wall_ms_max</th><th>binary_bytes_median</th><th>cpu_ms_median</th><th>ctx_switches_median</th><th>max_rss_kb_median</th><th>page_faults_median</th><th>io_read_bytes_median</th><th>io_write_bytes_median</th><th>network_packets_median</th><th>energy_uj_median</th><th>throughput_median</th><th>sample_count</th><th>timestamp</th></tr></thead>\
-             <tbody><tr><td>{bench}</td><td>{wall_med}</td><td>{wall_min}</td><td>{wall_max}</td><td>{binary}</td><td>{cpu}</td><td>{ctx}</td><td>{rss}</td><td>{pf}</td><td>{io_read}</td><td>{io_write}</td><td>{net}</td><td>{energy}</td><td>{throughput}</td><td>{sample_count}</td><td>{timestamp}</td></tr></tbody>\
-             </table></body></html>\n",
-            bench = html_escape(&row.bench_name),
-            wall_med = row.wall_ms_median,
-            wall_min = row.wall_ms_min,
-            wall_max = row.wall_ms_max,
-            binary = row
-                .binary_bytes_median
-                .map_or(String::new(), |v| v.to_string()),
-            cpu = row.cpu_ms_median.map_or(String::new(), |v| v.to_string()),
-            ctx = row
-                .ctx_switches_median
-                .map_or(String::new(), |v| v.to_string()),
-            rss = row
-                .max_rss_kb_median
-                .map_or(String::new(), |v| v.to_string()),
-            pf = row
-                .page_faults_median
-                .map_or(String::new(), |v| v.to_string()),
-            io_read = row
-                .io_read_bytes_median
-                .map_or(String::new(), |v| v.to_string()),
-            io_write = row
-                .io_write_bytes_median
-                .map_or(String::new(), |v| v.to_string()),
-            net = row
-                .network_packets_median
-                .map_or(String::new(), |v| v.to_string()),
-            energy = row
-                .energy_uj_median
-                .map_or(String::new(), |v| v.to_string()),
-            throughput = row
-                .throughput_median
-                .map_or(String::new(), |v| format!("{:.6}", v)),
-            sample_count = row.sample_count,
-            timestamp = html_escape(&row.timestamp),
-        );
-        Ok(html)
-    }
-
-    fn compare_rows_to_html(rows: &[CompareExportRow]) -> anyhow::Result<String> {
-        let mut out = String::from(
-            "<!doctype html><html><head><meta charset=\"utf-8\"><title>perfgate compare export</title></head><body><h1>perfgate compare export</h1><table border=\"1\"><thead><tr><th>bench_name</th><th>metric</th><th>baseline_value</th><th>current_value</th><th>regression_pct</th><th>status</th><th>threshold</th></tr></thead><tbody>",
-        );
-
-        for row in rows {
-            write!(
-                out,
-                "<tr><td>{}</td><td>{}</td><td>{:.6}</td><td>{:.6}</td><td>{:.6}</td><td>{}</td><td>{:.6}</td></tr>",
-                html_escape(&row.bench_name),
-                html_escape(&row.metric),
-                row.baseline_value,
-                row.current_value,
-                row.regression_pct,
-                html_escape(&row.status),
-                row.threshold
-            )?;
-        }
-
-        out.push_str("</tbody></table></body></html>\n");
-        Ok(out)
-    }
-
-    fn run_row_to_prometheus(row: &RunExportRow) -> anyhow::Result<String> {
-        let bench = prometheus_escape_label_value(&row.bench_name);
-        let mut out = String::new();
-        writeln!(
-            out,
-            "perfgate_run_wall_ms_median{{bench=\"{}\"}} {}",
-            bench, row.wall_ms_median
-        )?;
-        writeln!(
-            out,
-            "perfgate_run_wall_ms_min{{bench=\"{}\"}} {}",
-            bench, row.wall_ms_min
-        )?;
-        writeln!(
-            out,
-            "perfgate_run_wall_ms_max{{bench=\"{}\"}} {}",
-            bench, row.wall_ms_max
-        )?;
-        if let Some(v) = row.binary_bytes_median {
-            writeln!(
-                out,
-                "perfgate_run_binary_bytes_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.cpu_ms_median {
-            writeln!(
-                out,
-                "perfgate_run_cpu_ms_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.ctx_switches_median {
-            writeln!(
-                out,
-                "perfgate_run_ctx_switches_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.max_rss_kb_median {
-            writeln!(
-                out,
-                "perfgate_run_max_rss_kb_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.page_faults_median {
-            writeln!(
-                out,
-                "perfgate_run_page_faults_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.io_read_bytes_median {
-            writeln!(
-                out,
-                "perfgate_run_io_read_bytes_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.io_write_bytes_median {
-            writeln!(
-                out,
-                "perfgate_run_io_write_bytes_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.network_packets_median {
-            writeln!(
-                out,
-                "perfgate_run_network_packets_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.energy_uj_median {
-            writeln!(
-                out,
-                "perfgate_run_energy_uj_median{{bench=\"{}\"}} {}",
-                bench, v
-            )?;
-        }
-        if let Some(v) = row.throughput_median {
-            writeln!(
-                out,
-                "perfgate_run_throughput_per_s_median{{bench=\"{}\"}} {:.6}",
-                bench, v
-            )?;
-        }
-        writeln!(
-            out,
-            "perfgate_run_sample_count{{bench=\"{}\"}} {}",
-            bench, row.sample_count
-        )?;
-        Ok(out)
-    }
-
-    fn compare_rows_to_junit(
-        receipt: &CompareReceipt,
-        rows: &[CompareExportRow],
-    ) -> anyhow::Result<String> {
-        let mut out = String::new();
-        let total = rows.len();
-        let failures = rows.iter().filter(|r| r.status == "fail").count();
-        let errors = rows.iter().filter(|r| r.status == "error").count();
-
-        out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
-        writeln!(
-            out,
-            "<testsuites name=\"perfgate\" tests=\"{}\" failures=\"{}\" errors=\"{}\">",
-            total, failures, errors
-        )?;
-
-        writeln!(
-            out,
-            "  <testsuite name=\"{}\" tests=\"{}\" failures=\"{}\" errors=\"{}\">",
-            html_escape(&receipt.bench.name),
-            total,
-            failures,
-            errors
-        )?;
-
-        for row in rows {
-            writeln!(
-                out,
-                "    <testcase name=\"{}\" classname=\"perfgate.{}\" time=\"0.0\">",
-                html_escape(&row.metric),
-                html_escape(&receipt.bench.name)
-            )?;
-
-            if row.status == "fail" {
-                write!(
-                    out,
-                    "      <failure message=\"Performance regression detected for {}\">",
-                    html_escape(&row.metric)
-                )?;
-                write!(
-                    out,
-                    "Metric: {}\nBaseline: {:.6}\nCurrent: {:.6}\nRegression: {:.2}%\nThreshold: {:.2}%",
-                    row.metric,
-                    row.baseline_value,
-                    row.current_value,
-                    row.regression_pct,
-                    row.threshold
-                )?;
-                out.push_str("</failure>\n");
-            } else if row.status == "error" {
-                write!(
-                    out,
-                    "      <error message=\"Error occurred during performance check for {}\">",
-                    html_escape(&row.metric)
-                )?;
-                out.push_str("</error>\n");
-            }
-
-            out.push_str("    </testcase>\n");
-        }
-
-        out.push_str("  </testsuite>\n");
-        out.push_str("</testsuites>\n");
-
-        Ok(out)
-    }
-
-    fn compare_rows_to_prometheus(rows: &[CompareExportRow]) -> anyhow::Result<String> {
-        let mut out = String::new();
-        for row in rows {
-            let bench = prometheus_escape_label_value(&row.bench_name);
-            let metric = prometheus_escape_label_value(&row.metric);
-            writeln!(
-                out,
-                "perfgate_compare_baseline_value{{bench=\"{}\",metric=\"{}\"}} {:.6}",
-                bench, metric, row.baseline_value
-            )?;
-            writeln!(
-                out,
-                "perfgate_compare_current_value{{bench=\"{}\",metric=\"{}\"}} {:.6}",
-                bench, metric, row.current_value
-            )?;
-            writeln!(
-                out,
-                "perfgate_compare_regression_pct{{bench=\"{}\",metric=\"{}\"}} {:.6}",
-                bench, metric, row.regression_pct
-            )?;
-            writeln!(
-                out,
-                "perfgate_compare_threshold_pct{{bench=\"{}\",metric=\"{}\"}} {:.6}",
-                bench, metric, row.threshold
-            )?;
-
-            let status_code = match row.status.as_str() {
-                "pass" => 0,
-                "warn" => 1,
-                "fail" => 2,
-                _ => -1,
-            };
-            writeln!(
-                out,
-                "perfgate_compare_status{{bench=\"{}\",metric=\"{}\",status=\"{}\"}} {}",
-                bench,
-                metric,
-                prometheus_escape_label_value(&row.status),
-                status_code
-            )?;
-        }
-        Ok(out)
-    }
 }
 
 /// Convert Metric enum to snake_case string.
@@ -761,47 +388,9 @@ fn status_to_string(status: MetricStatus) -> String {
     }
 }
 
-/// Write an optional u64 value to a buffer. Writes nothing if `None`.
-fn write_opt_u64(buf: &mut String, val: Option<u64>) {
-    if let Some(v) = val {
-        // write! to a String is infallible, unwrap is safe
-        let _ = write!(buf, "{}", v);
-    }
-}
-
-/// Escape a string for CSV per RFC 4180.
-/// If the string contains comma, double quote, or newline, wrap in quotes and escape quotes.
-///
-/// # Examples
-///
-/// ```
-/// use perfgate::app::export::csv_escape;
-///
-/// assert_eq!(csv_escape("hello"), "hello");
-/// assert_eq!(csv_escape("has,comma"), "\"has,comma\"");
-/// assert_eq!(csv_escape("has\"quote"), "\"has\"\"quote\"");
-/// ```
-pub fn csv_escape(s: &str) -> String {
-    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
-        format!("\"{}\"", s.replace('"', "\"\""))
-    } else {
-        s.to_string()
-    }
-}
-
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
-
-fn prometheus_escape_label_value(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
 #[cfg(test)]
 mod tests {
+    use super::escape::{html_escape, prometheus_escape_label_value};
     use super::*;
     use perfgate_types::{
         BenchMeta, Budget, COMPARE_SCHEMA_V1, CompareRef, Delta, Direction, F64Summary, HostInfo,

--- a/crates/perfgate/src/app/export/csv.rs
+++ b/crates/perfgate/src/app/export/csv.rs
@@ -1,0 +1,77 @@
+//! CSV export rendering.
+
+use std::fmt::Write;
+
+use super::escape::csv_escape;
+use super::{CompareExportRow, RunExportRow};
+
+pub(super) fn run_row_to_csv(row: &RunExportRow) -> anyhow::Result<String> {
+    let mut output = String::new();
+
+    output.push_str("bench_name,wall_ms_median,wall_ms_min,wall_ms_max,binary_bytes_median,cpu_ms_median,ctx_switches_median,max_rss_kb_median,page_faults_median,io_read_bytes_median,io_write_bytes_median,network_packets_median,energy_uj_median,throughput_median,sample_count,timestamp\n");
+
+    output.push_str(&csv_escape(&row.bench_name));
+    write!(
+        output,
+        ",{},{},{},",
+        row.wall_ms_median, row.wall_ms_min, row.wall_ms_max
+    )?;
+    write_opt_u64(&mut output, row.binary_bytes_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.cpu_ms_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.ctx_switches_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.max_rss_kb_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.page_faults_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.io_read_bytes_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.io_write_bytes_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.network_packets_median);
+    output.push(',');
+    write_opt_u64(&mut output, row.energy_uj_median);
+    output.push(',');
+    if let Some(v) = row.throughput_median {
+        write!(output, "{v:.6}")?;
+    }
+    write!(output, ",{},", row.sample_count)?;
+    output.push_str(&csv_escape(&row.timestamp));
+    output.push('\n');
+
+    Ok(output)
+}
+
+/// Format CompareExportRows as CSV (RFC 4180).
+pub(super) fn compare_rows_to_csv(rows: &[CompareExportRow]) -> anyhow::Result<String> {
+    let mut output = String::new();
+
+    output.push_str(
+        "bench_name,metric,baseline_value,current_value,regression_pct,status,threshold\n",
+    );
+
+    for row in rows {
+        output.push_str(&csv_escape(&row.bench_name));
+        output.push(',');
+        output.push_str(&csv_escape(&row.metric));
+        write!(
+            output,
+            ",{:.6},{:.6},{:.6},",
+            row.baseline_value, row.current_value, row.regression_pct
+        )?;
+        output.push_str(&csv_escape(&row.status));
+        writeln!(output, ",{:.6}", row.threshold)?;
+    }
+
+    Ok(output)
+}
+
+/// Write an optional u64 value to a buffer. Writes nothing if `None`.
+fn write_opt_u64(buf: &mut String, val: Option<u64>) {
+    if let Some(v) = val {
+        // write! to a String is infallible, unwrap is safe
+        let _ = write!(buf, "{v}");
+    }
+}

--- a/crates/perfgate/src/app/export/escape.rs
+++ b/crates/perfgate/src/app/export/escape.rs
@@ -1,0 +1,32 @@
+//! Escaping helpers for export renderers.
+
+/// Escape a string for CSV per RFC 4180.
+/// If the string contains comma, double quote, or newline, wrap in quotes and escape quotes.
+///
+/// # Examples
+///
+/// ```
+/// use perfgate::app::export::csv_escape;
+///
+/// assert_eq!(csv_escape("hello"), "hello");
+/// assert_eq!(csv_escape("has,comma"), "\"has,comma\"");
+/// assert_eq!(csv_escape("has\"quote"), "\"has\"\"quote\"");
+/// ```
+pub fn csv_escape(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') || s.contains('\r') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}
+
+pub(super) fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+pub(super) fn prometheus_escape_label_value(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}

--- a/crates/perfgate/src/app/export/html.rs
+++ b/crates/perfgate/src/app/export/html.rs
@@ -1,0 +1,75 @@
+//! HTML export rendering.
+
+use std::fmt::Write;
+
+use super::escape::html_escape;
+use super::{CompareExportRow, RunExportRow};
+
+pub(super) fn run_row_to_html(row: &RunExportRow) -> anyhow::Result<String> {
+    let html = format!(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>perfgate run export</title></head><body>\
+         <h1>perfgate run export</h1>\
+         <table border=\"1\">\
+         <thead><tr><th>bench_name</th><th>wall_ms_median</th><th>wall_ms_min</th><th>wall_ms_max</th><th>binary_bytes_median</th><th>cpu_ms_median</th><th>ctx_switches_median</th><th>max_rss_kb_median</th><th>page_faults_median</th><th>io_read_bytes_median</th><th>io_write_bytes_median</th><th>network_packets_median</th><th>energy_uj_median</th><th>throughput_median</th><th>sample_count</th><th>timestamp</th></tr></thead>\
+         <tbody><tr><td>{bench}</td><td>{wall_med}</td><td>{wall_min}</td><td>{wall_max}</td><td>{binary}</td><td>{cpu}</td><td>{ctx}</td><td>{rss}</td><td>{pf}</td><td>{io_read}</td><td>{io_write}</td><td>{net}</td><td>{energy}</td><td>{throughput}</td><td>{sample_count}</td><td>{timestamp}</td></tr></tbody>\
+         </table></body></html>\n",
+        bench = html_escape(&row.bench_name),
+        wall_med = row.wall_ms_median,
+        wall_min = row.wall_ms_min,
+        wall_max = row.wall_ms_max,
+        binary = row
+            .binary_bytes_median
+            .map_or(String::new(), |v| v.to_string()),
+        cpu = row.cpu_ms_median.map_or(String::new(), |v| v.to_string()),
+        ctx = row
+            .ctx_switches_median
+            .map_or(String::new(), |v| v.to_string()),
+        rss = row
+            .max_rss_kb_median
+            .map_or(String::new(), |v| v.to_string()),
+        pf = row
+            .page_faults_median
+            .map_or(String::new(), |v| v.to_string()),
+        io_read = row
+            .io_read_bytes_median
+            .map_or(String::new(), |v| v.to_string()),
+        io_write = row
+            .io_write_bytes_median
+            .map_or(String::new(), |v| v.to_string()),
+        net = row
+            .network_packets_median
+            .map_or(String::new(), |v| v.to_string()),
+        energy = row
+            .energy_uj_median
+            .map_or(String::new(), |v| v.to_string()),
+        throughput = row
+            .throughput_median
+            .map_or(String::new(), |v| format!("{v:.6}")),
+        sample_count = row.sample_count,
+        timestamp = html_escape(&row.timestamp),
+    );
+    Ok(html)
+}
+
+pub(super) fn compare_rows_to_html(rows: &[CompareExportRow]) -> anyhow::Result<String> {
+    let mut out = String::from(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>perfgate compare export</title></head><body><h1>perfgate compare export</h1><table border=\"1\"><thead><tr><th>bench_name</th><th>metric</th><th>baseline_value</th><th>current_value</th><th>regression_pct</th><th>status</th><th>threshold</th></tr></thead><tbody>",
+    );
+
+    for row in rows {
+        write!(
+            out,
+            "<tr><td>{}</td><td>{}</td><td>{:.6}</td><td>{:.6}</td><td>{:.6}</td><td>{}</td><td>{:.6}</td></tr>",
+            html_escape(&row.bench_name),
+            html_escape(&row.metric),
+            row.baseline_value,
+            row.current_value,
+            row.regression_pct,
+            html_escape(&row.status),
+            row.threshold
+        )?;
+    }
+
+    out.push_str("</tbody></table></body></html>\n");
+    Ok(out)
+}

--- a/crates/perfgate/src/app/export/jsonl.rs
+++ b/crates/perfgate/src/app/export/jsonl.rs
@@ -1,0 +1,25 @@
+//! JSON Lines export rendering.
+
+use std::fmt::Write;
+
+use super::{CompareExportRow, RunExportRow};
+
+/// Format RunExportRow as JSONL.
+pub(super) fn run_row_to_jsonl(row: &RunExportRow) -> anyhow::Result<String> {
+    let json = serde_json::to_string(row)?;
+    let mut out = json;
+    out.push('\n');
+    Ok(out)
+}
+
+/// Format CompareExportRows as JSONL.
+pub(super) fn compare_rows_to_jsonl(rows: &[CompareExportRow]) -> anyhow::Result<String> {
+    let mut output = String::new();
+
+    for row in rows {
+        let json = serde_json::to_string(row)?;
+        writeln!(output, "{json}")?;
+    }
+
+    Ok(output)
+}

--- a/crates/perfgate/src/app/export/junit.rs
+++ b/crates/perfgate/src/app/export/junit.rs
@@ -1,0 +1,96 @@
+//! JUnit XML export rendering.
+
+use std::fmt::Write;
+
+use perfgate_types::RunReceipt;
+
+use super::escape::html_escape;
+use super::{CompareExportRow, RunExportRow};
+use perfgate_types::CompareReceipt;
+
+pub(super) fn run_row_to_junit_run(
+    receipt: &RunReceipt,
+    _row: &RunExportRow,
+) -> anyhow::Result<String> {
+    let mut out = String::new();
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    out.push_str("<testsuites name=\"perfgate\">\n");
+    writeln!(
+        out,
+        "  <testsuite name=\"{}\" tests=\"1\" failures=\"0\" errors=\"0\">",
+        html_escape(&receipt.bench.name)
+    )?;
+    writeln!(
+        out,
+        "    <testcase name=\"execution\" classname=\"perfgate.{}\" time=\"{}\">",
+        html_escape(&receipt.bench.name),
+        receipt.stats.wall_ms.median as f64 / 1000.0
+    )?;
+    out.push_str("    </testcase>\n");
+    out.push_str("  </testsuite>\n");
+    out.push_str("</testsuites>\n");
+    Ok(out)
+}
+
+pub(super) fn compare_rows_to_junit(
+    receipt: &CompareReceipt,
+    rows: &[CompareExportRow],
+) -> anyhow::Result<String> {
+    let mut out = String::new();
+    let total = rows.len();
+    let failures = rows.iter().filter(|r| r.status == "fail").count();
+    let errors = rows.iter().filter(|r| r.status == "error").count();
+
+    out.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    writeln!(
+        out,
+        "<testsuites name=\"perfgate\" tests=\"{total}\" failures=\"{failures}\" errors=\"{errors}\">"
+    )?;
+
+    writeln!(
+        out,
+        "  <testsuite name=\"{}\" tests=\"{total}\" failures=\"{failures}\" errors=\"{errors}\">",
+        html_escape(&receipt.bench.name)
+    )?;
+
+    for row in rows {
+        writeln!(
+            out,
+            "    <testcase name=\"{}\" classname=\"perfgate.{}\" time=\"0.0\">",
+            html_escape(&row.metric),
+            html_escape(&receipt.bench.name)
+        )?;
+
+        if row.status == "fail" {
+            write!(
+                out,
+                "      <failure message=\"Performance regression detected for {}\">",
+                html_escape(&row.metric)
+            )?;
+            write!(
+                out,
+                "Metric: {}\nBaseline: {:.6}\nCurrent: {:.6}\nRegression: {:.2}%\nThreshold: {:.2}%",
+                row.metric,
+                row.baseline_value,
+                row.current_value,
+                row.regression_pct,
+                row.threshold
+            )?;
+            out.push_str("</failure>\n");
+        } else if row.status == "error" {
+            write!(
+                out,
+                "      <error message=\"Error occurred during performance check for {}\">",
+                html_escape(&row.metric)
+            )?;
+            out.push_str("</error>\n");
+        }
+
+        out.push_str("    </testcase>\n");
+    }
+
+    out.push_str("  </testsuite>\n");
+    out.push_str("</testsuites>\n");
+
+    Ok(out)
+}

--- a/crates/perfgate/src/app/export/prometheus.rs
+++ b/crates/perfgate/src/app/export/prometheus.rs
@@ -1,0 +1,113 @@
+//! Prometheus text exposition export rendering.
+
+use std::fmt::Write;
+
+use super::escape::prometheus_escape_label_value;
+use super::{CompareExportRow, RunExportRow};
+
+pub(super) fn run_row_to_prometheus(row: &RunExportRow) -> anyhow::Result<String> {
+    let bench = prometheus_escape_label_value(&row.bench_name);
+    let mut out = String::new();
+    writeln!(
+        out,
+        "perfgate_run_wall_ms_median{{bench=\"{bench}\"}} {}",
+        row.wall_ms_median
+    )?;
+    writeln!(
+        out,
+        "perfgate_run_wall_ms_min{{bench=\"{bench}\"}} {}",
+        row.wall_ms_min
+    )?;
+    writeln!(
+        out,
+        "perfgate_run_wall_ms_max{{bench=\"{bench}\"}} {}",
+        row.wall_ms_max
+    )?;
+    write_optional_u64(&mut out, &bench, "binary_bytes", row.binary_bytes_median)?;
+    write_optional_u64(&mut out, &bench, "cpu_ms", row.cpu_ms_median)?;
+    write_optional_u64(&mut out, &bench, "ctx_switches", row.ctx_switches_median)?;
+    write_optional_u64(&mut out, &bench, "max_rss_kb", row.max_rss_kb_median)?;
+    write_optional_u64(&mut out, &bench, "page_faults", row.page_faults_median)?;
+    write_optional_u64(&mut out, &bench, "io_read_bytes", row.io_read_bytes_median)?;
+    write_optional_u64(
+        &mut out,
+        &bench,
+        "io_write_bytes",
+        row.io_write_bytes_median,
+    )?;
+    write_optional_u64(
+        &mut out,
+        &bench,
+        "network_packets",
+        row.network_packets_median,
+    )?;
+    write_optional_u64(&mut out, &bench, "energy_uj", row.energy_uj_median)?;
+    if let Some(v) = row.throughput_median {
+        writeln!(
+            out,
+            "perfgate_run_throughput_per_s_median{{bench=\"{bench}\"}} {v:.6}"
+        )?;
+    }
+    writeln!(
+        out,
+        "perfgate_run_sample_count{{bench=\"{bench}\"}} {}",
+        row.sample_count
+    )?;
+    Ok(out)
+}
+
+pub(super) fn compare_rows_to_prometheus(rows: &[CompareExportRow]) -> anyhow::Result<String> {
+    let mut out = String::new();
+    for row in rows {
+        let bench = prometheus_escape_label_value(&row.bench_name);
+        let metric = prometheus_escape_label_value(&row.metric);
+        writeln!(
+            out,
+            "perfgate_compare_baseline_value{{bench=\"{bench}\",metric=\"{metric}\"}} {:.6}",
+            row.baseline_value
+        )?;
+        writeln!(
+            out,
+            "perfgate_compare_current_value{{bench=\"{bench}\",metric=\"{metric}\"}} {:.6}",
+            row.current_value
+        )?;
+        writeln!(
+            out,
+            "perfgate_compare_regression_pct{{bench=\"{bench}\",metric=\"{metric}\"}} {:.6}",
+            row.regression_pct
+        )?;
+        writeln!(
+            out,
+            "perfgate_compare_threshold_pct{{bench=\"{bench}\",metric=\"{metric}\"}} {:.6}",
+            row.threshold
+        )?;
+
+        let status_code = match row.status.as_str() {
+            "pass" => 0,
+            "warn" => 1,
+            "fail" => 2,
+            _ => -1,
+        };
+        writeln!(
+            out,
+            "perfgate_compare_status{{bench=\"{bench}\",metric=\"{metric}\",status=\"{}\"}} {status_code}",
+            prometheus_escape_label_value(&row.status)
+        )?;
+    }
+    Ok(out)
+}
+
+fn write_optional_u64(
+    out: &mut String,
+    bench: &str,
+    metric_name: &str,
+    value: Option<u64>,
+) -> anyhow::Result<()> {
+    if let Some(v) = value {
+        writeln!(
+            out,
+            "perfgate_run_{metric_name}_median{{bench=\"{bench}\"}} {v}"
+        )?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- The `app::export` implementation was large and mixed responsibilities for multiple output formats, making it hard to read and maintain.
- Split format-specific rendering into single-responsibility modules to improve clarity and reduce the surface area for future changes.

### Description
- Split the monolithic `crates/perfgate/src/app/export.rs` renderer into format-owned submodules: `csv`, `jsonl`, `html`, `junit`, `prometheus`, and `escape` under `crates/perfgate/src/app/export/` and re-exported `csv_escape` from `escape`.
- Updated `ExportUseCase` to delegate format rendering to the new modules while keeping the public API stable (`ExportUseCase`, `RunExportRow`, `CompareExportRow`, and `csv_escape`).
- Moved helper logic such as CSV escaping, optional u64 writers, HTML escaping, Prometheus label escaping, and format-specific string assembly into their respective modules.
- Adjusted unit tests to import escape helpers from the new `escape` module and left test behaviour unchanged.

### Testing
- Ran formatting: `cargo fmt --all` and confirmed code formatted successfully.
- Ran unit tests for the export use case: `cargo test -p perfgate --all-features app::export` and observed all tests passed (`68` tests passed, `0` failed).
- Ran lints: `cargo clippy -p perfgate --all-features --lib -- -D warnings` and ensured there are no clippy warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd987ba88333ac39b4cdb414af3b)