### PR TITLE
Refactor CLI storage helpers into SRP storage module

### DIFF
--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1,9 +1,15 @@
 //! perfgate CLI - entry point for all workflows.
 
+mod storage;
+
+use crate::storage::{
+    atomic_write, load_optional_baseline_receipt, location_exists, read_json,
+    read_json_from_location, with_tokio_runtime, write_json, write_json_to_location,
+};
+
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use glob::glob;
-use object_store::{ObjectStore, path::Path as ObjectPath};
 use perfgate::app as perfgate_app;
 use perfgate::domain as perfgate_domain;
 use perfgate::integrations::github::{self, CommentOptions, GitHubClient};
@@ -67,7 +73,6 @@ use std::process::Command as ProcessCommand;
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-use url::Url;
 
 const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured; set `--baseline-server`, `PERFGATE_SERVER_URL`, or `[baseline_server].url` in `perfgate.toml`";
 const DEFAULT_FALLBACK_BASELINE_DIR: &str = "baselines";
@@ -10485,162 +10490,6 @@ fn normalize_paired_cli_command(args: Vec<String>, flag_name: &str) -> anyhow::R
     }
 
     Ok(args)
-}
-
-struct RemoteLocation {
-    store: Arc<dyn ObjectStore>,
-    object_path: ObjectPath,
-}
-
-fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
-    let uri = path.to_string_lossy().to_string();
-    if !is_remote_storage_uri(&uri) {
-        return Ok(None);
-    }
-
-    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
-    let (store, object_path) =
-        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
-
-    Ok(Some(RemoteLocation {
-        store: store.into(),
-        object_path,
-    }))
-}
-
-fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
-where
-    F: std::future::Future<Output = anyhow::Result<T>>,
-{
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("initialize async runtime")?;
-    rt.block_on(f)
-}
-
-fn is_object_not_found(err: &object_store::Error) -> bool {
-    matches!(err, object_store::Error::NotFound { .. })
-        || err.to_string().to_ascii_lowercase().contains("not found")
-}
-
-fn location_exists(path: &Path) -> anyhow::Result<bool> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let head = with_tokio_runtime(async move {
-            remote
-                .store
-                .head(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)
-        });
-        return match head {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                if err
-                    .downcast_ref::<object_store::Error>()
-                    .is_some_and(is_object_not_found)
-                {
-                    Ok(false)
-                } else {
-                    Err(err).with_context(|| format!("check existence {}", path.display()))
-                }
-            }
-        };
-    }
-    Ok(path.exists())
-}
-
-fn read_json_from_location<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = with_tokio_runtime(async move {
-            let result = remote
-                .store
-                .get(&remote.object_path)
-                .await
-                .map_err(anyhow::Error::from)?;
-            result.bytes().await.map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("read {}", path.display()))?;
-
-        return serde_json::from_slice(&bytes)
-            .with_context(|| format!("parse json {}", path.display()));
-    }
-
-    read_json(path)
-}
-
-fn write_json_to_location<T: serde::Serialize>(
-    path: &Path,
-    value: &T,
-    pretty: bool,
-) -> anyhow::Result<()> {
-    if let Some(remote) = parse_remote_location(path)? {
-        let bytes = if pretty {
-            serde_json::to_vec_pretty(value)?
-        } else {
-            serde_json::to_vec(value)?
-        };
-
-        with_tokio_runtime(async move {
-            remote
-                .store
-                .put(&remote.object_path, bytes.into())
-                .await
-                .map(|_| ())
-                .map_err(anyhow::Error::from)
-        })
-        .with_context(|| format!("write {}", path.display()))?;
-        return Ok(());
-    }
-
-    write_json(path, value, pretty)
-}
-
-fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
-    if location_exists(path)? {
-        Ok(Some(read_json_from_location(path)?))
-    } else {
-        Ok(None)
-    }
-}
-
-fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
-    Ok(perfgate_types::read_json_file(path)?)
-}
-
-fn write_json<T: serde::Serialize>(path: &Path, value: &T, pretty: bool) -> anyhow::Result<()> {
-    let parent = path.parent().unwrap_or_else(|| Path::new(""));
-    if !parent.as_os_str().is_empty() {
-        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
-    }
-
-    let bytes = if pretty {
-        serde_json::to_vec_pretty(value)?
-    } else {
-        serde_json::to_vec(value)?
-    };
-
-    atomic_write(path, &bytes)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
-    use std::io::Write;
-
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    let mut tmp = parent.to_path_buf();
-    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
-
-    {
-        let mut f =
-            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
-        f.write_all(bytes)
-            .with_context(|| format!("write temp {}", tmp.display()))?;
-        f.sync_all().ok();
-    }
-
-    fs::rename(&tmp, path)
-        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/perfgate-cli/src/storage.rs
+++ b/crates/perfgate-cli/src/storage.rs
@@ -1,0 +1,172 @@
+//! Storage helpers for local and object-store backed JSON artifacts.
+
+use anyhow::Context;
+use object_store::{ObjectStore, path::Path as ObjectPath};
+use perfgate::app::baseline_resolve::is_remote_storage_uri;
+use perfgate_types::RunReceipt;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use url::Url;
+
+struct RemoteLocation {
+    store: Arc<dyn ObjectStore>,
+    object_path: ObjectPath,
+}
+
+fn parse_remote_location(path: &Path) -> anyhow::Result<Option<RemoteLocation>> {
+    let uri = path.to_string_lossy().to_string();
+    if !is_remote_storage_uri(&uri) {
+        return Ok(None);
+    }
+
+    let url = Url::parse(&uri).with_context(|| format!("invalid remote URI {}", uri))?;
+    let (store, object_path) =
+        object_store::parse_url(&url).with_context(|| format!("parse remote URI {}", uri))?;
+
+    Ok(Some(RemoteLocation {
+        store: store.into(),
+        object_path,
+    }))
+}
+
+pub(crate) fn with_tokio_runtime<T, F>(f: F) -> anyhow::Result<T>
+where
+    F: std::future::Future<Output = anyhow::Result<T>>,
+{
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("initialize async runtime")?;
+    rt.block_on(f)
+}
+
+fn is_object_not_found(err: &object_store::Error) -> bool {
+    matches!(err, object_store::Error::NotFound { .. })
+        || err.to_string().to_ascii_lowercase().contains("not found")
+}
+
+pub(crate) fn location_exists(path: &Path) -> anyhow::Result<bool> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let head = with_tokio_runtime(async move {
+            remote
+                .store
+                .head(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)
+        });
+        return match head {
+            Ok(_) => Ok(true),
+            Err(err) => {
+                if err
+                    .downcast_ref::<object_store::Error>()
+                    .is_some_and(is_object_not_found)
+                {
+                    Ok(false)
+                } else {
+                    Err(err).with_context(|| format!("check existence {}", path.display()))
+                }
+            }
+        };
+    }
+    Ok(path.exists())
+}
+
+pub(crate) fn read_json_from_location<T: serde::de::DeserializeOwned>(
+    path: &Path,
+) -> anyhow::Result<T> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = with_tokio_runtime(async move {
+            let result = remote
+                .store
+                .get(&remote.object_path)
+                .await
+                .map_err(anyhow::Error::from)?;
+            result.bytes().await.map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("read {}", path.display()))?;
+
+        return serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse json {}", path.display()));
+    }
+
+    read_json(path)
+}
+
+pub(crate) fn write_json_to_location<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    if let Some(remote) = parse_remote_location(path)? {
+        let bytes = if pretty {
+            serde_json::to_vec_pretty(value)?
+        } else {
+            serde_json::to_vec(value)?
+        };
+
+        with_tokio_runtime(async move {
+            remote
+                .store
+                .put(&remote.object_path, bytes.into())
+                .await
+                .map(|_| ())
+                .map_err(anyhow::Error::from)
+        })
+        .with_context(|| format!("write {}", path.display()))?;
+        return Ok(());
+    }
+
+    write_json(path, value, pretty)
+}
+
+pub(crate) fn load_optional_baseline_receipt(path: &Path) -> anyhow::Result<Option<RunReceipt>> {
+    if location_exists(path)? {
+        Ok(Some(read_json_from_location(path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+pub(crate) fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> anyhow::Result<T> {
+    Ok(perfgate_types::read_json_file(path)?)
+}
+
+pub(crate) fn write_json<T: serde::Serialize>(
+    path: &Path,
+    value: &T,
+    pretty: bool,
+) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    if !parent.as_os_str().is_empty() {
+        fs::create_dir_all(parent).with_context(|| format!("create dir {}", parent.display()))?;
+    }
+
+    let bytes = if pretty {
+        serde_json::to_vec_pretty(value)?
+    } else {
+        serde_json::to_vec(value)?
+    };
+
+    atomic_write(path, &bytes)
+}
+
+pub(crate) fn atomic_write(path: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = parent.to_path_buf();
+    tmp.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+
+    {
+        let mut f =
+            fs::File::create(&tmp).with_context(|| format!("create temp {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("write temp {}", tmp.display()))?;
+        f.sync_all().ok();
+    }
+
+    fs::rename(&tmp, path)
+        .with_context(|| format!("rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Reduce the size and responsibilities of the CLI entrypoint by moving storage-related code into a focused module to follow the Single Responsibility Principle. 
- Isolate local vs remote (object-store) JSON read/write, existence checks, and atomic write logic so they can be reused and tested independently. 

### Description
- Extracted storage helpers into a new module at `crates/perfgate-cli/src/storage.rs` implementing `parse_remote_location`, `with_tokio_runtime`, `location_exists`, `read_json_from_location`, `write_json_to_location`, `load_optional_baseline_receipt`, `read_json`, `write_json`, and `atomic_write`. 
- Updated `crates/perfgate-cli/src/main.rs` to `mod storage;` and import the storage API (`atomic_write`, `load_optional_baseline_receipt`, `location_exists`, `read_json`, `read_json_from_location`, `with_tokio_runtime`, `write_json`, and `write_json_to_location`) so the CLI remains focused on command orchestration. 
- Preserved existing behavior for local filesystem operations and object-store-backed URIs, and kept error contexts and JSON pretty/compact serialization semantics unchanged. 

### Testing
- Ran formatting check with `cargo fmt --all -- --check`, which succeeded. 
- Exercised unit tests for the storage surface with `cargo test -p perfgate-cli storage --no-default-features` and targeted tests `cargo test -p perfgate-cli write_json` and `cargo test -p perfgate-cli atomic_write`, all of which passed. 
- Performed a project build check with `cargo check -p perfgate-cli`, which succeeded. 
- Ran lints with `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`, which completed without warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07bd987ba88333ac39b4cdb414af3b)