### PR TITLE
domain: centralize metric movement semantics

### DIFF
--- a/crates/perfgate-cli/src/decision_suggest.rs
+++ b/crates/perfgate-cli/src/decision_suggest.rs
@@ -10,7 +10,8 @@ use crate::{
     COMPARE_RECEIPT_FILE, DecisionSuggestArgs, is_regression, load_validated_config,
     resolve_configured_out_dir,
 };
-use perfgate_types::{CompareReceipt, ConfigFile, Direction};
+use perfgate::domain::is_improvement;
+use perfgate_types::{CompareReceipt, ConfigFile};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DecisionReadiness {
@@ -154,14 +155,10 @@ fn collect_decision_readiness_evidence(
             format!("read compare receipt for {bench_name}: {}", path.display())
         })?;
         has_regression |= is_regression(compare.verdict.status);
-        has_improvement |=
-            compare
-                .deltas
-                .iter()
-                .any(|(metric, delta)| match metric.default_direction() {
-                    Direction::Lower => delta.pct < 0.0,
-                    Direction::Higher => delta.pct > 0.0,
-                });
+        has_improvement |= compare
+            .deltas
+            .iter()
+            .any(|(metric, delta)| is_improvement(*metric, delta));
         high_noise |= compare
             .deltas
             .values()

--- a/crates/perfgate/src/app/tradeoff.rs
+++ b/crates/perfgate/src/app/tradeoff.rs
@@ -1,4 +1,5 @@
 use crate::domain::budget::{aggregate_verdict, reason_token};
+use crate::domain::improvement_ratio;
 use perfgate_types::{
     DecisionPolicyConfig, Delta, HostInfo, Metric, MetricStatus, MissingNoisePolicy,
     PROBE_COMPARE_SCHEMA_V1, ProbeCompareObservation, ProbeCompareReceipt, RunMeta,
@@ -364,7 +365,7 @@ fn evaluate_requirements(
                 };
             };
 
-            let observed_ratio = improvement_ratio(delta, requirement.metric);
+            let observed_ratio = improvement_ratio(requirement.metric, delta);
             let satisfied = observed_ratio
                 .map(|ratio| ratio >= requirement.min_improvement_ratio)
                 .unwrap_or(false);
@@ -490,7 +491,7 @@ fn evaluate_probe_requirement(
         };
     };
 
-    let observed_ratio = improvement_ratio(delta, requirement.metric);
+    let observed_ratio = improvement_ratio(requirement.metric, delta);
     let satisfied = observed_ratio
         .map(|ratio| ratio >= requirement.min_improvement_ratio)
         .unwrap_or(false);
@@ -557,17 +558,6 @@ fn required_change(requirement: &TradeoffRequirement) -> f64 {
     match requirement.metric.default_direction() {
         perfgate_types::Direction::Higher => requirement.min_improvement_ratio - 1.0,
         perfgate_types::Direction::Lower => (1.0 / requirement.min_improvement_ratio) - 1.0,
-    }
-}
-
-fn improvement_ratio(delta: &Delta, metric: Metric) -> Option<f64> {
-    match metric.default_direction() {
-        perfgate_types::Direction::Higher => Some(delta.ratio),
-        perfgate_types::Direction::Lower => Some(if delta.current <= 0.0 {
-            f64::INFINITY
-        } else {
-            delta.baseline / delta.current
-        }),
     }
 }
 

--- a/crates/perfgate/src/domain/comparison.rs
+++ b/crates/perfgate/src/domain/comparison.rs
@@ -7,8 +7,8 @@ use perfgate_types::{
 };
 
 use super::{
-    DomainError, compute_significance, evaluate_budget, metric_cv, metric_series_from_run,
-    metric_value, metric_value_from_run, reason_token,
+    DomainError, compute_significance, evaluate_budget, improvement_ratio, metric_cv,
+    metric_series_from_run, metric_value, metric_value_from_run, reason_token,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -348,17 +348,6 @@ fn remove_reason(reasons: &mut Vec<String>, token: &str) {
     reasons.retain(|reason| reason != token);
 }
 
-fn improvement_ratio(delta: &Delta, metric: Metric) -> Option<f64> {
-    match metric.default_direction() {
-        perfgate_types::Direction::Higher => Some(delta.ratio),
-        perfgate_types::Direction::Lower => Some(if delta.current <= 0.0 {
-            f64::INFINITY
-        } else {
-            delta.baseline / delta.current
-        }),
-    }
-}
-
 fn apply_tradeoffs(
     deltas: &mut BTreeMap<Metric, Delta>,
     counts: &mut VerdictCounts,
@@ -395,7 +384,7 @@ fn apply_tradeoffs(
                     break;
                 };
 
-                let Some(ratio) = improvement_ratio(required_delta, requirement.metric) else {
+                let Some(ratio) = improvement_ratio(requirement.metric, required_delta) else {
                     satisfied = false;
                     break;
                 };
@@ -482,21 +471,21 @@ mod tests {
 
     #[test]
     fn improvement_ratio_treats_lower_is_better_decrease_as_improvement() {
-        let observed = improvement_ratio(&delta(100.0, 80.0), Metric::WallMs);
+        let observed = improvement_ratio(Metric::WallMs, &delta(100.0, 80.0));
 
         assert_eq!(observed, Some(1.25));
     }
 
     #[test]
     fn improvement_ratio_treats_higher_is_better_increase_as_improvement() {
-        let observed = improvement_ratio(&delta(100.0, 125.0), Metric::ThroughputPerS);
+        let observed = improvement_ratio(Metric::ThroughputPerS, &delta(100.0, 125.0));
 
         assert_eq!(observed, Some(1.25));
     }
 
     #[test]
     fn improvement_ratio_treats_higher_is_better_decrease_as_not_enough() {
-        let observed = improvement_ratio(&delta(100.0, 80.0), Metric::ThroughputPerS);
+        let observed = improvement_ratio(Metric::ThroughputPerS, &delta(100.0, 80.0));
 
         assert_eq!(observed, Some(0.8));
     }

--- a/crates/perfgate/src/domain/mod.rs
+++ b/crates/perfgate/src/domain/mod.rs
@@ -11,6 +11,7 @@ pub mod budget;
 mod comparison;
 pub mod host;
 mod metrics;
+pub mod movement;
 pub mod paired;
 mod report;
 pub mod scaling;
@@ -33,6 +34,10 @@ pub use host::detect_host_mismatch;
 pub use metrics::metric_value;
 pub(crate) use metrics::{
     metric_cv, metric_series_from_run, metric_to_string, metric_value_from_run,
+};
+pub use movement::{
+    MetricMovement, improvement_ratio, is_improvement, is_regression, movement_for_delta,
+    movement_for_pct,
 };
 pub use report::{Finding, FindingData, Report, derive_report};
 pub use stats_compute::compute_stats;

--- a/crates/perfgate/src/domain/movement.rs
+++ b/crates/perfgate/src/domain/movement.rs
@@ -1,0 +1,150 @@
+//! Direction-aware metric movement semantics.
+//!
+//! Raw percentage sign is display data. Product judgment must flow through
+//! metric direction so lower-is-better and higher-is-better metrics agree on
+//! what counts as improvement or regression.
+
+use perfgate_types::{Delta, Direction, Metric};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricMovement {
+    Improved,
+    Regressed,
+    Unchanged,
+    Unknown,
+}
+
+#[must_use = "movement classification should drive user-facing judgment"]
+pub fn movement_for_delta(metric: Metric, delta: &Delta) -> MetricMovement {
+    movement_for_pct(metric, delta.pct)
+}
+
+#[must_use = "movement classification should drive user-facing judgment"]
+pub fn movement_for_pct(metric: Metric, pct: f64) -> MetricMovement {
+    if !pct.is_finite() {
+        return MetricMovement::Unknown;
+    }
+    if pct == 0.0 {
+        return MetricMovement::Unchanged;
+    }
+
+    match metric.default_direction() {
+        Direction::Lower => {
+            if pct < 0.0 {
+                MetricMovement::Improved
+            } else {
+                MetricMovement::Regressed
+            }
+        }
+        Direction::Higher => {
+            if pct > 0.0 {
+                MetricMovement::Improved
+            } else {
+                MetricMovement::Regressed
+            }
+        }
+    }
+}
+
+#[must_use = "call site should branch on whether the metric improved"]
+pub fn is_improvement(metric: Metric, delta: &Delta) -> bool {
+    matches!(movement_for_delta(metric, delta), MetricMovement::Improved)
+}
+
+#[must_use = "call site should branch on whether the metric regressed"]
+pub fn is_regression(metric: Metric, delta: &Delta) -> bool {
+    matches!(movement_for_delta(metric, delta), MetricMovement::Regressed)
+}
+
+#[must_use = "tradeoff requirements should compare normalized improvement ratios"]
+pub fn improvement_ratio(metric: Metric, delta: &Delta) -> Option<f64> {
+    match metric.default_direction() {
+        Direction::Higher => Some(delta.ratio),
+        Direction::Lower => Some(if delta.current <= 0.0 {
+            f64::INFINITY
+        } else {
+            delta.baseline / delta.current
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perfgate_types::{MetricStatistic, MetricStatus};
+
+    fn delta(baseline: f64, current: f64) -> Delta {
+        Delta {
+            baseline,
+            current,
+            ratio: current / baseline,
+            pct: (current - baseline) / baseline,
+            regression: 0.0,
+            cv: None,
+            noise_threshold: None,
+            statistic: MetricStatistic::Median,
+            significance: None,
+            status: MetricStatus::Pass,
+        }
+    }
+
+    #[test]
+    fn movement_treats_lower_is_better_decrease_as_improvement() {
+        let observed = movement_for_delta(Metric::WallMs, &delta(100.0, 80.0));
+
+        assert_eq!(observed, MetricMovement::Improved);
+    }
+
+    #[test]
+    fn movement_treats_lower_is_better_increase_as_regression() {
+        let observed = movement_for_delta(Metric::WallMs, &delta(100.0, 120.0));
+
+        assert_eq!(observed, MetricMovement::Regressed);
+    }
+
+    #[test]
+    fn movement_treats_higher_is_better_increase_as_improvement() {
+        let observed = movement_for_delta(Metric::ThroughputPerS, &delta(100.0, 125.0));
+
+        assert_eq!(observed, MetricMovement::Improved);
+    }
+
+    #[test]
+    fn movement_treats_higher_is_better_decrease_as_regression() {
+        let observed = movement_for_delta(Metric::ThroughputPerS, &delta(100.0, 80.0));
+
+        assert_eq!(observed, MetricMovement::Regressed);
+    }
+
+    #[test]
+    fn movement_treats_zero_change_as_unchanged() {
+        let observed = movement_for_delta(Metric::WallMs, &delta(100.0, 100.0));
+
+        assert_eq!(observed, MetricMovement::Unchanged);
+    }
+
+    #[test]
+    fn movement_treats_non_finite_pct_as_unknown() {
+        let mut delta = delta(100.0, 80.0);
+        delta.pct = f64::NAN;
+
+        assert_eq!(
+            movement_for_delta(Metric::WallMs, &delta),
+            MetricMovement::Unknown
+        );
+    }
+
+    #[test]
+    fn improvement_ratio_uses_lower_is_better_direction() {
+        let observed = improvement_ratio(Metric::WallMs, &delta(100.0, 80.0));
+
+        assert_eq!(observed, Some(1.25));
+    }
+
+    #[test]
+    fn improvement_ratio_uses_higher_is_better_direction() {
+        let observed = improvement_ratio(Metric::ThroughputPerS, &delta(100.0, 125.0));
+
+        assert_eq!(observed, Some(1.25));
+    }
+}

--- a/docs/audits/metric-direction-semantics.md
+++ b/docs/audits/metric-direction-semantics.md
@@ -41,8 +41,8 @@ direction-aware semantics or already-normalized receipt fields such as
 | --- | --- | --- | --- |
 | Compare receipt verdict | `crates/perfgate/src/domain/budget.rs`, `crates/perfgate/src/domain/comparison.rs` | Direction-aware through `calculate_regression` and budget direction. | Centralize movement vocabulary so callers do not need to know regression math. |
 | Report derivation | `crates/perfgate/src/app/report.rs` | Uses `Delta::regression` and `MetricStatus`; no raw sign judgment found in report construction. | Add higher-is-better report fixture in the fixture matrix PR. |
-| Decision readiness | `crates/perfgate-cli/src/decision_suggest.rs` | Direction-aware after the higher-is-better fix. | Replace local match with shared movement helper once it exists. |
-| Tradeoff requirements | `crates/perfgate/src/domain/comparison.rs`, `crates/perfgate/src/app/tradeoff.rs` | Direction-aware `improvement_ratio` helpers translate lower-is-better and higher-is-better metrics into comparable improvement ratios. | Deduplicate the two helper implementations through the shared domain helper. |
+| Decision readiness | `crates/perfgate-cli/src/decision_suggest.rs` | Direction-aware through the shared domain movement helper. | Cover this through higher/lower fixture matrix tests. |
+| Tradeoff requirements | `crates/perfgate/src/domain/comparison.rs`, `crates/perfgate/src/app/tradeoff.rs` | Direction-aware `improvement_ratio` translates lower-is-better and higher-is-better metrics into comparable improvement ratios. | Cover scenario and probe requirements through higher/lower fixture matrix tests. |
 | Tradeoff allowances | `crates/perfgate/src/app/tradeoff.rs` | Uses `Delta::regression`, which is already positive normalized regression. | Add probe-backed higher-is-better allowance fixtures. |
 | Probe compare | `crates/perfgate/src/app/probe.rs` | Direction-aware through parsed metric defaults and probe metric heuristics for throughput/rate/count names. | Add fixture coverage for custom higher-is-better probe metrics. |
 | Repair context | `crates/perfgate-cli/src/repair_context.rs` | Uses non-pass `MetricStatus` and `Delta::regression`; no raw sign judgment found. | Add higher-is-better repair context fixture in the fixture matrix PR. |
@@ -64,11 +64,10 @@ helper:
 
 ## Follow-up PRs
 
-1. Add a shared movement model such as `MetricMovement::{Improved, Regressed, Unchanged, Unknown}` in the domain layer.
-2. Replace local raw-sign improvement checks with the shared helper.
-3. Add fixture coverage for lower-is-better and higher-is-better metrics across compare, report, decision suggest, tradeoff, probe compare, repair context, comments, and bundles.
-4. Harden tradeoff and probe requirement tests for higher-is-better dominant improvements and lower-is-better accepted local regressions.
-5. Update product claims only after the fixture matrix covers the core user-facing surfaces.
+1. Route remaining judgment call sites through the shared domain movement model.
+2. Add fixture coverage for lower-is-better and higher-is-better metrics across compare, report, decision suggest, tradeoff, probe compare, repair context, comments, and bundles.
+3. Harden tradeoff and probe requirement tests for higher-is-better dominant improvements and lower-is-better accepted local regressions.
+4. Update product claims only after the fixture matrix covers the core user-facing surfaces.
 
 ## Proof Commands
 


### PR DESCRIPTION
## Summary
- add perfgate::domain::movement with MetricMovement, direction-aware movement classification, and shared improvement ratio helpers
- route decision readiness and tradeoff requirement logic through the shared domain helper
- update the metric-direction audit so the remaining work is fixture coverage and remaining judgment call sites

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate --all-features domain::movement
- cargo +1.95.0 test -p perfgate --all-features domain::comparison::tests
- cargo +1.95.0 test -p perfgate --all-features app::tradeoff
- cargo +1.95.0 test -p perfgate-cli --test cli_decision_suggest_tests
- cargo +1.95.0 clippy -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

Note: Cargo-heavy proof ran with CARGO_TARGET_DIR=C:\perfgate-target-metric-movement so the repo target directory stays disposable.