### PR TITLE
test: cover metric direction fixtures

### DIFF
--- a/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
+++ b/crates/perfgate-cli/tests/cli_tradeoff_tests.rs
@@ -52,6 +52,44 @@ fn test_tradeoff_evaluate_writes_tradeoff_receipt() {
 }
 
 #[test]
+fn test_tradeoff_evaluate_accepts_higher_is_better_requirement() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let config_path = temp_dir.path().join("perfgate.toml");
+    let scenario_path = temp_dir.path().join("scenario.json");
+    let output_path = temp_dir.path().join("tradeoff.json");
+
+    write_throughput_tradeoff_config(&config_path, 1.10, "warn");
+    write_throughput_scenario_receipt(&scenario_path, 125.0, "fail");
+
+    perfgate_cmd()
+        .arg("tradeoff")
+        .arg("evaluate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--scenario")
+        .arg(&scenario_path)
+        .arg("--out")
+        .arg(&output_path)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Tradeoff receipt written"));
+
+    let typed: perfgate_types::TradeoffReceipt = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read tradeoff receipt"),
+    )
+    .expect("tradeoff receipt should deserialize");
+
+    assert!(typed.decision.accepted_tradeoff);
+    assert_eq!(typed.verdict.status, perfgate_types::VerdictStatus::Warn);
+    assert_eq!(typed.rules[0].requirements[0].metric, "throughput_per_s");
+    assert!(typed.rules[0].requirements[0].satisfied);
+    assert_eq!(
+        typed.weighted_deltas["throughput_per_s"].pct, 0.25,
+        "positive throughput pct should satisfy the higher-is-better requirement"
+    );
+}
+
+#[test]
 fn test_tradeoff_evaluate_fails_when_rule_not_satisfied() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let config_path = temp_dir.path().join("perfgate.toml");
@@ -351,6 +389,24 @@ min_improvement_ratio = {min_improvement_ratio}
     .expect("failed to write config");
 }
 
+fn write_throughput_tradeoff_config(path: &Path, min_improvement_ratio: f64, downgrade_to: &str) {
+    fs::write(
+        path,
+        format!(
+            r#"[[tradeoff]]
+name = "memory_for_throughput"
+if_failed = "max_rss_kb"
+downgrade_to = "{downgrade_to}"
+
+[[tradeoff.require]]
+metric = "throughput_per_s"
+min_improvement_ratio = {min_improvement_ratio}
+"#
+        ),
+    )
+    .expect("failed to write config");
+}
+
 fn write_probe_tradeoff_config(path: &Path, min_improvement_ratio: f64, downgrade_to: &str) {
     fs::write(
         path,
@@ -473,6 +529,69 @@ fn write_scenario_receipt_inner(
                 "current": wall_current,
                 "ratio": wall_current / 100.0,
                 "pct": (wall_current - 100.0) / 100.0,
+                "regression": 0.0,
+                "status": "pass"
+            },
+            "max_rss_kb": {
+                "baseline": 100.0,
+                "current": 120.0,
+                "ratio": 1.20,
+                "pct": 0.20,
+                "regression": 0.20,
+                "status": memory_status
+            }
+        },
+        "verdict": {
+            "status": memory_status,
+            "counts": {
+                "pass": 1 + memory_pass,
+                "warn": memory_warn,
+                "fail": memory_fail,
+                "skip": 0
+            },
+            "reasons": reasons
+        }
+    });
+
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize scenario fixture"),
+    )
+    .expect("failed to write scenario fixture");
+}
+
+fn write_throughput_scenario_receipt(path: &Path, throughput_current: f64, memory_status: &str) {
+    let memory_fail = u32::from(memory_status == "fail");
+    let memory_warn = u32::from(memory_status == "warn");
+    let memory_pass = u32::from(memory_status == "pass");
+    let reasons: Vec<&str> = if memory_status == "fail" {
+        vec!["max_rss_kb_fail"]
+    } else if memory_status == "warn" {
+        vec!["max_rss_kb_warn"]
+    } else {
+        Vec::new()
+    };
+    let throughput_pct = (throughput_current - 100.0) / 100.0;
+    let receipt = json!({
+        "schema": "perfgate.scenario.v1",
+        "tool": {"name": "perfgate", "version": "0.16.0"},
+        "run": {
+            "id": "scenario-run",
+            "started_at": "2026-05-08T00:00:00Z",
+            "ended_at": "2026-05-08T00:00:01Z",
+            "host": {"os": "linux", "arch": "x86_64"}
+        },
+        "scenario": {
+            "name": "release_workload",
+            "weight": 1.0
+        },
+        "components": [],
+        "weighted_deltas": {
+            "throughput_per_s": {
+                "baseline": 100.0,
+                "current": throughput_current,
+                "ratio": throughput_current / 100.0,
+                "pct": throughput_pct,
                 "regression": 0.0,
                 "status": "pass"
             },

--- a/crates/perfgate/src/app/probe.rs
+++ b/crates/perfgate/src/app/probe.rs
@@ -514,6 +514,35 @@ mod tests {
     }
 
     #[test]
+    fn probe_compare_treats_per_second_metrics_as_higher_is_better() {
+        let outcome = ProbeCompareUseCase::compare(ProbeCompareRequest {
+            baseline: probe_receipt(vec![probe("parser.batch_loop", "items_per_s", 100.0)]),
+            current: probe_receipt(vec![probe("parser.batch_loop", "items_per_s", 125.0)]),
+            baseline_ref: CompareRef {
+                path: Some("baselines/probes.json".to_string()),
+                run_id: Some("base".to_string()),
+            },
+            current_ref: CompareRef {
+                path: Some("artifacts/probes.json".to_string()),
+                run_id: Some("current".to_string()),
+            },
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+        })
+        .expect("compare probes");
+
+        let receipt = outcome.receipt;
+        let delta = &receipt.probes[0].deltas["items_per_s"];
+        assert!(delta.pct > 0.0);
+        assert_eq!(delta.regression, 0.0);
+        assert_eq!(delta.status, MetricStatus::Pass);
+        assert_eq!(receipt.probes[0].status, MetricStatus::Pass);
+        assert_eq!(receipt.verdict.status, VerdictStatus::Pass);
+    }
+
+    #[test]
     fn probe_compare_warns_on_missing_probe() {
         let outcome = ProbeCompareUseCase::compare(ProbeCompareRequest {
             baseline: probe_receipt(vec![probe("parser.tokenize", "wall_ms", 10.0)]),

--- a/crates/perfgate/src/app/report.rs
+++ b/crates/perfgate/src/app/report.rs
@@ -309,6 +309,68 @@ mod tests {
         }
     }
 
+    fn create_throughput_fail_compare_receipt() -> CompareReceipt {
+        let mut budgets = BTreeMap::new();
+        budgets.insert(
+            Metric::ThroughputPerS,
+            Budget::new(0.2, 0.18, Direction::Higher),
+        );
+
+        let mut deltas = BTreeMap::new();
+        deltas.insert(
+            Metric::ThroughputPerS,
+            Delta {
+                baseline: 100.0,
+                current: 70.0,
+                ratio: 0.7,
+                pct: -0.3,
+                regression: 0.3,
+                cv: None,
+                noise_threshold: None,
+                statistic: MetricStatistic::Median,
+                significance: None,
+                status: MetricStatus::Fail,
+            },
+        );
+
+        CompareReceipt {
+            schema: COMPARE_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            bench: BenchMeta {
+                name: "throughput-bench".to_string(),
+                cwd: None,
+                command: vec!["bench".to_string()],
+                repeat: 5,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            baseline_ref: CompareRef {
+                path: Some("baseline.json".to_string()),
+                run_id: Some("baseline-001".to_string()),
+            },
+            current_ref: CompareRef {
+                path: Some("current.json".to_string()),
+                run_id: Some("current-001".to_string()),
+            },
+            budgets,
+            deltas,
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    pass: 0,
+                    warn: 0,
+                    fail: 1,
+                    skip: 0,
+                },
+                reasons: vec!["throughput_per_s_fail".to_string()],
+            },
+        }
+    }
+
     #[test]
     fn test_report_from_pass_compare() {
         let compare = create_pass_compare_receipt();
@@ -347,6 +409,22 @@ mod tests {
         assert_eq!(result.report.findings[0].code, "metric_fail");
         assert_eq!(result.report.findings[0].severity, Severity::Fail);
         assert_eq!(result.report.summary.fail_count, 1);
+    }
+
+    #[test]
+    fn test_report_preserves_higher_is_better_direction_for_throughput_failure() {
+        let compare = create_throughput_fail_compare_receipt();
+        let result = ReportUseCase::execute(ReportRequest { compare });
+
+        assert_eq!(result.report.verdict.status, VerdictStatus::Fail);
+        assert_eq!(result.report.findings.len(), 1);
+        let data = result.report.findings[0]
+            .data
+            .as_ref()
+            .expect("finding data");
+        assert_eq!(data.metric_name, "throughput_per_s");
+        assert_eq!(data.direction, Direction::Higher);
+        assert_eq!(data.regression_pct, 0.3);
     }
 
     #[test]

--- a/crates/perfgate/src/domain/mod.rs
+++ b/crates/perfgate/src/domain/mod.rs
@@ -3409,6 +3409,47 @@ mod tests {
         assert_eq!(d.status, MetricStatus::Pass);
     }
 
+    #[test]
+    fn compare_higher_is_better_improvement_is_positive_pct() {
+        let baseline = Stats {
+            wall_ms: U64Summary::new(1000, 1000, 1000),
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            throughput_per_s: Some(F64Summary::new(100.0, 100.0, 100.0)),
+        };
+        let current = Stats {
+            wall_ms: U64Summary::new(1000, 1000, 1000),
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            throughput_per_s: Some(F64Summary::new(120.0, 120.0, 120.0)),
+        };
+        let mut budgets = BTreeMap::new();
+        budgets.insert(
+            Metric::ThroughputPerS,
+            Budget::new(0.15, 0.135, Direction::Higher),
+        );
+
+        let c = compare_stats(&baseline, &current, &budgets).unwrap();
+        let d = c.deltas.get(&Metric::ThroughputPerS).unwrap();
+        assert!(d.pct > 0.0);
+        assert_eq!(d.regression, 0.0);
+        assert_eq!(d.status, MetricStatus::Pass);
+    }
+
     // =========================================================================
     // Unit Tests for Domain Error Conditions
     // **Validates: Requirements 11.1, 11.2**


### PR DESCRIPTION
## Summary
- add higher-is-better throughput fixtures for compare receipt movement, report finding direction, probe compare, and tradeoff evaluation
- prove positive throughput pct is treated as improvement, while throughput failures preserve normalized regression and Direction::Higher
- keep this as test-only coverage over the movement helper landed in #464

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate --all-features compare_higher_is_better_improvement_is_positive_pct
- cargo +1.95.0 test -p perfgate --all-features test_report_preserves_higher_is_better_direction_for_throughput_failure
- cargo +1.95.0 test -p perfgate --all-features probe_compare_treats_per_second_metrics_as_higher_is_better
- cargo +1.95.0 test -p perfgate-cli --test cli_tradeoff_tests test_tradeoff_evaluate_accepts_higher_is_better_requirement
- cargo +1.95.0 clippy -p perfgate -p perfgate-cli --all-targets --all-features -- -D warnings
- git diff --check

Note: Cargo-heavy proof ran with CARGO_TARGET_DIR=C:\perfgate-target-metric-fixtures.