### PR TITLE
docs: explain metric direction semantics

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -74,7 +74,9 @@ let pct = (current - baseline) / baseline;  // e.g., 0.10 for 10% increase
 
 ### Direction Semantics
 
-Each metric has a **direction** that determines what constitutes a regression:
+Each metric has a **direction** that determines what constitutes improvement
+or regression. perfgate MUST NOT infer movement from the raw sign of `pct`
+alone.
 
 | Direction | Meaning | Regression When |
 |-----------|---------|-----------------|
@@ -85,6 +87,26 @@ Each metric has a **direction** that determines what constitutes a regression:
 - `wall_ms`: Lower (faster is better)
 - `max_rss_kb`: Lower (less memory is better)
 - `throughput_per_s`: Higher (more work per second is better)
+
+Movement semantics are direction-aware:
+
+| Metric shape | Improved | Regressed |
+|--------------|----------|-----------|
+| Lower is better, such as `wall_ms` | `pct < 0` | `pct > 0` |
+| Higher is better, such as `throughput_per_s` | `pct > 0` | `pct < 0` |
+
+The raw `pct` field is a signed measurement change:
+
+```text
++10% throughput is an improvement.
++10% latency is a regression.
+-10% throughput is a regression.
+-10% latency is an improvement.
+```
+
+User-facing judgment should use movement/regression semantics, not sign-only
+language. Raw signed percentages are still useful for display when the output
+also carries metric direction, status, or normalized regression.
 
 ### Regression Calculation
 
@@ -173,11 +195,18 @@ pub struct Delta {
     pub baseline: f64,    // Baseline median value
     pub current: f64,     // Current median value
     pub ratio: f64,       // current / baseline
-    pub pct: f64,         // (current - baseline) / baseline
+    pub pct: f64,         // Signed change: (current - baseline) / baseline
     pub regression: f64,  // Positive regression amount (0 if improvement)
     pub status: MetricStatus,  // Pass, Warn, or Fail
 }
 ```
+
+`pct` and `regression` intentionally answer different questions. `pct` says how
+the number moved. `regression` says how much worse it got after applying metric
+direction. Downstream receipts, reports, decision suggestions, tradeoff policy,
+repair context, Action summaries, and decision bundles should use
+`regression`, `MetricStatus`, or the shared movement helpers when deciding
+whether a change is better or worse.
 
 ## Report Synthesis
 

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -286,6 +286,31 @@ probe_compare = "artifacts/perfgate/large-file-probe-compare.json"
 
 Probe evidence is advisory until a tradeoff rule explicitly requires it.
 
+## Metric Direction
+
+perfgate treats movement through the metric's direction. A signed percentage is
+not enough to decide whether performance improved:
+
+| Metric | Better direction | `+10%` means | `-10%` means |
+|--------|------------------|--------------|--------------|
+| `wall_ms` | lower | regression | improvement |
+| `max_rss_kb` | lower | regression | improvement |
+| `page_faults` | lower | regression | improvement |
+| `throughput_per_s` | higher | improvement | regression |
+
+Use the receipt fields this way:
+
+| Field | Meaning |
+|-------|---------|
+| `pct` | signed numeric movement, useful for display |
+| `regression` | positive normalized regression after applying direction |
+| `status` | budget result after thresholds and warning policy |
+
+Decision suggestions and tradeoff rules use direction-aware movement. For
+example, `throughput_per_s +12%` can satisfy a compensating improvement rule,
+while `wall_ms +12%` is a latency regression. The same rule applies to named
+probe metrics when a tradeoff uses `probe = "..."`.
+
 ## Config Shape
 
 Scenarios model workload importance:
@@ -332,6 +357,12 @@ keeps the local regression bounded; if `parser.tokenize` regresses by more than
 3%, the tradeoff is rejected even if `parser.batch_loop` improves enough.
 `[decision_policy]` can require the accepted evidence to stay below a CV cap
 before perfgate automatically accepts the tradeoff.
+
+`min_improvement_ratio` also follows direction. For `wall_ms`, `1.10` means
+the current value must be at least 10% lower than the baseline. For
+`throughput_per_s`, `1.10` means the current value must be at least 10% higher.
+`max_regression` is already normalized, so it caps worsening movement after
+direction has been applied.
 
 ## GitHub Actions
 


### PR DESCRIPTION
## Summary
- clarifies that metric movement is direction-aware, not raw pct-sign based
- explains pct vs normalized regression in the design contract
- adds user-facing examples for latency, memory, page faults, and throughput in performance decision docs
- documents how min_improvement_ratio and max_regression interpret direction

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check