### PR TITLE
decision: make GitHub trend comments direction-aware

### DIFF
--- a/crates/perfgate/src/integrations/github/comment.rs
+++ b/crates/perfgate/src/integrations/github/comment.rs
@@ -8,6 +8,7 @@ use crate::app::render::{
     direction_str, format_metric_with_statistic, format_pct, format_value, metric_status_icon,
     render_reason_line, render_tradeoff_markdown,
 };
+use crate::domain::{MetricMovement, movement_for_delta};
 use perfgate_types::{CompareReceipt, PerfgateReport, TradeoffReceipt, VerdictStatus};
 
 /// Options for customizing the rendered comment.
@@ -56,7 +57,7 @@ pub fn render_comment(compare: &CompareReceipt, options: &CommentOptions) -> Str
             (String::new(), "")
         };
 
-        let trend = trend_indicator(delta.pct);
+        let trend = trend_indicator(*metric, delta);
         let status_icon = metric_status_icon(delta.status);
 
         out.push_str(&format!(
@@ -184,23 +185,27 @@ fn verdict_header(status: VerdictStatus) -> String {
     }
 }
 
-/// Generate a trend indicator with arrow and percentage.
-///
-/// - Positive changes (regression for lower-is-better): red up arrow
-/// - Negative changes (improvement for lower-is-better): green down arrow
-/// - Near zero: dash
-fn trend_indicator(pct: f64) -> String {
-    let abs_pct = (pct * 100.0).abs();
+/// Generate a direction-aware movement indicator with numeric arrow and label.
+fn trend_indicator(metric: perfgate_types::Metric, delta: &perfgate_types::Delta) -> String {
+    let abs_pct = (delta.pct * 100.0).abs();
     if abs_pct < 0.5 {
         // Essentially flat
         return "\u{2014}".to_string(); // em dash
     }
 
-    if pct > 0.0 {
-        format!("\u{25B2} {:.1}%", abs_pct) // black up-pointing triangle
+    let arrow = if delta.pct > 0.0 {
+        "\u{25B2}" // black up-pointing triangle
     } else {
-        format!("\u{25BC} {:.1}%", abs_pct) // black down-pointing triangle
-    }
+        "\u{25BC}" // black down-pointing triangle
+    };
+    let label = match movement_for_delta(metric, delta) {
+        MetricMovement::Improved => "improved",
+        MetricMovement::Regressed => "regressed",
+        MetricMovement::Unchanged => "unchanged",
+        MetricMovement::Unknown => "unknown",
+    };
+
+    format!("{arrow} {abs_pct:.1}% {label}")
 }
 
 /// Parse the `GITHUB_REPOSITORY` env var into `(owner, repo)`.
@@ -290,6 +295,21 @@ mod tests {
         }
     }
 
+    fn trend_delta(pct: f64) -> Delta {
+        Delta {
+            baseline: 100.0,
+            current: 100.0 * (1.0 + pct),
+            ratio: 1.0 + pct,
+            pct,
+            regression: if pct > 0.0 { pct } else { 0.0 },
+            statistic: MetricStatistic::Median,
+            significance: None,
+            cv: None,
+            noise_threshold: None,
+            status: MetricStatus::Pass,
+        }
+    }
+
     #[test]
     fn comment_contains_marker() {
         let receipt = make_compare_receipt();
@@ -373,22 +393,40 @@ mod tests {
 
     #[test]
     fn trend_indicator_flat() {
-        let trend = trend_indicator(0.001); // 0.1%, below 0.5% threshold
+        let trend = trend_indicator(Metric::WallMs, &trend_delta(0.001)); // 0.1%, below 0.5% threshold
         assert_eq!(trend, "\u{2014}");
     }
 
     #[test]
-    fn trend_indicator_regression() {
-        let trend = trend_indicator(0.15); // +15%
+    fn trend_indicator_lower_is_better_regression() {
+        let trend = trend_indicator(Metric::WallMs, &trend_delta(0.15)); // +15%
         assert!(trend.contains("\u{25B2}"));
         assert!(trend.contains("15.0%"));
+        assert!(trend.contains("regressed"));
     }
 
     #[test]
-    fn trend_indicator_improvement() {
-        let trend = trend_indicator(-0.10); // -10%
+    fn trend_indicator_lower_is_better_improvement() {
+        let trend = trend_indicator(Metric::WallMs, &trend_delta(-0.10)); // -10%
         assert!(trend.contains("\u{25BC}"));
         assert!(trend.contains("10.0%"));
+        assert!(trend.contains("improved"));
+    }
+
+    #[test]
+    fn trend_indicator_higher_is_better_improvement() {
+        let trend = trend_indicator(Metric::ThroughputPerS, &trend_delta(0.25)); // +25%
+        assert!(trend.contains("\u{25B2}"));
+        assert!(trend.contains("25.0%"));
+        assert!(trend.contains("improved"));
+    }
+
+    #[test]
+    fn trend_indicator_higher_is_better_regression() {
+        let trend = trend_indicator(Metric::ThroughputPerS, &trend_delta(-0.20)); // -20%
+        assert!(trend.contains("\u{25BC}"));
+        assert!(trend.contains("20.0%"));
+        assert!(trend.contains("regressed"));
     }
 
     #[test]

--- a/docs/audits/decision-semantics-verification.md
+++ b/docs/audits/decision-semantics-verification.md
@@ -80,7 +80,7 @@ the active release cutover goal.
 This audit does not claim every display surface has been converted away from
 raw signed `pct`. The metric-direction audit still tracks follow-ups where raw
 display is intentional or where naming/language should be tightened, including
-trend arrows and export column naming.
+watch trend language and export column naming.
 
 This audit does not make the server ledger part of correctness. Local receipts
 remain the primary correctness contract; the server ledger remains optional

--- a/docs/audits/metric-direction-semantics.md
+++ b/docs/audits/metric-direction-semantics.md
@@ -39,18 +39,18 @@ direction-aware semantics or already-normalized receipt fields such as
 
 | Surface | Current source | Current state | Follow-up |
 | --- | --- | --- | --- |
-| Compare receipt verdict | `crates/perfgate/src/domain/budget.rs`, `crates/perfgate/src/domain/comparison.rs` | Direction-aware through `calculate_regression` and budget direction. | Centralize movement vocabulary so callers do not need to know regression math. |
-| Report derivation | `crates/perfgate/src/app/report.rs` | Uses `Delta::regression` and `MetricStatus`; no raw sign judgment found in report construction. | Add higher-is-better report fixture in the fixture matrix PR. |
-| Decision readiness | `crates/perfgate-cli/src/decision_suggest.rs` | Direction-aware through the shared domain movement helper. | Cover this through higher/lower fixture matrix tests. |
-| Tradeoff requirements | `crates/perfgate/src/domain/comparison.rs`, `crates/perfgate/src/app/tradeoff.rs` | Direction-aware `improvement_ratio` translates lower-is-better and higher-is-better metrics into comparable improvement ratios. | Cover scenario and probe requirements through higher/lower fixture matrix tests. |
-| Tradeoff allowances | `crates/perfgate/src/app/tradeoff.rs` | Uses `Delta::regression`, which is already positive normalized regression. | Add probe-backed higher-is-better allowance fixtures. |
-| Probe compare | `crates/perfgate/src/app/probe.rs` | Direction-aware through parsed metric defaults and probe metric heuristics for throughput/rate/count names. | Add fixture coverage for custom higher-is-better probe metrics. |
-| Repair context | `crates/perfgate-cli/src/repair_context.rs` | Uses non-pass `MetricStatus` and `Delta::regression`; no raw sign judgment found. | Add higher-is-better repair context fixture in the fixture matrix PR. |
+| Compare receipt verdict | `crates/perfgate/src/domain/budget.rs`, `crates/perfgate/src/domain/comparison.rs` | Direction-aware through `calculate_regression`, budget direction, and shared movement helpers. | Covered by movement and comparison fixture tests. |
+| Report derivation | `crates/perfgate/src/app/report.rs` | Uses `Delta::regression` and `MetricStatus`; higher-is-better report fixtures preserve throughput direction. | Covered by fixture matrix tests. |
+| Decision readiness | `crates/perfgate-cli/src/decision_suggest.rs` | Direction-aware through the shared domain movement helper. | Covered by higher/lower decision readiness tests. |
+| Tradeoff requirements | `crates/perfgate/src/domain/comparison.rs`, `crates/perfgate/src/app/tradeoff.rs` | Direction-aware `improvement_ratio` translates lower-is-better and higher-is-better metrics into comparable improvement ratios. | Covered by scenario and probe tradeoff tests. |
+| Tradeoff allowances | `crates/perfgate/src/app/tradeoff.rs` | Uses `Delta::regression`, which is already positive normalized regression. | Covered by probe-backed higher-is-better allowance fixtures. |
+| Probe compare | `crates/perfgate/src/app/probe.rs` | Direction-aware through parsed metric defaults and probe metric heuristics for throughput/rate/count names. | Covered by custom higher-is-better probe metric fixtures. |
+| Repair context | `crates/perfgate-cli/src/repair_context.rs` | Uses non-pass `MetricStatus` and `Delta::regression`; no raw sign judgment found. | Covered indirectly by status/normalized-regression fixtures; add a direct repair-context fixture when that surface changes next. |
 | Badge/status surfaces | `crates/perfgate/src/app/badge.rs` | Verdict and metric status are status-driven; raw `pct` is display-only. | Keep display labels as change, not judgment. |
-| Markdown rendering and annotations | `crates/perfgate/src/app/render.rs`, `crates/perfgate/src/integrations/github/comment.rs` | Status-driven warnings/failures are correct, but `trend_indicator(delta.pct)` still uses raw sign for arrow language. | Route trend indicators through shared movement semantics. |
+| Markdown rendering and annotations | `crates/perfgate/src/app/render.rs`, `crates/perfgate/src/integrations/github/comment.rs` | Status-driven warnings/failures are correct, and GitHub comment trend indicators label improvement/regression through shared movement semantics. | Keep raw percentage display separate from judgment labels. |
 | Watch/trend display | `crates/perfgate/src/app/watch.rs`, `crates/perfgate/src/app/trend.rs` | `app/trend.rs` is direction-aware; `watch.rs` stores raw `pct` history and classifies positive average as worsening. | Make watch trends metric-aware or restrict wording to lower-is-better deltas. |
 | Export rows | `crates/perfgate/src/app/export/rows.rs` | `regression_pct` currently exports raw signed `delta.pct * 100.0`, despite the column name implying normalized regression. | Decide whether to rename the column or export normalized `Delta::regression`. |
-| Decision bundles | `crates/perfgate-cli/src/main.rs` | Bundles preserve receipts and do not reinterpret metric movement. | No immediate semantic change; fixture matrix should include bundled higher-is-better receipts. |
+| Decision bundles | `crates/perfgate-cli/src/main.rs` | Bundles preserve receipts and do not reinterpret metric movement. | No immediate semantic change; bundle coverage follows receipt-level direction fixtures. |
 
 ## Focused Test Added
 

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -582,6 +582,6 @@ Artifacts:
 Known limits:
 
 - Raw signed `pct` remains a display field; callers must not treat its sign as judgment without metric direction.
-- Export column naming and some trend-arrow language remain tracked by the metric-direction audit follow-ups.
+- Export column naming and watch trend language remain tracked by the metric-direction audit follow-ups.
 
 Review after: next-decision-contract-change


### PR DESCRIPTION
## Summary
- routes GitHub PR comment trend indicators through the shared metric movement helper
- labels higher-is-better and lower-is-better changes as improved/regressed instead of relying on raw pct sign
- updates semantic audit and product-claim wording so trend arrows are no longer listed as an open gap

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate --all-features trend_indicator
- cargo +1.95.0 clippy -p perfgate --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- action-check
- git diff --check

## Release boundary
- no crates published
- no tags or aliases moved
- 0.18 release cutover goal remains active and operator-gated