### PR TITLE
decision: normalize watch and export movement semantics

### DIFF
--- a/crates/perfgate/src/app/check.rs
+++ b/crates/perfgate/src/app/check.rs
@@ -710,9 +710,11 @@ fn build_report(compare: &CompareReceipt) -> PerfgateReport {
         };
 
         let metric_name = format_metric(*metric).to_string();
+        let regression_pct = delta.regression * 100.0;
         let message = format!(
-            "{} regression: {} (threshold: {:.1}%)",
+            "{} regression: {:.2}% (change: {}, threshold: {:.1}%)",
             metric_name,
+            regression_pct,
             format_pct(delta.pct),
             threshold * 100.0
         );
@@ -726,7 +728,7 @@ fn build_report(compare: &CompareReceipt) -> PerfgateReport {
                 metric_name,
                 baseline: delta.baseline,
                 current: delta.current,
-                regression_pct: delta.pct * 100.0,
+                regression_pct,
                 threshold,
                 direction,
             }),
@@ -1165,6 +1167,83 @@ mod tests {
         assert_eq!(report.findings[0].check_id, "perf.budget");
         assert_eq!(report.summary.fail_count, 1);
         assert_eq!(report.summary.total_count, 1);
+    }
+
+    #[test]
+    fn build_report_normalizes_higher_is_better_regression() {
+        let mut budgets = BTreeMap::new();
+        budgets.insert(
+            Metric::ThroughputPerS,
+            Budget::new(0.10, 0.05, Direction::Higher),
+        );
+
+        let mut deltas = BTreeMap::new();
+        deltas.insert(
+            Metric::ThroughputPerS,
+            Delta {
+                baseline: 100.0,
+                current: 80.0,
+                ratio: 0.80,
+                pct: -0.20,
+                regression: 0.20,
+                cv: None,
+                noise_threshold: None,
+                statistic: MetricStatistic::Median,
+                significance: None,
+                status: MetricStatus::Fail,
+            },
+        );
+
+        let compare = CompareReceipt {
+            schema: COMPARE_SCHEMA_V1.to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.1.0".to_string(),
+            },
+            bench: BenchMeta {
+                name: "throughput-bench".to_string(),
+                cwd: None,
+                command: vec!["echo".to_string()],
+                repeat: 5,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            baseline_ref: CompareRef {
+                path: Some("baseline.json".to_string()),
+                run_id: Some("baseline-id".to_string()),
+            },
+            current_ref: CompareRef {
+                path: Some("current.json".to_string()),
+                run_id: Some("current-id".to_string()),
+            },
+            budgets,
+            deltas,
+            verdict: Verdict {
+                status: VerdictStatus::Fail,
+                counts: VerdictCounts {
+                    pass: 0,
+                    warn: 0,
+                    fail: 1,
+                    skip: 0,
+                },
+                reasons: vec!["throughput_per_s_fail".to_string()],
+            },
+        };
+
+        let report = build_report(&compare);
+
+        assert_eq!(report.findings.len(), 1);
+        let finding = &report.findings[0];
+        assert!(
+            finding
+                .message
+                .contains("throughput_per_s regression: 20.00%")
+        );
+        assert!(finding.message.contains("change: -20.00%"));
+        let data = finding.data.as_ref().unwrap();
+        assert_eq!(data.regression_pct, 20.0);
+        assert_eq!(data.direction, Direction::Higher);
     }
 
     #[test]

--- a/crates/perfgate/src/app/export.rs
+++ b/crates/perfgate/src/app/export.rs
@@ -1304,6 +1304,43 @@ mod tests {
                 }
             }
         }
+
+        #[test]
+        fn compare_regression_pct_uses_normalized_metric_direction() {
+            let mut receipt = create_test_compare_receipt();
+            receipt.budgets.insert(
+                Metric::ThroughputPerS,
+                Budget::new(0.20, 0.10, Direction::Higher),
+            );
+            receipt.deltas.insert(
+                Metric::ThroughputPerS,
+                Delta {
+                    baseline: 100.0,
+                    current: 125.0,
+                    ratio: 1.25,
+                    pct: 0.25,
+                    regression: 0.0,
+                    cv: None,
+                    noise_threshold: None,
+                    statistic: MetricStatistic::Median,
+                    significance: None,
+                    status: MetricStatus::Pass,
+                },
+            );
+
+            let jsonl = ExportUseCase::export_compare(&receipt, ExportFormat::Jsonl).unwrap();
+
+            for line in jsonl.trim().lines() {
+                let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
+                if parsed["metric"].as_str().unwrap() == "throughput_per_s" {
+                    let regression_pct = parsed["regression_pct"].as_f64().unwrap();
+                    assert!((regression_pct - 0.0).abs() < 0.01);
+                    return;
+                }
+            }
+
+            panic!("missing throughput_per_s export row");
+        }
     }
 }
 

--- a/crates/perfgate/src/app/export/rows.rs
+++ b/crates/perfgate/src/app/export/rows.rs
@@ -123,7 +123,7 @@ pub(super) fn compare_to_rows(receipt: &CompareReceipt) -> Vec<CompareExportRow>
                 metric: metric_to_string(*metric),
                 baseline_value: delta.baseline,
                 current_value: delta.current,
-                regression_pct: delta.pct * 100.0,
+                regression_pct: delta.regression * 100.0,
                 status: status_to_string(delta.status),
                 threshold: threshold * 100.0,
                 warn_threshold: warn_threshold.map(|t| t * 100.0),

--- a/crates/perfgate/src/app/watch.rs
+++ b/crates/perfgate/src/app/watch.rs
@@ -9,6 +9,7 @@
 
 use crate::app::runtime::{HostProbe, ProcessRunner};
 use crate::app::{CheckRequest, CheckUseCase, Clock, format_metric, format_value};
+use crate::domain::{MetricMovement, movement_for_pct};
 use perfgate_types::{
     ConfigFile, HostMismatchPolicy, Metric, MetricStatus, RunReceipt, ToolInfo, VerdictStatus,
 };
@@ -63,9 +64,9 @@ pub struct WatchRunResult {
 /// Trend direction for a metric across watch iterations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrendDirection {
-    /// Performance is improving (getting faster/smaller).
+    /// Performance is improving according to the metric's better direction.
     Improving,
-    /// Performance is degrading (getting slower/larger).
+    /// Performance is degrading according to the metric's better direction.
     Degrading,
     /// Performance is stable (within noise).
     Stable,
@@ -137,7 +138,7 @@ impl WatchState {
                 if trend.history.len() > MAX_TREND_HISTORY {
                     trend.history.remove(0);
                 }
-                trend.direction = compute_trend_direction(&trend.history);
+                trend.direction = compute_trend_direction(*metric, &trend.history);
             }
         } else {
             // No baseline means pass
@@ -162,8 +163,9 @@ const STABLE_THRESHOLD: f64 = 0.01;
 
 /// Compute trend direction from a history of delta percentages.
 ///
-/// Uses a simple moving average of the last 3 entries to determine direction.
-pub fn compute_trend_direction(history: &[f64]) -> TrendDirection {
+/// Uses a simple moving average of the last 3 entries and the metric's better
+/// direction to determine whether the trend is improving or degrading.
+pub fn compute_trend_direction(metric: Metric, history: &[f64]) -> TrendDirection {
     if history.len() < 2 {
         return TrendDirection::Stable;
     }
@@ -177,14 +179,13 @@ pub fn compute_trend_direction(history: &[f64]) -> TrendDirection {
     let avg: f64 = window.iter().sum::<f64>() / window.len() as f64;
 
     if avg.abs() < STABLE_THRESHOLD {
-        TrendDirection::Stable
-    } else if avg > 0.0 {
-        // Positive pct means current > baseline, which is a regression for "lower is better"
-        // metrics. But since pct is already direction-aware from the comparison logic,
-        // positive = worse, negative = better.
-        TrendDirection::Degrading
-    } else {
-        TrendDirection::Improving
+        return TrendDirection::Stable;
+    }
+
+    match movement_for_pct(metric, avg) {
+        MetricMovement::Improved => TrendDirection::Improving,
+        MetricMovement::Regressed => TrendDirection::Degrading,
+        MetricMovement::Unchanged | MetricMovement::Unknown => TrendDirection::Stable,
     }
 }
 
@@ -504,34 +505,56 @@ mod tests {
 
     #[test]
     fn trend_direction_stable_for_empty() {
-        assert_eq!(compute_trend_direction(&[]), TrendDirection::Stable);
+        assert_eq!(
+            compute_trend_direction(Metric::WallMs, &[]),
+            TrendDirection::Stable
+        );
     }
 
     #[test]
     fn trend_direction_stable_for_single() {
-        assert_eq!(compute_trend_direction(&[0.05]), TrendDirection::Stable);
+        assert_eq!(
+            compute_trend_direction(Metric::WallMs, &[0.05]),
+            TrendDirection::Stable
+        );
     }
 
     #[test]
-    fn trend_direction_degrading_for_positive() {
+    fn trend_direction_lower_is_better_degrading_for_positive() {
         assert_eq!(
-            compute_trend_direction(&[0.05, 0.06, 0.07]),
+            compute_trend_direction(Metric::WallMs, &[0.05, 0.06, 0.07]),
             TrendDirection::Degrading
         );
     }
 
     #[test]
-    fn trend_direction_improving_for_negative() {
+    fn trend_direction_lower_is_better_improving_for_negative() {
         assert_eq!(
-            compute_trend_direction(&[-0.05, -0.06, -0.07]),
+            compute_trend_direction(Metric::WallMs, &[-0.05, -0.06, -0.07]),
             TrendDirection::Improving
+        );
+    }
+
+    #[test]
+    fn trend_direction_higher_is_better_improving_for_positive() {
+        assert_eq!(
+            compute_trend_direction(Metric::ThroughputPerS, &[0.05, 0.06, 0.07]),
+            TrendDirection::Improving
+        );
+    }
+
+    #[test]
+    fn trend_direction_higher_is_better_degrading_for_negative() {
+        assert_eq!(
+            compute_trend_direction(Metric::ThroughputPerS, &[-0.05, -0.06, -0.07]),
+            TrendDirection::Degrading
         );
     }
 
     #[test]
     fn trend_direction_stable_for_small_values() {
         assert_eq!(
-            compute_trend_direction(&[0.001, -0.002, 0.003]),
+            compute_trend_direction(Metric::WallMs, &[0.001, -0.002, 0.003]),
             TrendDirection::Stable
         );
     }
@@ -540,7 +563,10 @@ mod tests {
     fn trend_uses_last_three_entries() {
         // History has old degrading values but recent improving values
         let history = vec![0.10, 0.15, 0.20, -0.05, -0.06, -0.07];
-        assert_eq!(compute_trend_direction(&history), TrendDirection::Improving);
+        assert_eq!(
+            compute_trend_direction(Metric::WallMs, &history),
+            TrendDirection::Improving
+        );
     }
 
     #[test]

--- a/docs/audits/decision-semantics-verification.md
+++ b/docs/audits/decision-semantics-verification.md
@@ -78,9 +78,8 @@ This audit does not publish 0.18.0, create tags, move action aliases, or close
 the active release cutover goal.
 
 This audit does not claim every display surface has been converted away from
-raw signed `pct`. The metric-direction audit still tracks follow-ups where raw
-display is intentional or where naming/language should be tightened, including
-watch trend language and export column naming.
+raw signed `pct`. Raw signed `pct` remains a change-display field, while
+judgment surfaces use metric direction, status, or normalized regression.
 
 This audit does not make the server ledger part of correctness. Local receipts
 remain the primary correctness contract; the server ledger remains optional

--- a/docs/audits/metric-direction-semantics.md
+++ b/docs/audits/metric-direction-semantics.md
@@ -40,7 +40,7 @@ direction-aware semantics or already-normalized receipt fields such as
 | Surface | Current source | Current state | Follow-up |
 | --- | --- | --- | --- |
 | Compare receipt verdict | `crates/perfgate/src/domain/budget.rs`, `crates/perfgate/src/domain/comparison.rs` | Direction-aware through `calculate_regression`, budget direction, and shared movement helpers. | Covered by movement and comparison fixture tests. |
-| Report derivation | `crates/perfgate/src/app/report.rs` | Uses `Delta::regression` and `MetricStatus`; higher-is-better report fixtures preserve throughput direction. | Covered by fixture matrix tests. |
+| Report derivation | `crates/perfgate/src/app/report.rs`, `crates/perfgate/src/app/check.rs` | Uses `Delta::regression` and `MetricStatus`; higher-is-better report fixtures preserve throughput direction. | Covered by fixture matrix tests. |
 | Decision readiness | `crates/perfgate-cli/src/decision_suggest.rs` | Direction-aware through the shared domain movement helper. | Covered by higher/lower decision readiness tests. |
 | Tradeoff requirements | `crates/perfgate/src/domain/comparison.rs`, `crates/perfgate/src/app/tradeoff.rs` | Direction-aware `improvement_ratio` translates lower-is-better and higher-is-better metrics into comparable improvement ratios. | Covered by scenario and probe tradeoff tests. |
 | Tradeoff allowances | `crates/perfgate/src/app/tradeoff.rs` | Uses `Delta::regression`, which is already positive normalized regression. | Covered by probe-backed higher-is-better allowance fixtures. |
@@ -48,8 +48,8 @@ direction-aware semantics or already-normalized receipt fields such as
 | Repair context | `crates/perfgate-cli/src/repair_context.rs` | Uses non-pass `MetricStatus` and `Delta::regression`; no raw sign judgment found. | Covered indirectly by status/normalized-regression fixtures; add a direct repair-context fixture when that surface changes next. |
 | Badge/status surfaces | `crates/perfgate/src/app/badge.rs` | Verdict and metric status are status-driven; raw `pct` is display-only. | Keep display labels as change, not judgment. |
 | Markdown rendering and annotations | `crates/perfgate/src/app/render.rs`, `crates/perfgate/src/integrations/github/comment.rs` | Status-driven warnings/failures are correct, and GitHub comment trend indicators label improvement/regression through shared movement semantics. | Keep raw percentage display separate from judgment labels. |
-| Watch/trend display | `crates/perfgate/src/app/watch.rs`, `crates/perfgate/src/app/trend.rs` | `app/trend.rs` is direction-aware; `watch.rs` stores raw `pct` history and classifies positive average as worsening. | Make watch trends metric-aware or restrict wording to lower-is-better deltas. |
-| Export rows | `crates/perfgate/src/app/export/rows.rs` | `regression_pct` currently exports raw signed `delta.pct * 100.0`, despite the column name implying normalized regression. | Decide whether to rename the column or export normalized `Delta::regression`. |
+| Watch/trend display | `crates/perfgate/src/app/watch.rs`, `crates/perfgate/src/app/trend.rs` | `app/trend.rs` is direction-aware; `watch.rs` classifies trend history through shared movement semantics. | Keep trend wording tied to metric direction. |
+| Export rows | `crates/perfgate/src/app/export/rows.rs` | `regression_pct` exports normalized `Delta::regression`, not raw signed `pct`. | Covered by higher-is-better export fixture coverage. |
 | Decision bundles | `crates/perfgate-cli/src/main.rs` | Bundles preserve receipts and do not reinterpret metric movement. | No immediate semantic change; bundle coverage follows receipt-level direction fixtures. |
 
 ## Focused Test Added

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -578,10 +578,10 @@ Artifacts:
 - `perfgate.probe_compare.v1` probe deltas using metric direction or probe metric heuristics
 - `perfgate.tradeoff.v1` requirements and allowances evaluated through direction-aware improvement/regression semantics
 - decision readiness output for lower-is-better and higher-is-better movement
+- watch trends, GitHub comment movement labels, and export `regression_pct` using direction-aware judgment fields
 
 Known limits:
 
 - Raw signed `pct` remains a display field; callers must not treat its sign as judgment without metric direction.
-- Export column naming and watch trend language remain tracked by the metric-direction audit follow-ups.
 
 Review after: next-decision-contract-change


### PR DESCRIPTION
## Summary
- makes watch trend classification use shared metric movement semantics
- exports normalized regression_pct from Delta::regression instead of raw signed pct
- normalizes check report regression data and clarifies report messages with raw change separately
- updates metric-direction audit and product-claim wording

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate --all-features trend_direction
- cargo +1.95.0 test -p perfgate --all-features compare_regression_pct
- cargo +1.95.0 test -p perfgate --all-features build_report_normalizes_higher_is_better_regression
- cargo +1.95.0 clippy -p perfgate --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check

## Release boundary
- no crates published
- no tags or aliases moved
- 0.18 release cutover goal remains active and operator-gated