### PR TITLE
docs: sync metric direction proof status

### DIFF
--- a/docs/audits/metric-direction-semantics.md
+++ b/docs/audits/metric-direction-semantics.md
@@ -62,12 +62,22 @@ helper:
 - higher-is-better decrease is below `1.0` and therefore cannot satisfy a
   `min_improvement_ratio` requirement.
 
-## Follow-up PRs
+## Follow-up Status
 
-1. Route remaining judgment call sites through the shared domain movement model.
-2. Add fixture coverage for lower-is-better and higher-is-better metrics across compare, report, decision suggest, tradeoff, probe compare, repair context, comments, and bundles.
-3. Harden tradeoff and probe requirement tests for higher-is-better dominant improvements and lower-is-better accepted local regressions.
-4. Update product claims only after the fixture matrix covers the core user-facing surfaces.
+Completed:
+
+1. Remaining judgment call sites route through shared domain movement,
+   metric status, or normalized regression fields.
+2. Fixture coverage now includes lower-is-better and higher-is-better metrics
+   across compare, report, decision readiness, tradeoff, probe compare,
+   GitHub comments, watch trend display, and export/report regression fields.
+3. Tradeoff and probe requirement tests cover higher-is-better dominant
+   improvements and accepted local regressions.
+4. Product claims map direction-aware metric movement to the merged proof
+   surfaces.
+
+Raw signed `pct` remains available as a display field. It is not the judgment
+field for improvement or regression.
 
 ## Proof Commands
 

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -559,6 +559,10 @@ Proof commands:
 ```bash
 cargo +1.95.0 test -p perfgate --all-features domain::movement
 cargo +1.95.0 test -p perfgate --all-features app::tradeoff
+cargo +1.95.0 test -p perfgate --all-features trend_indicator
+cargo +1.95.0 test -p perfgate --all-features trend_direction
+cargo +1.95.0 test -p perfgate --all-features compare_regression_pct
+cargo +1.95.0 test -p perfgate --all-features build_report_normalizes_higher_is_better_regression
 cargo +1.95.0 test -p perfgate-cli --test cli_decision_suggest_tests
 cargo +1.95.0 run -p xtask -- product-claims-check
 ```
@@ -569,6 +573,10 @@ Linked tests:
 - [`comparison.rs`](../../crates/perfgate/src/domain/comparison.rs)
 - [`probe.rs`](../../crates/perfgate/src/app/probe.rs)
 - [`tradeoff.rs`](../../crates/perfgate/src/app/tradeoff.rs)
+- [`check.rs`](../../crates/perfgate/src/app/check.rs)
+- [`export.rs`](../../crates/perfgate/src/app/export.rs)
+- [`watch.rs`](../../crates/perfgate/src/app/watch.rs)
+- [`comment.rs`](../../crates/perfgate/src/integrations/github/comment.rs)
 - [`cli_decision_suggest_tests.rs`](../../crates/perfgate-cli/tests/cli_decision_suggest_tests.rs)
 - [`cli_tradeoff_tests.rs`](../../crates/perfgate-cli/tests/cli_tradeoff_tests.rs)
 


### PR DESCRIPTION
## Summary
- updates the metric-direction audit follow-up section to reflect completed semantic PRs
- expands PG-CLAIM-0020 proof commands and linked tests for comment, watch, export, and check report coverage

## Validation
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check

## Release boundary
- no crates published
- no tags or aliases moved
- 0.18 release cutover goal remains active and operator-gated