### PR TITLE
test(cli): cover cli_parsing and repair_context helpers

### DIFF
--- a/crates/perfgate-cli/src/cli_parsing.rs
+++ b/crates/perfgate-cli/src/cli_parsing.rs
@@ -221,3 +221,524 @@ pub fn normalize_paired_cli_command(
 
     Ok(args)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_accepts_humantime_value() {
+        let d = parse_duration("1500ms").unwrap();
+        assert_eq!(d, Duration::from_millis(1500));
+        let d = parse_duration("2s").unwrap();
+        assert_eq!(d, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn parse_duration_rejects_garbage() {
+        let err = parse_duration("not-a-duration").unwrap_err().to_string();
+        assert!(err.contains("invalid duration"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_key_val_string_splits_on_first_equal() {
+        let (k, v) = parse_key_val_string("FOO=bar=baz").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "bar=baz");
+    }
+
+    #[test]
+    fn parse_key_val_string_requires_equal_sign() {
+        let err = parse_key_val_string("no-equals").unwrap_err();
+        assert_eq!(err, "expected KEY=VALUE");
+    }
+
+    #[test]
+    fn parse_key_val_f64_parses_value_as_float() {
+        let (k, v) = parse_key_val_f64("p99=12.5").unwrap();
+        assert_eq!(k, "p99");
+        assert!((v - 12.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_key_val_f64_rejects_non_numeric_value() {
+        let err = parse_key_val_f64("p99=abc").unwrap_err();
+        assert!(err.contains("invalid float value"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_key_val_f64_requires_equal_sign() {
+        let err = parse_key_val_f64("p99").unwrap_err();
+        assert_eq!(err, "expected KEY=VALUE");
+    }
+
+    #[test]
+    fn parse_noise_policy_round_trip_variants() {
+        assert!(matches!(
+            parse_noise_policy("warn").unwrap(),
+            perfgate_types::NoisePolicy::Warn
+        ));
+        assert!(matches!(
+            parse_noise_policy("SKIP").unwrap(),
+            perfgate_types::NoisePolicy::Skip
+        ));
+        assert!(matches!(
+            parse_noise_policy("Ignore").unwrap(),
+            perfgate_types::NoisePolicy::Ignore
+        ));
+    }
+
+    #[test]
+    fn parse_noise_policy_rejects_unknown_value() {
+        let err = parse_noise_policy("loud").unwrap_err();
+        assert!(err.contains("invalid noise policy"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_flakiness_score_accepts_in_range_values() {
+        assert_eq!(parse_flakiness_score("0").unwrap(), 0.0);
+        assert_eq!(parse_flakiness_score("0.5").unwrap(), 0.5);
+        assert_eq!(parse_flakiness_score("1").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_flakiness_score_rejects_out_of_range() {
+        assert!(parse_flakiness_score("-0.1").is_err());
+        assert!(parse_flakiness_score("1.1").is_err());
+    }
+
+    #[test]
+    fn parse_flakiness_score_rejects_non_finite() {
+        assert!(parse_flakiness_score("NaN").is_err());
+        assert!(parse_flakiness_score("inf").is_err());
+    }
+
+    #[test]
+    fn parse_flakiness_score_rejects_non_numeric() {
+        let err = parse_flakiness_score("noisy").unwrap_err();
+        assert!(err.contains("must be a number"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_verdict_status_handles_all_variants_case_insensitively() {
+        assert!(matches!(
+            parse_verdict_status("pass"),
+            Ok(VerdictStatus::Pass)
+        ));
+        assert!(matches!(
+            parse_verdict_status("WARN"),
+            Ok(VerdictStatus::Warn)
+        ));
+        assert!(matches!(
+            parse_verdict_status("Fail"),
+            Ok(VerdictStatus::Fail)
+        ));
+        assert!(matches!(
+            parse_verdict_status("skip"),
+            Ok(VerdictStatus::Skip)
+        ));
+        assert!(parse_verdict_status("blocked").is_err());
+    }
+
+    #[test]
+    fn parse_metric_status_handles_all_variants_case_insensitively() {
+        assert!(matches!(
+            parse_metric_status("pass"),
+            Ok(MetricStatus::Pass)
+        ));
+        assert!(matches!(
+            parse_metric_status("WARN"),
+            Ok(MetricStatus::Warn)
+        ));
+        assert!(matches!(
+            parse_metric_status("Fail"),
+            Ok(MetricStatus::Fail)
+        ));
+        assert!(matches!(
+            parse_metric_status("skip"),
+            Ok(MetricStatus::Skip)
+        ));
+        assert!(parse_metric_status("unknown").is_err());
+    }
+
+    #[test]
+    fn parse_host_mismatch_policy_aliases_fail_to_error() {
+        assert!(matches!(
+            parse_host_mismatch_policy("warn"),
+            Ok(HostMismatchPolicy::Warn)
+        ));
+        assert!(matches!(
+            parse_host_mismatch_policy("error"),
+            Ok(HostMismatchPolicy::Error)
+        ));
+        assert!(matches!(
+            parse_host_mismatch_policy("fail"),
+            Ok(HostMismatchPolicy::Error)
+        ));
+        assert!(matches!(
+            parse_host_mismatch_policy("ignore"),
+            Ok(HostMismatchPolicy::Ignore)
+        ));
+        assert!(
+            parse_host_mismatch_policy("WARN").is_err(),
+            "policy is case-sensitive"
+        );
+        assert!(parse_host_mismatch_policy("bogus").is_err());
+    }
+
+    #[test]
+    fn parse_aggregation_policy_covers_all_variants() {
+        assert!(matches!(
+            parse_aggregation_policy("all"),
+            Ok(AggregationPolicy::All)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("majority"),
+            Ok(AggregationPolicy::Majority)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("weighted"),
+            Ok(AggregationPolicy::Weighted)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("quorum"),
+            Ok(AggregationPolicy::Quorum)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("fail_if_n_of_m"),
+            Ok(AggregationPolicy::FailIfNOfM)
+        ));
+        assert!(parse_aggregation_policy("nope").is_err());
+    }
+
+    #[test]
+    fn parse_aggregate_weight_mode_covers_variants() {
+        assert!(matches!(
+            parse_aggregate_weight_mode("configured"),
+            Ok(AggregateWeightMode::Configured)
+        ));
+        assert!(matches!(
+            parse_aggregate_weight_mode("inverse_variance"),
+            Ok(AggregateWeightMode::InverseVariance)
+        ));
+        assert!(parse_aggregate_weight_mode("other").is_err());
+    }
+
+    #[test]
+    fn parse_weight_map_handles_multiple_entries_and_trims_labels() {
+        let input = vec!["foo=1.0".into(), " bar =2.5".into()];
+        let map = parse_weight_map(&input).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["foo"], 1.0);
+        assert_eq!(map["bar"], 2.5);
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_missing_equals() {
+        let err = parse_weight_map(&["foo".into()]).unwrap_err().to_string();
+        assert!(err.contains("expected label=value"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_empty_label() {
+        let err = parse_weight_map(&["=1.0".into()]).unwrap_err().to_string();
+        assert!(err.contains("label cannot be empty"), "got: {err}");
+        let err = parse_weight_map(&["   =1.0".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("label cannot be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_non_numeric_weight() {
+        let err = parse_weight_map(&["foo=bad".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("weight must be a number"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_negative_and_nonfinite() {
+        let err = parse_weight_map(&["foo=-1".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("non-negative"), "got: {err}");
+        let err = parse_weight_map(&["foo=NaN".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("non-negative"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_empty_input_returns_empty_map() {
+        let map = parse_weight_map(&[]).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn validate_aggregate_options_accepts_default_all_policy() {
+        let (q, fnm, vf) = validate_aggregate_options(
+            AggregationPolicy::All,
+            AggregateWeightMode::Configured,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(q.is_none());
+        assert!(fnm.is_none());
+        assert!(vf.is_none());
+    }
+
+    #[test]
+    fn validate_aggregate_options_rejects_quorum_out_of_range() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::Configured,
+            Some(1.5),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--quorum must be between"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::Configured,
+            Some(f64::NAN),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--quorum must be between"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_quorum_requires_weighted_or_quorum_policy() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::All,
+            AggregateWeightMode::Configured,
+            Some(0.5),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--quorum requires"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_inverse_variance_requires_weighted() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Majority,
+            AggregateWeightMode::InverseVariance,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("inverse_variance requires"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_variance_floor_rules() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::InverseVariance,
+            None,
+            None,
+            None,
+            Some(0.0),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("variance-floor"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::Configured,
+            None,
+            None,
+            None,
+            Some(1.0),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("inverse_variance"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_if_n_of_m_requires_fail_n() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--fail-n"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_if_n_of_m_rejects_zero_or_inverted() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(0),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--fail-n must be at least 1"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(3),
+            Some(0),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--fail-m must be at least 1"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(5),
+            Some(3),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("must be greater than or equal"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_if_n_of_m_success_path() {
+        let (q, fnm, vf) = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(2),
+            Some(5),
+            None,
+        )
+        .unwrap();
+        assert!(q.is_none());
+        let fnm = fnm.expect("should produce FailIfNOfM");
+        assert_eq!(fnm.n, 2);
+        assert_eq!(fnm.m, Some(5));
+        assert!(vf.is_none());
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_n_or_m_outside_correct_policy_errors() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::All,
+            AggregateWeightMode::Configured,
+            None,
+            Some(1),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("fail_if_n_of_m"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_inverse_variance_success_passes_floor_through() {
+        let (q, fnm, vf) = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::InverseVariance,
+            Some(0.6),
+            None,
+            None,
+            Some(2.5),
+        )
+        .unwrap();
+        assert_eq!(q, Some(0.6));
+        assert!(fnm.is_none());
+        assert_eq!(vf, Some(2.5));
+    }
+
+    #[test]
+    fn parse_significance_alpha_accepts_in_range() {
+        assert_eq!(parse_significance_alpha("0.05").unwrap(), 0.05);
+        assert_eq!(parse_significance_alpha("0").unwrap(), 0.0);
+        assert_eq!(parse_significance_alpha("1").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_significance_alpha_rejects_invalid_values() {
+        assert!(parse_significance_alpha("abc").is_err());
+        assert!(parse_significance_alpha("1.5").is_err());
+        assert!(parse_significance_alpha("-0.1").is_err());
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_requires_nonempty_input() {
+        let err = normalize_paired_cli_command(vec![], "--current-cmd")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--current-cmd"), "got: {err}");
+        assert!(err.contains("at least one argument"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_splits_quoted_single_arg() {
+        let out =
+            normalize_paired_cli_command(vec!["echo \"hello world\"".into()], "--current-cmd")
+                .unwrap();
+        assert_eq!(out, vec!["echo".to_string(), "hello world".to_string()]);
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_passes_through_multi_arg_form() {
+        let out = normalize_paired_cli_command(
+            vec!["echo".into(), "hello world".into()],
+            "--baseline-cmd",
+        )
+        .unwrap();
+        assert_eq!(out, vec!["echo".to_string(), "hello world".to_string()]);
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_single_arg_without_whitespace_returns_as_is() {
+        let out = normalize_paired_cli_command(vec!["./bench".into()], "--baseline-cmd").unwrap();
+        assert_eq!(out, vec!["./bench".to_string()]);
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_empty_quoted_string_is_an_error() {
+        // shell_words::split("   ") yields an empty Vec, which must trigger the empty-parse error
+        let err = normalize_paired_cli_command(vec!["   ".into()], "--current-cmd")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("parsed to an empty command"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_reports_invalid_shell_string() {
+        let err = normalize_paired_cli_command(vec!["echo \"unterminated".into()], "--current-cmd")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("failed to parse"), "got: {err}");
+    }
+}

--- a/crates/perfgate-cli/src/repair_context.rs
+++ b/crates/perfgate-cli/src/repair_context.rs
@@ -210,3 +210,80 @@ pub(crate) fn run_git_capture_bytes(args: &[&str]) -> Option<Vec<u8>> {
     }
     Some(output.stdout)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_changed_files_summary_handles_empty_input() {
+        let summary = parse_changed_files_summary(b"");
+        assert_eq!(summary.file_count, 0);
+        assert!(summary.files.is_empty());
+        assert!(summary.file_count_by_top_level.is_empty());
+    }
+
+    #[test]
+    fn parse_changed_files_summary_groups_by_top_level_directory() {
+        // Each entry has 2-byte status code, single space, then path, terminated by NUL.
+        // Use modified entries (no rename).
+        let input = b" M src/lib.rs\0 M src/util.rs\0 M tests/case.rs\0?? README.md\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 4);
+        assert_eq!(summary.files.len(), 4);
+        assert_eq!(summary.file_count_by_top_level["src"], 2);
+        assert_eq!(summary.file_count_by_top_level["tests"], 1);
+        // top-level file gets "README.md" bucket
+        assert_eq!(summary.file_count_by_top_level["README.md"], 1);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_handles_rename_two_path_entries() {
+        // Rename status uses two NUL-separated paths: "<old>\0<new>".
+        // The current path is the second entry (the new name).
+        let input = b"R  src/old.rs\0src/new.rs\0 M src/touched.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 2);
+        assert_eq!(summary.files, vec!["src/new.rs", "src/touched.rs"]);
+        assert_eq!(summary.file_count_by_top_level["src"], 2);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_skips_short_entries() {
+        // Entries with status header only (no path) must be ignored without panicking.
+        let input = b"M \0 M src/ok.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 1);
+        assert_eq!(summary.files, vec!["src/ok.rs"]);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_falls_back_to_dot_for_paths_starting_with_separator() {
+        // A path whose first component splits to empty (e.g., "/abs") should bucket under ".".
+        let input = b" M /abs/path.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 1);
+        assert_eq!(summary.file_count_by_top_level["."], 1);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_handles_windows_style_separators() {
+        let input = b" M crates\\perfgate\\src\\main.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 1);
+        assert_eq!(summary.file_count_by_top_level["crates"], 1);
+    }
+
+    #[test]
+    fn run_git_capture_returns_none_for_unknown_git_subcommand() {
+        // A bogus git subcommand should exit non-zero, so we expect None.
+        let result = run_git_capture(&["this-is-not-a-real-git-subcommand"]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn run_git_capture_bytes_returns_none_for_unknown_git_subcommand() {
+        let result = run_git_capture_bytes(&["this-is-not-a-real-git-subcommand"]);
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Adds 50 inline unit tests for two previously-untested helper modules in `perfgate-cli`:

- **`cli_parsing.rs`** (42 tests, was 0): every public parser / validator function and all error branches:
  - `parse_duration`, `parse_key_val_string`, `parse_key_val_f64`, `parse_significance_alpha`, `parse_flakiness_score` (including non-finite + out-of-range)
  - status/policy enums: `parse_noise_policy`, `parse_verdict_status`, `parse_metric_status`, `parse_host_mismatch_policy`, `parse_aggregation_policy`, `parse_aggregate_weight_mode`
  - `parse_weight_map` — equals-required, empty-label, non-numeric and negative/NaN weights, label trimming
  - `validate_aggregate_options` — quorum range, inverse-variance requires-weighted, variance-floor coupling, `fail_if_n_of_m` N/M rules incl. inverted M < N
  - `normalize_paired_cli_command` — empty input, single-arg shell-string split, multi-arg passthrough, empty-parse, unterminated quote
- **`repair_context.rs`** (8 tests, was 0):
  - `parse_changed_files_summary` — empty input, grouped top-level buckets, rename two-path entries, short/malformed entries, Windows separators, root-anchored paths
  - `run_git_capture` / `run_git_capture_bytes` — non-zero exit returns `None`

## Why

`cli_parsing` powers argument validation users hit on the command line; its error branches (especially the `validate_aggregate_options` policy matrix and the paired-cmd normalizer) are user-visible but had no coverage. `parse_changed_files_summary` parses raw `git status -z` output and has multiple subtle branches (rename pairing, separator handling) that were also uncovered.

Per CLAUDE.md, perfgate-cli targets a 70% mutation-kill rate. These tests close the largest "no tests at all" gaps for that crate.

## Test plan

- [x] `cargo test -p perfgate-cli --bin perfgate cli_parsing::` — 42 pass
- [x] `cargo test -p perfgate-cli --bin perfgate repair_context::` — 8 pass
- [x] `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCTeJsZjUhMc4FGAFWJ9Tb)_