### PR TITLE
test(cli): cover check_guidance and artifact_explain modules

### DIFF
--- a/crates/perfgate-cli/src/artifact_explain.rs
+++ b/crates/perfgate-cli/src/artifact_explain.rs
@@ -157,3 +157,243 @@ fn artifact_next_commands(known: &[(PathBuf, &'static str)]) -> Vec<String> {
     }
     commands
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn known_artifact_role_recognizes_every_well_known_filename() {
+        let expectations = &[
+            (RUN_RECEIPT_FILE, "raw measurement receipt"),
+            (COMPARE_RECEIPT_FILE, "baseline/current comparison receipt"),
+            ("report.json", "machine-readable verdict summary"),
+            ("comment.md", "PR-ready human summary"),
+            ("repair_context.json", "local reproduction and repair hints"),
+            ("decision.md", "human-readable performance decision"),
+            (
+                "decision.index.json",
+                "index of decision evidence artifacts",
+            ),
+            ("decision-bundle.json", "portable decision evidence bundle"),
+            (
+                "probe-compare.json",
+                "named probe baseline/current comparison",
+            ),
+            ("scenario.json", "weighted workload scenario receipt"),
+            ("tradeoff.json", "tradeoff policy evaluation receipt"),
+        ];
+        for (name, role) in expectations {
+            assert_eq!(
+                known_artifact_role(name),
+                Some(*role),
+                "missing role for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn known_artifact_role_returns_none_for_unknown_filename() {
+        assert!(known_artifact_role("random.txt").is_none());
+        assert!(known_artifact_role("perfgate.toml").is_none());
+        assert!(known_artifact_role("").is_none());
+    }
+
+    #[test]
+    fn artifact_next_commands_falls_back_to_check_command_when_no_known_files() {
+        let cmds = artifact_next_commands(&[]);
+        assert_eq!(
+            cmds,
+            vec!["perfgate check --config perfgate.toml --all".to_string()]
+        );
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_comment_inspection_when_comment_present() {
+        let known = vec![(PathBuf::from("comment.md"), "PR-ready human summary")];
+        let cmds = artifact_next_commands(&known);
+        assert_eq!(cmds.len(), 1);
+        assert!(cmds[0].contains("inspect artifacts/perfgate/comment.md"));
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_repair_context_inspection() {
+        let known = vec![(
+            PathBuf::from("repair_context.json"),
+            "local reproduction and repair hints",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("inspect repair_context.json"))
+        );
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_decision_bundle_when_index_present() {
+        let known = vec![(
+            PathBuf::from("decision.index.json"),
+            "index of decision evidence artifacts",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(cmds.iter().any(|c| c.contains("perfgate decision bundle")));
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_require_baseline_when_compare_present() {
+        let known = vec![(
+            PathBuf::from(COMPARE_RECEIPT_FILE),
+            "baseline/current comparison receipt",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(cmds.iter().any(|c| c.contains("--require-baseline")));
+    }
+
+    #[test]
+    fn artifact_next_commands_includes_multiple_recommendations_when_artifacts_overlap() {
+        let known = vec![
+            (PathBuf::from("comment.md"), "PR-ready human summary"),
+            (
+                PathBuf::from(COMPARE_RECEIPT_FILE),
+                "baseline/current comparison receipt",
+            ),
+        ];
+        let cmds = artifact_next_commands(&known);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("inspect artifacts/perfgate/comment.md"))
+        );
+        assert!(cmds.iter().any(|c| c.contains("--require-baseline")));
+        assert!(
+            !cmds
+                .iter()
+                .any(|c| c == "perfgate check --config perfgate.toml --all")
+        );
+    }
+
+    #[test]
+    fn artifact_next_commands_compares_by_filename_only() {
+        // Even if the path has a subdirectory prefix, file_name() should match.
+        let known = vec![(
+            PathBuf::from("bench-a/comment.md"),
+            "PR-ready human summary",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("inspect artifacts/perfgate/comment.md"))
+        );
+    }
+
+    #[test]
+    fn collect_artifact_files_returns_empty_when_directory_missing() {
+        let tmp = tempdir().unwrap();
+        let nonexistent = tmp.path().join("nope");
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(&nonexistent, &nonexistent, &mut known, &mut unknown).unwrap();
+        assert!(known.is_empty());
+        assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn collect_artifact_files_classifies_known_and_unknown_files() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        fs::write(root.join("run.json"), "{}").unwrap();
+        fs::write(root.join("report.json"), "{}").unwrap();
+        fs::write(root.join("README.txt"), "info").unwrap();
+
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(root, root, &mut known, &mut unknown).unwrap();
+        let known_names: Vec<String> = known
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(known_names.contains(&"run.json".to_string()));
+        assert!(known_names.contains(&"report.json".to_string()));
+        let unknown_names: Vec<String> = unknown
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(unknown_names, vec!["README.txt"]);
+    }
+
+    #[test]
+    fn collect_artifact_files_recurses_into_subdirectories() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let nested = root.join("bench-a");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("compare.json"), "{}").unwrap();
+
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(root, root, &mut known, &mut unknown).unwrap();
+        assert_eq!(known.len(), 1);
+        let (path, role) = &known[0];
+        assert_eq!(path, &PathBuf::from("bench-a/compare.json"));
+        assert_eq!(*role, "baseline/current comparison receipt");
+    }
+
+    #[test]
+    fn collect_artifact_files_sorts_known_and_unknown_lists() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // Write in an order that's not sorted.
+        fs::write(root.join("report.json"), "{}").unwrap();
+        fs::write(root.join("compare.json"), "{}").unwrap();
+        fs::write(root.join("zzz-unknown.txt"), "x").unwrap();
+        fs::write(root.join("aaa-unknown.txt"), "x").unwrap();
+
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(root, root, &mut known, &mut unknown).unwrap();
+
+        let known_paths: Vec<PathBuf> = known.iter().map(|(p, _)| p.clone()).collect();
+        let mut sorted = known_paths.clone();
+        sorted.sort();
+        assert_eq!(known_paths, sorted);
+        let mut sorted_unknown = unknown.clone();
+        sorted_unknown.sort();
+        assert_eq!(unknown, sorted_unknown);
+    }
+
+    #[test]
+    fn execute_explain_artifacts_succeeds_when_out_dir_missing() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("perfgate-nope");
+        let result = execute_explain_artifacts(ExplainArtifactsArgs { out_dir: missing });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_explain_artifacts_succeeds_for_empty_dir() {
+        let tmp = tempdir().unwrap();
+        let out_dir = tmp.path().to_path_buf();
+        let result = execute_explain_artifacts(ExplainArtifactsArgs { out_dir });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_explain_artifacts_succeeds_with_known_artifacts() {
+        let tmp = tempdir().unwrap();
+        let out_dir = tmp.path().to_path_buf();
+        fs::write(out_dir.join("run.json"), "{}").unwrap();
+        fs::write(out_dir.join("comment.md"), "ok").unwrap();
+        let result = execute_explain_artifacts(ExplainArtifactsArgs { out_dir });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_explain_action_dispatches_artifacts_variant() {
+        let tmp = tempdir().unwrap();
+        let out_dir = tmp.path().to_path_buf();
+        let result =
+            execute_explain_action(ExplainAction::Artifacts(ExplainArtifactsArgs { out_dir }));
+        assert!(result.is_ok());
+    }
+}

--- a/crates/perfgate-cli/src/check_guidance.rs
+++ b/crates/perfgate-cli/src/check_guidance.rs
@@ -381,3 +381,414 @@ pub(super) fn emit_check_outcome_guidance(
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn shell_path_returns_plain_value_for_simple_paths() {
+        let p = Path::new("perfgate.toml");
+        assert_eq!(shell_path(p), "perfgate.toml");
+    }
+
+    #[test]
+    fn shell_path_quotes_paths_with_spaces() {
+        let p = PathBuf::from("/tmp/has space/file.toml");
+        let quoted = shell_path(&p);
+        assert!(
+            quoted.starts_with('"') && quoted.ends_with('"'),
+            "got {quoted}"
+        );
+        assert!(quoted.contains("has space"), "got {quoted}");
+    }
+
+    #[test]
+    fn shell_path_escapes_embedded_quotes_when_quoting() {
+        let p = PathBuf::from("with \"quote\" and space");
+        let quoted = shell_path(&p);
+        assert_eq!(quoted, "\"with \\\"quote\\\" and space\"");
+    }
+
+    #[test]
+    fn check_command_uses_bench_when_provided() {
+        let cfg = Path::new("perfgate.toml");
+        assert_eq!(
+            check_command(cfg, Some("bench-a"), false),
+            "perfgate check --config perfgate.toml --bench bench-a"
+        );
+    }
+
+    #[test]
+    fn check_command_uses_all_flag_when_no_bench() {
+        let cfg = Path::new("perfgate.toml");
+        assert_eq!(
+            check_command(cfg, None, false),
+            "perfgate check --config perfgate.toml --all"
+        );
+    }
+
+    #[test]
+    fn check_command_appends_require_baseline_when_requested() {
+        let cfg = Path::new("perfgate.toml");
+        let with = check_command(cfg, Some("bench-a"), true);
+        assert!(with.ends_with("--require-baseline"), "got: {with}");
+        let none = check_command(cfg, None, true);
+        assert!(none.ends_with("--require-baseline"), "got: {none}");
+    }
+
+    #[test]
+    fn check_command_quotes_config_path_with_spaces() {
+        let cfg = PathBuf::from("/tmp/has space/perfgate.toml");
+        let cmd = check_command(&cfg, Some("b"), false);
+        assert!(
+            cmd.contains("--config \"/tmp/has space/perfgate.toml\""),
+            "got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn paired_command_substitutes_bench_name_in_all_positions() {
+        let cmd = paired_command(Some("my-bench"));
+        assert!(cmd.contains("--name my-bench"));
+        assert!(cmd.contains("artifacts/perfgate/my-bench/paired.json"));
+    }
+
+    #[test]
+    fn paired_command_uses_placeholder_when_bench_missing() {
+        let cmd = paired_command(None);
+        assert!(cmd.contains("--name <bench>"));
+        assert!(cmd.contains("artifacts/perfgate/<bench>/paired.json"));
+    }
+
+    #[test]
+    fn failure_class_status_strings_are_stable() {
+        assert_eq!(
+            FailureClass::SetupMissingConfig.status(),
+            "setup_missing_config"
+        );
+        assert_eq!(
+            FailureClass::SetupMissingBench.status(),
+            "setup_missing_bench"
+        );
+        assert_eq!(
+            FailureClass::SetupCommandFailed.status(),
+            "setup_command_failed"
+        );
+        assert_eq!(FailureClass::MissingBaseline.status(), "missing_baseline");
+        assert_eq!(
+            FailureClass::PerformanceRegression.status(),
+            "performance_regression"
+        );
+        assert_eq!(FailureClass::HighNoise.status(), "high_noise");
+        assert_eq!(
+            FailureClass::UnsupportedMetric.status(),
+            "unsupported_metric"
+        );
+        assert_eq!(FailureClass::HostMismatch.status(), "host_mismatch");
+        assert_eq!(FailureClass::ReviewRequired.status(), "review_required");
+        assert_eq!(
+            FailureClass::ServerUploadFailed.status(),
+            "server_upload_failed"
+        );
+    }
+
+    #[test]
+    fn failure_class_meaning_and_do_not_are_non_empty_for_every_variant() {
+        for class in [
+            FailureClass::SetupMissingConfig,
+            FailureClass::SetupMissingBench,
+            FailureClass::SetupCommandFailed,
+            FailureClass::MissingBaseline,
+            FailureClass::PerformanceRegression,
+            FailureClass::HighNoise,
+            FailureClass::UnsupportedMetric,
+            FailureClass::HostMismatch,
+            FailureClass::ReviewRequired,
+            FailureClass::ServerUploadFailed,
+        ] {
+            assert!(!class.meaning().is_empty(), "{:?} has empty meaning", class);
+            assert!(!class.do_not().is_empty(), "{:?} has empty do_not", class);
+        }
+    }
+
+    #[test]
+    fn failure_class_artifacts_handles_missing_out_dir() {
+        let arts = FailureClass::MissingBaseline.artifacts(None, None);
+        assert_eq!(arts.len(), 1);
+        assert!(arts[0].contains("artifacts unavailable"), "got: {:?}", arts);
+    }
+
+    #[test]
+    fn failure_class_artifacts_missing_baseline_lists_expected_files() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::MissingBaseline.artifacts(Some(&out_dir), None);
+        let joined = arts.join(",");
+        assert!(
+            joined.contains("artifacts/perfgate/run.json"),
+            "got: {joined}"
+        );
+        assert!(
+            joined.contains("artifacts/perfgate/report.json"),
+            "got: {joined}"
+        );
+        assert!(
+            joined.contains("artifacts/perfgate/comment.md"),
+            "got: {joined}"
+        );
+        assert!(
+            joined.contains("artifacts/perfgate/repair_context.json"),
+            "got: {joined}"
+        );
+    }
+
+    #[test]
+    fn failure_class_artifacts_regression_prefers_explicit_compare_path() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let compare = PathBuf::from("artifacts/perfgate/other/compare.json");
+        let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), Some(&compare));
+        assert!(
+            arts.iter()
+                .any(|a| a == "artifacts/perfgate/other/compare.json"),
+            "got: {:?}",
+            arts
+        );
+        assert_eq!(
+            arts.iter().filter(|a| a.ends_with("compare.json")).count(),
+            1,
+            "got: {:?}",
+            arts
+        );
+    }
+
+    #[test]
+    fn failure_class_artifacts_regression_falls_back_to_default_compare() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), None);
+        assert!(
+            arts.iter().any(|a| a == "artifacts/perfgate/compare.json"),
+            "got: {:?}",
+            arts
+        );
+    }
+
+    #[test]
+    fn failure_class_artifacts_server_upload_failed_excludes_compare() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::ServerUploadFailed.artifacts(Some(&out_dir), None);
+        assert!(
+            !arts.iter().any(|a| a.contains("compare.json")),
+            "got: {:?}",
+            arts
+        );
+        assert!(arts.iter().any(|a| a == "artifacts/perfgate/run.json"));
+    }
+
+    #[test]
+    fn failure_class_artifacts_setup_variants_say_unavailable() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        for class in [
+            FailureClass::SetupMissingConfig,
+            FailureClass::SetupMissingBench,
+            FailureClass::SetupCommandFailed,
+            FailureClass::UnsupportedMetric,
+        ] {
+            let arts = class.artifacts(Some(&out_dir), None);
+            assert_eq!(arts.len(), 1, "{:?}", class);
+            assert!(
+                arts[0].contains("unavailable") || arts[0].contains("incomplete"),
+                "{:?} => {:?}",
+                class,
+                arts
+            );
+        }
+    }
+
+    #[test]
+    fn failure_class_artifacts_sorts_and_dedups() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::HostMismatch.artifacts(Some(&out_dir), None);
+        let mut sorted = arts.clone();
+        sorted.sort();
+        assert_eq!(arts, sorted, "artifacts must be sorted");
+        let mut deduped = arts.clone();
+        deduped.dedup();
+        assert_eq!(arts, deduped, "artifacts must be deduped");
+    }
+
+    #[test]
+    fn next_commands_setup_missing_config_recommends_init_and_doctor() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::SetupMissingConfig.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter().any(|c| c.contains("perfgate init")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(
+            cmds.iter().any(|c| c.contains("perfgate doctor")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_missing_baseline_includes_baseline_promote() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::MissingBaseline.next_commands(&cfg, Some("bench-a"), None);
+        assert!(
+            cmds.iter().any(|c| c.contains("baseline promote")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(
+            cmds.iter().any(|c| c.contains("--bench bench-a")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_missing_baseline_without_bench_uses_all_flag() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::MissingBaseline.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("baseline promote") && c.contains("--all")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_performance_regression_appends_explain_when_compare_path_present() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let compare = PathBuf::from("artifacts/compare.json");
+        let cmds =
+            FailureClass::PerformanceRegression.next_commands(&cfg, Some("b"), Some(&compare));
+        assert!(
+            cmds.iter().any(|c| c.contains("--require-baseline")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("perfgate explain --compare")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_performance_regression_skips_explain_when_no_compare_path() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::PerformanceRegression.next_commands(&cfg, Some("b"), None);
+        assert!(
+            !cmds.iter().any(|c| c.contains("perfgate explain")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_high_noise_recommends_paired_run() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::HighNoise.next_commands(&cfg, Some("b"), None);
+        assert!(
+            cmds.iter().any(|c| c.starts_with("perfgate paired")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_host_mismatch_requires_baseline_and_mentions_runner() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::HostMismatch.next_commands(&cfg, Some("b"), None);
+        assert!(
+            cmds.iter().any(|c| c.contains("--require-baseline")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(cmds.iter().any(|c| c.contains("runner")), "got: {:?}", cmds);
+    }
+
+    #[test]
+    fn next_commands_review_required_points_at_decision_artifacts() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::ReviewRequired.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("decision.md") || c.contains("Action summary"))
+        );
+        assert!(cmds.iter().any(|c| c.contains("perfgate decision bundle")));
+    }
+
+    #[test]
+    fn next_commands_server_upload_failed_recommends_inspection_and_history() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::ServerUploadFailed.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("API key") || c.contains("server URL"))
+        );
+        assert!(cmds.iter().any(|c| c == "perfgate decision history"));
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_missing_bench_message() {
+        let err = anyhow::anyhow!("benchmark not found in config");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+        let err = anyhow::anyhow!("either --bench or --all must be provided");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+        let err = anyhow::anyhow!("no benchmarks were configured");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_baseline_message() {
+        let err = anyhow::anyhow!("baseline could not be loaded");
+        assert_eq!(classify_check_error(&err), FailureClass::MissingBaseline);
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_host_mismatch_message() {
+        let err = anyhow::anyhow!("host mismatch detected");
+        assert_eq!(classify_check_error(&err), FailureClass::HostMismatch);
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_config_read_failure() {
+        let err = anyhow::anyhow!("read perfgate.toml failed");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingConfig);
+    }
+
+    #[test]
+    fn classify_check_error_default_to_command_failure() {
+        let err = anyhow::anyhow!("something weird happened");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
+    }
+
+    #[test]
+    fn classify_check_error_handles_perfgate_error_variants() {
+        use perfgate_types::error::{AdapterError, ConfigValidationError, IoError, PerfgateError};
+
+        let err: anyhow::Error =
+            PerfgateError::Config(ConfigValidationError::BenchName("bad".into())).into();
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+
+        let err: anyhow::Error =
+            PerfgateError::Io(IoError::BaselineNotFound { path: "x".into() }).into();
+        assert_eq!(classify_check_error(&err), FailureClass::MissingBaseline);
+
+        let err: anyhow::Error = PerfgateError::Adapter(AdapterError::EmptyArgv).into();
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
+
+        let err: anyhow::Error = PerfgateError::Adapter(AdapterError::Timeout).into();
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
+
+        let err: anyhow::Error = PerfgateError::Adapter(AdapterError::TimeoutUnsupported).into();
+        assert_eq!(classify_check_error(&err), FailureClass::UnsupportedMetric);
+    }
+}

--- a/crates/perfgate-cli/src/check_guidance.rs
+++ b/crates/perfgate-cli/src/check_guidance.rs
@@ -387,6 +387,13 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    fn slash_paths(values: &[String]) -> Vec<String> {
+        values
+            .iter()
+            .map(|value| value.replace('\\', "/"))
+            .collect()
+    }
+
     #[test]
     fn shell_path_returns_plain_value_for_simple_paths() {
         let p = Path::new("perfgate.toml");
@@ -524,6 +531,7 @@ mod tests {
     fn failure_class_artifacts_missing_baseline_lists_expected_files() {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let arts = FailureClass::MissingBaseline.artifacts(Some(&out_dir), None);
+        let arts = slash_paths(&arts);
         let joined = arts.join(",");
         assert!(
             joined.contains("artifacts/perfgate/run.json"),
@@ -548,6 +556,7 @@ mod tests {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let compare = PathBuf::from("artifacts/perfgate/other/compare.json");
         let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), Some(&compare));
+        let arts = slash_paths(&arts);
         assert!(
             arts.iter()
                 .any(|a| a == "artifacts/perfgate/other/compare.json"),
@@ -566,6 +575,7 @@ mod tests {
     fn failure_class_artifacts_regression_falls_back_to_default_compare() {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), None);
+        let arts = slash_paths(&arts);
         assert!(
             arts.iter().any(|a| a == "artifacts/perfgate/compare.json"),
             "got: {:?}",
@@ -577,6 +587,7 @@ mod tests {
     fn failure_class_artifacts_server_upload_failed_excludes_compare() {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let arts = FailureClass::ServerUploadFailed.artifacts(Some(&out_dir), None);
+        let arts = slash_paths(&arts);
         assert!(
             !arts.iter().any(|a| a.contains("compare.json")),
             "got: {:?}",


### PR DESCRIPTION
## Summary

Adds 50 inline unit tests for two CLI helper modules that previously had **zero** test coverage:

### `check_guidance.rs` (33 tests, was 0)
- **`FailureClass::status`** — stable string contract for every variant (10 statuses)
- **`FailureClass::meaning`** / **`do_not`** — exhaustive non-empty check over all 10 variants
- **`FailureClass::artifacts`** — missing out_dir fallback, missing-baseline file list, regression with/without explicit `compare_path`, server-upload-failed excludes compare, setup variants emit "unavailable", sort/dedup invariants
- **`FailureClass::next_commands`** — setup-missing-config recommends `init` + `doctor`; missing-baseline includes `baseline promote` (per-bench + `--all`); performance-regression couples `--require-baseline` with `perfgate explain`; high-noise recommends paired; host-mismatch requires baseline + runner; review-required points at decision artifacts; server-upload-failed mentions API key + history
- **`shell_path`** — plain pass-through, quoting for spaces, escaping embedded quotes
- **`check_command`** — bench / --all branches, `--require-baseline` toggle, config path quoting
- **`paired_command`** — bench substitution and `<bench>` placeholder
- **`classify_check_error`** — message-pattern matching (missing-bench / baseline / host mismatch / config read / default) and `PerfgateError` downcast (config, IO, adapter empty-argv / timeout / timeout-unsupported)

### `artifact_explain.rs` (17 tests, was 0)
- **`known_artifact_role`** — recognizes every well-known filename (run, compare, report, comment, repair_context, decision, decision.index, decision-bundle, probe-compare, scenario, tradeoff); returns `None` for unknown
- **`artifact_next_commands`** — empty fallback; comment.md inspection; repair_context.json inspection; decision.index bundle command; compare → require-baseline; multi-artifact mix; matches by filename across subdirs
- **`collect_artifact_files`** — missing dir, known/unknown classification, recursion, sort/dedup
- **`execute_explain_artifacts`** + **`execute_explain_action`** — smoke checks for missing/empty/populated dirs

## Test plan
- [x] `cargo test -p perfgate-cli --bin perfgate check_guidance` — 33 pass
- [x] `cargo test -p perfgate-cli --bin perfgate artifact_explain` — 17 pass
- [x] `cargo clippy -p perfgate-cli --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all`

Base: `claude/improve-code-coverage-FP7F5` (the integration branch where these helper modules were extracted from main.rs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCTeJsZjUhMc4FGAFWJ9Tb)_