### PR TITLE
release: refresh 0.18.0 final proof after coverage hardening

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,12 +1,13 @@
 # Release Readiness
 
-Last verified: 2026-05-14 for v0.17.0 publication reconciliation and the
-0.18.0 release-candidate cutover proof. See
+Last verified: 2026-05-17 for v0.17.0 publication reconciliation and the
+0.18.0 release-candidate cutover proof after post-SRP coverage hardening. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
 [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md),
 [v0.18.0 Final Pre-Publish Proof](audits/release-0.18.0-final-prepublish-proof.md),
+[v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md),
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
@@ -77,6 +78,7 @@ but it does not authorize publication by itself.
 | 0.18 adoption hardening | Covered | [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md), including wrapper absorption, first-hour smoke, structured decision bundle proof, action summary examples, and server ledger operations smoke |
 | 0.18 publish dry-run matrix | Passing | [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md) packaged and verified `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, and `perfgate-cli` at `0.18.0` without uploading. |
 | 0.18 final pre-publish proof | Passing | [v0.18.0 Final Pre-Publish Proof](audits/release-0.18.0-final-prepublish-proof.md) reran fmt, check, test, docs, source-doc, product-claim, public-surface, arch, action, schema, package-list, and five per-crate dry-run gates from the reopened release lane without publishing. |
+| 0.18 final proof after coverage hardening | Passing | [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #473-#476 and the generated badge refresh landed. |
 | 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields without publishing. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |

--- a/docs/audits/release-0.18.0-final-proof-after-coverage-hardening.md
+++ b/docs/audits/release-0.18.0-final-proof-after-coverage-hardening.md
@@ -1,0 +1,85 @@
+# v0.18.0 Final Proof After Coverage Hardening
+
+Date: 2026-05-17
+
+Branch: `release/0-18-final-proof-after-coverage-hardening`
+
+Commit under proof: `b9488986a44294971e55370dec549c9feb4fe1a9`
+
+Purpose: refresh the 0.18.0 release-candidate proof after the post-SRP
+coverage hardening tranche landed. This proof does not publish crates, create
+tags, create a GitHub release, move action aliases, prove public install, or
+close the active release cutover lane.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Linked prior proof:
+
+- [`v0.18.0 Final Pre-Publish Proof`](release-0.18.0-final-prepublish-proof.md)
+- [`v0.18.0 Publish Packet`](release-0.18.0-publish-packet.md)
+- [`Metric Direction Semantics Audit`](metric-direction-semantics.md)
+- [`Decision Semantics Verification`](decision-semantics-verification.md)
+
+## Coverage Tranche Included
+
+This proof was refreshed after these follow-up PRs landed:
+
+| PR | Scope |
+| --- | --- |
+| #473 | `cli_parsing` and `repair_context` helper coverage |
+| #474 | `check_guidance` and `artifact_explain` helper coverage |
+| #475 | in-memory server store baseline, verdict, decision, and audit coverage |
+| #476 | `decision_suggest` readiness helper coverage |
+| #462 | generated public badge endpoint refresh |
+
+The nightly baseline/trend refresh remains separate release-adjacent generated
+data. It is not included in this proof as a product or release-semantics gate.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Version under test | `0.18.0` |
+| Target dir for heavy Cargo proof | `C:\perfgate-target-final-post-coverage-proof` |
+| Cargo incremental | disabled with `CARGO_INCREMENTAL=0` |
+| Publishable crates | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+| Publication state | Pre-publish only; no crates were uploaded |
+
+## Command Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 fmt --all -- --check` | Pass | Formatting check completed without changes. |
+| `cargo +1.95.0 check --workspace --all-targets --all-features --locked` | Pass | Workspace check completed under the post-coverage target directory. |
+| `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings` | Pass | Workspace Clippy completed with warnings denied. |
+| `cargo +1.95.0 test --workspace --all-targets --all-features --locked` | Pass | Full workspace test suite passed under the post-coverage target directory. |
+| `cargo +1.95.0 run -p xtask -- public-surface --strict` | Pass | Public-surface policy accounts for the five publishable packages. |
+| `cargo +1.95.0 run -p xtask -- arch` | Pass | Architecture dependency rules hold. |
+| `cargo +1.95.0 run -p xtask -- schema-compat` | Pass | 18 historical schema fixtures deserialize with current types. |
+| `cargo +1.95.0 run -p xtask -- action-check` | Pass | GitHub Action install, release asset, and failure diagnostic wiring are aligned. |
+| `cargo +1.95.0 run -p xtask -- docs-source-check` | Pass | Source-of-truth metadata, IDs, links, and active goal are valid. |
+| `cargo +1.95.0 run -p xtask -- product-claims-check` | Pass | Product claim proof map is valid. |
+| `cargo +1.95.0 run -p xtask -- docs-check` | Pass | Documentation drift check passed. |
+| `cargo +1.95.0 run -p xtask -- doc-test` | Pass | Checked 70 CLI examples and 36 structured snippets. |
+| `git diff --check` | Pass | Checked before and after this audit was added. |
+
+## Non-Inferences
+
+- This does not publish `0.18.0` to crates.io.
+- This does not create `v0.18.0`.
+- This does not create a GitHub release or release assets.
+- This does not move `v0.18` or `v0`.
+- This does not prove public install from crates.io, `cargo-binstall`, or
+  GitHub release assets.
+- This does not close the release cutover lane.
+
+## Release Boundary
+
+The active 0.18.0 release cutover remains blocked only at explicit
+release-operator boundaries: crates.io publication, exact release tag, GitHub
+release/assets, intentional action alias movement, public install smoke, and
+publication closeout.


### PR DESCRIPTION
## Summary

- records the 0.18.0 final proof refresh after post-SRP coverage hardening landed
- links the new audit from docs/RELEASE_READINESS.md
- keeps the release boundary explicit: no crates published, no tags/releases/assets created, no action aliases moved, no public install smoke claimed, and the active release lane remains open

## Validation

- cargo +1.95.0 fmt --all -- --check - pass
- cargo +1.95.0 check --workspace --all-targets --all-features --locked - pass
- cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings - pass
- cargo +1.95.0 test --workspace --all-targets --all-features --locked - pass
- cargo +1.95.0 run -p xtask -- public-surface --strict - pass
- cargo +1.95.0 run -p xtask -- arch - pass
- cargo +1.95.0 run -p xtask -- schema-compat - pass
- cargo +1.95.0 run -p xtask -- action-check - pass
- cargo +1.95.0 run -p xtask -- docs-source-check - pass
- cargo +1.95.0 run -p xtask -- product-claims-check - pass
- cargo +1.95.0 run -p xtask -- docs-check - pass
- cargo +1.95.0 run -p xtask -- doc-test - pass
- git diff --check - pass

Heavy Cargo proof used CARGO_TARGET_DIR=C:\perfgate-target-final-post-coverage-proof and CARGO_INCREMENTAL=0.