### PR TITLE
test: restore post-SRP coverage hardening

### DIFF
--- a/crates/perfgate-cli/src/artifact_explain.rs
+++ b/crates/perfgate-cli/src/artifact_explain.rs
@@ -157,3 +157,243 @@ fn artifact_next_commands(known: &[(PathBuf, &'static str)]) -> Vec<String> {
     }
     commands
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn known_artifact_role_recognizes_every_well_known_filename() {
+        let expectations = &[
+            (RUN_RECEIPT_FILE, "raw measurement receipt"),
+            (COMPARE_RECEIPT_FILE, "baseline/current comparison receipt"),
+            ("report.json", "machine-readable verdict summary"),
+            ("comment.md", "PR-ready human summary"),
+            ("repair_context.json", "local reproduction and repair hints"),
+            ("decision.md", "human-readable performance decision"),
+            (
+                "decision.index.json",
+                "index of decision evidence artifacts",
+            ),
+            ("decision-bundle.json", "portable decision evidence bundle"),
+            (
+                "probe-compare.json",
+                "named probe baseline/current comparison",
+            ),
+            ("scenario.json", "weighted workload scenario receipt"),
+            ("tradeoff.json", "tradeoff policy evaluation receipt"),
+        ];
+        for (name, role) in expectations {
+            assert_eq!(
+                known_artifact_role(name),
+                Some(*role),
+                "missing role for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn known_artifact_role_returns_none_for_unknown_filename() {
+        assert!(known_artifact_role("random.txt").is_none());
+        assert!(known_artifact_role("perfgate.toml").is_none());
+        assert!(known_artifact_role("").is_none());
+    }
+
+    #[test]
+    fn artifact_next_commands_falls_back_to_check_command_when_no_known_files() {
+        let cmds = artifact_next_commands(&[]);
+        assert_eq!(
+            cmds,
+            vec!["perfgate check --config perfgate.toml --all".to_string()]
+        );
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_comment_inspection_when_comment_present() {
+        let known = vec![(PathBuf::from("comment.md"), "PR-ready human summary")];
+        let cmds = artifact_next_commands(&known);
+        assert_eq!(cmds.len(), 1);
+        assert!(cmds[0].contains("inspect artifacts/perfgate/comment.md"));
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_repair_context_inspection() {
+        let known = vec![(
+            PathBuf::from("repair_context.json"),
+            "local reproduction and repair hints",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("inspect repair_context.json"))
+        );
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_decision_bundle_when_index_present() {
+        let known = vec![(
+            PathBuf::from("decision.index.json"),
+            "index of decision evidence artifacts",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(cmds.iter().any(|c| c.contains("perfgate decision bundle")));
+    }
+
+    #[test]
+    fn artifact_next_commands_recommends_require_baseline_when_compare_present() {
+        let known = vec![(
+            PathBuf::from(COMPARE_RECEIPT_FILE),
+            "baseline/current comparison receipt",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(cmds.iter().any(|c| c.contains("--require-baseline")));
+    }
+
+    #[test]
+    fn artifact_next_commands_includes_multiple_recommendations_when_artifacts_overlap() {
+        let known = vec![
+            (PathBuf::from("comment.md"), "PR-ready human summary"),
+            (
+                PathBuf::from(COMPARE_RECEIPT_FILE),
+                "baseline/current comparison receipt",
+            ),
+        ];
+        let cmds = artifact_next_commands(&known);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("inspect artifacts/perfgate/comment.md"))
+        );
+        assert!(cmds.iter().any(|c| c.contains("--require-baseline")));
+        assert!(
+            !cmds
+                .iter()
+                .any(|c| c == "perfgate check --config perfgate.toml --all")
+        );
+    }
+
+    #[test]
+    fn artifact_next_commands_compares_by_filename_only() {
+        // Even if the path has a subdirectory prefix, file_name() should match.
+        let known = vec![(
+            PathBuf::from("bench-a/comment.md"),
+            "PR-ready human summary",
+        )];
+        let cmds = artifact_next_commands(&known);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("inspect artifacts/perfgate/comment.md"))
+        );
+    }
+
+    #[test]
+    fn collect_artifact_files_returns_empty_when_directory_missing() {
+        let tmp = tempdir().unwrap();
+        let nonexistent = tmp.path().join("nope");
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(&nonexistent, &nonexistent, &mut known, &mut unknown).unwrap();
+        assert!(known.is_empty());
+        assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn collect_artifact_files_classifies_known_and_unknown_files() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        fs::write(root.join("run.json"), "{}").unwrap();
+        fs::write(root.join("report.json"), "{}").unwrap();
+        fs::write(root.join("README.txt"), "info").unwrap();
+
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(root, root, &mut known, &mut unknown).unwrap();
+        let known_names: Vec<String> = known
+            .iter()
+            .map(|(p, _)| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(known_names.contains(&"run.json".to_string()));
+        assert!(known_names.contains(&"report.json".to_string()));
+        let unknown_names: Vec<String> = unknown
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(unknown_names, vec!["README.txt"]);
+    }
+
+    #[test]
+    fn collect_artifact_files_recurses_into_subdirectories() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let nested = root.join("bench-a");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("compare.json"), "{}").unwrap();
+
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(root, root, &mut known, &mut unknown).unwrap();
+        assert_eq!(known.len(), 1);
+        let (path, role) = &known[0];
+        assert_eq!(path, &PathBuf::from("bench-a/compare.json"));
+        assert_eq!(*role, "baseline/current comparison receipt");
+    }
+
+    #[test]
+    fn collect_artifact_files_sorts_known_and_unknown_lists() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // Write in an order that's not sorted.
+        fs::write(root.join("report.json"), "{}").unwrap();
+        fs::write(root.join("compare.json"), "{}").unwrap();
+        fs::write(root.join("zzz-unknown.txt"), "x").unwrap();
+        fs::write(root.join("aaa-unknown.txt"), "x").unwrap();
+
+        let mut known = Vec::new();
+        let mut unknown = Vec::new();
+        collect_artifact_files(root, root, &mut known, &mut unknown).unwrap();
+
+        let known_paths: Vec<PathBuf> = known.iter().map(|(p, _)| p.clone()).collect();
+        let mut sorted = known_paths.clone();
+        sorted.sort();
+        assert_eq!(known_paths, sorted);
+        let mut sorted_unknown = unknown.clone();
+        sorted_unknown.sort();
+        assert_eq!(unknown, sorted_unknown);
+    }
+
+    #[test]
+    fn execute_explain_artifacts_succeeds_when_out_dir_missing() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("perfgate-nope");
+        let result = execute_explain_artifacts(ExplainArtifactsArgs { out_dir: missing });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_explain_artifacts_succeeds_for_empty_dir() {
+        let tmp = tempdir().unwrap();
+        let out_dir = tmp.path().to_path_buf();
+        let result = execute_explain_artifacts(ExplainArtifactsArgs { out_dir });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_explain_artifacts_succeeds_with_known_artifacts() {
+        let tmp = tempdir().unwrap();
+        let out_dir = tmp.path().to_path_buf();
+        fs::write(out_dir.join("run.json"), "{}").unwrap();
+        fs::write(out_dir.join("comment.md"), "ok").unwrap();
+        let result = execute_explain_artifacts(ExplainArtifactsArgs { out_dir });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn execute_explain_action_dispatches_artifacts_variant() {
+        let tmp = tempdir().unwrap();
+        let out_dir = tmp.path().to_path_buf();
+        let result =
+            execute_explain_action(ExplainAction::Artifacts(ExplainArtifactsArgs { out_dir }));
+        assert!(result.is_ok());
+    }
+}

--- a/crates/perfgate-cli/src/check_guidance.rs
+++ b/crates/perfgate-cli/src/check_guidance.rs
@@ -381,3 +381,414 @@ pub(super) fn emit_check_outcome_guidance(
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn shell_path_returns_plain_value_for_simple_paths() {
+        let p = Path::new("perfgate.toml");
+        assert_eq!(shell_path(p), "perfgate.toml");
+    }
+
+    #[test]
+    fn shell_path_quotes_paths_with_spaces() {
+        let p = PathBuf::from("/tmp/has space/file.toml");
+        let quoted = shell_path(&p);
+        assert!(
+            quoted.starts_with('"') && quoted.ends_with('"'),
+            "got {quoted}"
+        );
+        assert!(quoted.contains("has space"), "got {quoted}");
+    }
+
+    #[test]
+    fn shell_path_escapes_embedded_quotes_when_quoting() {
+        let p = PathBuf::from("with \"quote\" and space");
+        let quoted = shell_path(&p);
+        assert_eq!(quoted, "\"with \\\"quote\\\" and space\"");
+    }
+
+    #[test]
+    fn check_command_uses_bench_when_provided() {
+        let cfg = Path::new("perfgate.toml");
+        assert_eq!(
+            check_command(cfg, Some("bench-a"), false),
+            "perfgate check --config perfgate.toml --bench bench-a"
+        );
+    }
+
+    #[test]
+    fn check_command_uses_all_flag_when_no_bench() {
+        let cfg = Path::new("perfgate.toml");
+        assert_eq!(
+            check_command(cfg, None, false),
+            "perfgate check --config perfgate.toml --all"
+        );
+    }
+
+    #[test]
+    fn check_command_appends_require_baseline_when_requested() {
+        let cfg = Path::new("perfgate.toml");
+        let with = check_command(cfg, Some("bench-a"), true);
+        assert!(with.ends_with("--require-baseline"), "got: {with}");
+        let none = check_command(cfg, None, true);
+        assert!(none.ends_with("--require-baseline"), "got: {none}");
+    }
+
+    #[test]
+    fn check_command_quotes_config_path_with_spaces() {
+        let cfg = PathBuf::from("/tmp/has space/perfgate.toml");
+        let cmd = check_command(&cfg, Some("b"), false);
+        assert!(
+            cmd.contains("--config \"/tmp/has space/perfgate.toml\""),
+            "got: {cmd}"
+        );
+    }
+
+    #[test]
+    fn paired_command_substitutes_bench_name_in_all_positions() {
+        let cmd = paired_command(Some("my-bench"));
+        assert!(cmd.contains("--name my-bench"));
+        assert!(cmd.contains("artifacts/perfgate/my-bench/paired.json"));
+    }
+
+    #[test]
+    fn paired_command_uses_placeholder_when_bench_missing() {
+        let cmd = paired_command(None);
+        assert!(cmd.contains("--name <bench>"));
+        assert!(cmd.contains("artifacts/perfgate/<bench>/paired.json"));
+    }
+
+    #[test]
+    fn failure_class_status_strings_are_stable() {
+        assert_eq!(
+            FailureClass::SetupMissingConfig.status(),
+            "setup_missing_config"
+        );
+        assert_eq!(
+            FailureClass::SetupMissingBench.status(),
+            "setup_missing_bench"
+        );
+        assert_eq!(
+            FailureClass::SetupCommandFailed.status(),
+            "setup_command_failed"
+        );
+        assert_eq!(FailureClass::MissingBaseline.status(), "missing_baseline");
+        assert_eq!(
+            FailureClass::PerformanceRegression.status(),
+            "performance_regression"
+        );
+        assert_eq!(FailureClass::HighNoise.status(), "high_noise");
+        assert_eq!(
+            FailureClass::UnsupportedMetric.status(),
+            "unsupported_metric"
+        );
+        assert_eq!(FailureClass::HostMismatch.status(), "host_mismatch");
+        assert_eq!(FailureClass::ReviewRequired.status(), "review_required");
+        assert_eq!(
+            FailureClass::ServerUploadFailed.status(),
+            "server_upload_failed"
+        );
+    }
+
+    #[test]
+    fn failure_class_meaning_and_do_not_are_non_empty_for_every_variant() {
+        for class in [
+            FailureClass::SetupMissingConfig,
+            FailureClass::SetupMissingBench,
+            FailureClass::SetupCommandFailed,
+            FailureClass::MissingBaseline,
+            FailureClass::PerformanceRegression,
+            FailureClass::HighNoise,
+            FailureClass::UnsupportedMetric,
+            FailureClass::HostMismatch,
+            FailureClass::ReviewRequired,
+            FailureClass::ServerUploadFailed,
+        ] {
+            assert!(!class.meaning().is_empty(), "{:?} has empty meaning", class);
+            assert!(!class.do_not().is_empty(), "{:?} has empty do_not", class);
+        }
+    }
+
+    #[test]
+    fn failure_class_artifacts_handles_missing_out_dir() {
+        let arts = FailureClass::MissingBaseline.artifacts(None, None);
+        assert_eq!(arts.len(), 1);
+        assert!(arts[0].contains("artifacts unavailable"), "got: {:?}", arts);
+    }
+
+    #[test]
+    fn failure_class_artifacts_missing_baseline_lists_expected_files() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::MissingBaseline.artifacts(Some(&out_dir), None);
+        let joined = arts.join(",");
+        assert!(
+            joined.contains("artifacts/perfgate/run.json"),
+            "got: {joined}"
+        );
+        assert!(
+            joined.contains("artifacts/perfgate/report.json"),
+            "got: {joined}"
+        );
+        assert!(
+            joined.contains("artifacts/perfgate/comment.md"),
+            "got: {joined}"
+        );
+        assert!(
+            joined.contains("artifacts/perfgate/repair_context.json"),
+            "got: {joined}"
+        );
+    }
+
+    #[test]
+    fn failure_class_artifacts_regression_prefers_explicit_compare_path() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let compare = PathBuf::from("artifacts/perfgate/other/compare.json");
+        let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), Some(&compare));
+        assert!(
+            arts.iter()
+                .any(|a| a == "artifacts/perfgate/other/compare.json"),
+            "got: {:?}",
+            arts
+        );
+        assert_eq!(
+            arts.iter().filter(|a| a.ends_with("compare.json")).count(),
+            1,
+            "got: {:?}",
+            arts
+        );
+    }
+
+    #[test]
+    fn failure_class_artifacts_regression_falls_back_to_default_compare() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), None);
+        assert!(
+            arts.iter().any(|a| a == "artifacts/perfgate/compare.json"),
+            "got: {:?}",
+            arts
+        );
+    }
+
+    #[test]
+    fn failure_class_artifacts_server_upload_failed_excludes_compare() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::ServerUploadFailed.artifacts(Some(&out_dir), None);
+        assert!(
+            !arts.iter().any(|a| a.contains("compare.json")),
+            "got: {:?}",
+            arts
+        );
+        assert!(arts.iter().any(|a| a == "artifacts/perfgate/run.json"));
+    }
+
+    #[test]
+    fn failure_class_artifacts_setup_variants_say_unavailable() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        for class in [
+            FailureClass::SetupMissingConfig,
+            FailureClass::SetupMissingBench,
+            FailureClass::SetupCommandFailed,
+            FailureClass::UnsupportedMetric,
+        ] {
+            let arts = class.artifacts(Some(&out_dir), None);
+            assert_eq!(arts.len(), 1, "{:?}", class);
+            assert!(
+                arts[0].contains("unavailable") || arts[0].contains("incomplete"),
+                "{:?} => {:?}",
+                class,
+                arts
+            );
+        }
+    }
+
+    #[test]
+    fn failure_class_artifacts_sorts_and_dedups() {
+        let out_dir = PathBuf::from("artifacts/perfgate");
+        let arts = FailureClass::HostMismatch.artifacts(Some(&out_dir), None);
+        let mut sorted = arts.clone();
+        sorted.sort();
+        assert_eq!(arts, sorted, "artifacts must be sorted");
+        let mut deduped = arts.clone();
+        deduped.dedup();
+        assert_eq!(arts, deduped, "artifacts must be deduped");
+    }
+
+    #[test]
+    fn next_commands_setup_missing_config_recommends_init_and_doctor() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::SetupMissingConfig.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter().any(|c| c.contains("perfgate init")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(
+            cmds.iter().any(|c| c.contains("perfgate doctor")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_missing_baseline_includes_baseline_promote() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::MissingBaseline.next_commands(&cfg, Some("bench-a"), None);
+        assert!(
+            cmds.iter().any(|c| c.contains("baseline promote")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(
+            cmds.iter().any(|c| c.contains("--bench bench-a")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_missing_baseline_without_bench_uses_all_flag() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::MissingBaseline.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("baseline promote") && c.contains("--all")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_performance_regression_appends_explain_when_compare_path_present() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let compare = PathBuf::from("artifacts/compare.json");
+        let cmds =
+            FailureClass::PerformanceRegression.next_commands(&cfg, Some("b"), Some(&compare));
+        assert!(
+            cmds.iter().any(|c| c.contains("--require-baseline")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("perfgate explain --compare")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_performance_regression_skips_explain_when_no_compare_path() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::PerformanceRegression.next_commands(&cfg, Some("b"), None);
+        assert!(
+            !cmds.iter().any(|c| c.contains("perfgate explain")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_high_noise_recommends_paired_run() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::HighNoise.next_commands(&cfg, Some("b"), None);
+        assert!(
+            cmds.iter().any(|c| c.starts_with("perfgate paired")),
+            "got: {:?}",
+            cmds
+        );
+    }
+
+    #[test]
+    fn next_commands_host_mismatch_requires_baseline_and_mentions_runner() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::HostMismatch.next_commands(&cfg, Some("b"), None);
+        assert!(
+            cmds.iter().any(|c| c.contains("--require-baseline")),
+            "got: {:?}",
+            cmds
+        );
+        assert!(cmds.iter().any(|c| c.contains("runner")), "got: {:?}", cmds);
+    }
+
+    #[test]
+    fn next_commands_review_required_points_at_decision_artifacts() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::ReviewRequired.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("decision.md") || c.contains("Action summary"))
+        );
+        assert!(cmds.iter().any(|c| c.contains("perfgate decision bundle")));
+    }
+
+    #[test]
+    fn next_commands_server_upload_failed_recommends_inspection_and_history() {
+        let cfg = PathBuf::from("perfgate.toml");
+        let cmds = FailureClass::ServerUploadFailed.next_commands(&cfg, None, None);
+        assert!(
+            cmds.iter()
+                .any(|c| c.contains("API key") || c.contains("server URL"))
+        );
+        assert!(cmds.iter().any(|c| c == "perfgate decision history"));
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_missing_bench_message() {
+        let err = anyhow::anyhow!("benchmark not found in config");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+        let err = anyhow::anyhow!("either --bench or --all must be provided");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+        let err = anyhow::anyhow!("no benchmarks were configured");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_baseline_message() {
+        let err = anyhow::anyhow!("baseline could not be loaded");
+        assert_eq!(classify_check_error(&err), FailureClass::MissingBaseline);
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_host_mismatch_message() {
+        let err = anyhow::anyhow!("host mismatch detected");
+        assert_eq!(classify_check_error(&err), FailureClass::HostMismatch);
+    }
+
+    #[test]
+    fn classify_check_error_recognizes_config_read_failure() {
+        let err = anyhow::anyhow!("read perfgate.toml failed");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingConfig);
+    }
+
+    #[test]
+    fn classify_check_error_default_to_command_failure() {
+        let err = anyhow::anyhow!("something weird happened");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
+    }
+
+    #[test]
+    fn classify_check_error_handles_perfgate_error_variants() {
+        use perfgate_types::error::{AdapterError, ConfigValidationError, IoError, PerfgateError};
+
+        let err: anyhow::Error =
+            PerfgateError::Config(ConfigValidationError::BenchName("bad".into())).into();
+        assert_eq!(classify_check_error(&err), FailureClass::SetupMissingBench);
+
+        let err: anyhow::Error =
+            PerfgateError::Io(IoError::BaselineNotFound { path: "x".into() }).into();
+        assert_eq!(classify_check_error(&err), FailureClass::MissingBaseline);
+
+        let err: anyhow::Error = PerfgateError::Adapter(AdapterError::EmptyArgv).into();
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
+
+        let err: anyhow::Error = PerfgateError::Adapter(AdapterError::Timeout).into();
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
+
+        let err: anyhow::Error = PerfgateError::Adapter(AdapterError::TimeoutUnsupported).into();
+        assert_eq!(classify_check_error(&err), FailureClass::UnsupportedMetric);
+    }
+}

--- a/crates/perfgate-cli/src/check_guidance.rs
+++ b/crates/perfgate-cli/src/check_guidance.rs
@@ -387,6 +387,13 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
+    fn slash_paths(values: &[String]) -> Vec<String> {
+        values
+            .iter()
+            .map(|value| value.replace('\\', "/"))
+            .collect()
+    }
+
     #[test]
     fn shell_path_returns_plain_value_for_simple_paths() {
         let p = Path::new("perfgate.toml");
@@ -524,6 +531,7 @@ mod tests {
     fn failure_class_artifacts_missing_baseline_lists_expected_files() {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let arts = FailureClass::MissingBaseline.artifacts(Some(&out_dir), None);
+        let arts = slash_paths(&arts);
         let joined = arts.join(",");
         assert!(
             joined.contains("artifacts/perfgate/run.json"),
@@ -548,6 +556,7 @@ mod tests {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let compare = PathBuf::from("artifacts/perfgate/other/compare.json");
         let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), Some(&compare));
+        let arts = slash_paths(&arts);
         assert!(
             arts.iter()
                 .any(|a| a == "artifacts/perfgate/other/compare.json"),
@@ -566,6 +575,7 @@ mod tests {
     fn failure_class_artifacts_regression_falls_back_to_default_compare() {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let arts = FailureClass::PerformanceRegression.artifacts(Some(&out_dir), None);
+        let arts = slash_paths(&arts);
         assert!(
             arts.iter().any(|a| a == "artifacts/perfgate/compare.json"),
             "got: {:?}",
@@ -577,6 +587,7 @@ mod tests {
     fn failure_class_artifacts_server_upload_failed_excludes_compare() {
         let out_dir = PathBuf::from("artifacts/perfgate");
         let arts = FailureClass::ServerUploadFailed.artifacts(Some(&out_dir), None);
+        let arts = slash_paths(&arts);
         assert!(
             !arts.iter().any(|a| a.contains("compare.json")),
             "got: {:?}",

--- a/crates/perfgate-cli/src/cli_parsing.rs
+++ b/crates/perfgate-cli/src/cli_parsing.rs
@@ -221,3 +221,524 @@ pub fn normalize_paired_cli_command(
 
     Ok(args)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_accepts_humantime_value() {
+        let d = parse_duration("1500ms").unwrap();
+        assert_eq!(d, Duration::from_millis(1500));
+        let d = parse_duration("2s").unwrap();
+        assert_eq!(d, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn parse_duration_rejects_garbage() {
+        let err = parse_duration("not-a-duration").unwrap_err().to_string();
+        assert!(err.contains("invalid duration"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_key_val_string_splits_on_first_equal() {
+        let (k, v) = parse_key_val_string("FOO=bar=baz").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "bar=baz");
+    }
+
+    #[test]
+    fn parse_key_val_string_requires_equal_sign() {
+        let err = parse_key_val_string("no-equals").unwrap_err();
+        assert_eq!(err, "expected KEY=VALUE");
+    }
+
+    #[test]
+    fn parse_key_val_f64_parses_value_as_float() {
+        let (k, v) = parse_key_val_f64("p99=12.5").unwrap();
+        assert_eq!(k, "p99");
+        assert!((v - 12.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parse_key_val_f64_rejects_non_numeric_value() {
+        let err = parse_key_val_f64("p99=abc").unwrap_err();
+        assert!(err.contains("invalid float value"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_key_val_f64_requires_equal_sign() {
+        let err = parse_key_val_f64("p99").unwrap_err();
+        assert_eq!(err, "expected KEY=VALUE");
+    }
+
+    #[test]
+    fn parse_noise_policy_round_trip_variants() {
+        assert!(matches!(
+            parse_noise_policy("warn").unwrap(),
+            perfgate_types::NoisePolicy::Warn
+        ));
+        assert!(matches!(
+            parse_noise_policy("SKIP").unwrap(),
+            perfgate_types::NoisePolicy::Skip
+        ));
+        assert!(matches!(
+            parse_noise_policy("Ignore").unwrap(),
+            perfgate_types::NoisePolicy::Ignore
+        ));
+    }
+
+    #[test]
+    fn parse_noise_policy_rejects_unknown_value() {
+        let err = parse_noise_policy("loud").unwrap_err();
+        assert!(err.contains("invalid noise policy"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_flakiness_score_accepts_in_range_values() {
+        assert_eq!(parse_flakiness_score("0").unwrap(), 0.0);
+        assert_eq!(parse_flakiness_score("0.5").unwrap(), 0.5);
+        assert_eq!(parse_flakiness_score("1").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_flakiness_score_rejects_out_of_range() {
+        assert!(parse_flakiness_score("-0.1").is_err());
+        assert!(parse_flakiness_score("1.1").is_err());
+    }
+
+    #[test]
+    fn parse_flakiness_score_rejects_non_finite() {
+        assert!(parse_flakiness_score("NaN").is_err());
+        assert!(parse_flakiness_score("inf").is_err());
+    }
+
+    #[test]
+    fn parse_flakiness_score_rejects_non_numeric() {
+        let err = parse_flakiness_score("noisy").unwrap_err();
+        assert!(err.contains("must be a number"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_verdict_status_handles_all_variants_case_insensitively() {
+        assert!(matches!(
+            parse_verdict_status("pass"),
+            Ok(VerdictStatus::Pass)
+        ));
+        assert!(matches!(
+            parse_verdict_status("WARN"),
+            Ok(VerdictStatus::Warn)
+        ));
+        assert!(matches!(
+            parse_verdict_status("Fail"),
+            Ok(VerdictStatus::Fail)
+        ));
+        assert!(matches!(
+            parse_verdict_status("skip"),
+            Ok(VerdictStatus::Skip)
+        ));
+        assert!(parse_verdict_status("blocked").is_err());
+    }
+
+    #[test]
+    fn parse_metric_status_handles_all_variants_case_insensitively() {
+        assert!(matches!(
+            parse_metric_status("pass"),
+            Ok(MetricStatus::Pass)
+        ));
+        assert!(matches!(
+            parse_metric_status("WARN"),
+            Ok(MetricStatus::Warn)
+        ));
+        assert!(matches!(
+            parse_metric_status("Fail"),
+            Ok(MetricStatus::Fail)
+        ));
+        assert!(matches!(
+            parse_metric_status("skip"),
+            Ok(MetricStatus::Skip)
+        ));
+        assert!(parse_metric_status("unknown").is_err());
+    }
+
+    #[test]
+    fn parse_host_mismatch_policy_aliases_fail_to_error() {
+        assert!(matches!(
+            parse_host_mismatch_policy("warn"),
+            Ok(HostMismatchPolicy::Warn)
+        ));
+        assert!(matches!(
+            parse_host_mismatch_policy("error"),
+            Ok(HostMismatchPolicy::Error)
+        ));
+        assert!(matches!(
+            parse_host_mismatch_policy("fail"),
+            Ok(HostMismatchPolicy::Error)
+        ));
+        assert!(matches!(
+            parse_host_mismatch_policy("ignore"),
+            Ok(HostMismatchPolicy::Ignore)
+        ));
+        assert!(
+            parse_host_mismatch_policy("WARN").is_err(),
+            "policy is case-sensitive"
+        );
+        assert!(parse_host_mismatch_policy("bogus").is_err());
+    }
+
+    #[test]
+    fn parse_aggregation_policy_covers_all_variants() {
+        assert!(matches!(
+            parse_aggregation_policy("all"),
+            Ok(AggregationPolicy::All)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("majority"),
+            Ok(AggregationPolicy::Majority)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("weighted"),
+            Ok(AggregationPolicy::Weighted)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("quorum"),
+            Ok(AggregationPolicy::Quorum)
+        ));
+        assert!(matches!(
+            parse_aggregation_policy("fail_if_n_of_m"),
+            Ok(AggregationPolicy::FailIfNOfM)
+        ));
+        assert!(parse_aggregation_policy("nope").is_err());
+    }
+
+    #[test]
+    fn parse_aggregate_weight_mode_covers_variants() {
+        assert!(matches!(
+            parse_aggregate_weight_mode("configured"),
+            Ok(AggregateWeightMode::Configured)
+        ));
+        assert!(matches!(
+            parse_aggregate_weight_mode("inverse_variance"),
+            Ok(AggregateWeightMode::InverseVariance)
+        ));
+        assert!(parse_aggregate_weight_mode("other").is_err());
+    }
+
+    #[test]
+    fn parse_weight_map_handles_multiple_entries_and_trims_labels() {
+        let input = vec!["foo=1.0".into(), " bar =2.5".into()];
+        let map = parse_weight_map(&input).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["foo"], 1.0);
+        assert_eq!(map["bar"], 2.5);
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_missing_equals() {
+        let err = parse_weight_map(&["foo".into()]).unwrap_err().to_string();
+        assert!(err.contains("expected label=value"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_empty_label() {
+        let err = parse_weight_map(&["=1.0".into()]).unwrap_err().to_string();
+        assert!(err.contains("label cannot be empty"), "got: {err}");
+        let err = parse_weight_map(&["   =1.0".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("label cannot be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_non_numeric_weight() {
+        let err = parse_weight_map(&["foo=bad".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("weight must be a number"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_rejects_negative_and_nonfinite() {
+        let err = parse_weight_map(&["foo=-1".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("non-negative"), "got: {err}");
+        let err = parse_weight_map(&["foo=NaN".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("non-negative"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_weight_map_empty_input_returns_empty_map() {
+        let map = parse_weight_map(&[]).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn validate_aggregate_options_accepts_default_all_policy() {
+        let (q, fnm, vf) = validate_aggregate_options(
+            AggregationPolicy::All,
+            AggregateWeightMode::Configured,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(q.is_none());
+        assert!(fnm.is_none());
+        assert!(vf.is_none());
+    }
+
+    #[test]
+    fn validate_aggregate_options_rejects_quorum_out_of_range() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::Configured,
+            Some(1.5),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--quorum must be between"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::Configured,
+            Some(f64::NAN),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--quorum must be between"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_quorum_requires_weighted_or_quorum_policy() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::All,
+            AggregateWeightMode::Configured,
+            Some(0.5),
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--quorum requires"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_inverse_variance_requires_weighted() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Majority,
+            AggregateWeightMode::InverseVariance,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("inverse_variance requires"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_variance_floor_rules() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::InverseVariance,
+            None,
+            None,
+            None,
+            Some(0.0),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("variance-floor"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::Configured,
+            None,
+            None,
+            None,
+            Some(1.0),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("inverse_variance"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_if_n_of_m_requires_fail_n() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--fail-n"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_if_n_of_m_rejects_zero_or_inverted() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(0),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--fail-n must be at least 1"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(3),
+            Some(0),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--fail-m must be at least 1"), "got: {err}");
+
+        let err = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(5),
+            Some(3),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("must be greater than or equal"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_if_n_of_m_success_path() {
+        let (q, fnm, vf) = validate_aggregate_options(
+            AggregationPolicy::FailIfNOfM,
+            AggregateWeightMode::Configured,
+            None,
+            Some(2),
+            Some(5),
+            None,
+        )
+        .unwrap();
+        assert!(q.is_none());
+        let fnm = fnm.expect("should produce FailIfNOfM");
+        assert_eq!(fnm.n, 2);
+        assert_eq!(fnm.m, Some(5));
+        assert!(vf.is_none());
+    }
+
+    #[test]
+    fn validate_aggregate_options_fail_n_or_m_outside_correct_policy_errors() {
+        let err = validate_aggregate_options(
+            AggregationPolicy::All,
+            AggregateWeightMode::Configured,
+            None,
+            Some(1),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("fail_if_n_of_m"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_aggregate_options_inverse_variance_success_passes_floor_through() {
+        let (q, fnm, vf) = validate_aggregate_options(
+            AggregationPolicy::Weighted,
+            AggregateWeightMode::InverseVariance,
+            Some(0.6),
+            None,
+            None,
+            Some(2.5),
+        )
+        .unwrap();
+        assert_eq!(q, Some(0.6));
+        assert!(fnm.is_none());
+        assert_eq!(vf, Some(2.5));
+    }
+
+    #[test]
+    fn parse_significance_alpha_accepts_in_range() {
+        assert_eq!(parse_significance_alpha("0.05").unwrap(), 0.05);
+        assert_eq!(parse_significance_alpha("0").unwrap(), 0.0);
+        assert_eq!(parse_significance_alpha("1").unwrap(), 1.0);
+    }
+
+    #[test]
+    fn parse_significance_alpha_rejects_invalid_values() {
+        assert!(parse_significance_alpha("abc").is_err());
+        assert!(parse_significance_alpha("1.5").is_err());
+        assert!(parse_significance_alpha("-0.1").is_err());
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_requires_nonempty_input() {
+        let err = normalize_paired_cli_command(vec![], "--current-cmd")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--current-cmd"), "got: {err}");
+        assert!(err.contains("at least one argument"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_splits_quoted_single_arg() {
+        let out =
+            normalize_paired_cli_command(vec!["echo \"hello world\"".into()], "--current-cmd")
+                .unwrap();
+        assert_eq!(out, vec!["echo".to_string(), "hello world".to_string()]);
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_passes_through_multi_arg_form() {
+        let out = normalize_paired_cli_command(
+            vec!["echo".into(), "hello world".into()],
+            "--baseline-cmd",
+        )
+        .unwrap();
+        assert_eq!(out, vec!["echo".to_string(), "hello world".to_string()]);
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_single_arg_without_whitespace_returns_as_is() {
+        let out = normalize_paired_cli_command(vec!["./bench".into()], "--baseline-cmd").unwrap();
+        assert_eq!(out, vec!["./bench".to_string()]);
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_empty_quoted_string_is_an_error() {
+        // shell_words::split("   ") yields an empty Vec, which must trigger the empty-parse error
+        let err = normalize_paired_cli_command(vec!["   ".into()], "--current-cmd")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("parsed to an empty command"), "got: {err}");
+    }
+
+    #[test]
+    fn normalize_paired_cli_command_reports_invalid_shell_string() {
+        let err = normalize_paired_cli_command(vec!["echo \"unterminated".into()], "--current-cmd")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("failed to parse"), "got: {err}");
+    }
+}

--- a/crates/perfgate-cli/src/repair_context.rs
+++ b/crates/perfgate-cli/src/repair_context.rs
@@ -210,3 +210,80 @@ pub(crate) fn run_git_capture_bytes(args: &[&str]) -> Option<Vec<u8>> {
     }
     Some(output.stdout)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_changed_files_summary_handles_empty_input() {
+        let summary = parse_changed_files_summary(b"");
+        assert_eq!(summary.file_count, 0);
+        assert!(summary.files.is_empty());
+        assert!(summary.file_count_by_top_level.is_empty());
+    }
+
+    #[test]
+    fn parse_changed_files_summary_groups_by_top_level_directory() {
+        // Each entry has 2-byte status code, single space, then path, terminated by NUL.
+        // Use modified entries (no rename).
+        let input = b" M src/lib.rs\0 M src/util.rs\0 M tests/case.rs\0?? README.md\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 4);
+        assert_eq!(summary.files.len(), 4);
+        assert_eq!(summary.file_count_by_top_level["src"], 2);
+        assert_eq!(summary.file_count_by_top_level["tests"], 1);
+        // top-level file gets "README.md" bucket
+        assert_eq!(summary.file_count_by_top_level["README.md"], 1);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_handles_rename_two_path_entries() {
+        // Rename status uses two NUL-separated paths: "<old>\0<new>".
+        // The current path is the second entry (the new name).
+        let input = b"R  src/old.rs\0src/new.rs\0 M src/touched.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 2);
+        assert_eq!(summary.files, vec!["src/new.rs", "src/touched.rs"]);
+        assert_eq!(summary.file_count_by_top_level["src"], 2);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_skips_short_entries() {
+        // Entries with status header only (no path) must be ignored without panicking.
+        let input = b"M \0 M src/ok.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 1);
+        assert_eq!(summary.files, vec!["src/ok.rs"]);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_falls_back_to_dot_for_paths_starting_with_separator() {
+        // A path whose first component splits to empty (e.g., "/abs") should bucket under ".".
+        let input = b" M /abs/path.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 1);
+        assert_eq!(summary.file_count_by_top_level["."], 1);
+    }
+
+    #[test]
+    fn parse_changed_files_summary_handles_windows_style_separators() {
+        let input = b" M crates\\perfgate\\src\\main.rs\0";
+        let summary = parse_changed_files_summary(input);
+        assert_eq!(summary.file_count, 1);
+        assert_eq!(summary.file_count_by_top_level["crates"], 1);
+    }
+
+    #[test]
+    fn run_git_capture_returns_none_for_unknown_git_subcommand() {
+        // A bogus git subcommand should exit non-zero, so we expect None.
+        let result = run_git_capture(&["this-is-not-a-real-git-subcommand"]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn run_git_capture_bytes_returns_none_for_unknown_git_subcommand() {
+        let result = run_git_capture_bytes(&["this-is-not-a-real-git-subcommand"]);
+        assert!(result.is_none());
+    }
+}

--- a/crates/perfgate-server/src/storage/memory.rs
+++ b/crates/perfgate-server/src/storage/memory.rs
@@ -539,3 +539,928 @@ impl AuditStore for InMemoryStore {
         })
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{
+        AuditAction, AuditResourceType, BaselineRecordExt, BaselineSource, BaselineVersion,
+    };
+    use chrono::{Duration, TimeZone, Utc};
+    use perfgate_types::{
+        BenchMeta, HostInfo, MetricStatus, RunMeta, RunReceipt, Stats, ToolInfo, U64Summary,
+        VerdictCounts, VerdictStatus,
+    };
+
+    fn dummy_receipt(bench: &str) -> RunReceipt {
+        RunReceipt {
+            schema: "perfgate.run.v1".to_string(),
+            tool: ToolInfo {
+                name: "perfgate".to_string(),
+                version: "0.0.0-test".to_string(),
+            },
+            run: RunMeta {
+                id: "test-run".to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                ended_at: "2026-01-01T00:00:01Z".to_string(),
+                host: HostInfo {
+                    os: "linux".to_string(),
+                    arch: "x86_64".to_string(),
+                    cpu_count: Some(4),
+                    memory_bytes: Some(8 * 1024 * 1024 * 1024),
+                    hostname_hash: None,
+                },
+            },
+            bench: BenchMeta {
+                name: bench.to_string(),
+                cwd: None,
+                command: vec!["true".to_string()],
+                repeat: 1,
+                warmup: 0,
+                work_units: None,
+                timeout_ms: None,
+            },
+            samples: vec![],
+            stats: Stats {
+                wall_ms: U64Summary::new(10, 9, 11),
+                cpu_ms: None,
+                page_faults: None,
+                ctx_switches: None,
+                max_rss_kb: None,
+                io_read_bytes: None,
+                io_write_bytes: None,
+                network_packets: None,
+                energy_uj: None,
+                binary_bytes: None,
+                throughput_per_s: None,
+            },
+        }
+    }
+
+    fn record(
+        project: &str,
+        benchmark: &str,
+        version: &str,
+        git_ref: Option<&str>,
+        git_sha: Option<&str>,
+        tags: Vec<&str>,
+    ) -> BaselineRecord {
+        BaselineRecord::new(
+            project.to_string(),
+            benchmark.to_string(),
+            version.to_string(),
+            dummy_receipt(benchmark),
+            git_ref.map(String::from),
+            git_sha.map(String::from),
+            BTreeMap::new(),
+            tags.into_iter().map(String::from).collect(),
+            BaselineSource::Upload,
+        )
+    }
+
+    /// Builds a record and stamps `created_at` / `updated_at` to a specific instant
+    /// so we can reason about ordering deterministically.
+    fn record_at(
+        project: &str,
+        benchmark: &str,
+        version: &str,
+        ts: chrono::DateTime<Utc>,
+    ) -> BaselineRecord {
+        let mut r = record(project, benchmark, version, None, None, vec![]);
+        r.created_at = ts;
+        r.updated_at = ts;
+        r
+    }
+
+    fn verdict_at(
+        project: &str,
+        benchmark: &str,
+        status: VerdictStatus,
+        ts: chrono::DateTime<Utc>,
+    ) -> VerdictRecord {
+        VerdictRecord {
+            schema: "perfgate.verdict.v1".to_string(),
+            id: format!("v-{}-{}", benchmark, ts.timestamp_millis()),
+            project: project.to_string(),
+            benchmark: benchmark.to_string(),
+            run_id: format!("run-{}", ts.timestamp_millis()),
+            status,
+            counts: VerdictCounts {
+                pass: 1,
+                warn: 0,
+                fail: 0,
+                skip: 0,
+            },
+            reasons: Vec::new(),
+            git_ref: None,
+            git_sha: None,
+            wall_ms_cv: None,
+            flakiness_score: None,
+            created_at: ts,
+        }
+    }
+
+    fn audit_at(
+        project: &str,
+        actor: &str,
+        action: AuditAction,
+        resource_type: AuditResourceType,
+        resource_id: &str,
+        ts: chrono::DateTime<Utc>,
+    ) -> AuditEvent {
+        AuditEvent {
+            id: format!("evt-{}", ts.timestamp_millis()),
+            timestamp: ts,
+            actor: actor.to_string(),
+            action,
+            resource_type,
+            resource_id: resource_id.to_string(),
+            project: project.to_string(),
+            metadata: serde_json::Value::Null,
+        }
+    }
+
+    fn day(n: i64) -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap() + Duration::days(n)
+    }
+
+    #[tokio::test]
+    async fn new_and_default_produce_empty_stores() {
+        let s = InMemoryStore::new();
+        let default_store = InMemoryStore::default();
+        for store in [&s, &default_store] {
+            assert_eq!(store.backend_type(), "memory");
+            assert!(matches!(
+                store.health_check().await.unwrap(),
+                StorageHealth::Healthy
+            ));
+            assert!(store.get("p", "b", "v").await.unwrap().is_none());
+            assert!(store.get_latest("p", "b").await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn create_then_get_round_trip() {
+        let s = InMemoryStore::new();
+        let r = record(
+            "p",
+            "b",
+            "v1",
+            Some("refs/heads/main"),
+            Some("abc"),
+            vec!["a"],
+        );
+        s.create(&r).await.unwrap();
+        let got = s.get("p", "b", "v1").await.unwrap().unwrap();
+        assert_eq!(got.version, "v1");
+        assert_eq!(got.git_ref.as_deref(), Some("refs/heads/main"));
+        assert_eq!(got.tags, vec!["a".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn create_duplicate_returns_already_exists() {
+        let s = InMemoryStore::new();
+        let r = record("p", "b", "v1", None, None, vec![]);
+        s.create(&r).await.unwrap();
+        let err = s.create(&r).await.expect_err("expected duplicate error");
+        assert!(matches!(err, StoreError::AlreadyExists(_)));
+    }
+
+    #[tokio::test]
+    async fn get_treats_soft_deleted_record_as_absent() {
+        let s = InMemoryStore::new();
+        s.create(&record("p", "b", "v1", None, None, vec![]))
+            .await
+            .unwrap();
+        assert!(s.delete("p", "b", "v1").await.unwrap());
+        assert!(s.get("p", "b", "v1").await.unwrap().is_none());
+        // Second soft-delete returns false (already deleted).
+        assert!(!s.delete("p", "b", "v1").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_returns_false() {
+        let s = InMemoryStore::new();
+        assert!(!s.delete("p", "b", "missing").await.unwrap());
+        assert!(!s.hard_delete("p", "b", "missing").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn hard_delete_removes_record_completely() {
+        let s = InMemoryStore::new();
+        s.create(&record("p", "b", "v1", None, None, vec![]))
+            .await
+            .unwrap();
+        assert!(s.hard_delete("p", "b", "v1").await.unwrap());
+        // After hard delete the record is truly gone — create must succeed again.
+        s.create(&record("p", "b", "v1", None, None, vec![]))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_existing_record_succeeds_and_update_missing_errors() {
+        let s = InMemoryStore::new();
+        let mut r = record("p", "b", "v1", None, None, vec!["old"]);
+        s.create(&r).await.unwrap();
+        r.tags = vec!["new".to_string()];
+        s.update(&r).await.unwrap();
+        let got = s.get("p", "b", "v1").await.unwrap().unwrap();
+        assert_eq!(got.tags, vec!["new".to_string()]);
+
+        let missing = record("p", "b", "vmissing", None, None, vec![]);
+        let err = s.update(&missing).await.expect_err("expected not found");
+        assert!(matches!(err, StoreError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn get_latest_returns_record_with_max_created_at_skipping_deleted() {
+        let s = InMemoryStore::new();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        s.create(&record_at("p", "b", "v2", day(3))).await.unwrap();
+        s.create(&record_at("p", "b", "v3", day(2))).await.unwrap();
+        let latest = s.get_latest("p", "b").await.unwrap().unwrap();
+        assert_eq!(latest.version, "v2");
+
+        s.delete("p", "b", "v2").await.unwrap();
+        let latest = s.get_latest("p", "b").await.unwrap().unwrap();
+        assert_eq!(latest.version, "v3");
+    }
+
+    #[tokio::test]
+    async fn get_latest_filters_by_project_and_benchmark() {
+        let s = InMemoryStore::new();
+        s.create(&record_at("other", "b", "v1", day(5)))
+            .await
+            .unwrap();
+        s.create(&record_at("p", "other-bench", "v1", day(5)))
+            .await
+            .unwrap();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        let latest = s.get_latest("p", "b").await.unwrap().unwrap();
+        assert_eq!(latest.project, "p");
+        assert_eq!(latest.benchmark, "b");
+        assert_eq!(latest.version, "v1");
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_benchmark_exact_and_prefix() {
+        let s = InMemoryStore::new();
+        for (b, v) in [("bench-a", "v1"), ("bench-ab", "v1"), ("other", "v1")] {
+            s.create(&record_at("p", b, v, day(1))).await.unwrap();
+        }
+        // Exact match
+        let q = ListBaselinesQuery::new().with_benchmark("bench-a");
+        let resp = s.list("p", &q).await.unwrap();
+        let names: Vec<_> = resp.baselines.iter().map(|b| b.benchmark.clone()).collect();
+        assert_eq!(names, vec!["bench-a".to_string()]);
+        assert_eq!(resp.pagination.total, 1);
+
+        // Prefix match
+        let q = ListBaselinesQuery::new().with_benchmark_prefix("bench-");
+        let resp = s.list("p", &q).await.unwrap();
+        let mut names: Vec<_> = resp.baselines.iter().map(|b| b.benchmark.clone()).collect();
+        names.sort();
+        assert_eq!(names, vec!["bench-a".to_string(), "bench-ab".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_git_ref_git_sha_and_tags() {
+        let s = InMemoryStore::new();
+        s.create(&record(
+            "p",
+            "b",
+            "v1",
+            Some("refs/heads/main"),
+            Some("aaa"),
+            vec!["release", "smoke"],
+        ))
+        .await
+        .unwrap();
+        s.create(&record(
+            "p",
+            "b",
+            "v2",
+            Some("refs/heads/main"),
+            Some("bbb"),
+            vec!["smoke"],
+        ))
+        .await
+        .unwrap();
+        s.create(&record(
+            "p",
+            "b",
+            "v3",
+            Some("refs/heads/dev"),
+            Some("ccc"),
+            vec!["release"],
+        ))
+        .await
+        .unwrap();
+
+        // git_ref filter
+        let q = ListBaselinesQuery {
+            git_ref: Some("refs/heads/main".into()),
+            ..Default::default()
+        };
+        let resp = s.list("p", &q).await.unwrap();
+        assert_eq!(resp.pagination.total, 2);
+
+        // git_sha filter
+        let q = ListBaselinesQuery {
+            git_sha: Some("bbb".into()),
+            ..Default::default()
+        };
+        let resp = s.list("p", &q).await.unwrap();
+        assert_eq!(resp.pagination.total, 1);
+        assert_eq!(resp.baselines[0].version, "v2");
+
+        // Tags filter: AND semantics - "release,smoke" requires both
+        let q = ListBaselinesQuery {
+            tags: Some("release,smoke".into()),
+            ..Default::default()
+        };
+        let resp = s.list("p", &q).await.unwrap();
+        assert_eq!(resp.pagination.total, 1);
+        assert_eq!(resp.baselines[0].version, "v1");
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_since_until_window() {
+        let s = InMemoryStore::new();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        s.create(&record_at("p", "b", "v2", day(5))).await.unwrap();
+        s.create(&record_at("p", "b", "v3", day(10))).await.unwrap();
+
+        let q = ListBaselinesQuery {
+            since: Some(day(4)),
+            until: Some(day(9)),
+            ..Default::default()
+        };
+        let resp = s.list("p", &q).await.unwrap();
+        assert_eq!(resp.pagination.total, 1);
+        assert_eq!(resp.baselines[0].version, "v2");
+    }
+
+    #[tokio::test]
+    async fn list_paginates_in_descending_created_at_order() {
+        let s = InMemoryStore::new();
+        for i in 0..5 {
+            s.create(&record_at("p", "b", &format!("v{i}"), day(i)))
+                .await
+                .unwrap();
+        }
+        let q = ListBaselinesQuery {
+            limit: 2,
+            offset: 0,
+            ..Default::default()
+        };
+        let page1 = s.list("p", &q).await.unwrap();
+        assert_eq!(page1.baselines.len(), 2);
+        assert!(page1.pagination.has_more);
+        assert_eq!(page1.pagination.total, 5);
+        // descending by created_at => newest first => v4 then v3
+        assert_eq!(page1.baselines[0].version, "v4");
+        assert_eq!(page1.baselines[1].version, "v3");
+
+        let q = ListBaselinesQuery {
+            limit: 2,
+            offset: 4,
+            ..Default::default()
+        };
+        let last = s.list("p", &q).await.unwrap();
+        assert_eq!(last.baselines.len(), 1);
+        assert!(!last.pagination.has_more);
+        assert_eq!(last.baselines[0].version, "v0");
+    }
+
+    #[tokio::test]
+    async fn list_excludes_deleted_and_other_projects() {
+        let s = InMemoryStore::new();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        s.create(&record_at("p", "b", "v2", day(2))).await.unwrap();
+        s.create(&record_at("other", "b", "v1", day(3)))
+            .await
+            .unwrap();
+        s.delete("p", "b", "v1").await.unwrap();
+
+        let resp = s.list("p", &ListBaselinesQuery::default()).await.unwrap();
+        assert_eq!(resp.pagination.total, 1);
+        assert_eq!(resp.baselines[0].version, "v2");
+    }
+
+    #[tokio::test]
+    async fn list_returns_receipt_in_summary_and_respects_include_receipt_flag() {
+        // The InMemoryStore relies on the BaselineRecord -> BaselineSummary `From`
+        // impl, which always populates `receipt: Some(...)`. The include_receipt
+        // flag forces the same overwrite. This test pins that current behavior
+        // so a future refactor that intentionally hides receipts behind the flag
+        // will trip and prompt an update.
+        let s = InMemoryStore::new();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        let default = s.list("p", &ListBaselinesQuery::default()).await.unwrap();
+        assert!(default.baselines[0].receipt.is_some());
+        let with_receipt = s
+            .list("p", &ListBaselinesQuery::new().with_receipts())
+            .await
+            .unwrap();
+        assert!(with_receipt.baselines[0].receipt.is_some());
+        assert_eq!(
+            default.baselines[0].receipt.as_ref().unwrap().bench.name,
+            with_receipt.baselines[0]
+                .receipt
+                .as_ref()
+                .unwrap()
+                .bench
+                .name
+        );
+    }
+
+    #[tokio::test]
+    async fn list_versions_marks_newest_as_current_and_sorts_desc() {
+        let s = InMemoryStore::new();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        s.create(&record_at("p", "b", "v3", day(3))).await.unwrap();
+        s.create(&record_at("p", "b", "v2", day(2))).await.unwrap();
+        let versions: Vec<BaselineVersion> = s.list_versions("p", "b").await.unwrap();
+        let names: Vec<_> = versions.iter().map(|v| v.version.clone()).collect();
+        assert_eq!(names, vec!["v3", "v2", "v1"]);
+        assert!(versions[0].is_current);
+        assert!(versions[1..].iter().all(|v| !v.is_current));
+    }
+
+    #[tokio::test]
+    async fn list_versions_skips_deleted_versions() {
+        let s = InMemoryStore::new();
+        s.create(&record_at("p", "b", "v1", day(1))).await.unwrap();
+        s.create(&record_at("p", "b", "v2", day(2))).await.unwrap();
+        s.delete("p", "b", "v2").await.unwrap();
+        let names: Vec<_> = s
+            .list_versions("p", "b")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|v| v.version)
+            .collect();
+        assert_eq!(names, vec!["v1"]);
+    }
+
+    #[tokio::test]
+    async fn create_verdict_and_list_filters_by_status_and_benchmark() {
+        let s = InMemoryStore::new();
+        s.create_verdict(&verdict_at("p", "b1", VerdictStatus::Pass, day(1)))
+            .await
+            .unwrap();
+        s.create_verdict(&verdict_at("p", "b1", VerdictStatus::Fail, day(2)))
+            .await
+            .unwrap();
+        s.create_verdict(&verdict_at("p", "b2", VerdictStatus::Pass, day(3)))
+            .await
+            .unwrap();
+        s.create_verdict(&verdict_at("other", "b1", VerdictStatus::Pass, day(4)))
+            .await
+            .unwrap();
+
+        // project isolation
+        let all = s
+            .list_verdicts("p", &ListVerdictsQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(all.pagination.total, 3);
+        // desc by created_at
+        assert_eq!(all.verdicts[0].benchmark, "b2");
+
+        let only_b1 = s
+            .list_verdicts("p", &ListVerdictsQuery::new().with_benchmark("b1"))
+            .await
+            .unwrap();
+        assert_eq!(only_b1.pagination.total, 2);
+
+        let only_fail = s
+            .list_verdicts(
+                "p",
+                &ListVerdictsQuery::new().with_status(VerdictStatus::Fail),
+            )
+            .await
+            .unwrap();
+        assert_eq!(only_fail.pagination.total, 1);
+        assert_eq!(only_fail.verdicts[0].benchmark, "b1");
+    }
+
+    #[tokio::test]
+    async fn list_verdicts_filters_by_time_window_and_paginates() {
+        let s = InMemoryStore::new();
+        for i in 0..5 {
+            s.create_verdict(&verdict_at("p", "b", VerdictStatus::Pass, day(i)))
+                .await
+                .unwrap();
+        }
+        let q = ListVerdictsQuery {
+            since: Some(day(1)),
+            until: Some(day(3)),
+            ..Default::default()
+        };
+        let resp = s.list_verdicts("p", &q).await.unwrap();
+        assert_eq!(resp.pagination.total, 3);
+
+        let q = ListVerdictsQuery::new().with_limit(2).with_offset(2);
+        let resp = s.list_verdicts("p", &q).await.unwrap();
+        assert_eq!(resp.verdicts.len(), 2);
+        // With 5 total and offset=2/limit=2 we still have 1 page remaining.
+        assert!(resp.pagination.has_more);
+        assert_eq!(resp.pagination.total, 5);
+
+        let q = ListVerdictsQuery::new().with_limit(2).with_offset(4);
+        let resp = s.list_verdicts("p", &q).await.unwrap();
+        assert_eq!(resp.verdicts.len(), 1);
+        assert!(!resp.pagination.has_more);
+    }
+
+    fn decision_at(
+        project: &str,
+        scenario: Option<&str>,
+        status: MetricStatus,
+        verdict: VerdictStatus,
+        accepted_rules: Vec<&str>,
+        review_required: bool,
+        ts: chrono::DateTime<Utc>,
+    ) -> DecisionRecord {
+        let tradeoff_json = serde_json::json!({
+            "schema": "perfgate.tradeoff.v1",
+            "tool": {"name": "perfgate", "version": "0.0.0-test"},
+            "run": {
+                "id": format!("run-{}", ts.timestamp_millis()),
+                "started_at": "2026-01-01T00:00:00Z",
+                "ended_at": "2026-01-01T00:00:01Z",
+                "host": {"os": "linux", "arch": "x86_64"}
+            },
+            "scenario": scenario.unwrap_or(""),
+            "configured_rules": [],
+            "rules": [],
+            "weighted_deltas": {},
+            "decision": {
+                "accepted_tradeoff": !accepted_rules.is_empty(),
+                "review_required": review_required,
+                "review_reasons": [],
+                "status": status.as_str(),
+                "reason": "test"
+            },
+            "verdict": {
+                "status": verdict.as_str(),
+                "counts": {"pass": 1, "warn": 0, "fail": 0, "skip": 0},
+                "reasons": []
+            }
+        });
+        let tradeoff: perfgate_types::TradeoffReceipt =
+            serde_json::from_value(tradeoff_json).expect("tradeoff fixture must parse");
+
+        DecisionRecord {
+            schema: perfgate_types::baseline_service::DECISION_RECORD_SCHEMA_V1.to_string(),
+            id: format!("dec-{}", ts.timestamp_millis()),
+            project: project.to_string(),
+            scenario: scenario.map(String::from),
+            status,
+            verdict,
+            accepted_rules: accepted_rules.into_iter().map(String::from).collect(),
+            review_required,
+            review_reasons: Vec::new(),
+            git_ref: None,
+            git_sha: None,
+            scenario_receipt: None,
+            tradeoff_receipt: tradeoff,
+            artifact_index: None,
+            created_at: ts,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_and_latest_decision_returns_max_by_created_at() {
+        let s = InMemoryStore::new();
+        for (project, ts) in [
+            ("p", day(1)),
+            ("p", day(5)),
+            ("p", day(3)),
+            ("other", day(10)),
+        ] {
+            s.create_decision(&decision_at(
+                project,
+                Some("scn"),
+                MetricStatus::Pass,
+                VerdictStatus::Pass,
+                vec![],
+                false,
+                ts,
+            ))
+            .await
+            .unwrap();
+        }
+        let latest = s.latest_decision("p").await.unwrap().unwrap();
+        assert_eq!(latest.created_at, day(5));
+    }
+
+    #[tokio::test]
+    async fn latest_decision_returns_none_when_empty() {
+        let s = InMemoryStore::new();
+        assert!(s.latest_decision("p").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_decisions_filters_by_scenario_status_verdict_review_required_accepted_and_rule() {
+        let s = InMemoryStore::new();
+        // d1: scenario=a, status=Pass, verdict=Pass, review=false, accepted=[r1]
+        s.create_decision(&decision_at(
+            "p",
+            Some("a"),
+            MetricStatus::Pass,
+            VerdictStatus::Pass,
+            vec!["r1"],
+            false,
+            day(1),
+        ))
+        .await
+        .unwrap();
+        // d2: scenario=b, status=Warn, verdict=Warn, review=true, accepted=[]
+        s.create_decision(&decision_at(
+            "p",
+            Some("b"),
+            MetricStatus::Warn,
+            VerdictStatus::Warn,
+            vec![],
+            true,
+            day(2),
+        ))
+        .await
+        .unwrap();
+        // d3: scenario=a, status=Fail, verdict=Fail, review=false, accepted=[r1,r2]
+        s.create_decision(&decision_at(
+            "p",
+            Some("a"),
+            MetricStatus::Fail,
+            VerdictStatus::Fail,
+            vec!["r1", "r2"],
+            false,
+            day(3),
+        ))
+        .await
+        .unwrap();
+
+        let q = ListDecisionsQuery::new().with_scenario("a");
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 2);
+
+        let q = ListDecisionsQuery::new().with_status(MetricStatus::Fail);
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 1);
+
+        let q = ListDecisionsQuery::new().with_verdict(VerdictStatus::Warn);
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 1);
+
+        let q = ListDecisionsQuery::new().with_review_required(true);
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 1);
+
+        // accepted=true => has any accepted_rules
+        let q = ListDecisionsQuery::new().with_accepted(true);
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 2);
+
+        let q = ListDecisionsQuery::new().with_accepted(false);
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 1);
+
+        // rule filter matches against accepted_rules
+        let q = ListDecisionsQuery::new().with_rule("r2");
+        assert_eq!(s.list_decisions("p", &q).await.unwrap().pagination.total, 1);
+    }
+
+    #[tokio::test]
+    async fn list_decisions_sorts_desc_and_paginates() {
+        let s = InMemoryStore::new();
+        for i in 0..4 {
+            s.create_decision(&decision_at(
+                "p",
+                Some("scn"),
+                MetricStatus::Pass,
+                VerdictStatus::Pass,
+                vec![],
+                false,
+                day(i),
+            ))
+            .await
+            .unwrap();
+        }
+        let q = ListDecisionsQuery {
+            limit: 2,
+            offset: 0,
+            ..Default::default()
+        };
+        let page1 = s.list_decisions("p", &q).await.unwrap();
+        assert!(page1.pagination.has_more);
+        assert_eq!(page1.decisions[0].created_at, day(3));
+        assert_eq!(page1.decisions[1].created_at, day(2));
+        let q = ListDecisionsQuery {
+            limit: 2,
+            offset: 2,
+            ..Default::default()
+        };
+        let page2 = s.list_decisions("p", &q).await.unwrap();
+        assert!(!page2.pagination.has_more);
+    }
+
+    #[tokio::test]
+    async fn prune_decisions_dry_run_does_not_remove_anything() {
+        let s = InMemoryStore::new();
+        s.create_decision(&decision_at(
+            "p",
+            Some("a"),
+            MetricStatus::Pass,
+            VerdictStatus::Pass,
+            vec![],
+            false,
+            day(1),
+        ))
+        .await
+        .unwrap();
+        s.create_decision(&decision_at(
+            "p",
+            Some("a"),
+            MetricStatus::Pass,
+            VerdictStatus::Pass,
+            vec![],
+            false,
+            day(5),
+        ))
+        .await
+        .unwrap();
+
+        let resp = s.prune_decisions("p", day(3), true).await.unwrap();
+        assert_eq!(resp.matched, 1);
+        assert_eq!(resp.deleted, 0);
+        assert!(resp.dry_run);
+        // Still two decisions in the store
+        assert_eq!(
+            s.list_decisions("p", &ListDecisionsQuery::default())
+                .await
+                .unwrap()
+                .pagination
+                .total,
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_decisions_removes_older_and_respects_project_scope() {
+        let s = InMemoryStore::new();
+        s.create_decision(&decision_at(
+            "p",
+            Some("a"),
+            MetricStatus::Pass,
+            VerdictStatus::Pass,
+            vec![],
+            false,
+            day(1),
+        ))
+        .await
+        .unwrap();
+        s.create_decision(&decision_at(
+            "p",
+            Some("a"),
+            MetricStatus::Pass,
+            VerdictStatus::Pass,
+            vec![],
+            false,
+            day(5),
+        ))
+        .await
+        .unwrap();
+        // Old decision in another project must not be pruned.
+        s.create_decision(&decision_at(
+            "other",
+            Some("a"),
+            MetricStatus::Pass,
+            VerdictStatus::Pass,
+            vec![],
+            false,
+            day(1),
+        ))
+        .await
+        .unwrap();
+
+        let resp = s.prune_decisions("p", day(3), false).await.unwrap();
+        assert_eq!(resp.matched, 1);
+        assert_eq!(resp.deleted, 1);
+        assert!(!resp.dry_run);
+        assert_eq!(resp.decision_ids.len(), 1);
+
+        // p has only the newer one left
+        assert_eq!(
+            s.list_decisions("p", &ListDecisionsQuery::default())
+                .await
+                .unwrap()
+                .pagination
+                .total,
+            1
+        );
+        // other project untouched
+        assert_eq!(
+            s.list_decisions("other", &ListDecisionsQuery::default())
+                .await
+                .unwrap()
+                .pagination
+                .total,
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_log_event_then_list_filters_by_project_actor_action_resource_and_time() {
+        let s = InMemoryStore::new();
+        s.log_event(&audit_at(
+            "p",
+            "alice",
+            AuditAction::Create,
+            AuditResourceType::Baseline,
+            "v1",
+            day(1),
+        ))
+        .await
+        .unwrap();
+        s.log_event(&audit_at(
+            "p",
+            "bob",
+            AuditAction::Delete,
+            AuditResourceType::Baseline,
+            "v2",
+            day(2),
+        ))
+        .await
+        .unwrap();
+        s.log_event(&audit_at(
+            "other",
+            "alice",
+            AuditAction::Promote,
+            AuditResourceType::Baseline,
+            "v3",
+            day(3),
+        ))
+        .await
+        .unwrap();
+
+        // project filter
+        let q = ListAuditEventsQuery {
+            project: Some("p".into()),
+            ..Default::default()
+        };
+        assert_eq!(s.list_events(&q).await.unwrap().pagination.total, 2);
+
+        // actor filter
+        let q = ListAuditEventsQuery {
+            actor: Some("alice".into()),
+            ..Default::default()
+        };
+        assert_eq!(s.list_events(&q).await.unwrap().pagination.total, 2);
+
+        // action filter (matches the Display impl: lowercase)
+        let q = ListAuditEventsQuery {
+            action: Some("delete".into()),
+            ..Default::default()
+        };
+        assert_eq!(s.list_events(&q).await.unwrap().pagination.total, 1);
+
+        // resource_type filter
+        let q = ListAuditEventsQuery {
+            resource_type: Some("baseline".into()),
+            ..Default::default()
+        };
+        assert_eq!(s.list_events(&q).await.unwrap().pagination.total, 3);
+
+        // time window filter
+        let q = ListAuditEventsQuery {
+            since: Some(day(2)),
+            until: Some(day(2)),
+            ..Default::default()
+        };
+        assert_eq!(s.list_events(&q).await.unwrap().pagination.total, 1);
+    }
+
+    #[tokio::test]
+    async fn audit_list_sorts_desc_and_paginates() {
+        let s = InMemoryStore::new();
+        for i in 0..5 {
+            s.log_event(&audit_at(
+                "p",
+                "actor",
+                AuditAction::Create,
+                AuditResourceType::Baseline,
+                &format!("v{i}"),
+                day(i),
+            ))
+            .await
+            .unwrap();
+        }
+        let q = ListAuditEventsQuery {
+            limit: 2,
+            offset: 0,
+            ..Default::default()
+        };
+        let page = s.list_events(&q).await.unwrap();
+        assert!(page.pagination.has_more);
+        assert_eq!(page.events.len(), 2);
+        assert_eq!(page.events[0].resource_id, "v4");
+        assert_eq!(page.events[1].resource_id, "v3");
+    }
+}

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,13 +1,15 @@
 # Release Readiness
 
 Last verified: 2026-05-17 for v0.17.0 publication reconciliation and the
-0.18.0 release-candidate cutover proof after post-SRP coverage hardening. See
+0.18.0 release-candidate cutover proof after restored post-SRP coverage
+hardening. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
 [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md),
 [v0.18.0 Final Pre-Publish Proof](audits/release-0.18.0-final-prepublish-proof.md),
 [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md),
+[v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md),
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
@@ -78,7 +80,8 @@ but it does not authorize publication by itself.
 | 0.18 adoption hardening | Covered | [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md), including wrapper absorption, first-hour smoke, structured decision bundle proof, action summary examples, and server ledger operations smoke |
 | 0.18 publish dry-run matrix | Passing | [v0.18.0 Publish Readiness Proof](audits/release-0.18.0-publish-readiness.md) packaged and verified `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, and `perfgate-cli` at `0.18.0` without uploading. |
 | 0.18 final pre-publish proof | Passing | [v0.18.0 Final Pre-Publish Proof](audits/release-0.18.0-final-prepublish-proof.md) reran fmt, check, test, docs, source-doc, product-claim, public-surface, arch, action, schema, package-list, and five per-crate dry-run gates from the reopened release lane without publishing. |
-| 0.18 final proof after coverage hardening | Passing | [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #473-#476 and the generated badge refresh landed. |
+| 0.18 final proof after coverage hardening | Superseded | [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md) was superseded after a completion audit found #473-#475 were cited but absent from the checked `main` tree. |
+| 0.18 restored coverage proof | Passing | [v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md) restores #473-#475 coverage hardening onto current `main` and reruns fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks. |
 | 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields without publishing. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |

--- a/docs/audits/release-0.18.0-final-proof-after-coverage-hardening.md
+++ b/docs/audits/release-0.18.0-final-proof-after-coverage-hardening.md
@@ -11,6 +11,13 @@ coverage hardening tranche landed. This proof does not publish crates, create
 tags, create a GitHub release, move action aliases, prove public install, or
 close the active release cutover lane.
 
+Superseded by:
+[`v0.18.0 Restored Coverage Proof`](release-0.18.0-restored-coverage-proof.md).
+A completion audit after this proof merged found that the #473, #474, and #475
+merge commits referenced below were not contained in the current `main` history.
+The restored proof ports those test-only commits onto current `main` and reruns
+the release-candidate proof from that corrected tree.
+
 Linked proposal:
 [`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 

--- a/docs/audits/release-0.18.0-restored-coverage-proof.md
+++ b/docs/audits/release-0.18.0-restored-coverage-proof.md
@@ -1,0 +1,109 @@
+# v0.18.0 Restored Coverage Proof
+
+Date: 2026-05-17
+
+Branch: `test/restore-post-srp-coverage-hardening`
+
+Purpose: restore the post-SRP coverage hardening tranche onto current `main`
+after a completion audit found the earlier
+[`v0.18.0 Final Proof After Coverage Hardening`](release-0.18.0-final-proof-after-coverage-hardening.md)
+referenced #473, #474, and #475 even though their merge commits were not present
+in the branch under proof. This proof reruns the release-candidate gates from
+the corrected tree. It does not publish crates, create tags, create a GitHub
+release, move action aliases, prove public install, or close the active release
+cutover lane.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Linked prior proof:
+
+- [`v0.18.0 Final Pre-Publish Proof`](release-0.18.0-final-prepublish-proof.md)
+- [`v0.18.0 Publish Packet`](release-0.18.0-publish-packet.md)
+- [`Metric Direction Semantics Audit`](metric-direction-semantics.md)
+- [`Decision Semantics Verification`](decision-semantics-verification.md)
+- [`v0.18.0 Final Proof After Coverage Hardening`](release-0.18.0-final-proof-after-coverage-hardening.md)
+
+## Correction
+
+The earlier final proof after coverage hardening was merged from a branch that
+included #476 and the generated badge refresh, but current `main` did not contain
+the #473, #474, or #475 merge commits it cited. GitHub reported those PRs merged,
+but their merge commits were absent from the checked-out `main` history and the
+expected test bodies were not present in the working tree.
+
+This restored proof ports the original test-only coverage commits onto current
+`main`:
+
+| Restored commit | Original PR scope |
+| --- | --- |
+| `0fdad9d` | #473 `cli_parsing` and `repair_context` helper coverage |
+| `2104916` | #474 `check_guidance` and `artifact_explain` helper coverage |
+| `343fc0a` | #474 Windows guidance artifact path normalization |
+| `be993e5` | #475 in-memory server store baseline, verdict, decision, and audit coverage |
+
+The already-present #476 `decision_suggest` readiness helper coverage and the
+generated badge refresh remain on the corrected release-candidate tree.
+
+The nightly baseline/trend refresh remains separate release-adjacent generated
+data. It is not included in this proof as a product or release-semantics gate.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Version under test | `0.18.0` |
+| Target dir for targeted coverage proof | `C:\perfgate-target-restored-coverage` |
+| Target dir for full release proof | `C:\perfgate-target-restored-final-proof` |
+| Cargo incremental | disabled with `CARGO_INCREMENTAL=0` for full proof |
+| Publishable crates | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+| Publication state | Pre-publish only; no crates were uploaded |
+
+## Targeted Coverage Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 test -p perfgate-cli cli_parsing::tests` | Pass | 42 CLI parsing tests passed. |
+| `cargo +1.95.0 test -p perfgate-cli repair_context::tests` | Pass | 8 repair context tests passed. |
+| `cargo +1.95.0 test -p perfgate-cli check_guidance::tests` | Pass | 33 check guidance tests passed. |
+| `cargo +1.95.0 test -p perfgate-cli artifact_explain::tests` | Pass | 17 artifact explanation tests passed. |
+| `cargo +1.95.0 test -p perfgate-cli decision_suggest::tests` | Pass | 6 decision suggest tests passed. |
+| `cargo +1.95.0 test -p perfgate-server storage::memory::tests` | Pass | Server memory store storage tests passed. |
+
+## Command Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 fmt --all -- --check` | Pass | Formatting check completed without changes. |
+| `cargo +1.95.0 check --workspace --all-targets --all-features --locked` | Pass | Workspace check completed under the restored final-proof target directory. |
+| `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings` | Pass | Workspace Clippy completed with warnings denied. |
+| `cargo +1.95.0 test --workspace --all-targets --all-features --locked` | Pass | Full workspace test suite passed under the restored final-proof target directory. |
+| `cargo +1.95.0 run -p xtask -- public-surface --strict` | Pass | Public-surface policy accounts for the five publishable packages. |
+| `cargo +1.95.0 run -p xtask -- arch` | Pass | Architecture dependency rules hold. |
+| `cargo +1.95.0 run -p xtask -- schema-compat` | Pass | Historical schema fixtures deserialize with current types. |
+| `cargo +1.95.0 run -p xtask -- action-check` | Pass | GitHub Action install, release asset, and failure diagnostic wiring are aligned. |
+| `cargo +1.95.0 run -p xtask -- docs-source-check` | Pass | Source-of-truth metadata, IDs, links, and active goal are valid. |
+| `cargo +1.95.0 run -p xtask -- product-claims-check` | Pass | Product claim proof map is valid. |
+| `cargo +1.95.0 run -p xtask -- docs-check` | Pass | Documentation drift check passed. |
+| `cargo +1.95.0 run -p xtask -- doc-test` | Pass | CLI examples and structured snippets passed. |
+| `git diff --check` | Pass | Whitespace check passed. |
+
+## Non-Inferences
+
+- This does not publish `0.18.0` to crates.io.
+- This does not create `v0.18.0`.
+- This does not create a GitHub release or release assets.
+- This does not move `v0.18` or `v0`.
+- This does not prove public install from crates.io, `cargo-binstall`, or
+  GitHub release assets.
+- This does not close the release cutover lane.
+
+## Release Boundary
+
+The active 0.18.0 release cutover remains blocked only at explicit
+release-operator boundaries: crates.io publication, exact release tag, GitHub
+release/assets, intentional action alias movement, public install smoke, and
+publication closeout.


### PR DESCRIPTION
## Summary
- restores the #473-#475 post-SRP coverage hardening commits onto current main after a completion audit found their merge commits were not present in the checked main history
- keeps the existing #476 decision-suggest coverage and badge refresh intact
- marks the earlier final coverage proof as superseded and adds a restored-coverage release proof without publishing, tagging, moving aliases, or closing the active 0.18 release goal

## Validation
- cargo +1.95.0 test -p perfgate-cli cli_parsing::tests
- cargo +1.95.0 test -p perfgate-cli repair_context::tests
- cargo +1.95.0 test -p perfgate-cli check_guidance::tests
- cargo +1.95.0 test -p perfgate-cli artifact_explain::tests
- cargo +1.95.0 test -p perfgate-cli decision_suggest::tests
- cargo +1.95.0 test -p perfgate-server storage::memory::tests
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 check --workspace --all-targets --all-features --locked
- cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 test --workspace --all-targets --all-features --locked
- cargo +1.95.0 run -p xtask -- public-surface --strict
- cargo +1.95.0 run -p xtask -- arch
- cargo +1.95.0 run -p xtask -- schema-compat
- cargo +1.95.0 run -p xtask -- action-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check

## Release boundary
No crates were published, no tags or aliases were created or moved, no GitHub release was created, no public install smoke was claimed, and the active 0.18 release cutover goal remains open at the operator-gated publication boundary.