### PR TITLE
release: refresh 0.18.0 final proof after restored coverage

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -2,7 +2,7 @@
 
 Last verified: 2026-05-17 for v0.17.0 publication reconciliation and the
 0.18.0 release-candidate cutover proof after restored post-SRP coverage
-hardening. See
+hardening and generated queue resolution. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
@@ -10,6 +10,7 @@ hardening. See
 [v0.18.0 Final Pre-Publish Proof](audits/release-0.18.0-final-prepublish-proof.md),
 [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md),
 [v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md),
+[v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md),
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
@@ -82,6 +83,7 @@ but it does not authorize publication by itself.
 | 0.18 final pre-publish proof | Passing | [v0.18.0 Final Pre-Publish Proof](audits/release-0.18.0-final-prepublish-proof.md) reran fmt, check, test, docs, source-doc, product-claim, public-surface, arch, action, schema, package-list, and five per-crate dry-run gates from the reopened release lane without publishing. |
 | 0.18 final proof after coverage hardening | Superseded | [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md) was superseded after a completion audit found #473-#475 were cited but absent from the checked `main` tree. |
 | 0.18 restored coverage proof | Passing | [v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md) restores #473-#475 coverage hardening onto current `main` and reruns fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks. |
+| 0.18 final proof after restored coverage | Passing | [v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #480, #481, and #477 landed. |
 | 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields without publishing. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |

--- a/docs/audits/release-0.18.0-final-proof-after-restored-coverage.md
+++ b/docs/audits/release-0.18.0-final-proof-after-restored-coverage.md
@@ -1,0 +1,88 @@
+# v0.18.0 Final Proof After Restored Coverage
+
+Date: 2026-05-17
+
+Branch: `release/0-18-final-proof-after-restored-coverage`
+
+Commit under proof: `ab70b44`
+
+Purpose: refresh the 0.18.0 release-candidate proof after #480 restored the
+missing post-SRP coverage hardening commits onto `main`, #481 refreshed the
+generated public badge endpoint, and #477 refreshed generated nightly baselines
+and trends. This proof does not publish crates, create tags, create a GitHub
+release, move action aliases, prove public install, or close the active release
+cutover lane.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Linked prior proof:
+
+- [`v0.18.0 Final Pre-Publish Proof`](release-0.18.0-final-prepublish-proof.md)
+- [`v0.18.0 Publish Packet`](release-0.18.0-publish-packet.md)
+- [`Metric Direction Semantics Audit`](metric-direction-semantics.md)
+- [`Decision Semantics Verification`](decision-semantics-verification.md)
+- [`v0.18.0 Restored Coverage Proof`](release-0.18.0-restored-coverage-proof.md)
+
+## Queue State Included
+
+This proof was refreshed after the remaining generated release-adjacent queue was
+resolved:
+
+| PR | Scope |
+| --- | --- |
+| #480 | restored #473-#475 post-SRP coverage hardening onto current `main` |
+| #481 | generated public badge endpoint refresh |
+| #477 | generated nightly baselines and trend data refresh |
+
+The badge and baseline/trend refreshes are generated operational inputs. They
+are included in the checked tree for this proof, but they do not change release
+semantics, publish state, action aliases, receipt schemas, or public APIs.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Version under test | `0.18.0` |
+| Target dir for full release proof | `C:\perfgate-target-0-18-final-proof-after-restored-coverage` |
+| Cargo incremental | disabled with `CARGO_INCREMENTAL=0` |
+| Publishable crates | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+| Publication state | Pre-publish only; no crates were uploaded |
+
+## Command Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 fmt --all -- --check` | Pass | Formatting check completed without changes. |
+| `cargo +1.95.0 check --workspace --all-targets --all-features --locked` | Pass | Workspace check completed under the final post-restore target directory. |
+| `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings` | Pass | Workspace Clippy completed with warnings denied. |
+| `cargo +1.95.0 test --workspace --all-targets --all-features --locked` | Pass | Full workspace test suite passed under the final post-restore target directory. |
+| `cargo +1.95.0 run -p xtask -- public-surface --strict` | Pass | Public-surface policy accounts for the five publishable packages. |
+| `cargo +1.95.0 run -p xtask -- arch` | Pass | Architecture dependency rules hold. |
+| `cargo +1.95.0 run -p xtask -- schema-compat` | Pass | 18 historical schema fixtures deserialize with current types. |
+| `cargo +1.95.0 run -p xtask -- action-check` | Pass | GitHub Action install, release asset, and failure diagnostic wiring are aligned. |
+| `cargo +1.95.0 run -p xtask -- docs-source-check` | Pass | Source-of-truth metadata, IDs, links, and active goal are valid. |
+| `cargo +1.95.0 run -p xtask -- product-claims-check` | Pass | Product claim proof map is valid. |
+| `cargo +1.95.0 run -p xtask -- docs-check` | Pass | Documentation drift check passed. |
+| `cargo +1.95.0 run -p xtask -- doc-test` | Pass | Checked 70 CLI examples and 36 structured snippets. |
+| `git diff --check` | Pass | Whitespace check passed. |
+
+## Non-Inferences
+
+- This does not publish `0.18.0` to crates.io.
+- This does not create `v0.18.0`.
+- This does not create a GitHub release or release assets.
+- This does not move `v0.18` or `v0`.
+- This does not prove public install from crates.io, `cargo-binstall`, or
+  GitHub release assets.
+- This does not close the release cutover lane.
+
+## Release Boundary
+
+The active 0.18.0 release cutover remains blocked only at explicit
+release-operator boundaries: crates.io publication, exact release tag, GitHub
+release/assets, intentional action alias movement, public install smoke, and
+publication closeout.


### PR DESCRIPTION
## Summary
- records the final 0.18.0 release-candidate proof after #480 restored the post-SRP coverage hardening commits and after generated #481/#477 were merged
- updates release readiness to point at the new final proof audit
- keeps the release boundary explicit: no crates published, no tags/releases created, no action aliases moved, no public install smoke claimed, and the active release cutover remains operator-gated

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 check --workspace --all-targets --all-features --locked
- cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo +1.95.0 test --workspace --all-targets --all-features --locked
- cargo +1.95.0 run -p xtask -- public-surface --strict
- cargo +1.95.0 run -p xtask -- arch
- cargo +1.95.0 run -p xtask -- schema-compat
- cargo +1.95.0 run -p xtask -- action-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check

## Release boundary
This PR is still pre-publication proof only. The next steps remain operator-gated crates.io publication, crates.io verification, exact GitHub release, intentional alias movement, public install smoke, and publication closeout.