### PR TITLE
release: refresh 0.18 final proof after init extraction

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -2,7 +2,7 @@
 
 Last verified: 2026-05-17 for v0.17.0 publication reconciliation and the
 0.18.0 release-candidate cutover proof after restored post-SRP coverage
-hardening and generated queue resolution. See
+hardening, generated queue resolution, and the #484 init extraction. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
@@ -11,6 +11,7 @@ hardening and generated queue resolution. See
 [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md),
 [v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md),
 [v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md),
+[v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md),
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
@@ -37,9 +38,10 @@ structured-decision bundle proof, checked action failure examples, optional
 server-ledger operations smoke, external canaries, publish dry-runs for all five
 public crates, and staged Windows archive smoke. No public `0.18.0` crates,
 tags, GitHub release, action aliases, or public install smoke exist yet. The
-active release cutover lane has refreshed final pre-publish proof and is now
-waiting at release-operator-gated publication. The operator packet is prepared,
-but it does not authorize publication by itself.
+active release cutover lane has refreshed final release-candidate proof after
+the #484 init extraction and is now waiting at release-operator-gated
+publication. The operator packet is prepared, but it does not authorize
+publication by itself.
 
 ## Current Publication State
 
@@ -84,6 +86,7 @@ but it does not authorize publication by itself.
 | 0.18 final proof after coverage hardening | Superseded | [v0.18.0 Final Proof After Coverage Hardening](audits/release-0.18.0-final-proof-after-coverage-hardening.md) was superseded after a completion audit found #473-#475 were cited but absent from the checked `main` tree. |
 | 0.18 restored coverage proof | Passing | [v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md) restores #473-#475 coverage hardening onto current `main` and reruns fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks. |
 | 0.18 final proof after restored coverage | Passing | [v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #480, #481, and #477 landed. |
+| 0.18 final proof after init extraction | Passing | [v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #484 extracted `perfgate init` into `crates/perfgate-cli/src/init.rs`. |
 | 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields without publishing. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |

--- a/docs/audits/release-0.18.0-final-proof-after-init-extraction.md
+++ b/docs/audits/release-0.18.0-final-proof-after-init-extraction.md
@@ -1,0 +1,84 @@
+# v0.18.0 Final Proof After Init Extraction
+
+Date: 2026-05-17
+
+Branch: `release/0-18-final-proof-after-init-extraction`
+
+Commit under proof: `d87c1ee1ce4800cdb280341cbc862a1689030178`
+
+Purpose: refresh the 0.18.0 release-candidate proof after #484 extracted the
+`perfgate init` execution path into `crates/perfgate-cli/src/init.rs`. The
+extraction was behavior-preserving, but this audit makes the final
+release-candidate proof apply to the actual current `main` commit after that
+change. This proof does not publish crates, create tags, create a GitHub
+release, move action aliases, prove public install, or close the active release
+cutover lane.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Linked prior proof:
+
+- [`v0.18.0 Final Pre-Publish Proof`](release-0.18.0-final-prepublish-proof.md)
+- [`v0.18.0 Restored Coverage Proof`](release-0.18.0-restored-coverage-proof.md)
+- [`v0.18.0 Final Proof After Restored Coverage`](release-0.18.0-final-proof-after-restored-coverage.md)
+- [`v0.18.0 Pre-Release Readiness Handoff`](../handoffs/2026-05-17-0-18-pre-release-readiness.md)
+
+## Change Since Prior Final Proof
+
+#484 moved the `perfgate init` command implementation and benchmark-suggestion
+helpers out of `crates/perfgate-cli/src/main.rs` and into
+`crates/perfgate-cli/src/init.rs`. It preserved clap argument types, command
+dispatch, first-use benchmark suggestion behavior, receipt schemas, action
+behavior, and release state.
+
+Because #484 landed after the prior final proof and pre-release handoff, this
+audit reruns the full release-candidate proof from the post-#484 tree.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Version under test | `0.18.0` |
+| Commit under proof | `d87c1ee1ce4800cdb280341cbc862a1689030178` |
+| Target dir | default workspace `target/` |
+| Publishable crates | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+| Publication state | Pre-publish only; no crates were uploaded |
+
+## Command Proof
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 fmt --all -- --check` | Pass | Formatting check completed without changes. |
+| `cargo +1.95.0 check --workspace --all-targets --all-features --locked` | Pass | Workspace check completed after #484. |
+| `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings` | Pass | Workspace Clippy completed with warnings denied. |
+| `cargo +1.95.0 test --workspace --all-targets --all-features --locked` | Pass | Full workspace test suite passed after #484. |
+| `cargo +1.95.0 run -p xtask -- public-surface --strict` | Pass | Public-surface policy accounts for the five publishable packages. |
+| `cargo +1.95.0 run -p xtask -- arch` | Pass | Architecture dependency rules hold. |
+| `cargo +1.95.0 run -p xtask -- schema-compat` | Pass | 18 historical schema fixtures deserialize with current types. |
+| `cargo +1.95.0 run -p xtask -- action-check` | Pass | GitHub Action install, release asset, and failure diagnostic wiring are aligned. |
+| `cargo +1.95.0 run -p xtask -- docs-source-check` | Pass | Source-of-truth metadata, IDs, links, and active goal are valid. |
+| `cargo +1.95.0 run -p xtask -- product-claims-check` | Pass | Product claim proof map is valid. |
+| `cargo +1.95.0 run -p xtask -- docs-check` | Pass | Documentation drift check passed. |
+| `cargo +1.95.0 run -p xtask -- doc-test` | Pass | Checked 70 CLI examples and 36 structured snippets. |
+| `git diff --check` | Pass | Whitespace check passed. |
+
+## Non-Inferences
+
+- This does not publish `0.18.0` to crates.io.
+- This does not create `v0.18.0`.
+- This does not create a GitHub release or release assets.
+- This does not move `v0.18` or `v0`.
+- This does not prove public install from crates.io, cargo-binstall, or GitHub
+  release assets.
+- This does not close or archive the active release cutover goal.
+
+## Release Boundary
+
+The active 0.18.0 release cutover remains blocked only at explicit
+release-operator boundaries: crates.io publication, exact release tag, GitHub
+release/assets, intentional action alias movement, public install smoke, and
+publication closeout.

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -67,6 +67,9 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 481 | Badge refresh | merged | generated public badge endpoint data; no release-state change |
 | 477 | Nightly baseline/trend refresh | merged | generated baseline/trend data; no release-state change |
 | 482 | Final proof after restored coverage | merged | `docs/audits/release-0.18.0-final-proof-after-restored-coverage.md` |
+| 483 | Pre-release readiness handoff | merged | `docs/handoffs/2026-05-17-0-18-pre-release-readiness.md` |
+| 484 | CLI init module extraction | merged | `crates/perfgate-cli/src/init.rs`; no release-state change |
+| 485 | Final proof after init extraction | in review | `docs/audits/release-0.18.0-final-proof-after-init-extraction.md` |
 | 425 | Publish crates | blocked | crates.io publication in dependency order |
 | 426 | Verify crates.io publication | blocked | `cargo info` / `cargo search` registry proof |
 | 427 | Cut GitHub release | blocked | `v0.18.0`, GitHub release, release assets, checksums |


### PR DESCRIPTION
## Summary
- records the final 0.18.0 release-candidate proof after #484 extracted `perfgate init` into `crates/perfgate-cli/src/init.rs`
- updates release readiness and the cutover plan to point at the current-main proof
- preserves the release boundary: no crates published, no tags/releases/assets created, no aliases moved, no public install smoke claimed, and the active release goal remains open

## Validation
Broad proof run from current main commit `d87c1ee1ce4800cdb280341cbc862a1689030178` before this docs-only audit commit:
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 check --workspace --all-targets --all-features --locked`
- `cargo +1.95.0 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0 test --workspace --all-targets --all-features --locked`
- `cargo +1.95.0 run -p xtask -- public-surface --strict`
- `cargo +1.95.0 run -p xtask -- arch`
- `cargo +1.95.0 run -p xtask -- schema-compat`
- `cargo +1.95.0 run -p xtask -- action-check`
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

Post-edit docs gates:
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`