### PR TITLE
docs: add source-of-truth agent rails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Summary
+
+What changed?
+
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+What this PR explicitly does not do.
+
+## Proof
+
+```bash
+# commands run
+```
+
+## Results
+
+What passed? What failed? What could not run?
+
+## Claim boundary
+
+What may be claimed after this PR? What may not be claimed yet?
+
+## Rollback
+
+How can this PR be reverted safely?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,51 @@
 
 This file provides guidance to autonomous agents when working with code in this repository.
 
+## Repo Source-of-Truth Stack
+
+perfgate uses a linked source-of-truth stack:
+
+```text
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+```
+
+Read these before changing files:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.codex/goals/active.toml`
+3. The linked plan
+4. The linked spec
+5. Linked ADRs
+
+### Scope rule
+
+Implement one work item per PR. Docs-only artifacts are separate unless the
+linked plan explicitly says otherwise:
+
+- proposal PRs explain why;
+- spec PRs define behavior;
+- ADR PRs record durable decisions;
+- plan PRs define sequencing;
+- active goal PRs define current execution.
+
+Runtime/code PRs must link to the spec and plan item they implement.
+
+### Proof rule
+
+Run the proof commands listed in the selected plan item or active goal. If a
+proof command cannot run, record the command, why it was unavailable, any
+substitute evidence, and whether that blocks merge.
+
+### Generated status rule
+
+Do not hand-edit generated status. Run the generator or checker named in the
+plan.
+
+### Policy rule
+
+If you add an exception, update the relevant `policy/*.toml` ledger with owner,
+reason, coverage, creation date, review date, and expiry when temporary.
+
 ## Build and Test Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,35 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Repo Source-of-Truth Stack
+
+Before making changes, read:
+
+1. `AGENTS.md`
+2. `docs/reference/SPEC_SYSTEM.md`
+3. `.codex/goals/active.toml`
+4. The linked implementation plan
+5. The linked spec for the selected work item
+6. Any linked ADRs
+
+### Working rule
+
+Work on exactly one work item at a time. Do not create a new lane unless asked,
+do not broaden docs-only work into behavior changes, and do not claim success
+without proof commands or an explicit unavailable-proof note.
+
+### Completion rule
+
+A PR is ready only when the intended artifact or code change exists, linked docs
+are updated when required, claim boundaries are respected, and `git diff --check` passes.
+
+### Stop conditions
+
+Stop and report instead of guessing when the active goal is missing or stale,
+linked specs/plans/ADRs are missing, proof commands cannot run, generated
+status is dirty outside the selected work item, the requested work conflicts
+with an ADR, or the branch contains unrelated staged changes.
+
 ## Build and Test Commands
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Codex execution state stay reviewable.
 
 | Artifact | Owns | Location |
 |----------|------|----------|
+| Source-of-truth system | Artifact roles, agent workflow, proof rules, and stop conditions | [`reference/SPEC_SYSTEM.md`](reference/SPEC_SYSTEM.md) |
 | Proposal | Why a lane exists, who benefits, alternatives, and success criteria | [`proposals/`](proposals/) |
 | Spec | What behavior or proof contract must be true | [`specs/`](specs/) |
 | ADR | Durable architecture decisions | [`adr/`](adr/) |

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,213 @@
+# Repo source-of-truth system
+
+perfgate uses a linked source-of-truth stack so humans and agents can answer
+what truth lives where without reading chat history or treating stale prose as
+current state.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|----------|------|--------------|
+| Roadmap | Release direction, milestone framing, and lane selection | Detailed PR queue or proof receipts |
+| Proposal | Why a lane exists, users, surfaces, alternatives, risks, and success criteria | Behavior contracts or detailed PR order |
+| Spec | Required behavior, acceptance examples, proof, CI mapping, and claim boundaries | Product motivation or PR sequencing |
+| ADR | Durable architecture and operating decisions | Temporary task lists or current metrics |
+| Plan | PR order, work items, dependencies, proof commands, rollback, and handoff status | Product rationale or durable architecture decisions |
+| Active goal | Current machine-readable agent objective, active work items, proof commands, and claim boundaries | Generated status, policy exceptions, or new behavior |
+| Support tiers | Public claim support, limitations, proof, and next promotion requirements | Feature design or task sequencing |
+| Policy ledgers | Exceptions, governed surfaces, owners, reasons, coverage, and review dates | Broad architecture narratives |
+
+## Repository-specific locations
+
+| Truth | Source of truth |
+|-------|-----------------|
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What durable decision constrains the work? | `docs/adr/` and the historical `docs/adrs/` archive |
+| What PR lands next? | `plans/<milestone>/implementation-plan.md` or a lane-specific plan |
+| What is Codex actively executing? | `.codex/goals/active.toml` |
+| What proves public claims? | `docs/status/SUPPORT_TIERS.md`, `docs/status/PRODUCT_CLAIMS.md`, receipts, and CI |
+| What exceptions exist? | `policy/*.toml` and checked policy inventories |
+
+perfgate intentionally uses `.codex/goals/` for agent execution state because
+`.perfgate/` is reserved for product-generated user artifacts from
+`perfgate init` and related workflows.
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the linked plan explicitly says
+   otherwise.
+3. Proposals explain why; specs define behavior; ADRs record durable decisions.
+4. Plans sequence implementation and proof; they do not redefine specs.
+5. Active goals tell agents what to do now; they do not introduce new behavior.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require a support-tier row or an equivalent proof pointer.
+8. Policy exceptions require owner, reason, coverage, creation date, and review
+   date.
+9. Runtime/code PRs must link to the spec and plan item they implement.
+10. No claim is complete without a proof command or an explicit unavailable-proof
+    note.
+
+## Required metadata
+
+Proposal, spec, ADR, and plan headers are defined in their directory READMEs:
+
+- `docs/proposals/README.md`
+- `docs/specs/README.md`
+- `docs/adr/README.md`
+- `plans/README.md`
+
+Use `n/a` when a field is required but does not apply. Do not remove headers to
+avoid making an impact statement.
+
+## Agent workflow
+
+Agents must:
+
+1. Read `AGENTS.md` or tool-specific repo instructions.
+2. Read this file.
+3. Read `.codex/goals/active.toml`.
+4. Read the linked implementation plan.
+5. Read the linked proposal only for motivation.
+6. Read the linked spec for acceptance and proof.
+7. Read linked ADRs for constraints.
+8. Inspect `git status --short` before changing files.
+9. Pick exactly one ready work item.
+10. Implement only that work item.
+11. Run the proof commands listed by the plan or active goal.
+12. Update status, policy ledgers, receipts, or handoffs only when the selected
+    work item requires it.
+13. Commit one focused change and open a PR.
+
+If no ready work item exists, the correct result is a handoff or explicit
+blocked report, not invented scope.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing, stale, or contradictory;
+- linked proposal, spec, ADR, plan, status, or policy files do not exist;
+- the requested work conflicts with an ADR;
+- the branch contains unrelated staged changes;
+- generated status is dirty and the generator/checker is not part of the work
+  item;
+- proof commands cannot run and no substitute evidence is authorized;
+- a public claim lacks support-tier proof;
+- a policy exception lacks owner, reason, coverage, or review date.
+
+## Active goal lifecycle
+
+### Activate
+
+Create or update:
+
+```text
+.codex/goals/active.toml
+```
+
+The manifest should include the lane ID, status, owner, linked proposal, linked
+specs, linked ADRs, linked plan, objective, end state, work items, proof
+commands, and claim boundaries.
+
+### Pause
+
+Use a paused active manifest when no lane is selected:
+
+```toml
+status = "paused"
+reason = "No selected implementation lane."
+```
+
+### Archive
+
+Move completed or superseded manifests to:
+
+```text
+.codex/goals/archive/YYYY-MM-DD-<lane>.toml
+```
+
+Then create the next active manifest. Do not leave multiple active goals.
+
+## Closeout format
+
+At the end of a lane, write a closeout under the lane plan directory when the
+plan requires it:
+
+```text
+plans/<lane>/closeout.md
+```
+
+A closeout records what shipped, proof commands, receipts, PRs, CI runs,
+generated status, support-tier updates, policy updates, deferred work, claim
+boundaries, and the next lane recommendation.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<lane>/implementation-plan.md`; keep the spec focused
+on behavior, examples, acceptance, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move motivation to a proposal; keep the plan focused on work items, proof,
+dependencies, rollback, and handoff.
+
+### Active goal becomes prose
+
+Keep the manifest TOML-shaped and link out to docs. Do not copy generated
+status tables into it.
+
+### Agent hand-edits generated status
+
+Run the generator or checker named in the plan. If the command is unavailable,
+record the unavailable proof honestly.
+
+### Support claims drift
+
+Require support/status impact headers and update `docs/status/SUPPORT_TIERS.md`
+or `docs/status/PRODUCT_CLAIMS.md` when claims change.
+
+### Policy exceptions become silent debt
+
+Every exception must have an owner, reason, `covered_by`, `created`, and
+`review_after`; temporary exceptions should also have an expiry or removal plan.
+
+### Mega PR
+
+Split into one semantic artifact or one implementation work item per PR unless
+the active plan explicitly authorizes combining them.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer these questions from repo
+files alone:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+When the repo answers those questions without chat history, the source-of-truth
+system is working.


### PR DESCRIPTION
### Motivation

- Provide a single, machine- and human-readable source-of-truth for repo artifact roles and agent boot order so agents and contributors do not improvise or drift. 
- Make it explicit where to place proposals, specs, ADRs, plans, active goals, policy ledgers, and status proof so work items, proof commands, and claim boundaries are discoverable and enforceable.

### Description

- Add `docs/reference/SPEC_SYSTEM.md` describing the Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof stack, artifact roles, agent workflow, rules, stop conditions, and active-goal lifecycle.  
- Update `AGENTS.md` to require agents to read the new spec system and follow the one-work-item, proof-first, and no-hand-editing-generated-status rules.  
- Update `CLAUDE.md` with the same boot-order, working/stop rules, and completion conditions for Claude-based agents.  
- Link the new reference from `docs/README.md` and add a `.github/PULL_REQUEST_TEMPLATE.md` that requires source-of-truth links, scope, proof, claim boundary, and rollback notes.

### Testing

- Ran `cargo +1.95.0 run -p xtask -- docs-source-check`, which completed successfully.  
- Ran `cargo +1.95.0 run -p xtask -- docs-check`, which completed successfully.  
- Ran `cargo +1.95.0 run -p xtask -- doc-test`, which completed successfully.  
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a18904fb48333a1b248f1976133d2)