### PR TITLE
docs: define source-of-truth rail and agent execution guidance

### DIFF
--- a/.codex/goals/README.md
+++ b/.codex/goals/README.md
@@ -5,7 +5,8 @@ machine-readable pointers to the proposal, spec, plan, policy, proof commands,
 allowed files, forbidden files, and completion criteria for the active lane.
 
 Use `.codex/goals/active.toml` for the current goal and `.codex/goals/archive/`
-for completed or superseded manifests.
+for completed or superseded manifests. Read `docs/reference/SPEC_SYSTEM.md`
+before selecting or changing an active work item.
 
 Do not use `.perfgate/` for Codex goal state. `.perfgate/` is reserved for
 product-generated user artifacts from `perfgate init` and related workflows.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Summary
+
+What changed?
+
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+What this PR explicitly does not do.
+
+## Proof
+
+```text
+# commands run
+```
+
+## Results
+
+What passed? What failed? What could not run?
+
+## Claim boundary
+
+What may be claimed after this PR? What may not be claimed yet?
+
+## Rollback
+
+How can this PR be reverted safely?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,38 @@
 
 This file provides guidance to autonomous agents when working with code in this repository.
 
+## Repo source-of-truth stack
+
+perfgate uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Read these before changing files:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.codex/goals/active.toml`
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one work item per PR. Docs-only artifacts are separate PRs:
+proposals explain why, specs define behavior, ADRs record durable decisions,
+plans define sequencing, and active goals define current execution state.
+Runtime/code PRs must link to the spec and plan item they implement.
+
+Run the proof commands listed in the selected plan item. If proof cannot run,
+record the command, reason unavailable, substitute evidence if any, and whether
+that blocks merge. Do not hand-edit generated status; run the named generator or
+checker. If you add a policy exception, update the relevant `policy/*` ledger
+with owner, reason, coverage, creation date, and review date.
+
+Stop instead of guessing if the active goal is missing or stale, linked specs or
+plans are missing, proof commands cannot run, unrelated staged changes exist,
+work contradicts an ADR, or the request requires a new source-of-truth artifact
+that was not explicitly requested.
+
 ## Build and Test Commands
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,38 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Repo source-of-truth stack
+
+perfgate uses a linked source-of-truth stack:
+
+```text
+Roadmap -> Proposal -> Spec -> ADR -> Plan -> Active goal -> PR -> Proof
+```
+
+Read these before changing files:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.codex/goals/active.toml`
+3. The linked implementation plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one work item per PR. Docs-only artifacts are separate PRs:
+proposals explain why, specs define behavior, ADRs record durable decisions,
+plans define sequencing, and active goals define current execution state.
+Runtime/code PRs must link to the spec and plan item they implement.
+
+Run the proof commands listed in the selected plan item. If proof cannot run,
+record the command, reason unavailable, substitute evidence if any, and whether
+that blocks merge. Do not hand-edit generated status; run the named generator or
+checker. If you add a policy exception, update the relevant `policy/*` ledger
+with owner, reason, coverage, creation date, and review date.
+
+Stop instead of guessing if the active goal is missing or stale, linked specs or
+plans are missing, proof commands cannot run, unrelated staged changes exist,
+work contradicts an ADR, or the request requires a new source-of-truth artifact
+that was not explicitly requested.
+
 ## Build and Test Commands
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,12 @@ The stack separates why, what, how, what now, and what proves it.
 
 Existing topic docs remain valid. New governance and spec work should use these
 homes so product claims, policy gates, public surface rules, release proof, and
-Codex execution state stay reviewable.
+Codex execution state stay reviewable. The normative agent and contributor
+rail is [`reference/SPEC_SYSTEM.md`](reference/SPEC_SYSTEM.md).
 
 | Artifact | Owns | Location |
 |----------|------|----------|
+| Source-of-truth system | Artifact roles, agent boot order, stop conditions, and claim boundaries | [`reference/SPEC_SYSTEM.md`](reference/SPEC_SYSTEM.md) |
 | Proposal | Why a lane exists, who benefits, alternatives, and success criteria | [`proposals/`](proposals/) |
 | Spec | What behavior or proof contract must be true | [`specs/`](specs/) |
 | ADR | Durable architecture decisions | [`adr/`](adr/) |

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,201 @@
+# perfgate source-of-truth system
+
+perfgate uses a linked source-of-truth stack so humans and agents can find the
+right kind of truth without scraping chat history or treating stale notes as
+current state.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+| --- | --- | --- |
+| Roadmap | Release direction, milestone framing, and lane selection | PR queue or proof receipts |
+| Proposal | Why a lane exists, users, alternatives, risks, and success criteria | Behavior contracts or task lists |
+| Spec | Required behavior, acceptance, evidence, proof, and claim boundaries | PR sequencing or product rationale |
+| ADR | Durable architecture or operating decisions | Current task queues or metric state |
+| Plan | Work-item order, production deltas, proof commands, rollback, and blockers | Product motivation or durable decisions |
+| Active goal | Machine-readable current lane, work item, pointers, commands, and boundaries | Generated status or new behavior |
+| Support tiers | Public claim support, proof pointers, limitations, and promotion requirements | Feature design |
+| Policy ledgers | Exceptions, governed surfaces, owners, review dates, and coverage | Broad architecture rationale |
+| Handoffs | Closeout context, remaining work, and operator notes | Behavior contracts |
+
+## perfgate locations
+
+| Question | Source of truth |
+| --- | --- |
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What architecture decision did we make? | `docs/adr/` plus the historical `docs/adrs/` archive |
+| What PR lands next? | `plans/<milestone>/implementation-plan.md` or a linked work-item plan |
+| What is the agent actively executing? | `.codex/goals/active.toml` |
+| What proves product claims? | `docs/status/SUPPORT_TIERS.md`, `docs/status/PRODUCT_CLAIMS.md`, receipts, and CI proof |
+| What exceptions exist? | `policy/*.toml` and `policy/*.txt` ledgers |
+
+`.codex/goals/` is the active agent-control surface for this repository.
+`.perfgate/` is reserved for product-generated user artifacts and must not be
+used for Codex goal state.
+
+## Rules
+
+1. Keep one kind of truth per artifact.
+2. Prefer one semantic artifact per PR unless the plan explicitly says
+   otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier or product-claim proof.
+8. Policy exceptions require owner, reason, coverage, and review date.
+9. Proof commands must be run before claiming completion, or the unavailable
+   proof must be recorded explicitly.
+
+## Required metadata
+
+Every proposal, spec, ADR, and plan should start with a short metadata block.
+Use `n/a` or `none` when a field does not apply. Subdirectory READMEs define
+artifact-specific fields; source-of-truth artifacts should still declare these
+ideas somewhere in the header:
+
+```text
+Status:
+Owner:
+Created:
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Linked plan:
+Linked issues:
+Linked PRs:
+Support/status impact:
+Policy impact:
+Proof commands:
+```
+
+## Agent boot order
+
+Agents should begin with this sequence before changing files:
+
+1. Read `AGENTS.md`, `CLAUDE.md`, or other repo agent instructions.
+2. Read this file.
+3. Read `.codex/goals/active.toml`.
+4. Read the linked implementation plan.
+5. Read the linked proposal only for why.
+6. Read the linked spec for acceptance and proof.
+7. Read linked ADRs for constraints.
+8. Inspect `git status --short`.
+9. Pick exactly one ready work item.
+10. Implement only that work item.
+11. Run the listed proof commands and `git diff --check`.
+12. Update only the plan, status, policy, or receipts required by the work item.
+13. Open or update one focused PR.
+
+If no ready work item is identifiable, stop and write a handoff instead of
+inventing scope.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing, stale, or contradictory;
+- linked files do not exist;
+- generated status is dirty;
+- proof commands cannot run;
+- unrelated staged files exist;
+- requested work conflicts with an ADR;
+- the requested change would broaden public claims without support-tier proof;
+- a policy exception is needed but no policy ledger owner, reason, coverage,
+  and review date are available.
+
+## Active goal lifecycle
+
+Use exactly one active goal manifest:
+
+```text
+.codex/goals/active.toml
+```
+
+For a paused lane, set `status = "paused"` and include a reason. When replacing
+a lane, archive the old manifest under `.codex/goals/archive/` before creating a
+new active manifest.
+
+Active goals are TOML pointers and bounded execution state. They must not become
+long-form plans, generated status tables, or behavior specs.
+
+## Closeout format
+
+A completed lane should have a closeout or handoff that records:
+
+- what shipped;
+- proof commands and receipts;
+- PRs and CI runs;
+- generated status, support-tier, and policy updates;
+- what did not ship;
+- deferred work;
+- claim boundaries; and
+- the next lane recommendation.
+
+Closeout prevents the next agent from rediscovering old work.
+
+## Common failure modes
+
+### Spec becomes a task list
+
+Move PR order to `plans/<milestone>/implementation-plan.md` and keep the spec to
+behavior, examples, proof, and claim boundaries.
+
+### Plan becomes product rationale
+
+Move why to `docs/proposals/` and keep the plan to work items, dependencies,
+proof, and rollback.
+
+### Active goal becomes prose
+
+Keep `.codex/goals/active.toml` machine-readable and link out to prose docs.
+
+### Agent hand-edits generated status
+
+Run the generator or checker named in the plan. If it cannot run, record that as
+unavailable proof.
+
+### Support claims drift
+
+Require support/status impact in source-of-truth artifacts and map public claims
+to `docs/status/SUPPORT_TIERS.md` or `docs/status/PRODUCT_CLAIMS.md`.
+
+### Policy exceptions become silent debt
+
+Every exception needs an owner, reason, `covered_by` or equivalent coverage,
+`review_after`, and optional expiry.
+
+### Mega PR
+
+Split by semantic artifact or by one implementation work item per PR.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer from files alone:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the method is working.

--- a/docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md
+++ b/docs/specs/PERFGATE-SPEC-0001-source-of-truth-stack.md
@@ -44,6 +44,7 @@ claims, and closeout notes.
 
 | Truth | Source |
 |-------|--------|
+| Source-of-truth rail and agent boot order | `docs/reference/SPEC_SYSTEM.md` |
 | Why a lane exists | `docs/proposals/` |
 | Behavior and proof contract | `docs/specs/` |
 | Durable architecture decision | `docs/adr/` plus the historical `docs/adrs/` archive |
@@ -61,6 +62,8 @@ claims, and closeout notes.
 The stack MUST obey these duplicate-truth rules:
 
 - Proposals explain why. They MUST NOT contain the full PR checklist.
+- `docs/reference/SPEC_SYSTEM.md` defines the shared source-of-truth rail,
+  artifact roles, agent boot order, stop conditions, and closeout expectations.
 - Specs define behavior, evidence, non-goals, and proof. They MUST NOT copy
   policy ledger entries or release-readiness tables.
 - ADRs record durable architectural decisions. They MUST NOT own product


### PR DESCRIPTION
### Motivation

- Provide a single, normative repo rail that tells humans and agents where each kind of truth must live so work does not drift across READMEs and chat history.
- Make agent boot order, stop conditions, claim boundaries, and the active-goal lifecycle explicit so automated agents (Claude/Codex) and maintainers follow a clear one-work-item, proof-first workflow.

### Description

- Added `docs/reference/SPEC_SYSTEM.md` as the canonical source-of-truth rail documenting the stack, artifact roles, agent boot order, stop conditions, active-goal lifecycle, required metadata, and common failure modes.
- Updated agent-facing instructions in `AGENTS.md` and `CLAUDE.md` to require reading the rail and `.codex/goals/active.toml`, to enforce the one-work-item-per-PR rule, and to require running proof commands before claiming completion.
- Added a GitHub pull-request template at `.github/PULL_REQUEST_TEMPLATE.md` that includes source-of-truth links, scoped checkboxes, proof/results/claim-boundary, and rollback guidance.
- Linked the new reference rail from `docs/README.md`, clarified `.codex/goals/README.md`, and made a small cross-reference addition to `docs/specs/PERFGATE-SPEC-0001-...` so the spec and the reference rail point to each other.

### Testing

- Ran documentation validation and examples with `cargo +1.95.0 run -p xtask -- docs-check` and it passed.
- Validated CLI examples in docs with `cargo +1.95.0 run -p xtask -- doc-test` and it passed.
- Ran the source-of-truth structural checker with `cargo +1.95.0 run -p xtask -- docs-source-check` and it reported no errors for the updated scaffold.
- Ran `git diff --check` to ensure no whitespace or check failures and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a18904fb48333a1b248f1976133d2)