### PR TITLE
docs: add source-of-truth agent rails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Summary
+
+What changed?
+
+## Source-of-truth links
+
+Proposal:
+Spec:
+ADR:
+Plan item:
+Active goal:
+
+## Scope
+
+- [ ] Proposal / why
+- [ ] Spec / behavior contract
+- [ ] ADR / durable decision
+- [ ] Plan / sequencing
+- [ ] Active goal / current execution state
+- [ ] Runtime / implementation
+- [ ] Policy ledger
+- [ ] Support-tier or product-claim update
+- [ ] Generated status / receipt
+
+## Non-goals
+
+What this PR explicitly does not do.
+
+## Proof
+
+```bash
+# commands run
+```
+
+## Results
+
+What passed? What failed? What could not run?
+
+## Claim boundary
+
+What may be claimed after this PR? What may not be claimed yet?
+
+## Rollback
+
+How can this be reverted safely?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,32 @@
 # Agent Context: perfgate
 
+## Repo source-of-truth stack
+
+This repo uses a linked source-of-truth stack:
+
+Roadmap → Proposal → Spec → ADR → Plan → Active goal → PR → Proof
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.codex/goals/active.toml`
+3. The linked plan
+4. The linked spec
+5. Linked ADRs
+
+### Scope rule
+
+Implement one work item per PR unless the user explicitly asks to create or revise the source-of-truth rails. Docs-only artifacts stay separated by role: proposals explain why, specs define behavior, ADRs record durable decisions, plans define sequencing, and active goals define current execution. Runtime/code PRs must link to the spec and plan item they implement.
+
+### Proof rule
+
+Run the proof commands listed in the selected plan item. If a proof command cannot run, record the command, why it is unavailable, any substitute evidence, and whether that blocks merge. Always run `git diff --check` after edits.
+
+### Generated status and policy rule
+
+Do not hand-edit generated status. Run the generator/checker named in the plan. If you add a policy exception, update the relevant `policy/*` ledger with the owner, reason, coverage, creation date, review date, and expiry when the ledger supports those fields.
+
+
 This file provides guidance to autonomous agents when working with code in this repository.
 
 ## Build and Test Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # CLAUDE.md
 
+## Repo source-of-truth stack
+
+Before changing files, read:
+
+1. `docs/reference/SPEC_SYSTEM.md`
+2. `.codex/goals/active.toml`
+3. The linked implementation plan or lane plan
+4. The linked spec for the selected work item
+5. Any linked ADRs
+
+Work on exactly one work item at a time unless the user explicitly asks to create or revise the source-of-truth rails. Do not create a new lane, mix proposal/spec/ADR/plan/runtime changes, broaden support claims, or hand-edit generated status unless the selected work item says to. A PR is ready only when the intended artifact or code change exists, linked docs are updated, proof commands have run or are explicitly marked unavailable, claim boundaries are respected, and `git diff --check` passes.
+
+Stop and report instead of guessing when the active goal is missing or stale, linked specs are missing, proof commands cannot run, generated status differs from committed status, requested work conflicts with an ADR, or the branch contains unrelated staged changes.
+
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Build and Test Commands

--- a/docs/reference/SPEC_SYSTEM.md
+++ b/docs/reference/SPEC_SYSTEM.md
@@ -1,0 +1,210 @@
+# Repo source-of-truth system
+
+perfgate uses a linked source-of-truth stack so humans and agents can find the
+right owner for each kind of truth without scraping chat history or treating old
+plans as current behavior.
+
+## Stack
+
+```text
+Roadmap
+  -> Proposal
+    -> Spec
+      -> ADR
+        -> Implementation plan
+          -> Active goal
+            -> PR
+              -> Proof
+```
+
+## Artifact roles
+
+| Artifact | Owns | Does not own |
+|---|---|---|
+| Roadmap | Release direction and milestone framing | PR queue or generated metrics |
+| Proposal | Why, users, alternatives, success criteria | Behavior contract or detailed PR order |
+| Spec | Behavior, acceptance, proof, non-goals | PR sequence or active queue |
+| ADR | Durable decisions and consequences | Task list or current metric state |
+| Plan | PR order, work items, proof commands, rollback | Product rationale or durable architecture |
+| Active goal | Current machine-readable work and claim boundaries | Generated status or new product behavior |
+| Support tiers | Public claim proof and limitations | Feature design |
+| Policy ledgers | Exceptions and CI/policy receipts | Broad architecture |
+| Handoffs | Closeout context and remaining work | Behavior contracts |
+
+## Sources of truth
+
+| Question | Source |
+|---|---|
+| Why are we doing this? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What architecture decision constrains it? | `docs/adr/` and historical `docs/adrs/` |
+| What PR lands next? | `plans/<milestone>/implementation-plan.md` or a lane plan |
+| What is the agent actively executing? | `.codex/goals/active.toml` |
+| What proves a public claim? | `docs/status/SUPPORT_TIERS.md`, `docs/status/PRODUCT_CLAIMS.md`, receipts, and CI |
+| What exceptions exist? | `policy/*.toml` and policy text ledgers |
+
+## Rules
+
+1. One kind of truth per artifact.
+2. One semantic artifact per PR unless the selected plan item says otherwise.
+3. Specs define behavior; plans define sequencing.
+4. Proposals explain why; ADRs record durable decisions.
+5. Active goals tell agents what to do now.
+6. Generated status is updated by tools, not by hand.
+7. Public claims require support-tier or product-claim proof.
+8. Policy exceptions require an owner, reason, coverage, and review date when the ledger format supports them.
+9. Runtime/code PRs must link to the spec and plan item they implement.
+10. Do not broaden support claims without updating the proof surface that owns those claims.
+
+## Required headers
+
+Proposal, spec, ADR, and plan artifacts should use the required header set
+listed in their local README files:
+
+- `docs/proposals/README.md`
+- `docs/specs/README.md`
+- `docs/adr/README.md`
+- `plans/README.md`
+
+Use `n/a` when a field is not applicable. Existing historical artifacts may use
+legacy headers until a selected work item migrates them.
+
+## Agent workflow
+
+Agents must:
+
+1. Read `AGENTS.md` or `CLAUDE.md`.
+2. Read this file.
+3. Read `.codex/goals/active.toml`.
+4. Read the linked implementation plan or lane plan.
+5. Read the linked proposal only for motivation.
+6. Read the linked spec for acceptance and proof.
+7. Read linked ADRs for durable constraints.
+8. Inspect `git status --short` for unrelated work.
+9. Pick exactly one ready work item, unless the user explicitly requested a source-of-truth rail change.
+10. Implement only that item.
+11. Run the proof commands named by the selected plan item, plus `git diff --check`.
+12. Update receipts, status, support tiers, or policy ledgers only when the selected work item requires it.
+13. Stop and report rather than inventing a lane or broadening scope.
+
+## Stop conditions
+
+Stop and report instead of guessing when:
+
+- the active goal is missing or stale;
+- linked files do not exist;
+- the selected plan item is missing proof commands;
+- proof cannot run and no substitute evidence is available;
+- unrelated staged changes exist;
+- generated status differs from committed status;
+- requested work conflicts with an ADR;
+- a public claim lacks support-tier or product-claim proof;
+- the requested work requires a new proposal, spec, ADR, or lane and the user did not ask for that rail to be created.
+
+## Active goal lifecycle
+
+### Activate
+
+Use exactly one active manifest:
+
+```text
+.codex/goals/active.toml
+```
+
+Set:
+
+```toml
+status = "active"
+```
+
+### Pause
+
+Use a paused manifest only when there is deliberately no selected implementation
+lane:
+
+```toml
+status = "paused"
+reason = "No selected implementation lane."
+```
+
+### Archive
+
+Move old active goals to:
+
+```text
+.codex/goals/archive/<lane>.toml
+```
+
+Then create or update the new active manifest. Do not leave multiple active
+goals.
+
+## Closeout format
+
+At the end of a lane, write a handoff or closeout that answers:
+
+- what shipped;
+- proof commands and receipts;
+- PRs and CI runs;
+- generated status updates;
+- support-tier or policy updates;
+- what did not ship;
+- deferred work;
+- claim boundaries; and
+- the next lane recommendation.
+
+Use `docs/handoffs/` for closeout records unless a lane plan explicitly names a
+`plans/<lane>/closeout.md` file.
+
+## Common failure modes
+
+### Failure: spec becomes a task list
+
+Fix: move PR order to `plans/<lane>/implementation-plan.md` and keep the spec to
+behavior, examples, non-goals, and proof.
+
+### Failure: plan becomes product rationale
+
+Fix: move “why” to the proposal and keep the plan focused on work items,
+dependencies, proof, and rollback.
+
+### Failure: active goal becomes prose
+
+Fix: keep `.codex/goals/active.toml` machine-readable and link out to longer
+docs.
+
+### Failure: agent hand-edits generated status
+
+Fix: run the named generator/checker and record unavailable proof honestly.
+
+### Failure: support claims drift
+
+Fix: require support/status impact in source artifacts and update the status doc
+that owns the claim.
+
+### Failure: policy exceptions become silent debt
+
+Fix: every exception gets an owner, reason, coverage, and review date when the
+ledger supports those fields.
+
+### Failure: mega PR
+
+Fix: one semantic artifact or one implementation work item per PR unless the
+selected plan explicitly widens scope.
+
+## What good looks like
+
+A new contributor or agent can arrive cold and answer:
+
+```text
+What are we doing?
+Why?
+What must be true?
+What decision constrains it?
+What PR lands next?
+What command proves it?
+What may we claim?
+What must we not claim?
+```
+
+If the repo answers those questions without chat history, the source-of-truth
+system is working.


### PR DESCRIPTION
### Motivation

- Provide a single, discoverable repo-level guide that tells humans and agents where each kind of truth (why, what, decision, plan, active work, proof) must live. 
- Prevent agent and contributor drift by enforcing a small set of operating rules (first-read order, one-work-item-per-PR, proof commands, stop conditions). 

### Description

- Add `docs/reference/SPEC_SYSTEM.md` describing the source-of-truth stack, artifact roles, agent workflow, stop conditions, active-goal lifecycle, closeout format, and common failure-mode fixes. 
- Extend `AGENTS.md` with a Codex-facing first-read, scope, proof, generated-status, and policy-ledger rule set so implementers/agents know the one-item rule and proof expectations. 
- Extend `CLAUDE.md` with a Claude-facing first-read and completion/stop-condition guidance to keep multi-agent workflows on-rails. 
- Add `.github/PULL_REQUEST_TEMPLATE.md` to require source-of-truth links, scope checkboxes, proof commands, results, claim boundaries, and rollback notes for PRs. 
- No runtime or behavior changes were made; this is documentation and reviewer/agent guidance only. 

### Testing

- Ran the source-of-truth and documentation checks: `cargo +1.95.0 run -p xtask -- docs-source-check` and the command completed successfully. 
- Ran documentation drift and example validation: `cargo +1.95.0 run -p xtask -- docs-check` and `cargo +1.95.0 run -p xtask -- doc-test`, both completed successfully. 
- Ran repository formatting/consistency validation: `git diff --check` and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a18904fb48333a1b248f1976133d2)