### PR TITLE
docs: tighten 0.18 first-hour path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,21 +52,25 @@ action aliases, and public install smoke are recorded in the release closeout.
 
 ## Start Here
 
-From a repository with benchmark commands:
+From a repository root, use the smallest useful path first:
 
 ```bash
-perfgate init --ci github --profile standard
+perfgate doctor
+perfgate init --ci github --profile standard --suggest-benches
 perfgate doctor --config perfgate.toml
 perfgate check --config perfgate.toml --all
 perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
 git add perfgate.toml .github/workflows/perfgate.yml baselines/ .perfgate/
 ```
 
 For a concrete cold-start walkthrough, including expected files, artifacts,
 pass/fail behavior, and what to commit, see
-[`docs/FIRST_HOUR.md`](docs/FIRST_HOUR.md).
+[`docs/FIRST_HOUR.md`](docs/FIRST_HOUR.md). `--suggest-benches` appends
+commented benchmark candidates so benchmark choice stays reviewable; edit or
+replace them before promoting a baseline.
 
-`perfgate init --ci github --profile standard` creates:
+`perfgate init --ci github --profile standard --suggest-benches` creates:
 
 ```text
 perfgate.toml
@@ -76,7 +80,8 @@ baselines/.gitkeep
 ```
 
 The generated config defaults to local checked-in baselines and predictable
-artifacts:
+artifacts. Suggested benches are comments until you intentionally edit them
+into the config:
 
 ```toml
 [defaults]

--- a/docs/ADOPTION_LEVELS.md
+++ b/docs/ADOPTION_LEVELS.md
@@ -24,16 +24,20 @@ needs a local performance budget before CI or server setup.
 ### Commands
 
 ```bash
-perfgate init --ci github --profile standard
+perfgate doctor
+perfgate init --ci github --profile standard --suggest-benches
 perfgate doctor --config perfgate.toml
 perfgate check --config perfgate.toml --all
 perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
 ```
 
 ### Config
 
 Keep the first config boring: one benchmark, local baselines, and a budget wide
-enough to avoid making noise look like policy.
+enough to avoid making noise look like policy. `--suggest-benches` adds
+commented candidates; review and edit one into a real `[[bench]]` entry before
+promoting a baseline.
 
 ```toml
 [defaults]

--- a/docs/DEBUGGING_FIRST_CI_RUN.md
+++ b/docs/DEBUGGING_FIRST_CI_RUN.md
@@ -1,6 +1,7 @@
 # Debugging the First CI Run
 
-This guide covers the first run after `perfgate init --ci github --profile standard`.
+This guide covers the first run after
+`perfgate init --ci github --profile standard --suggest-benches`.
 
 ## Start Locally
 
@@ -17,6 +18,12 @@ If the check created a trusted first run, promote it into local baselines:
 perfgate baseline promote --config perfgate.toml --all
 ```
 
+Then prove the same baseline-required path locally:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
 Commit the generated baselines before expecting the generated GitHub workflow to
 pass with `require_baseline: "true"`.
 
@@ -30,6 +37,7 @@ If CI reports a missing baseline:
 ```bash
 perfgate check --config perfgate.toml --all
 perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
 ```
 
 Then commit `baselines/` and rerun CI.

--- a/docs/FIRST_HOUR.md
+++ b/docs/FIRST_HOUR.md
@@ -1,8 +1,10 @@
 # First Hour With perfgate
 
 This guide is for a cold user adding perfgate to an existing repository. It
-keeps the path small: install, initialize, run one local check, promote the
-first baseline, commit the durable files, and let CI reproduce the same gate.
+keeps the path small: install, check the environment, initialize with
+reviewable benchmark suggestions, run one local check, promote the first
+baseline, prove the CI-equivalent gate locally, commit the durable files, and
+let CI reproduce the same gate.
 
 You do not need the server, probes, scenarios, or structured decisions for this
 first hour.
@@ -33,7 +35,7 @@ perfgate doctor --help
 Run this from the repository root:
 
 ```bash
-perfgate init --ci github --profile standard
+perfgate init --ci github --profile standard --suggest-benches
 ```
 
 Expected new files:
@@ -46,7 +48,13 @@ baselines/.gitkeep
 ```
 
 Open `perfgate.toml` and replace the generated benchmark command with a real
-command for your project. Keep the first benchmark simple and deterministic.
+command for your project. `--suggest-benches` appends commented candidates for
+common repo shapes; they are suggestions, not policy. Keep the first benchmark
+simple and deterministic.
+
+Good first-hour benchmarks are usually fast, stable, and close to the workload
+you want to protect. Avoid making a compile-heavy command the first required
+gate until you have calibrated its noise.
 
 ## 3. Check The Setup
 
@@ -105,7 +113,19 @@ baselines/
 
 These files are the comparison point for future local and CI checks.
 
-## 6. Commit The Right Files
+## 6. Prove The CI-Equivalent Gate
+
+After promotion, run the same baseline-required check that the generated
+workflow will run:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+This is the point where a missing baseline becomes setup drift instead of a
+normal first-run condition. Fix setup drift before pushing the branch.
+
+## 7. Commit The Right Files
 
 Commit the durable setup and baseline:
 
@@ -129,7 +149,7 @@ Usually do not commit:
 - one-off decision bundles unless they are attached to a release, audit, issue,
   or review record on purpose
 
-## 7. Run CI
+## 8. Run CI
 
 Push the branch and let the generated GitHub workflow run. The workflow uses
 the repository action:
@@ -147,7 +167,7 @@ Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
 current compatible action tag until the `0.18.0` publication closeout moves
 the release aliases.
 
-## 8. Understand Pass And Fail
+## 9. Understand Pass And Fail
 
 A passing check means the current benchmark receipts are within configured
 budget policy relative to the committed baseline.
@@ -175,7 +195,7 @@ If the failure is a real intended performance change, rerun the benchmark
 enough times to trust the new result, then promote the new baseline in a
 separate, reviewable commit.
 
-## 9. Grow Later
+## 10. Grow Later
 
 After the basic gate is stable:
 

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -11,7 +11,7 @@ This guide shows a minimal GitHub Actions setup for `perfgate` with:
 Run this from the repository root:
 
 ```bash
-perfgate init --ci github --profile standard
+perfgate init --ci github --profile standard --suggest-benches
 ```
 
 This creates:
@@ -21,13 +21,18 @@ This creates:
 - `baselines/.gitkeep`
 - `.perfgate/README.md`
 
+`--suggest-benches` appends commented benchmark candidates. Review them, edit
+one into a real `[[bench]]`, and keep the first required gate simple until the
+signal is calibrated.
+
 The generated setup uses local in-repo baselines first. After a trusted local
-run, promote each first baseline and commit it:
+run, promote each first baseline and prove the CI-equivalent gate locally:
 
 ```bash
 perfgate check --config perfgate.toml --all
 perfgate baseline status --config perfgate.toml
 perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
 ```
 
 ## 2) Repository layout

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -97,7 +97,7 @@ handoff, see [`ADOPTION_LEVELS.md`](ADOPTION_LEVELS.md).
 Keep the local baseline path and make sure the normal gate is stable:
 
 ```bash
-perfgate init --ci github --profile standard
+perfgate init --ci github --profile standard --suggest-benches
 perfgate check --config perfgate.toml --all
 ```
 
@@ -105,6 +105,7 @@ Add baseline promotion after you trust the first run:
 
 ```bash
 perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
 ```
 
 ### 2) Decision mode

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -153,9 +153,11 @@ For the current first-run path, see the `Start Here` section in
 ```bash
 cargo binstall perfgate-cli
 perfgate doctor
-perfgate init --ci github --profile standard
+perfgate init --ci github --profile standard --suggest-benches
+perfgate doctor --config perfgate.toml
 perfgate check --config perfgate.toml --all
 perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
 ```
 
 For the structured-decision release proof, start from that generated setup and
@@ -166,7 +168,7 @@ change under review and writes compare receipts for `decision evaluate`:
 ```bash
 cargo binstall perfgate-cli
 perfgate doctor
-perfgate init --ci github --profile standard
+perfgate init --ci github --profile standard --suggest-benches
 perfgate doctor --config perfgate.toml
 perfgate check --config perfgate.toml --all
 perfgate baseline promote --config perfgate.toml --all
@@ -310,7 +312,8 @@ The **core local gating pipeline** is production-quality:
 
 - **Paved first-run setup** — `perfgate init --ci github --profile standard`
   writes `perfgate.toml`, `.github/workflows/perfgate.yml`,
-  `baselines/.gitkeep`, and `.perfgate/README.md`; `--preset` remains a
+  `baselines/.gitkeep`, and `.perfgate/README.md`; `--suggest-benches` appends
+  reviewable commented benchmark candidates, and `--preset` remains a
   compatibility alias.
 - **Baseline bootstrap UX** — `perfgate baseline status` and
   `perfgate baseline promote --all` cover the local-baseline path without


### PR DESCRIPTION
## Summary
- updates the first-hour path to start with `doctor`, `init --suggest-benches`, local `check`, baseline promotion, and a CI-equivalent `--require-baseline` confirmation
- clarifies that benchmark suggestions are commented, reviewable candidates rather than policy or auto-selected gates
- keeps advanced surfaces staged: structured decisions, probes, calibration, and ledger mode remain optional follow-ons; no release publication state changes

## Validation
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

## Release boundary
- Does not publish crates
- Does not create tags, GitHub release, or assets
- Does not move `v0.18` or `v0`
- Does not claim public install smoke
- Does not archive the active 0.18 release goal