### PR TITLE
docs: audit 0.18 install and action examples

### DIFF
--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -379,6 +379,11 @@ Enable decision mode in the repository action:
     review_required: "warn"
 ```
 
+`@v0` tracks the current public compatible action release. During the 0.18
+pre-publication state, do not pin `@v0.18` or `@v0.18.0` until the publication
+closeout records the exact tag, release assets, alias movement, and public
+install smoke.
+
 Decision mode runs `perfgate decision evaluate --config perfgate.toml` after
 `check`, uploads the decision artifacts, and appends `decision.md` to the job
 summary. If `check` exits `2` for a policy failure, the action can defer the

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -13,6 +13,7 @@ hardening, generated queue resolution, and the #484 init extraction. See
 [v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md),
 [v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md),
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
+[v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
 The current 0.18 cutover lane remains active. The earlier
@@ -88,6 +89,7 @@ publication by itself.
 | 0.18 final proof after restored coverage | Passing | [v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #480, #481, and #477 landed. |
 | 0.18 final proof after init extraction | Passing | [v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #484 extracted `perfgate init` into `crates/perfgate-cli/src/init.rs`. |
 | 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields against the current pre-publication candidate without publishing. |
+| 0.18 install/action examples | Covered | [v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md) verifies public install and action examples do not imply unpublished `0.18.0` crates, tags, release assets, aliases, or public install smoke. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 

--- a/docs/audits/release-0.18.0-install-action-example-audit.md
+++ b/docs/audits/release-0.18.0-install-action-example-audit.md
@@ -1,0 +1,55 @@
+# v0.18.0 Install And Action Example Audit
+
+Date: 2026-05-17
+
+Branch: `docs/0-18-install-action-audit`
+
+Purpose: verify that install and GitHub Action examples remain honest during
+the 0.18.0 pre-publication release-candidate state. This audit checks that
+public examples do not imply crates.io `0.18.0`, `v0.18.0`, `v0.18`, release
+assets, moved `v0`, or public install smoke before those release-operator
+steps happen.
+
+Linked proposal:
+[`PERFGATE-PROP-0004`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+Linked proof:
+
+- [`v0.18.0 Final Proof After Init Extraction`](release-0.18.0-final-proof-after-init-extraction.md)
+- [`v0.18.0 Publish Packet`](release-0.18.0-publish-packet.md)
+
+## Files Inspected
+
+| Surface | Finding |
+| --- | --- |
+| `README.md` | Install examples use public installer/source install paths while explicitly stating the latest public release is `v0.17.0` and `0.18.0` is not public yet. |
+| `docs/FIRST_HOUR.md` | First-hour install examples remain public-source examples and action guidance says `@v0.17.0`, `@v0.17`, and `@v0` are the current compatible public refs until the 0.18 publication closeout moves aliases. |
+| `docs/ADOPTION_LEVELS.md` | Action-level guidance keeps the same `@v0.17.0` / `@v0.17` / `@v0` release-state wording. |
+| `docs/GETTING_STARTED_GITHUB_ACTIONS.md` | Composite action examples pin `EffortlessMetrics/perfgate@v0.17.0` for exact public patch behavior. |
+| `docs/PERFORMANCE_DECISIONS.md` | Decision-mode action example uses `@v0` and now says it tracks the current public compatible action release until the 0.18 publication closeout moves aliases. |
+| `action.yml` | Optional `version` input example remains `0.17.0`; an empty version builds from the action source and does not claim crates.io `0.18.0` availability. |
+| `docs/RELEASE_READINESS.md` | Current publication state still says `v0.17.0` is latest public and that no public `0.18.0` crates, tags, GitHub release, action aliases, or public install smoke exist yet. |
+
+## Result
+
+The install and action examples are aligned with the current release state:
+
+- public install examples do not pin or claim `0.18.0`;
+- exact action examples use `@v0.17.0`;
+- moving action examples use `@v0` only with nearby wording that it follows the
+  current public compatible release;
+- `@v0.18` and `@v0.18.0` are not taught as public refs before release
+  execution;
+- public install smoke remains a blocked post-publication work item.
+
+## Non-Inferences
+
+- This audit does not publish crates.
+- This audit does not create `v0.18.0`.
+- This audit does not create a GitHub release or release assets.
+- This audit does not move `v0.18` or `v0`.
+- This audit does not prove public install from crates.io, cargo-binstall, or
+  GitHub release assets.
+- This audit does not close or archive the active release cutover goal.

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -72,6 +72,7 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 485 | Final proof after init extraction | merged | `docs/audits/release-0.18.0-final-proof-after-init-extraction.md` |
 | 490 | First-hour path tightening | merged | README and first-hour/action docs; no release-state change |
 | 491 | Publish packet/current-main sync | implemented | `docs/audits/release-0.18.0-publish-packet.md` |
+| 492 | Install/action example audit | implemented | `docs/audits/release-0.18.0-install-action-example-audit.md` |
 | 425 | Publish crates | blocked | crates.io publication in dependency order |
 | 426 | Verify crates.io publication | blocked | `cargo info` / `cargo search` registry proof |
 | 427 | Cut GitHub release | blocked | `v0.18.0`, GitHub release, release assets, checksums |


### PR DESCRIPTION
## Summary
- adds an audit proving install and action examples do not imply unpublished 0.18 public artifacts
- clarifies the decision-mode `@v0` action example during the 0.18 pre-publication state
- updates release readiness and the cutover plan with the audit pointer

## Validation
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

## Release boundary
- Does not publish crates
- Does not create tags, GitHub release, or assets
- Does not move `v0.18` or `v0`
- Does not claim public install smoke
- Does not archive the active 0.18 release goal