### PR TITLE
docs(handoff): close 0.18 release-candidate readiness

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -14,6 +14,7 @@ hardening, generated queue resolution, and the #484 init extraction. See
 [v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md),
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
 [v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md),
+[v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
 The current 0.18 cutover lane remains active. The earlier
@@ -90,6 +91,7 @@ publication by itself.
 | 0.18 final proof after init extraction | Passing | [v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #484 extracted `perfgate init` into `crates/perfgate-cli/src/init.rs`. |
 | 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields against the current pre-publication candidate without publishing. |
 | 0.18 install/action examples | Covered | [v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md) verifies public install and action examples do not imply unpublished `0.18.0` crates, tags, release assets, aliases, or public install smoke. |
+| 0.18 release-candidate readiness closeout | Ready | [v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md) records that the unreleased release candidate is ready while publication remains operator-gated. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 

--- a/docs/handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md
+++ b/docs/handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md
@@ -1,0 +1,96 @@
+# 0.18.0 Release-Candidate Readiness Closeout
+
+Status: release candidate ready; publication still operator-gated
+Owner: perfgate maintainers
+Created: 2026-05-18
+Milestone: 0.18.0
+Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
+Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+Linked policy: [`public_crates.txt`](../../policy/public_crates.txt), [`absorbed_crates.txt`](../../policy/absorbed_crates.txt)
+Support/status impact: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`PRODUCT_CLAIMS.md`](../status/PRODUCT_CLAIMS.md), and [`release-0.18.0-publish-packet.md`](../audits/release-0.18.0-publish-packet.md)
+Proof commands: docs-check; doc-test; docs-source-check; product-claims-check; git diff --check
+
+## Summary
+
+The 0.18 release candidate is ready as an unreleased candidate. The repo now
+records fresh proof after the `init.rs` extraction, tightened first-hour user
+path guidance, current-main publish-packet instructions, install/action example
+truth, and product-claim links to the latest proof.
+
+This closeout does not close the publication lane. `.codex/goals/active.toml`
+remains active with `current_work_item = "release-operator-gated-publication"`.
+The only remaining release work is explicit release-operator execution.
+
+## What Is Ready
+
+- First-use docs teach the paved path: `doctor`, `init --suggest-benches`,
+  `check`, `baseline promote`, `check --require-baseline`, then GitHub Action
+  wiring.
+- Benchmark suggestions are described as commented, reviewable candidates, not
+  auto-selected policy.
+- Setup and missing-baseline states remain distinct from regressions.
+- Direction-aware metric semantics are documented so users can tell why higher
+  throughput is good while higher latency is bad.
+- The publish packet records the five-crate order, exact publish commands,
+  registry verification commands, stop conditions, partial-publish handling,
+  and tag/alias policy.
+- Product claims link to the final proof after init extraction, install/action
+  audit, canaries, tests, and support boundaries without claiming public
+  `0.18.0` availability.
+
+## Proof Records
+
+- [`v0.18.0 Publish Readiness Proof`](../audits/release-0.18.0-publish-readiness.md)
+- [`v0.18.0 Staged Release Artifact Smoke`](../audits/release-0.18.0-artifact-smoke.md)
+- [`v0.18.0 Final Pre-Publish Proof`](../audits/release-0.18.0-final-prepublish-proof.md)
+- [`v0.18.0 Restored Coverage Proof`](../audits/release-0.18.0-restored-coverage-proof.md)
+- [`v0.18.0 Final Proof After Restored Coverage`](../audits/release-0.18.0-final-proof-after-restored-coverage.md)
+- [`v0.18.0 Final Proof After Init Extraction`](../audits/release-0.18.0-final-proof-after-init-extraction.md)
+- [`v0.18.0 Install And Action Example Audit`](../audits/release-0.18.0-install-action-example-audit.md)
+- [`v0.18.0 Publish Packet`](../audits/release-0.18.0-publish-packet.md)
+
+The final broad proof after init extraction passed fmt, workspace check,
+Clippy, workspace tests, public-surface, arch, schema-compat, action-check,
+docs-source-check, product-claims-check, docs-check, doc-test, and
+`git diff --check`.
+
+## Queue State
+
+At closeout, no release-candidate PR is intentionally left open. Generated
+baseline/trend refresh #494 was closed instead of merged because it would have
+changed `main` after the final proof and publish-packet sync. A scheduled run
+can regenerate that data after publication or after an explicitly refreshed
+proof.
+
+## Remaining Operator-Gated Work
+
+1. Publish the five public crates in dependency order.
+2. Verify crates.io publication for all five crates at `0.18.0`.
+3. Create the exact `v0.18.0` GitHub release with assets and checksums.
+4. Move `v0.18` only after release proof.
+5. Decide whether `v0` should move to `0.18.0`.
+6. Run public install smoke from public artifacts.
+7. Close publication with a public-state audit and archived active goal.
+
+## What Not To Infer
+
+- `0.18.0` is not published to crates.io.
+- `v0.18.0` does not exist as a release tag from this closeout.
+- No GitHub release or release assets are created here.
+- `v0.18` and `v0` are not moved here.
+- Public install smoke from crates.io, cargo-binstall, or GitHub release assets
+  has not run for `0.18.0`.
+- The active release goal is not archived here.
+
+## Next Operator Notes
+
+Start from these files:
+
+- [`release-0.18.0-publish-packet.md`](../audits/release-0.18.0-publish-packet.md)
+- [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+- [`.codex/goals/active.toml`](../../.codex/goals/active.toml)
+
+If any publish command fails, stop before tags, releases, aliases, or public
+smoke and record the partial public state before repairing forward.

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -74,6 +74,8 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 491 | Publish packet/current-main sync | implemented | `docs/audits/release-0.18.0-publish-packet.md` |
 | 492 | Install/action example audit | implemented | `docs/audits/release-0.18.0-install-action-example-audit.md` |
 | 493 | Product claims readiness sync | implemented | `docs/status/PRODUCT_CLAIMS.md` |
+| 494 | Generated baseline/trend refresh | closed | closed to preserve the current RC proof boundary; scheduled job can regenerate |
+| 495 | Release-candidate readiness closeout | implemented | `docs/handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md` |
 | 425 | Publish crates | blocked | crates.io publication in dependency order |
 | 426 | Verify crates.io publication | blocked | `cargo info` / `cargo search` registry proof |
 | 427 | Cut GitHub release | blocked | `v0.18.0`, GitHub release, release assets, checksums |


### PR DESCRIPTION
## Summary
- adds the 0.18 release-candidate readiness closeout without closing the publication lane
- records what is ready, which proof records support it, which generated PR was closed to preserve proof boundaries, and what remains operator-gated
- updates release readiness and the cutover plan with the closeout pointer

## Validation
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- doc-test`
- `git diff --check`

## Release boundary
- Does not publish crates
- Does not create tags, GitHub release, or assets
- Does not move `v0.18` or `v0`
- Does not claim public install smoke
- Does not archive `.codex/goals/active.toml`; publication remains operator-gated