### PR TITLE
release: sync 0.18 rc operator pointers

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,8 +1,9 @@
 # Release Readiness
 
-Last verified: 2026-05-17 for v0.17.0 publication reconciliation and the
+Last verified: 2026-05-18 for v0.17.0 publication reconciliation and the
 0.18.0 release-candidate cutover proof after restored post-SRP coverage
-hardening, generated queue resolution, and the #484 init extraction. See
+hardening, generated queue resolution, the #484 init extraction, install/action
+example audit, product-claim sync, and release-candidate readiness closeout. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),

--- a/docs/audits/release-0.18.0-publish-packet.md
+++ b/docs/audits/release-0.18.0-publish-packet.md
@@ -1,11 +1,12 @@
 # v0.18.0 Publish Packet
 
-Date: 2026-05-17
+Date: 2026-05-18
 
-Branch: `release/0-18-publish-packet-sync`
+Branch: `main` after the release-candidate pointer-sync PR merges
 
-Prepared from main state: through #490
-(`1d8e3e581451cf75c79e60491115f31ab9523858`) plus this packet-sync PR.
+Prepared from main state: through #495
+(`c4a8e16afc33a38f4ee431d49bceeba6ca4bde65`) plus this
+release-candidate pointer-sync PR.
 The release operator must publish from the pulled `main` commit that contains
 this packet, and must record that exact `git rev-parse HEAD` value in the
 publication audit.
@@ -28,6 +29,8 @@ Linked proof:
 - [`v0.18.0 Restored Coverage Proof`](release-0.18.0-restored-coverage-proof.md)
 - [`v0.18.0 Final Proof After Restored Coverage`](release-0.18.0-final-proof-after-restored-coverage.md)
 - [`v0.18.0 Final Proof After Init Extraction`](release-0.18.0-final-proof-after-init-extraction.md)
+- [`v0.18.0 Install And Action Example Audit`](release-0.18.0-install-action-example-audit.md)
+- [`v0.18.0 Release-Candidate Readiness Closeout`](../handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md)
 
 Current-main sync notes:
 
@@ -36,8 +39,13 @@ Current-main sync notes:
 - #490 tightened the first-hour user path to show `doctor`,
   `init --suggest-benches`, local `check`, baseline promotion, and the
   CI-equivalent `check --require-baseline` confirmation.
+- #492 audited install/action examples so public refs do not imply unpublished
+  `0.18.0` crates, tags, aliases, assets, or public install smoke.
+- #493 synced product claims to the final proof and readiness boundaries.
+- #495 closed release-candidate readiness while leaving the publication lane
+  active at release-operator-gated publication.
 - No crates were published, no tags or releases were created, no aliases moved,
-  and no public install smoke was claimed by either PR.
+  and no public install smoke was claimed by these PRs.
 
 ## Release Boundary
 

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -76,6 +76,7 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 493 | Product claims readiness sync | implemented | `docs/status/PRODUCT_CLAIMS.md` |
 | 494 | Generated baseline/trend refresh | closed | closed to preserve the current RC proof boundary; scheduled job can regenerate |
 | 495 | Release-candidate readiness closeout | implemented | `docs/handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md` |
+| 496 | Release-candidate pointer sync | implemented | release readiness and publish packet point at #495/current RC state |
 | 425 | Publish crates | blocked | crates.io publication in dependency order |
 | 426 | Verify crates.io publication | blocked | `cargo info` / `cargo search` registry proof |
 | 427 | Cut GitHub release | blocked | `v0.18.0`, GitHub release, release assets, checksums |


### PR DESCRIPTION
## Summary
- update release readiness last-verified text to include the May 18 RC closeout
- refresh publish packet prepared-through references from #490 to #495/current RC state
- record the pointer-sync PR in the release cutover plan

## Validation
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check

No crates published; no tags, releases, aliases, or public install smoke claimed.