### PR TITLE
release: close 0.18.0 publication

### DIFF
--- a/.codex/goals/archive/perfgate-0-18-release-cutover.toml
+++ b/.codex/goals/archive/perfgate-0-18-release-cutover.toml
@@ -1,11 +1,13 @@
 id = "perfgate-0-18-release-cutover"
 title = "perfgate 0.18.0 release cutover and public install proof"
-status = "active"
+status = "completed"
 owner = "codex"
 created = "2026-05-14"
+completed = "2026-05-18"
 milestone = "0.18.0"
-current_work_item = "release-operator-gated-publication"
-current_pr = "release: publish 0.18.0 crates"
+current_work_item = "none"
+current_pr = "complete"
+archive_reason = "perfgate 0.18.0 was published to crates.io, tagged, released with assets and checksums, mapped to v0.18 and v0 action aliases, smoke-tested from public artifacts, and closed with publication proof."
 
 objective = """
 Cut perfgate 0.18.0 with no ambiguity. The repo must
@@ -234,8 +236,8 @@ commands = [
 
 [[work_item]]
 id = "release-operator-gated-publication"
-status = "current"
-blocked_by = "explicit release-operator approval"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -254,8 +256,8 @@ commands = [
 
 [[work_item]]
 id = "publish-crates"
-status = "blocked"
-blocked_by = "explicit release-operator approval and publish-packet"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -269,8 +271,8 @@ commands = [
 
 [[work_item]]
 id = "verify-crates-publication"
-status = "blocked"
-blocked_by = "publish-crates"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -285,8 +287,8 @@ commands = [
 
 [[work_item]]
 id = "cut-github-release"
-status = "blocked"
-blocked_by = "explicit release-operator approval and verify-crates-publication"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -298,8 +300,8 @@ commands = [
 
 [[work_item]]
 id = "move-v0-18-alias"
-status = "blocked"
-blocked_by = "explicit release-operator approval and cut-github-release"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -310,8 +312,8 @@ commands = [
 
 [[work_item]]
 id = "move-v0-default-alias"
-status = "blocked"
-blocked_by = "explicit release-operator approval and move-v0-18-alias"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -322,8 +324,8 @@ commands = [
 
 [[work_item]]
 id = "public-install-smoke"
-status = "blocked"
-blocked_by = "verify-crates-publication and cut-github-release and move-v0-18-alias"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"
@@ -339,8 +341,8 @@ commands = [
 
 [[work_item]]
 id = "publication-closeout"
-status = "blocked"
-blocked_by = "public-install-smoke"
+status = "completed"
+blocked_by = ""
 proposal = "docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md"
 spec = "docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md"
 plan = "plans/0.18.0/release-cutover.md"

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ perfgate --version
 perfgate doctor --help
 ```
 
-Current public release: `v0.17.0`. The `0.18.0` source tree has release-candidate
-proof in progress, but it is not public until crates, tags, release assets,
-action aliases, and public install smoke are recorded in the release closeout.
+Current public release: `v0.18.0`. The five public crates, GitHub release
+assets, `v0.18`, and `v0` action aliases are published for 0.18.0.
 
 ## Start Here
 
@@ -110,9 +109,8 @@ The generated GitHub workflow uses the repository action:
     upload_artifact: "true"
 ```
 
-Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
-current compatible action tag until the `0.18.0` publication closeout moves
-the release aliases.
+Use `@v0.18.0` for an exact patch pin, `@v0.18` for the current 0.18 line, or
+`@v0` to follow the current compatible action tag.
 
 ## Performance Decisions
 

--- a/docs/ADOPTION_LEVELS.md
+++ b/docs/ADOPTION_LEVELS.md
@@ -112,9 +112,8 @@ The generated workflow calls the repository action:
     upload_artifact: "true"
 ```
 
-Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
-current compatible action tag until the `0.18.0` publication closeout moves
-the release aliases.
+Use `@v0.18.0` for an exact patch pin, `@v0.18` for the current 0.18 line, or
+`@v0` to follow the current compatible action tag.
 
 ### Artifacts
 

--- a/docs/FIRST_HOUR.md
+++ b/docs/FIRST_HOUR.md
@@ -163,9 +163,8 @@ the repository action:
     upload_artifact: "true"
 ```
 
-Use `@v0.17.0` for an exact patch pin, or `@v0.17` / `@v0` to follow the
-current compatible action tag until the `0.18.0` publication closeout moves
-the release aliases.
+Use `@v0.18.0` for an exact patch pin, `@v0.18` for the current 0.18 line, or
+`@v0` to follow the current compatible action tag.
 
 ## 9. Understand Pass And Fail
 

--- a/docs/GETTING_STARTED_GITHUB_ACTIONS.md
+++ b/docs/GETTING_STARTED_GITHUB_ACTIONS.md
@@ -78,7 +78,7 @@ jobs:
 
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.17.0
+        uses: EffortlessMetrics/perfgate@v0.18.0
         with:
           config: perfgate.toml
           all: "true"
@@ -90,8 +90,8 @@ Omit `out_dir` to let the action use `[defaults].out_dir` from
 `perfgate.toml`. Set `out_dir` only when the workflow should override the
 config.
 
-Use `@v0.17.0` when you want an exact patch pin. If you prefer a moving tag,
-the published action aliases `@v0.17` and `@v0` now track the current
+Use `@v0.18.0` when you want an exact patch pin. If you prefer a moving tag,
+the published action aliases `@v0.18` and `@v0` now track the current
 compatible release.
 
 Action outputs are available as:
@@ -114,7 +114,7 @@ comment, opt in to decision mode:
 ```yaml
       - name: Run perfgate
         id: perfgate
-        uses: EffortlessMetrics/perfgate@v0.17.0
+        uses: EffortlessMetrics/perfgate@v0.18.0
         with:
           config: perfgate.toml
           all: "true"

--- a/docs/PERFORMANCE_DECISIONS.md
+++ b/docs/PERFORMANCE_DECISIONS.md
@@ -379,10 +379,8 @@ Enable decision mode in the repository action:
     review_required: "warn"
 ```
 
-`@v0` tracks the current public compatible action release. During the 0.18
-pre-publication state, do not pin `@v0.18` or `@v0.18.0` until the publication
-closeout records the exact tag, release assets, alias movement, and public
-install smoke.
+`@v0` tracks the current public compatible action release. Use `@v0.18.0` for
+an exact 0.18 patch pin or `@v0.18` for the current 0.18 release line.
 
 Decision mode runs `perfgate decision evaluate --config perfgate.toml` after
 `check`, uploads the decision artifacts, and appends `decision.md` to the job

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,9 +1,9 @@
 # Release Readiness
 
-Last verified: 2026-05-18 for v0.17.0 publication reconciliation and the
-0.18.0 release-candidate cutover proof after restored post-SRP coverage
-hardening, generated queue resolution, the #484 init extraction, install/action
-example audit, product-claim sync, and release-candidate readiness closeout. See
+Last verified: 2026-05-18 for v0.18.0 publication, public install smoke,
+release-candidate proof after restored post-SRP coverage hardening, generated
+queue resolution, the #484 init extraction, install/action example audit,
+product-claim sync, and release-candidate readiness closeout. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
@@ -16,45 +16,43 @@ example audit, product-claim sync, and release-candidate readiness closeout. See
 [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md),
 [v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md),
 [v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md),
+[v0.18.0 Public Install Smoke](audits/release-0.18.0-public-install-smoke.md),
+[v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
-The current 0.18 cutover lane remains active. The earlier
+The 0.18 cutover lane is closed. The earlier
 [v0.18.0 Deferral Closeout](audits/release-0.18.0-deferral-closeout.md)
 is superseded because it correctly verified public state but incorrectly
 archived the lane before publication. The earlier cutover decision is recorded
 in [v0.18.0 Cutover Decision](audits/release-0.18.0-cutover-decision.md).
 
-Latest published release: v0.17.0. The five allowed crates are published on
-crates.io at `0.17.0`, the GitHub release `v0.17.0` is published with platform
-archives and `sha256sums.txt`, and action alias tags `v0.17` and `v0` point to
-the same release commit as `v0.17.0`.
+Latest published release: v0.18.0. The five allowed crates are published on
+crates.io at `0.18.0`, the GitHub release `v0.18.0` is published with platform
+archives and `sha256sums.txt`, and action alias tags `v0.18` and `v0` peel to
+the same release commit as `v0.18.0`.
 
 ## Current Published Release Snapshot
 
-The current published release is `v0.17.0`. It keeps the five-crate public
-surface from v0.16.0, raises the Rust floor to 1.95, and adds the governance
-rails that make the release conveyor explicit.
+The current published release is `v0.18.0`. It keeps the five-crate public
+surface, keeps Rust 1.95 as the governed MSRV, and ships the 0.18 adoption,
+decision, signal, wrapper-absorption, first-use, SRP, metric-direction,
+coverage, and release-proof work through the normal public install path.
 
-The 0.18.0 release-candidate proof records are pre-release records, not
-publication records. They document wrapper absorption, first-hour smoke proof,
+The 0.18.0 release records include wrapper absorption, first-hour smoke proof,
 structured-decision bundle proof, checked action failure examples, optional
 server-ledger operations smoke, external canaries, publish dry-runs for all five
-public crates, and staged Windows archive smoke. No public `0.18.0` crates,
-tags, GitHub release, action aliases, or public install smoke exist yet. The
-active release cutover lane has refreshed final release-candidate proof after
-the #484 init extraction and is now waiting at release-operator-gated
-publication. The operator packet is prepared, but it does not authorize
-publication by itself.
+public crates, staged Windows archive smoke, exact GitHub release assets,
+action alias movement, and public install smoke from public artifacts.
 
 ## Current Publication State
 
 | Surface | Status | Evidence |
 |---------|--------|----------|
-| crates.io packages | Published | The crates.io sparse index contains `0.17.0` entries for `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, and `perfgate-cli`. |
-| Exact release tag | Published | GitHub tag `v0.17.0` points to commit `71bdc33117d515d95885deb2d9350d9d67905265`. |
-| Action alias tags | Published | GitHub tags `v0.17` and `v0` also point to commit `71bdc33117d515d95885deb2d9350d9d67905265`. |
-| GitHub release | Published | GitHub release `v0.17.0` was published on 2026-05-12 with platform archives and `sha256sums.txt`. |
-| Public install smoke | Passing | `cargo +1.95.0 install perfgate-cli --version 0.17.0 --locked --root C:/perfgate-smoke/release-reconcile-0170 --force`; installed binary reported `perfgate 0.17.0` and `perfgate doctor --help` printed help. |
+| crates.io packages | Published | The crates.io index resolves `0.18.0` for `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, and `perfgate-cli`. |
+| Exact release tag | Published | GitHub tag `v0.18.0` peels to commit `f4f40dc5374ef3f389ea530e373da1c3e573bfe8`. |
+| Action alias tags | Published | GitHub tags `v0.18` and `v0` peel to commit `f4f40dc5374ef3f389ea530e373da1c3e573bfe8`. Alias-triggered release workflows were intentionally cancelled after the exact release workflow succeeded. |
+| GitHub release | Published | GitHub release `v0.18.0` was published on 2026-05-18 with six platform archives and `sha256sums.txt`. |
+| Public install smoke | Passing | `cargo binstall perfgate-cli --version 0.18.0` installed the public Windows archive; installed binary reported `perfgate 0.18.0` and completed doctor/init/check/promote/require-baseline smoke. |
 
 ## Release Proof Matrix
 
@@ -73,7 +71,7 @@ publication by itself.
 | Publish dry-run proof | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` |
 | Publish dry-run matrix | Passing | `cargo run -p xtask -- publish-check --dry-run --package perfgate-types`, `cargo run -p xtask -- publish-check --dry-run --package perfgate`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-client`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-server`, `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` |
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
-| Install smoke proof | Passing | Public registry install smoke passed with `cargo +1.95.0 install perfgate-cli --version 0.17.0 --locked --root C:/perfgate-smoke/release-reconcile-0170 --force`; installed binary reported `perfgate 0.17.0` and `perfgate doctor --help` printed help |
+| Install smoke proof | Passing | Public install smoke passed with `cargo binstall perfgate-cli --version 0.18.0`; installed binary reported `perfgate 0.18.0` and completed doctor/init/check/promote/require-baseline smoke |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |
 | Documentation examples | Passing | `cargo run -p xtask -- docs-check` and `cargo run -p xtask -- doc-test` |
 | Structured decision end-to-end | Verified | `perfgate ingest probes`, `perfgate decision evaluate`, `perfgate decision bundle` on `examples/performance-decision`, plus `perfgate serve --no-open` and `decision upload/history/debt/prune --dry-run` |
@@ -90,9 +88,11 @@ publication by itself.
 | 0.18 restored coverage proof | Passing | [v0.18.0 Restored Coverage Proof](audits/release-0.18.0-restored-coverage-proof.md) restores #473-#475 coverage hardening onto current `main` and reruns fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks. |
 | 0.18 final proof after restored coverage | Passing | [v0.18.0 Final Proof After Restored Coverage](audits/release-0.18.0-final-proof-after-restored-coverage.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #480, #481, and #477 landed. |
 | 0.18 final proof after init extraction | Passing | [v0.18.0 Final Proof After Init Extraction](audits/release-0.18.0-final-proof-after-init-extraction.md) reran fmt, check, Clippy, test, public-surface, arch, schema, action, source-doc, product-claim, docs, doc-test, and diff checks after #484 extracted `perfgate init` into `crates/perfgate-cli/src/init.rs`. |
-| 0.18 publish packet | Prepared | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields against the current pre-publication candidate without publishing. |
-| 0.18 install/action examples | Covered | [v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md) verifies public install and action examples do not imply unpublished `0.18.0` crates, tags, release assets, aliases, or public install smoke. |
-| 0.18 release-candidate readiness closeout | Ready | [v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md) records that the unreleased release candidate is ready while publication remains operator-gated. |
+| 0.18 publish packet | Completed | [v0.18.0 Publish Packet](audits/release-0.18.0-publish-packet.md) records the release-operator command packet, publish order, stop conditions, partial-publish handling, and verification fields used for publication. |
+| 0.18 install/action examples | Superseded | [v0.18.0 Install And Action Example Audit](audits/release-0.18.0-install-action-example-audit.md) covered pre-publication docs; public docs now point at `v0.18.0`, `v0.18`, and `v0`. |
+| 0.18 release-candidate readiness closeout | Superseded | [v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md) is superseded by the publication closeout. |
+| 0.18 public install smoke | Passing | [v0.18.0 Public Install Smoke](audits/release-0.18.0-public-install-smoke.md) installed `perfgate-cli` 0.18.0 from public GitHub release assets via `cargo binstall` and proved doctor/init/check/promote/require-baseline. |
+| 0.18 publication closeout | Published | [v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md) records crates, tags, GitHub release assets, checksums, aliases, public install smoke, and non-inferences. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
@@ -106,8 +106,8 @@ perfgate-client
 perfgate-server
 ```
 
-Required release proof commands for the current 0.18.0 release candidate (run
-without `--allow-dirty`):
+Required release proof commands for future patch release candidates should be
+run without `--allow-dirty`:
 
 ```bash
 cargo run -p xtask -- public-surface --strict

--- a/docs/audits/release-0.18.0-public-install-smoke.md
+++ b/docs/audits/release-0.18.0-public-install-smoke.md
@@ -1,0 +1,78 @@
+# v0.18.0 Public Install Smoke
+
+Date: 2026-05-18
+Source commit: `f4f40dc5374ef3f389ea530e373da1c3e573bfe8`
+GitHub release: https://github.com/EffortlessMetrics/perfgate/releases/tag/v0.18.0
+Install source: public GitHub release asset resolved by `cargo binstall`
+
+## Summary
+
+The public 0.18.0 install path passed from public artifacts after crates.io
+publication and the `v0.18.0` GitHub release. The smoke installed
+`perfgate-cli` 0.18.0 into an isolated temporary root, verified the binary
+reported `perfgate 0.18.0`, initialized a fresh Git repository, exercised the
+first-hour setup path, promoted a baseline, and reran the gate with
+`--require-baseline`.
+
+This smoke used the public Windows release archive downloaded by
+`cargo-binstall`; it did not use a workspace-built binary.
+
+## Commands And Results
+
+```bash
+cargo binstall perfgate-cli --version 0.18.0 --install-path %TEMP%/perfgate-public-smoke-0.18.0-pass/bin -y --force --disable-telemetry
+perfgate --version
+perfgate doctor
+perfgate init --ci github --profile standard --suggest-benches
+perfgate doctor --config perfgate.toml
+perfgate check --config perfgate.toml --all
+perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+Observed evidence:
+
+- `cargo binstall` resolved `perfgate-cli@=0.18.0` and downloaded the
+  `x86_64-pc-windows-msvc` package from `github.com`.
+- `perfgate --version` printed `perfgate 0.18.0`.
+- Initial `perfgate doctor` reported `State: no_config` with the expected
+  `perfgate init --ci github --profile standard` next step.
+- `perfgate init --ci github --profile standard --suggest-benches` wrote
+  `perfgate.toml`, `.github/workflows/perfgate.yml`, `baselines/.gitkeep`, and
+  `.perfgate/README.md`.
+- `doctor --config perfgate.toml` reported `State: benches_no_baselines` after
+  a reviewed manual benchmark was added to the generated config.
+- The first `check --all` wrote first-run artifacts and reported
+  `missing_baseline` as setup, not as a regression.
+- `baseline promote --all` wrote `baselines/command-smoke.json`.
+- `check --all --require-baseline` exited `0`.
+- The generated workflow referenced `EffortlessMetrics/perfgate@v0`.
+
+Generated artifact paths included:
+
+```text
+artifacts/perfgate/command-smoke/run.json
+artifacts/perfgate/command-smoke/compare.json
+artifacts/perfgate/command-smoke/report.json
+artifacts/perfgate/command-smoke/comment.md
+artifacts/perfgate/command-smoke/repair_context.json
+baselines/command-smoke.json
+```
+
+## Notes
+
+The temporary smoke benchmark used a simple Windows command and deliberately
+relaxed smoke-only threshold/noise settings so the test proved public install,
+init, artifact, baseline, and require-baseline plumbing rather than CI host
+benchmark quality. A first ultra-fast command also produced the expected
+high-noise/regression guidance, which confirms the failure-copy path remains
+visible when the workload is unsuitable.
+
+## What Not To Infer
+
+- This smoke does not prove every platform archive manually; the release
+  workflow performed archive build and smoke checks for the release matrix.
+- This smoke does not prove hosted external repository CI after publication.
+- This smoke does not make server ledger mode required for local correctness.
+- This smoke does not calibrate a production benchmark threshold.
+

--- a/docs/audits/release-0.18.0-publication-closeout.md
+++ b/docs/audits/release-0.18.0-publication-closeout.md
@@ -1,0 +1,131 @@
+# v0.18.0 Publication Closeout
+
+Date: 2026-05-18
+Source commit: `f4f40dc5374ef3f389ea530e373da1c3e573bfe8`
+Operator: Codex local release shell using configured maintainer credentials
+Milestone: 0.18.0
+Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
+Linked spec: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md)
+Linked plan: [`release-cutover.md`](../../plans/0.18.0/release-cutover.md)
+
+## Summary
+
+perfgate 0.18.0 is now publicly released. The five public crates are visible on
+crates.io at `0.18.0`, the exact `v0.18.0` tag and GitHub release exist, release
+assets and checksums are uploaded, `v0.18` and `v0` action aliases peel to the
+same release commit, and public install smoke passed from public artifacts.
+
+## Published Crates
+
+Published in dependency order:
+
+| Crate | Version | crates.io URL | Verification |
+| --- | --- | --- | --- |
+| `perfgate-types` | `0.18.0` | https://crates.io/crates/perfgate-types/0.18.0 | `cargo +1.95.0 info perfgate-types`; `cargo +1.95.0 search perfgate-types --limit 5` |
+| `perfgate` | `0.18.0` | https://crates.io/crates/perfgate/0.18.0 | `cargo +1.95.0 info perfgate`; `cargo +1.95.0 search perfgate --limit 1` |
+| `perfgate-client` | `0.18.0` | https://crates.io/crates/perfgate-client/0.18.0 | `cargo +1.95.0 info perfgate-client`; `cargo +1.95.0 search perfgate-client --limit 5` |
+| `perfgate-server` | `0.18.0` | https://crates.io/crates/perfgate-server/0.18.0 | `cargo +1.95.0 info perfgate-server`; `cargo +1.95.0 search perfgate-server --limit 5` |
+| `perfgate-cli` | `0.18.0` | https://crates.io/crates/perfgate-cli/0.18.0 | `cargo +1.95.0 info perfgate-cli`; `cargo +1.95.0 search perfgate-cli --limit 5` |
+
+Each `cargo publish` command completed and Cargo reported the crate published
+to registry `crates-io`. No partial-publish repair was needed.
+
+## GitHub Release
+
+GitHub release: https://github.com/EffortlessMetrics/perfgate/releases/tag/v0.18.0
+Release workflow: https://github.com/EffortlessMetrics/perfgate/actions/runs/26016756334
+Published at: 2026-05-18T06:23:24Z
+
+The release workflow completed successfully. It built and packaged:
+
+```text
+perfgate-aarch64-apple-darwin.tar.gz
+perfgate-aarch64-unknown-linux-gnu.tar.gz
+perfgate-x86_64-apple-darwin.tar.gz
+perfgate-x86_64-pc-windows-msvc.zip
+perfgate-x86_64-unknown-linux-gnu.tar.gz
+perfgate-x86_64-unknown-linux-musl.tar.gz
+sha256sums.txt
+```
+
+Recorded checksums:
+
+```text
+95562fd23400e207969731fa918db2717fcd0943d0f9bd8bbed056d79a5f5ecc  perfgate-aarch64-apple-darwin.tar.gz
+5f7c17f53e3260595da34379e8e700aeab1dca5e965a313ab53736900c0d84f9  perfgate-aarch64-unknown-linux-gnu.tar.gz
+4bcfaa9a89bf1b2f99bf006209785cc09299a2faed4ea3c96a9ffca7b239a8f6  perfgate-x86_64-apple-darwin.tar.gz
+596e068a1050c0bd9cb7693c5dcdca3a06a7e061b047353109651f8f09d27acb  perfgate-x86_64-unknown-linux-gnu.tar.gz
+a18aad72b6fa04cd525c08a67e0200e8c0e9f03027016e67391aabed8fc3938e  perfgate-x86_64-unknown-linux-musl.tar.gz
+f9e5996baf21a82de25bd5167add0f74b6e348a1288083d67668014ab8940e35  perfgate-x86_64-pc-windows-msvc.zip
+```
+
+## Tags And Action Aliases
+
+All three action tags peel to the release commit
+`f4f40dc5374ef3f389ea530e373da1c3e573bfe8`:
+
+```text
+v0.18.0^{} -> f4f40dc5374ef3f389ea530e373da1c3e573bfe8
+v0.18^{}   -> f4f40dc5374ef3f389ea530e373da1c3e573bfe8
+v0^{}      -> f4f40dc5374ef3f389ea530e373da1c3e573bfe8
+```
+
+The exact `v0.18.0` release workflow completed successfully. The alias-triggered
+release workflows were intentionally cancelled after the exact release assets
+were created:
+
+```text
+v0.18 alias workflow: https://github.com/EffortlessMetrics/perfgate/actions/runs/26017227706
+v0 alias workflow:    https://github.com/EffortlessMetrics/perfgate/actions/runs/26017398157
+```
+
+## Public Install Smoke
+
+Public install smoke is recorded in
+[`release-0.18.0-public-install-smoke.md`](release-0.18.0-public-install-smoke.md).
+
+Verified path:
+
+```bash
+cargo binstall perfgate-cli --version 0.18.0
+perfgate --version
+perfgate doctor
+perfgate init --ci github --profile standard --suggest-benches
+perfgate doctor --config perfgate.toml
+perfgate check --config perfgate.toml --all
+perfgate baseline promote --config perfgate.toml --all
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+The installed binary reported `perfgate 0.18.0`, generated the expected files,
+used `EffortlessMetrics/perfgate@v0` in the workflow, wrote run/compare/report/
+comment/repair-context artifacts, promoted a local baseline, and passed the
+require-baseline check.
+
+## Prior Proof Inputs
+
+- [`v0.18.0 Publish Readiness Proof`](release-0.18.0-publish-readiness.md)
+- [`v0.18.0 Staged Release Artifact Smoke`](release-0.18.0-artifact-smoke.md)
+- [`v0.18.0 Final Pre-Publish Proof`](release-0.18.0-final-prepublish-proof.md)
+- [`v0.18.0 Restored Coverage Proof`](release-0.18.0-restored-coverage-proof.md)
+- [`v0.18.0 Final Proof After Restored Coverage`](release-0.18.0-final-proof-after-restored-coverage.md)
+- [`v0.18.0 Final Proof After Init Extraction`](release-0.18.0-final-proof-after-init-extraction.md)
+- [`v0.18.0 Install And Action Example Audit`](release-0.18.0-install-action-example-audit.md)
+- [`v0.18.0 Release-Candidate Readiness Closeout`](../handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md)
+
+## What Remains Unproven
+
+- Hosted external canaries were not rerun from `v0.18.0` in this closeout.
+- The public install smoke was run on Windows; other platform archives are
+  covered by the release workflow's archive smoke, not by manual install smoke.
+- Server ledger mode remains optional team history and is not required for
+  local correctness.
+- Docs.rs page rendering may lag crates.io publication.
+
+## Next Recommended Lane
+
+The next non-release lane should focus on adoption intelligence and signal
+maturity: benchmark recipe selection, baseline maturity, signal doctor output,
+decision example packs, canary freshness, server backup/restore drills, and
+agent-operable repair context.
+

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -217,7 +217,7 @@ Review after: next-decision-contract-change
 
 Tier: supported
 Surface: release, crates, CI
-Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-final-prepublish-proof.md`](../audits/release-0.18.0-final-prepublish-proof.md), [`audits/release-0.18.0-restored-coverage-proof.md`](../audits/release-0.18.0-restored-coverage-proof.md), [`audits/release-0.18.0-final-proof-after-restored-coverage.md`](../audits/release-0.18.0-final-proof-after-restored-coverage.md), [`audits/release-0.18.0-final-proof-after-init-extraction.md`](../audits/release-0.18.0-final-proof-after-init-extraction.md), [`audits/release-0.18.0-publish-packet.md`](../audits/release-0.18.0-publish-packet.md), [`audits/release-0.18.0-install-action-example-audit.md`](../audits/release-0.18.0-install-action-example-audit.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md)
+Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-final-prepublish-proof.md`](../audits/release-0.18.0-final-prepublish-proof.md), [`audits/release-0.18.0-restored-coverage-proof.md`](../audits/release-0.18.0-restored-coverage-proof.md), [`audits/release-0.18.0-final-proof-after-restored-coverage.md`](../audits/release-0.18.0-final-proof-after-restored-coverage.md), [`audits/release-0.18.0-final-proof-after-init-extraction.md`](../audits/release-0.18.0-final-proof-after-init-extraction.md), [`audits/release-0.18.0-publish-packet.md`](../audits/release-0.18.0-publish-packet.md), [`audits/release-0.18.0-install-action-example-audit.md`](../audits/release-0.18.0-install-action-example-audit.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`audits/release-0.18.0-public-install-smoke.md`](../audits/release-0.18.0-public-install-smoke.md), [`audits/release-0.18.0-publication-closeout.md`](../audits/release-0.18.0-publication-closeout.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md)
 Linked gates: publish-check --package-list and per-package publish dry-runs
 Proof commands:
@@ -233,17 +233,19 @@ cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli
 
 Known limits:
 
-- `0.18.0` is not published until the release-operator publication step runs.
-- Public install smoke for `0.18.0` remains unproven until it uses public
-  crates.io or GitHub release artifacts after publication.
+- Alias-triggered release workflows for `v0.18` and `v0` were intentionally
+  cancelled after the exact `v0.18.0` release workflow produced assets.
+- Public install smoke was run on Windows from the public release asset path;
+  hosted external repository canaries were not rerun from `v0.18.0` in the
+  publication closeout.
 
-Review after: next-release-candidate
+Review after: next-release
 
 ## PG-CLAIM-0009: First-hour local adoption path
 
 Tier: supported
 Surface: CLI, docs, artifacts
-Linked docs: [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`DEBUGGING_FIRST_CI_RUN.md`](../DEBUGGING_FIRST_CI_RUN.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md), [`release-0.18.0-final-proof-after-init-extraction.md`](../audits/release-0.18.0-final-proof-after-init-extraction.md), [`release-0.18.0-install-action-example-audit.md`](../audits/release-0.18.0-install-action-example-audit.md), [`release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`2026-05-13-external-canary-diffguard-small-rust-cli.md`](../audits/2026-05-13-external-canary-diffguard-small-rust-cli.md), [`2026-05-13-external-canary-shipper-large-rust-workspace.md`](../audits/2026-05-13-external-canary-shipper-large-rust-workspace.md), [`2026-05-13-external-canary-droid-action-non-rust-command.md`](../audits/2026-05-13-external-canary-droid-action-non-rust-command.md), [`2026-05-15-hosted-external-action-canary-droid-action.md`](../audits/2026-05-15-hosted-external-action-canary-droid-action.md)
+Linked docs: [`FIRST_HOUR.md`](../FIRST_HOUR.md), [`ADOPTION_LEVELS.md`](../ADOPTION_LEVELS.md), [`SIGNAL_CALIBRATION.md`](../SIGNAL_CALIBRATION.md), [`DEBUGGING_FIRST_CI_RUN.md`](../DEBUGGING_FIRST_CI_RUN.md), [`release-0.18.0-adoption-readiness.md`](../audits/release-0.18.0-adoption-readiness.md), [`release-0.18.0-final-proof-after-init-extraction.md`](../audits/release-0.18.0-final-proof-after-init-extraction.md), [`release-0.18.0-install-action-example-audit.md`](../audits/release-0.18.0-install-action-example-audit.md), [`release-0.18.0-public-install-smoke.md`](../audits/release-0.18.0-public-install-smoke.md), [`release-0.18.0-publication-closeout.md`](../audits/release-0.18.0-publication-closeout.md), [`release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`2026-05-13-external-canary-diffguard-small-rust-cli.md`](../audits/2026-05-13-external-canary-diffguard-small-rust-cli.md), [`2026-05-13-external-canary-shipper-large-rust-workspace.md`](../audits/2026-05-13-external-canary-shipper-large-rust-workspace.md), [`2026-05-13-external-canary-droid-action-non-rust-command.md`](../audits/2026-05-13-external-canary-droid-action-non-rust-command.md), [`2026-05-15-hosted-external-action-canary-droid-action.md`](../audits/2026-05-15-hosted-external-action-canary-droid-action.md)
 Linked specs: [`PERFGATE-SPEC-0004-user-devex-paved-road`](../specs/PERFGATE-SPEC-0004-user-devex-paved-road.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.md)
 Proof commands:
 
@@ -269,8 +271,9 @@ Artifacts:
 
 Known limits:
 
-- The release-candidate docs teach the 0.18 first-hour path, but public
-  `0.18.0` install smoke remains blocked until the release is published.
+- Public `0.18.0` install smoke proves the Windows public release asset path;
+  external hosted canaries were not rerun from `v0.18.0` in the release
+  closeout.
 
 Review after: before-0.18.0-release
 

--- a/plans/0.18.0/release-cutover.md
+++ b/plans/0.18.0/release-cutover.md
@@ -1,18 +1,18 @@
 # perfgate 0.18.0 Release Cutover Plan
 
-Status: active
+Status: completed
 Owner: perfgate maintainers
 Created: 2026-05-14
 Milestone: 0.18.0
-Current PR: release-operator-gated publication
+Current PR: complete
 Linked proposal: [`PERFGATE-PROP-0004-0-18-release-cutover`](../../docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../../docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md), [`PERFGATE-SPEC-0007-guided-adoption-contract`](../../docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md), [`PERFGATE-SPEC-0003-performance-decision-contract`](../../docs/specs/PERFGATE-SPEC-0003-performance-decision-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0001-public-crates-are-contracts`](../../docs/adr/PERFGATE-ADR-0001-public-crates-are-contracts.md), [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
 Linked policy: [`public_crates.txt`](../../policy/public_crates.txt), [`absorbed_crates.txt`](../../policy/absorbed_crates.txt)
 Support/status impact: [`PRODUCT_CLAIMS.md`](../../docs/status/PRODUCT_CLAIMS.md) and [`RELEASE_READINESS.md`](../../docs/RELEASE_READINESS.md) must match the public release state
 Proof commands: docs-check; doc-test; docs-source-check; product-claims-check; public-surface --strict; arch; action-check; schema-compat; publish-check dry-runs; public install smoke after publication
-Blocks: 0.18 publication closeout
-Blocked by: explicit release-operator approval for crates.io publish, tags, GitHub release, and action alias movement
+Blocks:
+Blocked by:
 Rollback: before publication, revert the release-prep PRs; after publication, forward-fix crates/docs/tags and record repair notes because crates.io versions cannot be unpublished as a normal rollback
 
 ## Goal
@@ -30,8 +30,10 @@ what remains unproven
 what should happen next
 ```
 
-This plan sequences the release work. It does not authorize publishing crates,
-moving tags, creating a GitHub release, or moving action aliases by itself.
+This plan sequenced the release work. Planning artifacts did not authorize
+publishing crates, moving tags, creating a GitHub release, or moving action
+aliases by themselves; those steps were completed under release-operator
+control and recorded in the publication closeout.
 
 ## Operating Rules
 
@@ -77,13 +79,13 @@ moving tags, creating a GitHub release, or moving action aliases by itself.
 | 494 | Generated baseline/trend refresh | closed | closed to preserve the current RC proof boundary; scheduled job can regenerate |
 | 495 | Release-candidate readiness closeout | implemented | `docs/handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md` |
 | 496 | Release-candidate pointer sync | implemented | release readiness and publish packet point at #495/current RC state |
-| 425 | Publish crates | blocked | crates.io publication in dependency order |
-| 426 | Verify crates.io publication | blocked | `cargo info` / `cargo search` registry proof |
-| 427 | Cut GitHub release | blocked | `v0.18.0`, GitHub release, release assets, checksums |
-| 428 | Move `v0.18` alias | blocked | `v0.18` action alias |
-| 429 | Decide and move `v0` default alias | blocked | `v0` action alias or explicit non-movement |
-| 430 | Public install smoke | blocked | public path and first-hour smoke from published artifacts |
-| 431 | Publication closeout | blocked | release closeout audit, product claims, archived goal |
+| 425 | Publish crates | completed | crates.io publication in dependency order |
+| 426 | Verify crates.io publication | completed | `cargo info` / `cargo search` registry proof |
+| 427 | Cut GitHub release | completed | `v0.18.0`, GitHub release, release assets, checksums |
+| 428 | Move `v0.18` alias | completed | `v0.18` action alias |
+| 429 | Decide and move `v0` default alias | completed | `v0` action alias moved to `v0.18.0` release commit |
+| 430 | Public install smoke | completed | public path and first-hour smoke from published artifacts |
+| 431 | Publication closeout | completed | release closeout audit, product claims, archived goal |
 
 ## Work Item: version-prep
 
@@ -244,7 +246,7 @@ Revert the audit PR. No public state changes in this work item.
 
 ## Work Item: release-operator-gated-publication
 
-Status: current
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: publish-crates, tag-release-aliases, public-install-smoke, publication-closeout
@@ -252,18 +254,15 @@ Blocked by: explicit release-operator approval
 
 ### Goal
 
-Keep the lane active at the release-operator boundary. The next irreversible
-steps are publishing crates, creating tags/releases/assets, moving action
-aliases, and running public install smoke.
+Record that the release-operator boundary was crossed and completed.
 
 ### Acceptance
 
 - Prep remains recorded: 0.18.0 versions, publish dry-runs, staged artifact
   smoke, and public docs cutover.
-- Latest public release remains `v0.17.0` until crates, tags, release assets,
-  aliases, and public install smoke actually move.
-- The lane is not archived until public install smoke and publication closeout
-  are complete.
+- Latest public release is `v0.18.0` after crates, tag, release assets,
+  aliases, and public install smoke moved.
+- The lane is archived by the publication closeout.
 
 ### Rollback
 
@@ -308,7 +307,7 @@ item.
 
 ## Work Item: publish-crates
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: verify-crates-publication
@@ -342,7 +341,7 @@ release and document the issue.
 
 ## Work Item: verify-crates-publication
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: cut-github-release
@@ -379,7 +378,7 @@ repair audit.
 
 ## Work Item: cut-github-release
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: move-v0-18-alias
@@ -406,7 +405,7 @@ record repair notes.
 
 ## Work Item: move-v0-18-alias
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: move-v0-default-alias, public-install-smoke
@@ -429,7 +428,7 @@ notes.
 
 ## Work Item: move-v0-default-alias
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked spec: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md
 Blocks: public-install-smoke
@@ -454,7 +453,7 @@ Move `v0` only under explicit operator approval and record repair notes.
 
 ## Work Item: public-install-smoke
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Blocks: publication-closeout
@@ -490,7 +489,7 @@ release or docs correction, and update the publication closeout.
 
 ## Work Item: publication-closeout
 
-Status: blocked
+Status: completed
 Linked proposal: docs/proposals/PERFGATE-PROP-0004-0-18-release-cutover.md
 Linked specs: docs/specs/PERFGATE-SPEC-0005-release-proof-contract.md; docs/specs/PERFGATE-SPEC-0007-guided-adoption-contract.md
 Blocks:


### PR DESCRIPTION
## Summary
- record 0.18.0 public install smoke from public GitHub release artifacts
- record the 0.18.0 publication closeout with crates.io packages, GitHub release assets/checksums, v0.18/v0 aliases, and non-inferences
- update public docs, release readiness, product claims, the cutover plan, and archive the active release goal

## Release state
- crates.io: perfgate-types, perfgate, perfgate-client, perfgate-server, and perfgate-cli are published at 0.18.0
- GitHub release: https://github.com/EffortlessMetrics/perfgate/releases/tag/v0.18.0
- aliases: v0.18 and v0 peel to f4f40dc5374ef3f389ea530e373da1c3e573bfe8
- public smoke: cargo binstall perfgate-cli --version 0.18.0; doctor/init/check/promote/require-baseline passed from a fresh temp repo

## Validation
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check

## Not inferred
- hosted external canaries were not rerun from v0.18.0 in this closeout
- manual public install smoke was Windows-only; release workflow covers the platform archive matrix
- server ledger mode remains optional team history, not local correctness
