### PR TITLE
init: add benchmark recipe catalog

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "agent-repair-context-contract"
-current_pr = "docs(spec): define agent repair-context contract"
+current_work_item = "benchmark-recipe-catalog"
+current_pr = "init: add benchmark recipe catalog"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -138,14 +138,14 @@ commands = [
 
 [[work_item]]
 id = "agent-repair-context-contract"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "benchmark-recipe-catalog"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-cli/src/init.rs
+++ b/crates/perfgate-cli/src/init.rs
@@ -23,6 +23,13 @@ fn resolve_benchmark_suggestion_profile(
         return BenchmarkSuggestionProfile::Node;
     }
 
+    if scan_dir.join("pyproject.toml").exists()
+        || scan_dir.join("setup.py").exists()
+        || scan_dir.join("requirements.txt").exists()
+    {
+        return BenchmarkSuggestionProfile::PythonCommand;
+    }
+
     let cargo_toml = scan_dir.join("Cargo.toml");
     if let Ok(content) = fs::read_to_string(cargo_toml) {
         if content.contains("[workspace]") {
@@ -40,8 +47,14 @@ fn render_benchmark_suggestions(profile: BenchmarkSuggestionProfile) -> String {
             render_benchmark_suggestions(BenchmarkSuggestionProfile::GenericCommand)
         }
         BenchmarkSuggestionProfile::RustCli => r#"
-# Benchmark suggestions (rust-cli)
+# Benchmark recipe: rust-cli-smoke
 # Review and edit before committing. These are candidates, not policy.
+# Best for: CLI startup, argument parsing, and command wiring smoke.
+# Bad for: steady-state throughput, parser hot loops, and compile-heavy checks.
+# Expected noise: low to medium on stable hosts.
+# Recommended mode: advisory until calibrated, then gate if the workload matters.
+# Should block PRs: only after baseline and signal maturity are proven.
+# Paired-mode hint: use paired mode if host or startup variance dominates.
 #
 # Fast first-hour check: low setup cost and useful for smoke gating.
 # [[bench]]
@@ -55,8 +68,14 @@ fn render_benchmark_suggestions(profile: BenchmarkSuggestionProfile) -> String {
 "#
         .to_string(),
         BenchmarkSuggestionProfile::RustWorkspace => r#"
-# Benchmark suggestions (rust-workspace)
+# Benchmark recipe: rust-workspace-advisory
 # Review and edit before committing. These are candidates, not policy.
+# Best for: broad workspace health and catching expensive integration paths.
+# Bad for: first-hour blocking gates and isolated performance attribution.
+# Expected noise: medium to high because compile and test setup can dominate.
+# Recommended mode: advisory until calibrated; split into smaller gates later.
+# Should block PRs: not until compile/test noise is understood.
+# Paired-mode hint: use paired mode when CI runner drift changes the verdict.
 #
 # Fast first-hour check: choose one small package or command with low setup cost.
 # [[bench]]
@@ -70,8 +89,14 @@ fn render_benchmark_suggestions(profile: BenchmarkSuggestionProfile) -> String {
 "#
         .to_string(),
         BenchmarkSuggestionProfile::Node => r#"
-# Benchmark suggestions (node)
+# Benchmark recipe: node-command
 # Review and edit before committing. These are candidates, not policy.
+# Best for: dedicated Node benchmark scripts with stable local input.
+# Bad for: package install, network calls, and commands that mix build/test/perf.
+# Expected noise: low to medium when dependencies and inputs are stable.
+# Recommended mode: advisory until calibrated; gate only stable scripts.
+# Should block PRs: only for deterministic benchmark scripts.
+# Paired-mode hint: use paired mode if JIT warmup or runner variance dominates.
 #
 # Fast first-hour check: a dedicated benchmark script with stable input.
 # [[bench]]
@@ -84,9 +109,57 @@ fn render_benchmark_suggestions(profile: BenchmarkSuggestionProfile) -> String {
 # command = ["npm", "run", "bench"]
 "#
         .to_string(),
-        BenchmarkSuggestionProfile::GenericCommand => r#"
-# Benchmark suggestions (generic-command)
+        BenchmarkSuggestionProfile::PythonCommand => r#"
+# Benchmark recipe: python-command
 # Review and edit before committing. These are candidates, not policy.
+# Best for: dedicated Python benchmark scripts with fixed input and environment.
+# Bad for: dependency installation, network calls, and correctness-only test runs.
+# Expected noise: medium when interpreter startup or environment setup dominates.
+# Recommended mode: advisory until calibrated; gate only stable workloads.
+# Should block PRs: only after repeat count and baseline maturity are proven.
+# Paired-mode hint: use paired mode if interpreter startup or host variance dominates.
+#
+# Fast first-hour check: a dedicated benchmark script with stable input.
+# [[bench]]
+# name = "python-bench"
+# command = ["python", "scripts/bench.py"]
+#
+# Module path: useful when the project already exposes a benchmark module.
+# [[bench]]
+# name = "python-module-bench"
+# command = ["python", "-m", "benchmarks"]
+"#
+        .to_string(),
+        BenchmarkSuggestionProfile::HttpSmoke => r#"
+# Benchmark recipe: http-smoke
+# Review and edit before committing. These are candidates, not policy.
+# Best for: local HTTP handlers, smoke latency, and simple service endpoints.
+# Bad for: internet calls, shared staging services, and unisolated dependencies.
+# Expected noise: medium to high unless the service and host are isolated.
+# Recommended mode: advisory first; gate only local isolated endpoints.
+# Should block PRs: only after service startup and network noise are controlled.
+# Paired-mode hint: use paired mode when service startup or runner networking dominates.
+#
+# Local endpoint smoke: replace URL with a local service endpoint under test.
+# [[bench]]
+# name = "http-health"
+# command = ["curl", "-fsS", "http://127.0.0.1:8080/health"]
+#
+# Scripted HTTP benchmark: keep setup and request load deterministic.
+# [[bench]]
+# name = "http-smoke"
+# command = ["./scripts/bench-http.sh"]
+"#
+        .to_string(),
+        BenchmarkSuggestionProfile::GenericCommand => r#"
+# Benchmark recipe: generic-command
+# Review and edit before committing. These are candidates, not policy.
+# Best for: language-neutral command benchmarks with stable local input.
+# Bad for: commands that depend on external services or mix setup with runtime.
+# Expected noise: unknown until calibrated.
+# Recommended mode: advisory until signal maturity is proven.
+# Should block PRs: only after baseline and signal maturity are proven.
+# Paired-mode hint: use paired mode if repeated local runs disagree.
 #
 # Fast first-hour check: a stable command that measures the workload directly.
 # [[bench]]

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1721,11 +1721,19 @@ pub enum BenchmarkSuggestionProfile {
     /// Infer a conservative suggestion profile from nearby repo files.
     Auto,
     /// Rust command-line app suggestions.
+    #[value(name = "rust-cli", alias = "rust-cli-smoke")]
     RustCli,
     /// Rust workspace suggestions.
+    #[value(name = "rust-workspace", alias = "rust-workspace-advisory")]
     RustWorkspace,
     /// Node.js benchmark command suggestions.
+    #[value(name = "node", alias = "node-command")]
     Node,
+    /// Python benchmark command suggestions.
+    #[value(name = "python-command", alias = "python")]
+    PythonCommand,
+    /// HTTP smoke benchmark suggestions.
+    HttpSmoke,
     /// Language-neutral command benchmark suggestions.
     GenericCommand,
 }
@@ -1734,9 +1742,11 @@ impl BenchmarkSuggestionProfile {
     fn as_str(self) -> &'static str {
         match self {
             Self::Auto => "auto",
-            Self::RustCli => "rust-cli",
-            Self::RustWorkspace => "rust-workspace",
-            Self::Node => "node",
+            Self::RustCli => "rust-cli-smoke",
+            Self::RustWorkspace => "rust-workspace-advisory",
+            Self::Node => "node-command",
+            Self::PythonCommand => "python-command",
+            Self::HttpSmoke => "http-smoke",
             Self::GenericCommand => "generic-command",
         }
     }

--- a/crates/perfgate-cli/tests/cli_init_tests.rs
+++ b/crates/perfgate-cli/tests/cli_init_tests.rs
@@ -149,8 +149,20 @@ fn init_suggest_benches_generates_language_neutral_commented_candidates() {
 
     let config =
         fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
-    assert!(config.contains("# Benchmark suggestions (generic-command)"));
+    assert!(config.contains("# Benchmark recipe: generic-command"));
     assert!(config.contains("# Review and edit before committing."));
+    assert!(
+        config.contains("# Best for: language-neutral command benchmarks with stable local input.")
+    );
+    assert!(config.contains("# Bad for: commands that depend on external services"));
+    assert!(config.contains("# Expected noise: unknown until calibrated."));
+    assert!(config.contains("# Recommended mode: advisory until signal maturity is proven."));
+    assert!(
+        config.contains("# Should block PRs: only after baseline and signal maturity are proven.")
+    );
+    assert!(
+        config.contains("# Paired-mode hint: use paired mode if repeated local runs disagree.")
+    );
     assert!(config.contains("# [[bench]]"));
     assert!(config.contains("# name = \"command-smoke\""));
     assert!(config.contains("# command = [\"./scripts/bench.sh\"]"));
@@ -176,7 +188,7 @@ fn init_suggest_benches_accepts_explicit_rust_cli_profile() {
 
     let config =
         fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
-    assert!(config.contains("# Benchmark suggestions (rust-cli)"));
+    assert!(config.contains("# Benchmark recipe: rust-cli-smoke"));
     assert!(config.contains("# name = \"cli-help\""));
     assert!(config.contains("# command = [\"cargo\", \"run\", \"-q\", \"--\", \"--help\"]"));
     assert!(
@@ -202,7 +214,72 @@ fn init_suggest_benches_auto_detects_node_repo() {
 
     let config =
         fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
-    assert!(config.contains("# Benchmark suggestions (node)"));
+    assert!(config.contains("# Benchmark recipe: node-command"));
     assert!(config.contains("# command = [\"node\", \"scripts/bench.js\"]"));
     assert!(config.contains("# command = [\"npm\", \"run\", \"bench\"]"));
+}
+
+#[test]
+fn init_suggest_benches_accepts_rust_cli_recipe_alias() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+
+    let output = perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args(["init", "--suggest-benches", "rust-cli-smoke"])
+        .assert()
+        .success()
+        .get_output()
+        .stderr
+        .clone();
+    let stderr = String::from_utf8(output).expect("stderr is utf8");
+
+    let config =
+        fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
+    assert!(config.contains("# Benchmark recipe: rust-cli-smoke"));
+    assert!(stderr.contains("Appended reviewable benchmark suggestions (rust-cli-smoke)"));
+}
+
+#[test]
+fn init_suggest_benches_auto_detects_python_repo() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    fs::write(
+        temp_dir.path().join("pyproject.toml"),
+        r#"[project]
+name = "example"
+"#,
+    )
+    .expect("write pyproject.toml");
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args(["init", "--suggest-benches"])
+        .assert()
+        .success();
+
+    let config =
+        fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
+    assert!(config.contains("# Benchmark recipe: python-command"));
+    assert!(config.contains("# command = [\"python\", \"scripts/bench.py\"]"));
+    assert!(config.contains("# command = [\"python\", \"-m\", \"benchmarks\"]"));
+}
+
+#[test]
+fn init_suggest_benches_accepts_http_smoke_recipe() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args(["init", "--suggest-benches", "http-smoke"])
+        .assert()
+        .success();
+
+    let config =
+        fs::read_to_string(temp_dir.path().join("perfgate.toml")).expect("read generated config");
+    assert!(config.contains("# Benchmark recipe: http-smoke"));
+    assert!(config.contains("# command = [\"curl\", \"-fsS\", \"http://127.0.0.1:8080/health\"]"));
+    assert!(config.contains("# command = [\"./scripts/bench-http.sh\"]"));
+    assert!(
+        !config.contains("\n[[bench]]"),
+        "http suggestions must stay commented until reviewed"
+    );
 }

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: agent repair-context contract spec
+Current PR: benchmark recipe catalog
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -66,20 +66,20 @@ surface change requires an accepted spec and explicit proof.
 | 498 | Evidence maturity proposal | merged | `docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md` |
 | 499 | Evidence maturity contract spec | merged | `docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md` |
 | 500 | Evidence maturity implementation plan | merged | `plans/0.19.0/evidence-maturity-adoption-intelligence.md`, `.codex/goals/active.toml` |
-| 501 | Agent repair-context contract spec | current | `docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md` |
-| 502 | Benchmark recipe catalog | pending | `perfgate init`, recipe metadata, CLI tests |
-| 503 | Benchmark recipe guidance | pending | docs for recipes and anti-patterns |
-| 504 | Baseline maturity doctor | pending | `perfgate baseline doctor`, CLI tests |
-| 505 | Signal maturity doctor | pending | `perfgate doctor signal`, CLI tests |
-| 506 | Calibration patch output | pending | `perfgate calibrate --emit-patch`, CLI tests |
-| 507 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
-| 508 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
-| 509 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
-| 510 | Server backup/restore smoke | pending | server/CLI tests |
-| 511 | Server retention and migration policy | pending | server docs/status |
-| 512 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
-| 513 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 514 | Evidence maturity closeout | pending | handoff and goal archive |
+| 502 | Agent repair-context contract spec | merged | `docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md` |
+| 503 | Benchmark recipe catalog | current | `perfgate init`, recipe metadata, CLI tests |
+| 504 | Benchmark recipe guidance | pending | docs for recipes and anti-patterns |
+| 505 | Baseline maturity doctor | pending | `perfgate baseline doctor`, CLI tests |
+| 506 | Signal maturity doctor | pending | `perfgate doctor signal`, CLI tests |
+| 507 | Calibration patch output | pending | `perfgate calibrate --emit-patch`, CLI tests |
+| 508 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
+| 509 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
+| 510 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
+| 511 | Server backup/restore smoke | pending | server/CLI tests |
+| 512 | Server retention and migration policy | pending | server docs/status |
+| 513 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
+| 514 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 515 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 
@@ -117,7 +117,7 @@ Revert this plan and active goal manifest. Proposal and spec remain valid.
 
 ## Work item: agent-repair-context-contract
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked specs: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md; docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md
 Blocks: agent-repair-context-fixtures
@@ -180,7 +180,7 @@ Revert the spec PR. Evidence maturity spec remains valid without agent details.
 
 ## Work item: benchmark-recipe-catalog
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: benchmark-recipe-guidance, product-claims


### PR DESCRIPTION
Summary: adds reviewable benchmark recipe metadata to init --suggest-benches; adds Python and HTTP smoke recipes plus compatibility aliases for existing Rust/Node profiles; auto-detects Python repo files; keeps suggestions commented and non-policy; advances the 0.19 plan and active goal to benchmark-recipe-catalog. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p perfgate-cli --all-features init; cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features; cargo +1.95.0 test -p perfgate-cli --test cli_abi_conformance_tests --all-features; cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check.