### PR TITLE
baseline: add maturity doctor

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "benchmark-recipe-guidance"
-current_pr = "docs: explain benchmark recipe selection and anti-patterns"
+current_work_item = "baseline-maturity-doctor"
+current_pr = "baseline: add maturity doctor"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -152,14 +152,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "benchmark-recipe-guidance"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "baseline-maturity-doctor"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-cli/src/baseline_doctor.rs
+++ b/crates/perfgate-cli/src/baseline_doctor.rs
@@ -1,0 +1,372 @@
+//! Advisory baseline maturity reporting.
+
+use anyhow::Context;
+use chrono::{DateTime, Utc};
+use perfgate::app::baseline_resolve::{is_remote_storage_uri, resolve_baseline_path};
+use perfgate_types::config::load_config_file;
+use perfgate_types::error::ConfigValidationError;
+use perfgate_types::{ConfigFile, RunReceipt};
+use std::path::Path;
+
+use crate::doctor::plural;
+use crate::storage::read_json_from_location;
+
+const NEW_SAMPLE_LIMIT: usize = 3;
+const MATURE_SAMPLE_LIMIT: usize = 7;
+const HIGH_NOISE_CV: f64 = 0.10;
+const STALE_BASELINE_DAYS: i64 = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BaselineMaturity {
+    Missing,
+    New,
+    Immature,
+    Mature,
+    Stale,
+    HostMismatched,
+    HighNoise,
+    Remote,
+}
+
+impl BaselineMaturity {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::New => "new",
+            Self::Immature => "immature",
+            Self::Mature => "mature",
+            Self::Stale => "stale",
+            Self::HostMismatched => "host_mismatched",
+            Self::HighNoise => "high_noise",
+            Self::Remote => "remote",
+        }
+    }
+
+    fn recommendation(self) -> &'static str {
+        match self {
+            Self::Missing => "run a local check and promote only after reviewing the workload",
+            Self::New => "keep advisory until more measured samples exist",
+            Self::Immature => "increase repeat count or collect more runs before blocking PRs",
+            Self::Mature => "safe to use as a gate if the workload is still representative",
+            Self::Stale => "refresh and review the baseline before relying on it for blocking CI",
+            Self::HostMismatched => "refresh on the same runner class before comparing or gating",
+            Self::HighNoise => "keep advisory; calibrate or use paired mode before blocking PRs",
+            Self::Remote => "remote baseline configured; inspect server history before gating",
+        }
+    }
+}
+
+struct BaselineDoctorRow {
+    bench: String,
+    path: String,
+    maturity: BaselineMaturity,
+    samples: Option<usize>,
+    cv: Option<f64>,
+    host: Option<String>,
+    age_days: Option<i64>,
+}
+
+pub(crate) fn execute_baseline_doctor(
+    config_path: &Path,
+    bench: Option<&str>,
+) -> anyhow::Result<()> {
+    let config = load_validated_baseline_config(config_path)?;
+    let benches = configured_benches(&config, bench)?;
+
+    println!("Baseline doctor ({})", config_path.display());
+    if benches.is_empty() {
+        println!("No benchmarks are configured.");
+        println!();
+        println!("Next:");
+        println!("  perfgate init --ci github --profile standard --suggest-benches");
+        return Ok(());
+    }
+
+    let mut counts = BaselineDoctorCounts::default();
+    for bench_name in &benches {
+        let row = inspect_baseline(&config, bench_name)?;
+        counts.record(row.maturity);
+        print_row(&row);
+    }
+
+    println!();
+    println!(
+        "Summary: {} mature, {} immature, {} new, {} missing, {} stale, {} host-mismatched, {} high-noise, {} remote",
+        counts.mature,
+        counts.immature,
+        counts.new,
+        counts.missing,
+        counts.stale,
+        counts.host_mismatched,
+        counts.high_noise,
+        counts.remote
+    );
+    println!();
+    println!("Next:");
+    if counts.missing > 0 {
+        println!("  perfgate check --config {} --all", config_path.display());
+        println!(
+            "  perfgate baseline promote --config {} --all",
+            config_path.display()
+        );
+    } else if counts.high_noise > 0 {
+        println!(
+            "  perfgate calibrate --config {} --bench <bench>",
+            config_path.display()
+        );
+        println!(
+            "  perfgate paired --name <bench> --baseline-cmd \"<baseline-cmd>\" --current-cmd \"<current-cmd>\" --repeat 10 --out artifacts/perfgate/<bench>/paired.json"
+        );
+    } else if counts.stale > 0 || counts.host_mismatched > 0 {
+        println!(
+            "  perfgate check --config {} --all --require-baseline",
+            config_path.display()
+        );
+        println!("  refresh stale or host-mismatched baselines after review");
+    } else if counts.immature > 0 || counts.new > 0 {
+        println!("  collect more measured samples before making these benchmarks blocking");
+        println!(
+            "  perfgate calibrate --config {} --bench <bench>",
+            config_path.display()
+        );
+    } else {
+        println!(
+            "  perfgate check --config {} --all --require-baseline",
+            config_path.display()
+        );
+    }
+    println!();
+    println!("Do not:");
+    println!(
+        "  promote baselines blindly or loosen thresholds to make maturity warnings disappear"
+    );
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct BaselineDoctorCounts {
+    missing: usize,
+    new: usize,
+    immature: usize,
+    mature: usize,
+    stale: usize,
+    host_mismatched: usize,
+    high_noise: usize,
+    remote: usize,
+}
+
+impl BaselineDoctorCounts {
+    fn record(&mut self, maturity: BaselineMaturity) {
+        match maturity {
+            BaselineMaturity::Missing => self.missing += 1,
+            BaselineMaturity::New => self.new += 1,
+            BaselineMaturity::Immature => self.immature += 1,
+            BaselineMaturity::Mature => self.mature += 1,
+            BaselineMaturity::Stale => self.stale += 1,
+            BaselineMaturity::HostMismatched => self.host_mismatched += 1,
+            BaselineMaturity::HighNoise => self.high_noise += 1,
+            BaselineMaturity::Remote => self.remote += 1,
+        }
+    }
+}
+
+fn print_row(row: &BaselineDoctorRow) {
+    println!();
+    println!("bench: {}", row.bench);
+    println!("status: {}", row.maturity.as_str());
+    println!("path: {}", row.path);
+    if let Some(samples) = row.samples {
+        println!("samples: {samples} measured sample{}", plural(samples));
+    } else {
+        println!("samples: unavailable");
+    }
+    println!(
+        "cv: {}",
+        row.cv
+            .map(format_percent)
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+    println!(
+        "host: {}",
+        row.host.clone().unwrap_or_else(|| "unknown".to_string())
+    );
+    println!(
+        "age: {}",
+        row.age_days
+            .map(|days| format!("{days} day{}", plural(days as usize)))
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!("recommendation: {}", row.maturity.recommendation());
+}
+
+fn inspect_baseline(config: &ConfigFile, bench_name: &str) -> anyhow::Result<BaselineDoctorRow> {
+    let path = resolve_baseline_path(&None, bench_name, config);
+    let path_text = path.to_string_lossy().to_string();
+    if is_remote_storage_uri(&path_text) {
+        return Ok(BaselineDoctorRow {
+            bench: bench_name.to_string(),
+            path: path_text,
+            maturity: BaselineMaturity::Remote,
+            samples: None,
+            cv: None,
+            host: None,
+            age_days: None,
+        });
+    }
+
+    if !path.exists() {
+        return Ok(BaselineDoctorRow {
+            bench: bench_name.to_string(),
+            path: path.display().to_string(),
+            maturity: BaselineMaturity::Missing,
+            samples: None,
+            cv: None,
+            host: None,
+            age_days: None,
+        });
+    }
+
+    let receipt: RunReceipt = read_json_from_location(&path)
+        .with_context(|| format!("failed to read baseline receipt from {}", path.display()))?;
+    let samples = measured_sample_count(&receipt);
+    let cv = receipt.stats.wall_ms.cv();
+    let host = host_class(&receipt);
+    let age_days = baseline_age_days(&receipt);
+    let maturity = classify_baseline(samples, cv, &host, age_days);
+
+    Ok(BaselineDoctorRow {
+        bench: bench_name.to_string(),
+        path: path.display().to_string(),
+        maturity,
+        samples: Some(samples),
+        cv,
+        host: Some(host),
+        age_days,
+    })
+}
+
+fn classify_baseline(
+    samples: usize,
+    cv: Option<f64>,
+    host: &str,
+    age_days: Option<i64>,
+) -> BaselineMaturity {
+    if host != current_host_class() {
+        return BaselineMaturity::HostMismatched;
+    }
+    if cv.is_some_and(|cv| cv > HIGH_NOISE_CV) {
+        return BaselineMaturity::HighNoise;
+    }
+    if age_days.is_some_and(|days| days > STALE_BASELINE_DAYS) {
+        return BaselineMaturity::Stale;
+    }
+    if samples < NEW_SAMPLE_LIMIT {
+        return BaselineMaturity::New;
+    }
+    if samples < MATURE_SAMPLE_LIMIT || cv.is_none() {
+        return BaselineMaturity::Immature;
+    }
+    BaselineMaturity::Mature
+}
+
+fn load_validated_baseline_config(config_path: &Path) -> anyhow::Result<ConfigFile> {
+    let config = load_config_file(config_path)
+        .with_context(|| format!("failed to load {}", config_path.display()))?;
+    config
+        .validate()
+        .map_err(|error| anyhow::anyhow!("{} is invalid: {error}", config_path.display()))?;
+    Ok(config)
+}
+
+fn configured_benches(config: &ConfigFile, bench: Option<&str>) -> anyhow::Result<Vec<String>> {
+    if let Some(bench) = bench {
+        if config
+            .benches
+            .iter()
+            .any(|candidate| candidate.name == bench)
+        {
+            return Ok(vec![bench.to_string()]);
+        }
+
+        return Err(ConfigValidationError::BenchName(format!(
+            "benchmark '{}' is not defined in the config file",
+            bench
+        ))
+        .into());
+    }
+
+    Ok(config
+        .benches
+        .iter()
+        .map(|bench| bench.name.clone())
+        .collect())
+}
+
+fn measured_sample_count(receipt: &RunReceipt) -> usize {
+    receipt
+        .samples
+        .iter()
+        .filter(|sample| !sample.warmup)
+        .count()
+}
+
+fn host_class(receipt: &RunReceipt) -> String {
+    format!("{}-{}", receipt.run.host.os, receipt.run.host.arch)
+}
+
+fn current_host_class() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn baseline_age_days(receipt: &RunReceipt) -> Option<i64> {
+    let started_at = DateTime::parse_from_rfc3339(&receipt.run.started_at).ok()?;
+    let age = Utc::now().signed_duration_since(started_at.with_timezone(&Utc));
+    Some(age.num_days().max(0))
+}
+
+fn format_percent(value: f64) -> String {
+    format!("{:.1}%", value * 100.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_baseline_prefers_host_mismatch_before_noise() {
+        assert_eq!(
+            classify_baseline(10, Some(0.50), "other-os-x86_64", Some(0)),
+            BaselineMaturity::HostMismatched
+        );
+    }
+
+    #[test]
+    fn classify_baseline_distinguishes_core_maturity_states() {
+        let host = current_host_class();
+        assert_eq!(
+            classify_baseline(10, Some(0.11), &host, Some(0)),
+            BaselineMaturity::HighNoise
+        );
+        assert_eq!(
+            classify_baseline(10, Some(0.03), &host, Some(31)),
+            BaselineMaturity::Stale
+        );
+        assert_eq!(
+            classify_baseline(2, Some(0.03), &host, Some(0)),
+            BaselineMaturity::New
+        );
+        assert_eq!(
+            classify_baseline(5, Some(0.03), &host, Some(0)),
+            BaselineMaturity::Immature
+        );
+        assert_eq!(
+            classify_baseline(7, None, &host, Some(0)),
+            BaselineMaturity::Immature
+        );
+        assert_eq!(
+            classify_baseline(7, Some(0.03), &host, Some(0)),
+            BaselineMaturity::Mature
+        );
+    }
+}

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -2,6 +2,7 @@
 
 mod artifact_explain;
 mod baseline;
+mod baseline_doctor;
 mod check_guidance;
 mod cli_parsing;
 mod decision_suggest;
@@ -20,6 +21,7 @@ use storage::{
 use anyhow::Context;
 use artifact_explain::execute_explain_action;
 use baseline::{BaselineSelector, parse_baseline_selector};
+use baseline_doctor::execute_baseline_doctor;
 use check_guidance::{
     FailureClass, check_command, classify_check_error, emit_check_outcome_guidance, paired_command,
     print_check_failure_guidance,
@@ -2000,6 +2002,17 @@ enum BaselineAction {
         /// Path to the config file (TOML or JSON)
         #[arg(long, default_value = "perfgate.toml")]
         config: PathBuf,
+    },
+
+    /// Report advisory baseline maturity and trust guidance.
+    Doctor {
+        /// Path to the config file (TOML or JSON)
+        #[arg(long, default_value = "perfgate.toml")]
+        config: PathBuf,
+
+        /// Limit doctor output to one configured benchmark
+        #[arg(long)]
+        bench: Option<String>,
     },
 
     /// Promote the latest local check artifact into the configured baseline path.
@@ -5890,6 +5903,9 @@ fn execute_baseline_action(
             execute_local_baseline_status(&config, bench.as_deref())
         }
         BaselineAction::Init { config } => execute_local_baseline_init(&config),
+        BaselineAction::Doctor { config, bench } => {
+            execute_baseline_doctor(&config, bench.as_deref())
+        }
         BaselineAction::Promote {
             config,
             bench,
@@ -5927,6 +5943,7 @@ fn execute_remote_baseline_action(
     match action {
         BaselineAction::Status { .. }
         | BaselineAction::Init { .. }
+        | BaselineAction::Doctor { .. }
         | BaselineAction::Promote { .. } => {
             unreachable!("local baseline actions are handled before server dispatch");
         }

--- a/crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs
+++ b/crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs
@@ -54,6 +54,44 @@ fn write_run_fixture(path: &Path, bench: &str) {
     .expect("write run fixture");
 }
 
+fn write_baseline_maturity_fixture(
+    path: &Path,
+    bench: &str,
+    sample_count: usize,
+    cv: f64,
+    days_old: i64,
+) {
+    let mut receipt: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(fixtures_dir().join("baseline.json")).unwrap())
+            .expect("parse run fixture");
+    receipt["bench"]["name"] = serde_json::json!(bench);
+    receipt["run"]["host"]["os"] = serde_json::json!(std::env::consts::OS);
+    receipt["run"]["host"]["arch"] = serde_json::json!(std::env::consts::ARCH);
+    let started_at = chrono::Utc::now() - chrono::Duration::days(days_old);
+    receipt["run"]["started_at"] = serde_json::json!(started_at.to_rfc3339());
+    receipt["run"]["ended_at"] =
+        serde_json::json!((started_at + chrono::Duration::seconds(1)).to_rfc3339());
+    receipt["stats"]["wall_ms"]["mean"] = serde_json::json!(100.0);
+    receipt["stats"]["wall_ms"]["stddev"] = serde_json::json!(100.0 * cv);
+    receipt["samples"] = serde_json::json!(
+        (0..sample_count)
+            .map(|_| serde_json::json!({
+                "wall_ms": 100,
+                "exit_code": 0,
+                "warmup": false,
+                "timed_out": false
+            }))
+            .collect::<Vec<_>>()
+    );
+    fs::create_dir_all(path.parent().expect("baseline fixture has parent"))
+        .expect("create baseline parent");
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize baseline fixture"),
+    )
+    .expect("write baseline fixture");
+}
+
 #[test]
 fn baseline_status_reports_missing_then_found_local_baseline() {
     let temp_dir = tempfile::tempdir().expect("create temp dir");
@@ -86,6 +124,64 @@ fn baseline_status_reports_missing_then_found_local_baseline() {
         .stdout(predicate::str::contains(
             "Summary: 1/1 local baseline found",
         ));
+}
+
+#[test]
+fn baseline_doctor_reports_mature_and_missing_local_baselines() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    write_two_bench_config(temp_dir.path());
+    write_baseline_maturity_fixture(
+        &temp_dir.path().join("baselines/test-benchmark.json"),
+        "test-benchmark",
+        7,
+        0.03,
+        0,
+    );
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args(["baseline", "doctor", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Baseline doctor"))
+        .stdout(predicate::str::contains("bench: test-benchmark"))
+        .stdout(predicate::str::contains("status: mature"))
+        .stdout(predicate::str::contains("bench: second-benchmark"))
+        .stdout(predicate::str::contains("status: missing"))
+        .stdout(predicate::str::contains("Summary: 1 mature"))
+        .stdout(predicate::str::contains(
+            "perfgate baseline promote --config perfgate.toml --all",
+        ))
+        .stdout(predicate::str::contains("Do not:"));
+}
+
+#[test]
+fn baseline_doctor_classifies_high_noise_as_advisory() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    write_config(temp_dir.path());
+    write_baseline_maturity_fixture(
+        &temp_dir.path().join("baselines/test-benchmark.json"),
+        "test-benchmark",
+        7,
+        0.20,
+        0,
+    );
+
+    perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .args([
+            "baseline",
+            "doctor",
+            "--config",
+            "perfgate.toml",
+            "--bench",
+            "test-benchmark",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status: high_noise"))
+        .stdout(predicate::str::contains("keep advisory"))
+        .stdout(predicate::str::contains("perfgate paired"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -157,6 +157,7 @@ fn cli_help_baseline() {
         .stdout(predicate::str::contains("Inspect local baselines"))
         .stdout(predicate::str::contains("status"))
         .stdout(predicate::str::contains("init"))
+        .stdout(predicate::str::contains("doctor"))
         .stdout(predicate::str::contains("promote"))
         .stdout(predicate::str::contains("list"))
         .stdout(predicate::str::contains("download"));

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: benchmark recipe guidance
+Current PR: baseline maturity doctor
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -68,18 +68,18 @@ surface change requires an accepted spec and explicit proof.
 | 500 | Evidence maturity implementation plan | merged | `plans/0.19.0/evidence-maturity-adoption-intelligence.md`, `.codex/goals/active.toml` |
 | 502 | Agent repair-context contract spec | merged | `docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md` |
 | 503 | Benchmark recipe catalog | merged | `perfgate init`, recipe metadata, CLI tests |
-| 504 | Benchmark recipe guidance | current | docs for recipes and anti-patterns |
-| 505 | Baseline maturity doctor | pending | `perfgate baseline doctor`, CLI tests |
-| 506 | Signal maturity doctor | pending | `perfgate doctor signal`, CLI tests |
-| 507 | Calibration patch output | pending | `perfgate calibrate --emit-patch`, CLI tests |
-| 508 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
-| 509 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
-| 510 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
-| 511 | Server backup/restore smoke | pending | server/CLI tests |
-| 512 | Server retention and migration policy | pending | server docs/status |
-| 513 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
-| 514 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 515 | Evidence maturity closeout | pending | handoff and goal archive |
+| 505 | Benchmark recipe guidance | merged | docs for recipes and anti-patterns |
+| 506 | Baseline maturity doctor | current | `perfgate baseline doctor`, CLI tests |
+| 507 | Signal maturity doctor | pending | `perfgate doctor signal`, CLI tests |
+| 508 | Calibration patch output | pending | `perfgate calibrate --emit-patch`, CLI tests |
+| 509 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
+| 510 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
+| 511 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
+| 512 | Server backup/restore smoke | pending | server/CLI tests |
+| 513 | Server retention and migration policy | pending | server docs/status |
+| 514 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
+| 515 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 516 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 
@@ -240,10 +240,10 @@ Revert recipe metadata wiring and tests.
 
 ## Work item: benchmark-recipe-guidance
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
-Blocks:
+Blocks: baseline-maturity-doctor
 Blocked by: benchmark-recipe-catalog
 
 ### Goal
@@ -273,20 +273,26 @@ Add or update docs covering:
 cargo +1.95.0 run -p xtask -- docs-check
 cargo +1.95.0 run -p xtask -- doc-test
 cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
 git diff --check
 ```
 
+### Rollback
+
+Revert the guide and links. Recipe catalog behavior remains available.
+
 ## Work item: baseline-maturity-doctor
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: signal-maturity-doctor, product-claims
-Blocked by: implementation-plan
+Blocked by: benchmark-recipe-guidance
 
 ### Goal
 
-Add advisory baseline trust classification.
+Add advisory baseline trust classification without making maturity output a
+blocking policy.
 
 ### Production delta
 
@@ -308,26 +314,42 @@ host_mismatched
 high_noise
 ```
 
+Remote baselines may be reported as remote/not probed, but this PR must not
+make server ledger or baseline service mode required.
+
 ### Non-goals
 
 - Do not promote baselines automatically.
 - Do not rewrite config.
 - Do not change receipt schemas by default.
+- Do not make maturity output a blocking gate.
 
 ### Acceptance
 
-- Output says whether each baseline is safe to gate, advisory only, needs more
-  samples, needs host-compatible refresh, or should use paired mode.
-- Tests cover missing, immature, mature, stale, host mismatch, and high-noise
-  where fixtures exist.
+- Command reports per-bench status, path, samples, CV, host, age, and a
+  recommendation when evidence is available.
+- Missing baselines are explained as setup, not regression.
+- High-noise baselines recommend advisory/calibration/paired flow.
+- Tests cover missing/mature and high-noise local baselines.
 
 ### Proof commands
 
 ```bash
-cargo +1.95.0 test -p perfgate-cli --all-features baseline
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 test -p perfgate-cli --test cli_baseline_bootstrap_tests --all-features
+cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features
+cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
+cargo +1.95.0 run -p xtask -- docs-check
 cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
 git diff --check
 ```
+
+### Rollback
+
+Revert the command and tests. Existing `baseline status/init/promote` behavior
+remains intact.
 
 ## Work item: signal-maturity-doctor
 


### PR DESCRIPTION
Summary: Adds advisory perfgate baseline doctor for local baseline maturity checks; classifies missing, new, immature, mature, stale, host_mismatched, high_noise, and remote without promoting or rewriting config; updates 0.19 plan and active-goal pointers. Validation: fmt check, cli_baseline_bootstrap_tests, cli_help_snapshot_tests, perfgate-cli clippy, docs-check, doc-test, docs-source-check, product-claims-check, and git diff --check.