### PR TITLE
doctor: add signal maturity output

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "baseline-maturity-doctor"
-current_pr = "baseline: add maturity doctor"
+current_work_item = "signal-maturity-doctor"
+current_pr = "doctor: add signal maturity output"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -159,14 +159,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "baseline-maturity-doctor"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "signal-maturity-doctor"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-cli/src/doctor.rs
+++ b/crates/perfgate-cli/src/doctor.rs
@@ -4,19 +4,24 @@
 //! separate from argument parsing and command dispatch in `main.rs`.
 
 use crate::{
-    CalibrateArgs, DoctorArgs, RUN_RECEIPT_FILE, ServerFlags, check_command,
-    load_optional_baseline_receipt, paired_command, read_json, resolve_configured_out_dir,
-    run_git_capture, with_tokio_runtime,
+    COMPARE_RECEIPT_FILE, CalibrateArgs, DoctorArgs, RUN_RECEIPT_FILE, ServerFlags,
+    SignalDoctorArgs, check_command, load_optional_baseline_receipt, paired_command, read_json,
+    resolve_configured_out_dir, run_git_capture, with_tokio_runtime,
 };
+use chrono::{DateTime, Utc};
 use perfgate::app::baseline_resolve::{is_remote_storage_uri, resolve_baseline_path};
 use perfgate::app::init::{CiPlatform, ci_workflow_path};
 use perfgate_client::{BaselineClient, ClientConfig, RetryConfig};
 use perfgate_types::config::load_config_file;
 use perfgate_types::error::ConfigValidationError;
-use perfgate_types::{ConfigFile, Metric, RunReceipt};
+use perfgate_types::{CompareReceipt, ConfigFile, Metric, RunReceipt};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+
+const SIGNAL_MATURE_SAMPLE_LIMIT: usize = 7;
+const SIGNAL_HIGH_NOISE_CV: f64 = 0.10;
+const SIGNAL_STALE_BASELINE_DAYS: i64 = 30;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DoctorStatus {
@@ -461,6 +466,472 @@ fn host_class(receipt: &RunReceipt) -> String {
 
 fn format_percent(value: f64) -> String {
     format!("{:.1}%", value * 100.0)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SignalRecommendation {
+    SafeToGate,
+    AdvisoryOnly,
+    IncreaseSamples,
+    UsePairedMode,
+    RefreshBaseline,
+    CheckHostMismatch,
+    NoDecisionYet,
+}
+
+impl SignalRecommendation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SafeToGate => "safe_to_gate",
+            Self::AdvisoryOnly => "advisory_only",
+            Self::IncreaseSamples => "increase_samples",
+            Self::UsePairedMode => "use_paired_mode",
+            Self::RefreshBaseline => "refresh_baseline",
+            Self::CheckHostMismatch => "check_host_mismatch",
+            Self::NoDecisionYet => "no_decision_yet",
+        }
+    }
+
+    fn meaning(self) -> &'static str {
+        match self {
+            Self::SafeToGate => "signal looks stable enough for required-baseline checks",
+            Self::AdvisoryOnly => {
+                "evidence exists but is not complete enough to make blocking boring"
+            }
+            Self::IncreaseSamples => "collect more measured samples before tightening or blocking",
+            Self::UsePairedMode => {
+                "ordinary runs are noisy; compare baseline/current under paired conditions"
+            }
+            Self::RefreshBaseline => "baseline is stale enough to refresh before relying on it",
+            Self::CheckHostMismatch => {
+                "baseline/current host classes differ; rerun on a compatible host"
+            }
+            Self::NoDecisionYet => {
+                "setup or receipts are incomplete; do not treat this as a regression"
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SignalDoctorRow {
+    bench: String,
+    run_path: PathBuf,
+    baseline_path: PathBuf,
+    compare_path: PathBuf,
+    run_found: bool,
+    baseline_found: bool,
+    baseline_remote: bool,
+    compare_found: bool,
+    samples: usize,
+    cv: Option<f64>,
+    host_stability: String,
+    baseline_age_days: Option<i64>,
+    recent_drift: String,
+    recommendation: SignalRecommendation,
+}
+
+pub(crate) fn execute_signal_doctor(args: SignalDoctorArgs) -> anyhow::Result<()> {
+    let config = load_config_file(&args.config)?;
+    config
+        .validate()
+        .map_err(ConfigValidationError::ConfigFile)?;
+    let benches = configured_signal_benches(&config, args.bench.as_deref())?;
+    let out_dir = resolve_configured_out_dir(args.out_dir.as_ref(), Some(&config));
+
+    println!("perfgate doctor signal");
+    println!();
+    if benches.is_empty() {
+        println!("No benchmarks are configured.");
+        println!("Next:");
+        println!(
+            "  edit {} and add a reviewed [[bench]] command",
+            args.config.display()
+        );
+        println!("Do not:");
+        println!("  promote baselines until the benchmark measures the workload you care about");
+        return Ok(());
+    }
+
+    let mut counts = SignalDoctorCounts::default();
+    for bench_name in &benches {
+        let row = inspect_signal(&config, &out_dir, bench_name)?;
+        counts.record(row.recommendation);
+        print_signal_row(&row, &args.config);
+    }
+
+    println!();
+    println!(
+        "Summary: {} safe_to_gate, {} advisory_only, {} increase_samples, {} use_paired_mode, {} refresh_baseline, {} check_host_mismatch, {} no_decision_yet",
+        counts.safe_to_gate,
+        counts.advisory_only,
+        counts.increase_samples,
+        counts.use_paired_mode,
+        counts.refresh_baseline,
+        counts.check_host_mismatch,
+        counts.no_decision_yet
+    );
+    println!();
+    println!("Do not:");
+    println!("  treat noisy or immature evidence as policy just because receipts exist");
+    println!("  make server ledger upload part of local correctness");
+    println!();
+    println!("Advisory only: no config, baseline, threshold, or policy was changed.");
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct SignalDoctorCounts {
+    safe_to_gate: usize,
+    advisory_only: usize,
+    increase_samples: usize,
+    use_paired_mode: usize,
+    refresh_baseline: usize,
+    check_host_mismatch: usize,
+    no_decision_yet: usize,
+}
+
+impl SignalDoctorCounts {
+    fn record(&mut self, recommendation: SignalRecommendation) {
+        match recommendation {
+            SignalRecommendation::SafeToGate => self.safe_to_gate += 1,
+            SignalRecommendation::AdvisoryOnly => self.advisory_only += 1,
+            SignalRecommendation::IncreaseSamples => self.increase_samples += 1,
+            SignalRecommendation::UsePairedMode => self.use_paired_mode += 1,
+            SignalRecommendation::RefreshBaseline => self.refresh_baseline += 1,
+            SignalRecommendation::CheckHostMismatch => self.check_host_mismatch += 1,
+            SignalRecommendation::NoDecisionYet => self.no_decision_yet += 1,
+        }
+    }
+}
+
+fn print_signal_row(row: &SignalDoctorRow, config_path: &Path) {
+    println!("bench: {}", row.bench);
+    println!(
+        "samples: {} measured sample{}",
+        row.samples,
+        plural(row.samples)
+    );
+    println!(
+        "cv: {}",
+        row.cv
+            .map(format_percent)
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+    println!("host stability: {}", row.host_stability);
+    println!(
+        "baseline age: {}",
+        row.baseline_age_days
+            .map(|days| format!("{days} day{}", plural(days as usize)))
+            .unwrap_or_else(|| "unknown".to_string())
+    );
+    println!("recent drift: {}", row.recent_drift);
+    println!("recommendation: {}", row.recommendation.as_str());
+    println!("meaning: {}", row.recommendation.meaning());
+    println!("artifacts:");
+    println!(
+        "  run: {}{}",
+        row.run_path.display(),
+        if row.run_found { "" } else { " (missing)" }
+    );
+    if row.baseline_remote {
+        println!(
+            "  baseline: {} (remote, not probed)",
+            row.baseline_path.display()
+        );
+    } else {
+        println!(
+            "  baseline: {}{}",
+            row.baseline_path.display(),
+            if row.baseline_found { "" } else { " (missing)" }
+        );
+    }
+    println!(
+        "  compare: {}{}",
+        row.compare_path.display(),
+        if row.compare_found { "" } else { " (missing)" }
+    );
+    println!("next:");
+    for command in signal_next_commands(row, config_path) {
+        println!("  {command}");
+    }
+    println!();
+}
+
+fn signal_next_commands(row: &SignalDoctorRow, config_path: &Path) -> Vec<String> {
+    match row.recommendation {
+        SignalRecommendation::SafeToGate => {
+            vec![check_command(config_path, Some(&row.bench), true)]
+        }
+        SignalRecommendation::UsePairedMode => vec![
+            format!(
+                "perfgate calibrate --config {} --bench {}",
+                config_path.display(),
+                row.bench
+            ),
+            paired_command(Some(&row.bench)),
+        ],
+        SignalRecommendation::IncreaseSamples => vec![
+            check_command(config_path, Some(&row.bench), false),
+            format!(
+                "perfgate calibrate --config {} --bench {}",
+                config_path.display(),
+                row.bench
+            ),
+        ],
+        SignalRecommendation::RefreshBaseline => vec![
+            check_command(config_path, Some(&row.bench), true),
+            format!("review and refresh baseline for {}", row.bench),
+        ],
+        SignalRecommendation::CheckHostMismatch => vec![
+            "rerun on the same runner class as the baseline".to_string(),
+            check_command(config_path, Some(&row.bench), true),
+        ],
+        SignalRecommendation::AdvisoryOnly => vec![
+            check_command(config_path, Some(&row.bench), false),
+            format!(
+                "perfgate baseline doctor --config {} --bench {}",
+                config_path.display(),
+                row.bench
+            ),
+        ],
+        SignalRecommendation::NoDecisionYet => vec![
+            check_command(config_path, Some(&row.bench), false),
+            format!(
+                "perfgate baseline promote --config {} --bench {}",
+                config_path.display(),
+                row.bench
+            ),
+        ],
+    }
+}
+
+fn inspect_signal(
+    config: &ConfigFile,
+    out_dir: &Path,
+    bench_name: &str,
+) -> anyhow::Result<SignalDoctorRow> {
+    let run_path = signal_run_path(out_dir, bench_name);
+    let run_receipt = if run_path.exists() {
+        Some(read_json::<RunReceipt>(&run_path)?)
+    } else {
+        None
+    };
+
+    let baseline_path = resolve_baseline_path(&None, bench_name, config);
+    let baseline_text = baseline_path.to_string_lossy();
+    let baseline_remote = is_remote_storage_uri(&baseline_text);
+    let baseline_receipt = if baseline_remote {
+        None
+    } else {
+        load_optional_baseline_receipt(&baseline_path)?
+    };
+
+    let compare_path = signal_compare_path(out_dir, bench_name);
+    let compare_receipt = if compare_path.exists() {
+        Some(read_json::<CompareReceipt>(&compare_path)?)
+    } else {
+        None
+    };
+
+    let samples = run_receipt
+        .as_ref()
+        .or(baseline_receipt.as_ref())
+        .map(measured_sample_count)
+        .unwrap_or_default();
+    let cv = run_receipt
+        .as_ref()
+        .and_then(|receipt| receipt.stats.wall_ms.cv())
+        .or_else(|| compare_receipt.as_ref().and_then(compare_cv))
+        .or_else(|| {
+            baseline_receipt
+                .as_ref()
+                .and_then(|receipt| receipt.stats.wall_ms.cv())
+        });
+    let (host_stability, host_mismatch) =
+        signal_host_stability(run_receipt.as_ref(), baseline_receipt.as_ref());
+    let baseline_age_days = baseline_receipt.as_ref().and_then(baseline_age_days);
+    let recent_drift = compare_receipt
+        .as_ref()
+        .map(signal_recent_drift)
+        .unwrap_or_else(|| "missing compare receipt".to_string());
+    let recommendation = signal_recommendation(SignalRecommendationInput {
+        baseline_found: baseline_receipt.is_some(),
+        baseline_remote,
+        compare_found: compare_receipt.is_some(),
+        samples,
+        cv,
+        host_mismatch,
+        baseline_age_days,
+    });
+
+    Ok(SignalDoctorRow {
+        bench: bench_name.to_string(),
+        run_path,
+        baseline_path,
+        compare_path,
+        run_found: run_receipt.is_some(),
+        baseline_found: baseline_receipt.is_some(),
+        baseline_remote,
+        compare_found: compare_receipt.is_some(),
+        samples,
+        cv,
+        host_stability,
+        baseline_age_days,
+        recent_drift,
+        recommendation,
+    })
+}
+
+struct SignalRecommendationInput {
+    baseline_found: bool,
+    baseline_remote: bool,
+    compare_found: bool,
+    samples: usize,
+    cv: Option<f64>,
+    host_mismatch: bool,
+    baseline_age_days: Option<i64>,
+}
+
+fn signal_recommendation(input: SignalRecommendationInput) -> SignalRecommendation {
+    if !input.baseline_found && !input.baseline_remote {
+        return SignalRecommendation::NoDecisionYet;
+    }
+    if input.host_mismatch {
+        return SignalRecommendation::CheckHostMismatch;
+    }
+    if input
+        .baseline_age_days
+        .is_some_and(|days| days > SIGNAL_STALE_BASELINE_DAYS)
+    {
+        return SignalRecommendation::RefreshBaseline;
+    }
+    if input.cv.is_some_and(|cv| cv > SIGNAL_HIGH_NOISE_CV) {
+        return SignalRecommendation::UsePairedMode;
+    }
+    if input.samples < SIGNAL_MATURE_SAMPLE_LIMIT {
+        return SignalRecommendation::IncreaseSamples;
+    }
+    if !input.compare_found || input.baseline_remote {
+        return SignalRecommendation::AdvisoryOnly;
+    }
+    SignalRecommendation::SafeToGate
+}
+
+fn configured_signal_benches(
+    config: &ConfigFile,
+    bench: Option<&str>,
+) -> anyhow::Result<Vec<String>> {
+    if let Some(bench) = bench {
+        if config
+            .benches
+            .iter()
+            .any(|candidate| candidate.name == bench)
+        {
+            return Ok(vec![bench.to_string()]);
+        }
+        return Err(ConfigValidationError::BenchName(format!(
+            "bench '{}' not found in config",
+            bench
+        ))
+        .into());
+    }
+
+    Ok(config
+        .benches
+        .iter()
+        .map(|bench| bench.name.clone())
+        .collect())
+}
+
+fn signal_run_path(out_dir: &Path, bench_name: &str) -> PathBuf {
+    let per_bench = out_dir.join(bench_name).join(RUN_RECEIPT_FILE);
+    if per_bench.exists() {
+        per_bench
+    } else {
+        out_dir.join(RUN_RECEIPT_FILE)
+    }
+}
+
+fn signal_compare_path(out_dir: &Path, bench_name: &str) -> PathBuf {
+    let per_bench = out_dir.join(bench_name).join(COMPARE_RECEIPT_FILE);
+    if per_bench.exists() {
+        per_bench
+    } else {
+        out_dir.join(COMPARE_RECEIPT_FILE)
+    }
+}
+
+fn compare_cv(compare: &CompareReceipt) -> Option<f64> {
+    compare
+        .deltas
+        .values()
+        .filter_map(|delta| delta.cv)
+        .max_by(|left, right| left.total_cmp(right))
+}
+
+fn signal_recent_drift(compare: &CompareReceipt) -> String {
+    let status = compare.verdict.status.as_str();
+    let largest_regression = compare
+        .deltas
+        .iter()
+        .max_by(|(_, left), (_, right)| left.regression.total_cmp(&right.regression));
+
+    if let Some((metric, delta)) = largest_regression {
+        format!(
+            "{} ({} regression {})",
+            status,
+            metric.as_str(),
+            format_percent(delta.regression)
+        )
+    } else {
+        format!("{status} (no metric deltas)")
+    }
+}
+
+fn signal_host_stability(
+    run: Option<&RunReceipt>,
+    baseline: Option<&RunReceipt>,
+) -> (String, bool) {
+    match (run, baseline) {
+        (Some(run), Some(baseline)) => {
+            let run_host = host_class(run);
+            let baseline_host = host_class(baseline);
+            if run_host == baseline_host {
+                (format!("stable ({run_host})"), false)
+            } else {
+                (
+                    format!("mismatch (baseline {baseline_host}, current {run_host})"),
+                    true,
+                )
+            }
+        }
+        (None, Some(baseline)) => {
+            let baseline_host = host_class(baseline);
+            let current_host = current_host_class();
+            if baseline_host == current_host {
+                (format!("baseline-only ({baseline_host})"), false)
+            } else {
+                (
+                    format!("mismatch (baseline {baseline_host}, current {current_host})"),
+                    true,
+                )
+            }
+        }
+        (Some(run), None) => (format!("run-only ({})", host_class(run)), false),
+        (None, None) => ("unknown".to_string(), false),
+    }
+}
+
+fn current_host_class() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn baseline_age_days(receipt: &RunReceipt) -> Option<i64> {
+    let started_at = DateTime::parse_from_rfc3339(&receipt.run.started_at).ok()?;
+    let age = Utc::now().signed_duration_since(started_at.with_timezone(&Utc));
+    Some(age.num_days().max(0))
 }
 
 pub(crate) fn execute_doctor(args: DoctorArgs, server_flags: ServerFlags) -> anyhow::Result<()> {

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -92,7 +92,9 @@ use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use doctor::{DoctorCheck, DoctorStatus, execute_calibrate, execute_doctor, plural};
+use doctor::{
+    DoctorCheck, DoctorStatus, execute_calibrate, execute_doctor, execute_signal_doctor, plural,
+};
 use probe_templates::execute_probe_init;
 
 const BASELINE_SERVER_NOT_CONFIGURED: &str = "baseline server is not configured; set `--baseline-server`, `PERFGATE_SERVER_URL`, or `[baseline_server].url` in `perfgate.toml`";
@@ -1182,6 +1184,9 @@ pub struct CalibrateArgs {
 
 #[derive(Debug, Args)]
 pub struct DoctorArgs {
+    #[command(subcommand)]
+    pub command: Option<DoctorCommand>,
+
     /// Path to the config file (TOML or JSON)
     #[arg(long, default_value = "perfgate.toml")]
     pub config: PathBuf,
@@ -1193,6 +1198,27 @@ pub struct DoctorArgs {
     /// Exit non-zero if doctor finds a failed required check
     #[arg(long, default_value_t = false)]
     pub strict: bool,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum DoctorCommand {
+    /// Report advisory signal maturity from local receipts.
+    Signal(SignalDoctorArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct SignalDoctorArgs {
+    /// Path to the config file (TOML or JSON)
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate.
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Limit signal maturity output to one configured benchmark
+    #[arg(long)]
+    pub bench: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -2889,7 +2915,13 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
 
         Command::Calibrate(args) => execute_calibrate(*args),
 
-        Command::Doctor(args) => execute_doctor(*args, server_flags),
+        Command::Doctor(args) => {
+            let mut args = *args;
+            match args.command.take() {
+                Some(DoctorCommand::Signal(signal_args)) => execute_signal_doctor(signal_args),
+                None => execute_doctor(args, server_flags),
+            }
+        }
 
         Command::Paired(args) => {
             let PairedArgs {

--- a/crates/perfgate-cli/tests/cli_doctor_tests.rs
+++ b/crates/perfgate-cli/tests/cli_doctor_tests.rs
@@ -65,6 +65,99 @@ fn write_baseline_marker(dir: &std::path::Path) {
     .expect("write baseline marker");
 }
 
+fn write_signal_receipt(path: &std::path::Path, bench: &str, sample_count: usize, cv: f64) {
+    let started_at = chrono::Utc::now() - chrono::Duration::days(1);
+    let samples = (0..sample_count)
+        .map(|_| {
+            serde_json::json!({
+                "wall_ms": 100,
+                "exit_code": 0,
+                "warmup": false,
+                "timed_out": false
+            })
+        })
+        .collect::<Vec<_>>();
+    let receipt = serde_json::json!({
+        "schema": "perfgate.run.v1",
+        "tool": { "name": "perfgate", "version": "0.18.0" },
+        "run": {
+            "id": format!("{bench}-run"),
+            "started_at": started_at.to_rfc3339(),
+            "ended_at": (started_at + chrono::Duration::seconds(1)).to_rfc3339(),
+            "host": {
+                "os": std::env::consts::OS,
+                "arch": std::env::consts::ARCH
+            }
+        },
+        "bench": {
+            "name": bench,
+            "command": success_command(),
+            "repeat": sample_count as u32,
+            "warmup": 0
+        },
+        "samples": samples,
+        "stats": {
+            "wall_ms": {
+                "median": 100,
+                "min": 98,
+                "max": 102,
+                "mean": 100.0,
+                "stddev": 100.0 * cv
+            }
+        }
+    });
+    fs::create_dir_all(path.parent().expect("receipt parent")).expect("create receipt parent");
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize receipt"),
+    )
+    .expect("write receipt");
+}
+
+fn write_signal_compare(path: &std::path::Path, bench: &str) {
+    let compare = serde_json::json!({
+        "schema": "perfgate.compare.v1",
+        "tool": { "name": "perfgate", "version": "0.18.0" },
+        "bench": {
+            "name": bench,
+            "command": success_command(),
+            "repeat": 7,
+            "warmup": 0
+        },
+        "baseline_ref": { "path": "baselines/doctor-bench.json", "run_id": "baseline-run" },
+        "current_ref": { "path": "artifacts/perfgate/doctor-bench/run.json", "run_id": "current-run" },
+        "budgets": {
+            "wall_ms": {
+                "threshold": 0.20,
+                "warn_threshold": 0.10,
+                "direction": "lower"
+            }
+        },
+        "deltas": {
+            "wall_ms": {
+                "baseline": 100.0,
+                "current": 101.0,
+                "ratio": 1.01,
+                "pct": 0.01,
+                "regression": 0.01,
+                "cv": 0.03,
+                "status": "pass"
+            }
+        },
+        "verdict": {
+            "status": "pass",
+            "counts": { "pass": 1, "warn": 0, "fail": 0, "skip": 0 },
+            "reasons": []
+        }
+    });
+    fs::create_dir_all(path.parent().expect("compare parent")).expect("create compare parent");
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&compare).expect("serialize compare"),
+    )
+    .expect("write compare");
+}
+
 #[test]
 fn doctor_reports_local_setup_without_running_benchmarks() {
     let dir = tempdir().expect("tempdir");
@@ -93,6 +186,94 @@ fn doctor_reports_local_setup_without_running_benchmarks() {
             "do not loosen thresholds to fix missing baseline setup",
         ))
         .stdout(predicate::str::contains("Summary: 0 failed"));
+}
+
+#[test]
+fn doctor_signal_reports_safe_to_gate_when_receipts_are_mature() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_signal_receipt(
+        &dir.path().join("baselines/doctor-bench.json"),
+        "doctor-bench",
+        7,
+        0.03,
+    );
+    write_signal_receipt(
+        &dir.path().join("artifacts/perfgate/doctor-bench/run.json"),
+        "doctor-bench",
+        7,
+        0.03,
+    );
+    write_signal_compare(
+        &dir.path()
+            .join("artifacts/perfgate/doctor-bench/compare.json"),
+        "doctor-bench",
+    );
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["doctor", "signal", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("perfgate doctor signal"))
+        .stdout(predicate::str::contains("bench: doctor-bench"))
+        .stdout(predicate::str::contains("samples: 7 measured samples"))
+        .stdout(predicate::str::contains("cv: 3.0%"))
+        .stdout(predicate::str::contains("recent drift: pass"))
+        .stdout(predicate::str::contains("recommendation: safe_to_gate"))
+        .stdout(predicate::str::contains("perfgate check --config"))
+        .stdout(predicate::str::contains("--require-baseline"))
+        .stdout(predicate::str::contains("Advisory only: no config"));
+}
+
+#[test]
+fn doctor_signal_recommends_paired_mode_for_noisy_signal() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_signal_receipt(
+        &dir.path().join("baselines/doctor-bench.json"),
+        "doctor-bench",
+        7,
+        0.20,
+    );
+    write_signal_receipt(
+        &dir.path().join("artifacts/perfgate/doctor-bench/run.json"),
+        "doctor-bench",
+        7,
+        0.20,
+    );
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["doctor", "signal", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("recommendation: use_paired_mode"))
+        .stdout(predicate::str::contains("ordinary runs are noisy"))
+        .stdout(predicate::str::contains("perfgate paired"));
+}
+
+#[test]
+fn doctor_signal_treats_missing_baseline_as_incomplete_setup() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_signal_receipt(
+        &dir.path().join("artifacts/perfgate/doctor-bench/run.json"),
+        "doctor-bench",
+        7,
+        0.03,
+    );
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["doctor", "signal", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("baseline: baselines"))
+        .stdout(predicate::str::contains("(missing)"))
+        .stdout(predicate::str::contains("recommendation: no_decision_yet"))
+        .stdout(predicate::str::contains("setup or receipts are incomplete"))
+        .stdout(predicate::str::contains("perfgate baseline promote"));
 }
 
 #[test]

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -84,9 +84,22 @@ fn cli_help_doctor() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Diagnose local setup"))
+        .stdout(predicate::str::contains("signal"))
         .stdout(predicate::str::contains("--config"))
         .stdout(predicate::str::contains("--out-dir"))
         .stdout(predicate::str::contains("--strict"));
+}
+
+#[test]
+fn cli_help_doctor_signal() {
+    perfgate_cmd()
+        .args(["doctor", "signal", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Report advisory signal maturity"))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--bench"));
 }
 
 #[test]

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: baseline maturity doctor
+Current PR: signal maturity doctor
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -69,8 +69,8 @@ surface change requires an accepted spec and explicit proof.
 | 502 | Agent repair-context contract spec | merged | `docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md` |
 | 503 | Benchmark recipe catalog | merged | `perfgate init`, recipe metadata, CLI tests |
 | 505 | Benchmark recipe guidance | merged | docs for recipes and anti-patterns |
-| 506 | Baseline maturity doctor | current | `perfgate baseline doctor`, CLI tests |
-| 507 | Signal maturity doctor | pending | `perfgate doctor signal`, CLI tests |
+| 506 | Baseline maturity doctor | merged | `perfgate baseline doctor`, CLI tests |
+| 507 | Signal maturity doctor | current | `perfgate doctor signal`, CLI tests |
 | 508 | Calibration patch output | pending | `perfgate calibrate --emit-patch`, CLI tests |
 | 509 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
 | 510 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
@@ -283,7 +283,7 @@ Revert the guide and links. Recipe catalog behavior remains available.
 
 ## Work item: baseline-maturity-doctor
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: signal-maturity-doctor, product-claims
@@ -353,7 +353,7 @@ remains intact.
 
 ## Work item: signal-maturity-doctor
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: calibration-patch-output, product-claims
@@ -388,14 +388,36 @@ no_decision_yet
 
 - Do not treat noisy evidence as regression.
 - Do not imply a bad workload can be fixed only by automation.
+- Do not write config, promote baselines, or make signal maturity a blocking
+  gate.
+
+### Acceptance
+
+- `perfgate doctor signal --config perfgate.toml` reports sample count, CV,
+  host stability, baseline age, recent drift, artifact paths, and next command.
+- Mature local run/baseline/compare receipts produce `safe_to_gate`.
+- High-CV evidence recommends `use_paired_mode`.
+- Missing baseline remains `no_decision_yet` setup guidance.
+- The plain `perfgate doctor --config ...` path remains compatible.
 
 ### Proof commands
 
 ```bash
-cargo +1.95.0 test -p perfgate-cli --all-features doctor
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 test -p perfgate-cli --test cli_doctor_tests --all-features
+cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features
+cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
+cargo +1.95.0 run -p xtask -- docs-check
 cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
 git diff --check
 ```
+
+### Rollback
+
+Revert the `doctor signal` subcommand and tests. Existing plain `doctor` and
+`calibrate` behavior remains intact.
 
 ## Work item: calibration-patch-output
 


### PR DESCRIPTION
Summary: Adds advisory perfgate doctor signal for local signal maturity checks. It reports samples, CV, host stability, baseline age, recent drift, artifact paths, next commands, and do-not guidance while keeping maturity output advisory with no config writes, baseline promotion, schema changes, action changes, or server requirement. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p perfgate-cli --test cli_doctor_tests --all-features; cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features; cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check.