### PR TITLE
calibrate: emit reviewable config patch

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "signal-maturity-doctor"
-current_pr = "doctor: add signal maturity output"
+current_work_item = "calibration-patch-output"
+current_pr = "calibrate: emit reviewable config patch"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -166,14 +166,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "signal-maturity-doctor"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "calibration-patch-output"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-cli/src/doctor.rs
+++ b/crates/perfgate-cli/src/doctor.rs
@@ -327,12 +327,10 @@ pub(crate) fn execute_calibrate(args: CalibrateArgs) -> anyhow::Result<()> {
         cv.map(format_percent)
             .unwrap_or_else(|| "unavailable".to_string())
     );
-    println!(
-        "Host class: {}",
-        evidence_receipt
-            .map(host_class)
-            .unwrap_or_else(|| "unknown".to_string())
-    );
+    let evidence_host_class = evidence_receipt
+        .map(host_class)
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("Host class: {evidence_host_class}");
     println!();
     println!("Evidence:");
     if let Some(path) = run_path.as_ref().filter(|path| path.exists()) {
@@ -382,6 +380,11 @@ pub(crate) fn execute_calibrate(args: CalibrateArgs) -> anyhow::Result<()> {
     println!("  warn_factor = {:.2}", suggestion.warn_factor);
     println!("  noise_threshold = {:.2}", suggestion.noise_threshold);
     println!("  noise_policy = \"{}\"", suggestion.noise_policy.as_str());
+    if args.emit_patch {
+        print_calibration_patch(&suggestion, sample_count, cv, &evidence_host_class);
+    } else {
+        println!("  run with --emit-patch for a reasoned, copy-ready TOML fragment");
+    }
     println!();
     println!("Next:");
     if run_receipt.is_none() {
@@ -400,6 +403,69 @@ pub(crate) fn execute_calibrate(args: CalibrateArgs) -> anyhow::Result<()> {
     println!("Advisory only: no config was written.");
 
     Ok(())
+}
+
+fn print_calibration_patch(
+    suggestion: &CalibrationSuggestion,
+    sample_count: usize,
+    cv: Option<f64>,
+    host_class: &str,
+) {
+    println!();
+    println!("Reviewable TOML patch:");
+    if sample_count == 0 {
+        println!("# Suggested without local samples on {host_class}; collect receipts first.");
+    } else {
+        println!(
+            "# Suggested from {sample_count} measured sample{} on {host_class}.",
+            plural(sample_count)
+        );
+    }
+    println!(
+        "# CV: {}; {}.",
+        cv.map(format_percent)
+            .unwrap_or_else(|| "unavailable".to_string()),
+        calibration_patch_summary(suggestion)
+    );
+    println!("threshold = {:.2}", suggestion.fail_threshold);
+    println!("warn_factor = {:.2}", suggestion.warn_factor);
+    println!("noise_threshold = {:.2}", suggestion.noise_threshold);
+    println!("noise_policy = \"{}\"", suggestion.noise_policy.as_str());
+    println!("repeat = {}", suggestion.recommended_repeat);
+    println!();
+    println!("Reasons:");
+    println!(
+        "  samples: {}",
+        if sample_count == 0 {
+            "unavailable".to_string()
+        } else {
+            format!("{sample_count} measured sample{}", plural(sample_count))
+        }
+    );
+    println!(
+        "  noise: {}",
+        cv.map(format_percent)
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+    println!("  host: {host_class}");
+    if suggestion.suggest_paired {
+        println!("  paired mode: recommended before blocking");
+    } else {
+        println!("  paired mode: not required by current evidence");
+    }
+    println!();
+    println!("When not to apply:");
+    println!("  benchmark is not the workload reviewers want to gate");
+    println!("  samples are missing, too few, or collected on the wrong host class");
+    println!("  paired mode is recommended but has not been run");
+}
+
+fn calibration_patch_summary(suggestion: &CalibrationSuggestion) -> &'static str {
+    if suggestion.suggest_paired {
+        "keep advisory or use paired mode before required CI"
+    } else {
+        "review before applying to defaults or a specific benchmark budget"
+    }
 }
 
 fn find_calibration_run_path(out_dir: &Path, bench_name: &str) -> Option<PathBuf> {

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1180,6 +1180,10 @@ pub struct CalibrateArgs {
     /// Explicit baseline receipt. Defaults to the configured baseline path.
     #[arg(long)]
     pub baseline: Option<PathBuf>,
+
+    /// Emit a copy-ready advisory TOML fragment with reasons and guardrails.
+    #[arg(long, default_value_t = false)]
+    pub emit_patch: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/perfgate-cli/tests/cli_calibrate_tests.rs
+++ b/crates/perfgate-cli/tests/cli_calibrate_tests.rs
@@ -117,6 +117,7 @@ fn calibrate_suggests_thresholds_from_existing_run_receipt() {
         stdout.contains("noise_policy = \"warn\""),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("run with --emit-patch"), "stdout: {stdout}");
     assert!(
         stdout.contains("Advisory only: no config was written."),
         "stdout: {stdout}"
@@ -125,6 +126,57 @@ fn calibrate_suggests_thresholds_from_existing_run_receipt() {
         fs::read_to_string(&config_path).expect("read config after calibrate"),
         original_config,
         "calibrate must not edit config in the advisory-only version"
+    );
+}
+
+#[test]
+fn calibrate_emit_patch_prints_reviewable_toml_without_editing_config() {
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_config(temp_dir.path());
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    let run_path = out_dir.join("parser").join("run.json");
+    write_run_receipt(&run_path, "parser", 100.0, 4.0);
+    let original_config = fs::read_to_string(&config_path).expect("read config");
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("calibrate")
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--bench")
+        .arg("parser")
+        .arg("--emit-patch");
+
+    let output = cmd.output().expect("run calibrate");
+    assert!(
+        output.status.success(),
+        "calibrate should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Reviewable TOML patch:"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("# Suggested from 3 measured samples on linux-x86_64."),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("# CV: 4.0%; review before applying"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("repeat = 10"), "stdout: {stdout}");
+    assert!(stdout.contains("Reasons:"), "stdout: {stdout}");
+    assert!(stdout.contains("When not to apply:"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("benchmark is not the workload reviewers want to gate"),
+        "stdout: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(&config_path).expect("read config after calibrate"),
+        original_config,
+        "calibrate --emit-patch must not edit config"
     );
 }
 

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -78,6 +78,18 @@ fn cli_help_check() {
 }
 
 #[test]
+fn cli_help_calibrate() {
+    perfgate_cmd()
+        .args(["calibrate", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Suggest advisory thresholds"))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--bench"))
+        .stdout(predicate::str::contains("--emit-patch"));
+}
+
+#[test]
 fn cli_help_doctor() {
     perfgate_cmd()
         .args(["doctor", "--help"])

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: signal maturity doctor
+Current PR: calibration patch output
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -70,16 +70,16 @@ surface change requires an accepted spec and explicit proof.
 | 503 | Benchmark recipe catalog | merged | `perfgate init`, recipe metadata, CLI tests |
 | 505 | Benchmark recipe guidance | merged | docs for recipes and anti-patterns |
 | 506 | Baseline maturity doctor | merged | `perfgate baseline doctor`, CLI tests |
-| 507 | Signal maturity doctor | current | `perfgate doctor signal`, CLI tests |
-| 508 | Calibration patch output | pending | `perfgate calibrate --emit-patch`, CLI tests |
-| 509 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
-| 510 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
-| 511 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
-| 512 | Server backup/restore smoke | pending | server/CLI tests |
-| 513 | Server retention and migration policy | pending | server docs/status |
-| 514 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
-| 515 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 516 | Evidence maturity closeout | pending | handoff and goal archive |
+| 508 | Signal maturity doctor | merged | `perfgate doctor signal`, CLI tests |
+| 509 | Calibration patch output | current | `perfgate calibrate --emit-patch`, CLI tests |
+| 510 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
+| 511 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
+| 512 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
+| 513 | Server backup/restore smoke | pending | server/CLI tests |
+| 514 | Server retention and migration policy | pending | server docs/status |
+| 515 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
+| 516 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 517 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 
@@ -353,7 +353,7 @@ remains intact.
 
 ## Work item: signal-maturity-doctor
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: calibration-patch-output, product-claims
@@ -421,7 +421,7 @@ Revert the `doctor signal` subcommand and tests. Existing plain `doctor` and
 
 ## Work item: calibration-patch-output
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: product-claims
@@ -446,14 +446,33 @@ and when not to apply the suggestion.
 
 - No `--write` behavior.
 - No policy mutation.
+- Do not make calibration output a substitute for reviewing benchmark quality.
+
+### Acceptance
+
+- `perfgate calibrate --config perfgate.toml --bench parser --emit-patch`
+  prints a reviewable TOML fragment.
+- Patch output includes evidence used, sample count, host class, CV, suggested
+  threshold/noise values, repeat guidance, reasons, and when not to apply it.
+- Calibrate remains advisory and does not edit config.
+- Existing calibrate output still gives next commands and a no-write warning.
 
 ### Proof commands
 
 ```bash
-cargo +1.95.0 test -p perfgate-cli --all-features calibrate
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 test -p perfgate-cli --test cli_calibrate_tests --all-features
+cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features
+cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
 cargo +1.95.0 run -p xtask -- doc-test
+cargo +1.95.0 run -p xtask -- docs-source-check
 git diff --check
 ```
+
+### Rollback
+
+Revert the `--emit-patch` flag and the richer calibration patch output. The
+base advisory `calibrate` command remains usable.
 
 ## Work item: decision-example-pack
 


### PR DESCRIPTION
Summary: Adds explicit calibrate --emit-patch output for a copy-ready advisory TOML fragment with sample count, host class, CV, suggested threshold and noise settings, repeat guidance, reasons, and when-not-to-apply guardrails. Keeps calibration advisory with no config writes, no baseline promotion, no policy mutation, and no schema or action changes. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p perfgate-cli --test cli_calibrate_tests --all-features; cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features; cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; cargo +1.95.0 run -p xtask -- docs-check; git diff --check.