### PR TITLE
decision: add tradeoff example pack

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "calibration-patch-output"
-current_pr = "calibrate: emit reviewable config patch"
+current_work_item = "decision-example-pack"
+current_pr = "decision: add tradeoff example pack"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -173,14 +173,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "calibration-patch-output"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "decision-example-pack"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/docs/examples/decision-outcomes.md
+++ b/docs/examples/decision-outcomes.md
@@ -8,6 +8,11 @@ and [`PERFGATE-SPEC-0007`](../specs/PERFGATE-SPEC-0007-guided-adoption-contract.
 Use these examples when a CI summary, `decision.md`, or decision bundle looks
 unfamiliar.
 
+For examples of common tradeoff review conversations before the final verdict,
+see the
+[`examples/performance-decision/patterns`](../../examples/performance-decision/patterns/README.md)
+pack.
+
 ## Common Review Packet
 
 Structured decisions are review packets. A complete local packet usually has:
@@ -69,4 +74,3 @@ Before accepting a structured decision:
 - confirm the local reproduction command is present; and
 - bundle the decision when it needs to travel with a PR, release, issue, audit,
   or agent handoff.
-

--- a/examples/performance-decision/README.md
+++ b/examples/performance-decision/README.md
@@ -47,4 +47,6 @@ slightly. That evidence remains visible in the generated `probe-compare.json`;
 the tradeoff rule accepts the memory regression only because the local
 tokenizer regression stays bounded and the dominant batch-loop probe improves.
 
-For common decision shapes, see the [`outcomes`](outcomes/README.md) gallery.
+For common final verdicts, see the [`outcomes`](outcomes/README.md) gallery.
+For common review conversations before a decision is accepted, see the
+[`patterns`](patterns/README.md) pack.

--- a/examples/performance-decision/patterns/README.md
+++ b/examples/performance-decision/patterns/README.md
@@ -1,0 +1,32 @@
+# Decision Pattern Pack
+
+This pack gives reviewers recognizable structured-decision shapes before they
+need to author a full scenario or tradeoff policy from scratch. It complements
+the outcome gallery: outcomes describe final verdicts, while patterns describe
+the review conversation that usually leads to a decision.
+
+Use these examples when `perfgate decision suggest` says a structured decision
+may help, or when a PR has more than one meaningful metric movement.
+
+## Patterns
+
+| Pattern | Use when | First reviewer question |
+|---------|----------|-------------------------|
+| [Latency regression with throughput improvement](latency-vs-throughput.md) | request latency worsens but batch throughput improves | Does the workload that improved matter more for this change? |
+| [Memory regression with runtime improvement](memory-vs-runtime.md) | runtime improves by spending more memory | Is the memory increase inside policy for the deployment target? |
+| [Startup slower but steady-state faster](startup-vs-steady-state.md) | initialization cost moves into a better steady-state path | Which phase matters for users and release policy? |
+| [Probe regression with dominant workload improvement](probe-backed-tradeoff.md) | local work moved but the weighted scenario improved | Did the dominant workload improve enough to accept the local cost? |
+| [Noise too high for a decision](noisy-no-decision.md) | evidence moves but noise makes the judgment unsafe | Should this be rerun paired or kept advisory? |
+
+## Review Shape
+
+Each pattern follows the same contract:
+
+- what moved;
+- why it matters;
+- which receipts to inspect;
+- what the reviewer should run next; and
+- what not to do.
+
+Local receipts remain the correctness contract. The server ledger is optional
+team history and is not required for any example in this pack.

--- a/examples/performance-decision/patterns/latency-vs-throughput.md
+++ b/examples/performance-decision/patterns/latency-vs-throughput.md
@@ -1,0 +1,48 @@
+# Latency Regression With Throughput Improvement
+
+## Shape
+
+A request-path latency metric regresses, while a throughput metric improves.
+The raw signs differ by metric direction: higher throughput can be good while
+higher latency is bad.
+
+```text
+wall_ms             regressed 2.4%
+throughput_per_s    improved 12.4%
+```
+
+## Why It Matters
+
+This can be a real product win when the changed code improves batch capacity or
+worker throughput and the latency regression stays inside accepted policy. It
+can also be a bad tradeoff if the latency metric represents the user-facing
+path that reviewers care about.
+
+## Receipts To Inspect
+
+```text
+compare.json
+scenario.json
+tradeoff.json
+decision.md
+decision.index.json
+```
+
+## Reviewer Action
+
+Use a structured decision when both movements exceed policy thresholds and the
+project has scenario weights or tradeoff policy that says which workload
+matters.
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+## Do Not
+
+- Do not call a throughput improvement a regression because the percent is
+  positive.
+- Do not accept the tradeoff unless the latency regression is bounded by
+  policy.
+- Do not loosen the latency threshold just to make the review pass.

--- a/examples/performance-decision/patterns/memory-vs-runtime.md
+++ b/examples/performance-decision/patterns/memory-vs-runtime.md
@@ -1,0 +1,43 @@
+# Memory Regression With Runtime Improvement
+
+## Shape
+
+The workload finishes faster by using more memory.
+
+```text
+wall_ms       improved 9.8%
+max_rss_kb    regressed 3.1%
+```
+
+## Why It Matters
+
+This is one of the most common useful tradeoffs. It may be acceptable for a
+batch job or developer tool, but unacceptable for memory-constrained runners,
+serverless functions, or embedded deployments.
+
+## Receipts To Inspect
+
+```text
+compare.json
+report.json
+tradeoff.json
+decision.md
+repair_context.json
+```
+
+## Reviewer Action
+
+Check whether the memory regression is inside the configured local cap and
+whether the runtime improvement applies to the workload that actually matters.
+If the tradeoff is accepted, keep the decision bundle with the review.
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+## Do Not
+
+- Do not compare memory and runtime by raw percent alone.
+- Do not accept memory growth without deployment context.
+- Do not make the server ledger part of merge correctness.

--- a/examples/performance-decision/patterns/noisy-no-decision.md
+++ b/examples/performance-decision/patterns/noisy-no-decision.md
@@ -1,0 +1,45 @@
+# Noise Too High For A Decision
+
+## Shape
+
+Metrics move, but the signal is noisy enough that the decision would create
+false confidence.
+
+```text
+wall_ms    changed 4.0%
+cv         18.0%
+status     noisy
+```
+
+## Why It Matters
+
+Noise is not an accepted tradeoff. If the evidence is unstable, reviewers need a
+better run, paired mode, or advisory treatment before they can accept or reject
+the change.
+
+## Receipts To Inspect
+
+```text
+run.json
+compare.json
+report.json
+repair_context.json
+decision.md
+```
+
+## Reviewer Action
+
+Keep the benchmark advisory, increase samples, or run paired mode before making
+the result block a PR.
+
+```bash
+perfgate doctor signal --config perfgate.toml
+perfgate calibrate --config perfgate.toml --bench parser --emit-patch
+perfgate paired --name parser --baseline-cmd "cargo run -- benchmark-old" --current-cmd "cargo run -- benchmark-new" --repeat 10 --out artifacts/perfgate/parser/compare.json
+```
+
+## Do Not
+
+- Do not treat noise as a regression or an accepted tradeoff.
+- Do not promote a new baseline just to silence noisy evidence.
+- Do not tighten thresholds until receipts show stable signal.

--- a/examples/performance-decision/patterns/probe-backed-tradeoff.md
+++ b/examples/performance-decision/patterns/probe-backed-tradeoff.md
@@ -1,0 +1,47 @@
+# Probe Regression With Dominant Workload Improvement
+
+## Shape
+
+A local probe regresses, but the dominant scenario or workload improves enough
+to justify the change.
+
+```text
+parser.tokenize      regressed 2.0%
+parser.batch_loop    improved 11.0%
+weighted scenario    improved 8.5%
+```
+
+## Why It Matters
+
+Probes should explain where work moved. They are not a profiler replacement.
+This pattern is useful when reviewers need to see that a local cost is bounded
+and the overall workload improved.
+
+## Receipts To Inspect
+
+```text
+probe-compare.json
+scenario.json
+tradeoff.json
+decision.md
+decision.index.json
+decision-bundle.json
+```
+
+## Reviewer Action
+
+Check that the regressed probe is covered by a local cap and that the dominant
+probe or weighted scenario improved. Bundle the decision when it needs to
+travel with a PR, release, or agent handoff.
+
+```bash
+perfgate ingest probes --file probes-current.jsonl --out artifacts/perfgate/probes-current.json
+perfgate decision evaluate --config perfgate.toml
+perfgate decision bundle --index artifacts/perfgate/decision.index.json --out artifacts/perfgate/decision-bundle.json
+```
+
+## Do Not
+
+- Do not add probes before the benchmark shows a meaningful tradeoff.
+- Do not accept a local probe regression without a configured cap.
+- Do not treat probe evidence as a substitute for the outside benchmark result.

--- a/examples/performance-decision/patterns/startup-vs-steady-state.md
+++ b/examples/performance-decision/patterns/startup-vs-steady-state.md
@@ -1,0 +1,43 @@
+# Startup Slower But Steady-State Faster
+
+## Shape
+
+Initialization gets slower because work moves earlier, while steady-state
+operations get faster.
+
+```text
+startup_ms          regressed 6.0%
+steady_state_ops    improved 15.0%
+```
+
+## Why It Matters
+
+This tradeoff depends on how the product is used. A command-line tool that
+starts often may care about startup more. A long-lived service may accept a
+startup cost for better steady-state throughput.
+
+## Receipts To Inspect
+
+```text
+compare.json
+scenario.json
+decision.md
+decision.index.json
+```
+
+## Reviewer Action
+
+Use scenarios to weight startup and steady-state separately. If startup is part
+of the user promise, keep it as a gate or require review. If steady-state is the
+dominant workload, document why the startup cost is acceptable.
+
+```bash
+perfgate decision evaluate --config perfgate.toml
+```
+
+## Do Not
+
+- Do not collapse startup and steady-state into one benchmark if reviewers need
+  to reason about both.
+- Do not make a compile-heavy setup command the startup benchmark.
+- Do not accept the tradeoff without naming the workload that matters.

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: calibration patch output
+Current PR: decision example pack
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -71,15 +71,15 @@ surface change requires an accepted spec and explicit proof.
 | 505 | Benchmark recipe guidance | merged | docs for recipes and anti-patterns |
 | 506 | Baseline maturity doctor | merged | `perfgate baseline doctor`, CLI tests |
 | 508 | Signal maturity doctor | merged | `perfgate doctor signal`, CLI tests |
-| 509 | Calibration patch output | current | `perfgate calibrate --emit-patch`, CLI tests |
-| 510 | Decision example pack | pending | examples/fixtures and optional `decision examples` |
-| 511 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
-| 512 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
-| 513 | Server backup/restore smoke | pending | server/CLI tests |
-| 514 | Server retention and migration policy | pending | server docs/status |
-| 515 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
-| 516 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 517 | Evidence maturity closeout | pending | handoff and goal archive |
+| 510 | Calibration patch output | merged | `perfgate calibrate --emit-patch`, CLI tests |
+| 511 | Decision example pack | current | examples/fixtures and optional `decision examples` |
+| 512 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
+| 513 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
+| 514 | Server backup/restore smoke | pending | server/CLI tests |
+| 515 | Server retention and migration policy | pending | server docs/status |
+| 516 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
+| 517 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 518 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 
@@ -421,7 +421,7 @@ Revert the `doctor signal` subcommand and tests. Existing plain `doctor` and
 
 ## Work item: calibration-patch-output
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: product-claims
@@ -476,7 +476,7 @@ base advisory `calibrate` command remains usable.
 
 ## Work item: decision-example-pack
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: decision-suggestion-reasons
@@ -508,15 +508,31 @@ perfgate decision examples
 
 - Do not make structured decisions mandatory for local gates.
 - Do not treat noise as an accepted tradeoff.
+- Do not add a new CLI command unless the examples need it.
+
+### Acceptance
+
+- Pattern examples cover latency/throughput, memory/runtime,
+  startup/steady-state, probe-backed tradeoff, and noisy-no-decision shapes.
+- Each example names what moved, why it matters, receipts to inspect, reviewer
+  action, and what not to do.
+- Existing outcome gallery links to the pattern pack.
+- No receipt schema, action behavior, or public crate changes are made.
 
 ### Proof commands
 
 ```bash
-cargo +1.95.0 test -p perfgate-cli --all-features decision
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 run -p xtask -- docs-check
 cargo +1.95.0 run -p xtask -- doc-test
-cargo +1.95.0 run -p xtask -- schema-compat
+cargo +1.95.0 run -p xtask -- docs-source-check
 git diff --check
 ```
+
+### Rollback
+
+Remove the pattern pack docs and gallery links. Existing structured-decision
+commands and fixtures remain unchanged.
 
 ## Work item: decision-suggestion-reasons
 


### PR DESCRIPTION
Summary: Adds a docs/fixture decision pattern pack for latency-vs-throughput, memory-vs-runtime, startup-vs-steady-state, probe-backed tradeoff, and noisy-no-decision review shapes. Links the pack from the existing performance-decision fixture and outcome gallery. Keeps this slice docs-only with no CLI command, no receipt schema change, no action behavior change, and no server requirement. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- doc-test; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- product-claims-check; git diff --check.