### PR TITLE
decision: explain suggestion reasons

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "decision-example-pack"
-current_pr = "decision: add tradeoff example pack"
+current_work_item = "decision-suggestion-reasons"
+current_pr = "decision: explain suggestion reasons"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -180,14 +180,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "decision-example-pack"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "decision-suggestion-reasons"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-cli/src/decision_suggest.rs
+++ b/crates/perfgate-cli/src/decision_suggest.rs
@@ -10,8 +10,10 @@ use crate::{
     COMPARE_RECEIPT_FILE, DecisionSuggestArgs, is_regression, load_validated_config,
     resolve_configured_out_dir,
 };
-use perfgate::domain::is_improvement;
-use perfgate_types::{CompareReceipt, ConfigFile};
+use perfgate::domain::{MetricMovement, is_improvement, movement_for_delta};
+use perfgate_types::{CompareReceipt, ConfigFile, Delta, Direction, Metric, MetricStatus};
+
+const DECISION_HIGH_NOISE_CV: f64 = 0.10;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DecisionReadiness {
@@ -63,12 +65,40 @@ impl DecisionReadiness {
 struct DecisionReadinessEvidence {
     compare_found: usize,
     compare_missing: usize,
+    compare_artifacts: Vec<CompareEvidence>,
+    missing_compare_artifacts: Vec<(String, PathBuf)>,
     has_regression: bool,
     has_improvement: bool,
     high_noise: bool,
     has_probe_config: bool,
     probe_receipts_found: usize,
+    probe_artifacts: Vec<ProbeEvidence>,
     decision_index_exists: bool,
+}
+
+#[derive(Debug, Clone)]
+struct CompareEvidence {
+    bench: String,
+    path: PathBuf,
+    verdict: &'static str,
+    metrics: Vec<MetricEvidence>,
+}
+
+#[derive(Debug, Clone)]
+struct MetricEvidence {
+    metric: Metric,
+    movement: MetricMovement,
+    direction: Direction,
+    pct: f64,
+    status: MetricStatus,
+    cv: Option<f64>,
+    noise_threshold: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+struct ProbeEvidence {
+    path: PathBuf,
+    found: bool,
 }
 
 pub(crate) fn execute_decision_suggest(args: DecisionSuggestArgs) -> anyhow::Result<()> {
@@ -113,6 +143,14 @@ pub(crate) fn execute_decision_suggest(args: DecisionSuggestArgs) -> anyhow::Res
         }
     );
     println!();
+    println!("Why:");
+    for reason in decision_readiness_reasons(readiness, &config, &evidence, &out_dir) {
+        println!("  - {reason}");
+    }
+    println!();
+    println!("Artifacts:");
+    print_decision_artifacts(&evidence, &out_dir);
+    println!();
     println!("Structured decisions may help if:");
     println!("  - one benchmark regressed while another improved");
     println!("  - reviewers need to accept a bounded tradeoff");
@@ -141,6 +179,8 @@ fn collect_decision_readiness_evidence(
 ) -> anyhow::Result<DecisionReadinessEvidence> {
     let mut compare_found = 0usize;
     let mut compare_missing = 0usize;
+    let mut compare_artifacts = Vec::new();
+    let mut missing_compare_artifacts = Vec::new();
     let mut has_regression = false;
     let mut has_improvement = false;
     let mut high_noise = false;
@@ -148,6 +188,7 @@ fn collect_decision_readiness_evidence(
     for (bench_name, path) in decision_compare_paths(config, out_dir) {
         if !path.exists() {
             compare_missing += 1;
+            missing_compare_artifacts.push((bench_name, path));
             continue;
         }
         compare_found += 1;
@@ -162,23 +203,59 @@ fn collect_decision_readiness_evidence(
         high_noise |= compare
             .deltas
             .values()
-            .any(|delta| delta.cv.is_some_and(|cv| cv > 0.10));
+            .any(|delta| delta.cv.is_some_and(|cv| cv > DECISION_HIGH_NOISE_CV));
+        compare_artifacts.push(compare_evidence(bench_name, path, &compare));
     }
 
     let probe_paths = configured_decision_probe_paths(config);
     let has_probe_config = !probe_paths.is_empty();
     let probe_receipts_found = probe_paths.iter().filter(|path| path.exists()).count();
+    let probe_artifacts = probe_paths
+        .iter()
+        .map(|path| ProbeEvidence {
+            path: path.clone(),
+            found: path.exists(),
+        })
+        .collect();
 
     Ok(DecisionReadinessEvidence {
         compare_found,
         compare_missing,
+        compare_artifacts,
+        missing_compare_artifacts,
         has_regression,
         has_improvement,
         high_noise,
         has_probe_config,
         probe_receipts_found,
+        probe_artifacts,
         decision_index_exists: out_dir.join("decision.index.json").exists(),
     })
+}
+
+fn compare_evidence(bench: String, path: PathBuf, compare: &CompareReceipt) -> CompareEvidence {
+    CompareEvidence {
+        bench,
+        path,
+        verdict: compare.verdict.status.as_str(),
+        metrics: compare
+            .deltas
+            .iter()
+            .map(|(metric, delta)| metric_evidence(*metric, delta))
+            .collect(),
+    }
+}
+
+fn metric_evidence(metric: Metric, delta: &Delta) -> MetricEvidence {
+    MetricEvidence {
+        metric,
+        movement: movement_for_delta(metric, delta),
+        direction: metric.default_direction(),
+        pct: delta.pct,
+        status: delta.status,
+        cv: delta.cv,
+        noise_threshold: delta.noise_threshold,
+    }
 }
 
 fn decision_compare_paths(config: &ConfigFile, out_dir: &Path) -> Vec<(String, PathBuf)> {
@@ -292,6 +369,173 @@ fn decision_readiness_next_commands(
             out_dir.join("decision.index.json").display()
         )],
     }
+}
+
+fn decision_readiness_reasons(
+    readiness: DecisionReadiness,
+    config: &ConfigFile,
+    evidence: &DecisionReadinessEvidence,
+    out_dir: &Path,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    match readiness {
+        DecisionReadiness::RunLocalGateFirst => {
+            reasons.push(
+                "no compare receipts were found; local gate evidence must exist first".to_string(),
+            );
+        }
+        DecisionReadiness::SimpleGateEnough => {
+            reasons.push(
+                "compare receipts exist and no noisy or tradeoff-shaped movement was found"
+                    .to_string(),
+            );
+        }
+        DecisionReadiness::PairedModeRecommended => {
+            reasons.push(format!(
+                "at least one metric has CV above {:.1}%; paired mode is safer than policy",
+                DECISION_HIGH_NOISE_CV * 100.0
+            ));
+        }
+        DecisionReadiness::StructuredDecisionCandidate => {
+            reasons.push(
+                "metric movement exists, but scenario/tradeoff/probe evidence is incomplete"
+                    .to_string(),
+            );
+        }
+        DecisionReadiness::StructuredDecisionReady => {
+            reasons.push(format!(
+                "{} scenario{} and {} tradeoff rule{} are configured",
+                config.scenarios.len(),
+                plural(config.scenarios.len()),
+                config.tradeoffs.len(),
+                plural(config.tradeoffs.len())
+            ));
+        }
+        DecisionReadiness::ReadyToBundle => {
+            reasons.push(format!(
+                "decision index already exists at {}",
+                out_dir.join("decision.index.json").display()
+            ));
+        }
+    }
+
+    for compare in &evidence.compare_artifacts {
+        reasons.push(format!(
+            "{} compare verdict is {} ({})",
+            compare.bench,
+            compare.verdict,
+            compare.path.display()
+        ));
+        for metric in &compare.metrics {
+            reasons.push(metric_reason(metric));
+            if let Some(noise) = metric_noise_reason(metric) {
+                reasons.push(noise);
+            }
+        }
+    }
+
+    if evidence.has_probe_config {
+        reasons.push(format!(
+            "probe evidence configured with {} receipt{} found",
+            evidence.probe_receipts_found,
+            plural(evidence.probe_receipts_found)
+        ));
+    }
+    if !evidence.missing_compare_artifacts.is_empty() {
+        for (bench, path) in &evidence.missing_compare_artifacts {
+            reasons.push(format!(
+                "{bench} compare receipt is missing at {}",
+                path.display()
+            ));
+        }
+    }
+    if matches!(
+        readiness,
+        DecisionReadiness::StructuredDecisionReady | DecisionReadiness::ReadyToBundle
+    ) {
+        reasons.push(
+            "optional ledger history can record the decision after local receipts are reviewed"
+                .to_string(),
+        );
+    }
+
+    reasons
+}
+
+fn metric_reason(metric: &MetricEvidence) -> String {
+    format!(
+        "{} {} by {} (direction {}, threshold status {})",
+        metric.metric.as_str(),
+        movement_label(metric.movement),
+        format_percent(metric.pct.abs()),
+        direction_label(metric.direction),
+        metric.status.as_str()
+    )
+}
+
+fn metric_noise_reason(metric: &MetricEvidence) -> Option<String> {
+    let cv = metric.cv?;
+    let threshold = metric.noise_threshold.unwrap_or(DECISION_HIGH_NOISE_CV);
+    if cv > threshold {
+        Some(format!(
+            "{} noise is high: CV {} exceeds {}",
+            metric.metric.as_str(),
+            format_percent(cv),
+            format_percent(threshold)
+        ))
+    } else {
+        Some(format!(
+            "{} noise is within guidance: CV {} at or below {}",
+            metric.metric.as_str(),
+            format_percent(cv),
+            format_percent(threshold)
+        ))
+    }
+}
+
+fn print_decision_artifacts(evidence: &DecisionReadinessEvidence, out_dir: &Path) {
+    for compare in &evidence.compare_artifacts {
+        println!("  compare: {}", compare.path.display());
+    }
+    for (bench, path) in &evidence.missing_compare_artifacts {
+        println!("  compare: {} (missing for {bench})", path.display());
+    }
+    for probe in &evidence.probe_artifacts {
+        println!(
+            "  probe: {}{}",
+            probe.path.display(),
+            if probe.found { "" } else { " (missing)" }
+        );
+    }
+    println!(
+        "  decision index: {}{}",
+        out_dir.join("decision.index.json").display(),
+        if evidence.decision_index_exists {
+            ""
+        } else {
+            " (missing)"
+        }
+    );
+}
+
+fn movement_label(movement: MetricMovement) -> &'static str {
+    match movement {
+        MetricMovement::Improved => "improved",
+        MetricMovement::Regressed => "regressed",
+        MetricMovement::Unchanged => "stayed unchanged",
+        MetricMovement::Unknown => "has unknown movement",
+    }
+}
+
+fn direction_label(direction: Direction) -> &'static str {
+    match direction {
+        Direction::Lower => "lower_is_better",
+        Direction::Higher => "higher_is_better",
+    }
+}
+
+fn format_percent(value: f64) -> String {
+    format!("{:.1}%", value * 100.0)
 }
 
 #[cfg(test)]
@@ -510,11 +754,14 @@ mod tests {
         let evidence = DecisionReadinessEvidence {
             compare_found: 0,
             compare_missing: 1,
+            compare_artifacts: Vec::new(),
+            missing_compare_artifacts: vec![("bench".into(), PathBuf::from("compare.json"))],
             has_regression: false,
             has_improvement: false,
             high_noise: false,
             has_probe_config: false,
             probe_receipts_found: 0,
+            probe_artifacts: Vec::new(),
             decision_index_exists: false,
         };
         assert_eq!(
@@ -548,11 +795,17 @@ mod tests {
         let configured_only = DecisionReadinessEvidence {
             compare_found: 1,
             compare_missing: 0,
+            compare_artifacts: Vec::new(),
+            missing_compare_artifacts: Vec::new(),
             has_regression: false,
             has_improvement: false,
             high_noise: false,
             has_probe_config: true,
             probe_receipts_found: 0,
+            probe_artifacts: vec![ProbeEvidence {
+                path: PathBuf::from("probe-compare.json"),
+                found: false,
+            }],
             decision_index_exists: false,
         };
         assert_eq!(
@@ -567,11 +820,14 @@ mod tests {
         let evidence = DecisionReadinessEvidence {
             compare_found: 1,
             compare_missing: 0,
+            compare_artifacts: Vec::new(),
+            missing_compare_artifacts: Vec::new(),
             has_regression: true,
             has_improvement: true,
             high_noise: true,
             has_probe_config: false,
             probe_receipts_found: 0,
+            probe_artifacts: Vec::new(),
             decision_index_exists: false,
         };
         config.scenarios.push(ScenarioConfigFile {

--- a/crates/perfgate-cli/tests/cli_decision_suggest_tests.rs
+++ b/crates/perfgate-cli/tests/cli_decision_suggest_tests.rs
@@ -81,6 +81,26 @@ fn write_compare_receipt_for_metric(
     current: f64,
     regression: f64,
 ) {
+    write_compare_receipt_for_metric_with_noise(
+        path,
+        metric,
+        status,
+        baseline,
+        current,
+        regression,
+        (None, None),
+    );
+}
+
+fn write_compare_receipt_for_metric_with_noise(
+    path: &Path,
+    metric: &str,
+    status: &str,
+    baseline: f64,
+    current: f64,
+    regression: f64,
+    noise: (Option<f64>, Option<f64>),
+) {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).expect("create compare parent");
     }
@@ -106,6 +126,8 @@ fn write_compare_receipt_for_metric(
                 "ratio": current / baseline,
                 "pct": (current - baseline) / baseline,
                 "regression": regression,
+                "cv": noise.0,
+                "noise_threshold": noise.1,
                 "status": status
             }
         },
@@ -141,6 +163,12 @@ fn decision_suggest_tells_user_to_run_local_gate_first_without_compares() {
         stdout.contains("Status: run_local_gate_first"),
         "stdout: {stdout}"
     );
+    assert!(stdout.contains("Why:"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("local gate evidence must exist first"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("Artifacts:"), "stdout: {stdout}");
     assert!(
         stdout.contains("no compare receipts found"),
         "stdout: {stdout}"
@@ -183,6 +211,17 @@ fn decision_suggest_detects_throughput_improvement_as_structured_candidate() {
         stdout.contains("Status: structured_decision_candidate"),
         "expected throughput improvement to flag structured_decision_candidate, stdout: {stdout}"
     );
+    assert!(
+        stdout.contains(
+            "throughput_per_s improved by 20.0% (direction higher_is_better, threshold status pass)"
+        ),
+        "expected direction-aware reason line, stdout: {stdout}"
+    );
+    assert!(
+        stdout
+            .contains("metric movement exists, but scenario/tradeoff/probe evidence is incomplete"),
+        "expected structured-decision reason, stdout: {stdout}"
+    );
 }
 
 #[test]
@@ -217,6 +256,56 @@ fn decision_suggest_detects_throughput_regression_as_structured_candidate() {
         stdout.contains("Status: structured_decision_candidate"),
         "expected throughput regression to flag structured_decision_candidate, stdout: {stdout}"
     );
+    assert!(
+        stdout.contains(
+            "throughput_per_s regressed by 20.0% (direction higher_is_better, threshold status fail)"
+        ),
+        "expected direction-aware regression reason line, stdout: {stdout}"
+    );
+}
+
+#[test]
+fn decision_suggest_explains_paired_mode_when_compare_is_noisy() {
+    let temp_dir = tempdir().expect("temp dir");
+    let config_path = write_basic_config(temp_dir.path());
+    let out_dir = temp_dir.path().join("artifacts").join("perfgate");
+    write_compare_receipt_for_metric_with_noise(
+        &out_dir.join("parser").join("compare.json"),
+        "wall_ms",
+        "warn",
+        100.0,
+        104.0,
+        0.04,
+        (Some(0.18), Some(0.10)),
+    );
+
+    let mut cmd = perfgate_cmd();
+    cmd.current_dir(temp_dir.path())
+        .arg("decision")
+        .arg("suggest")
+        .arg("--config")
+        .arg(&config_path);
+
+    let output = cmd.output().expect("run decision suggest");
+    assert!(
+        output.status.success(),
+        "decision suggest should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Status: paired_mode_recommended"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("at least one metric has CV above 10.0%"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("wall_ms noise is high: CV 18.0% exceeds 10.0%"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("perfgate paired"), "stdout: {stdout}");
 }
 
 #[test]
@@ -258,6 +347,18 @@ fn decision_suggest_reports_structured_decision_ready_when_policy_and_evidence_e
     );
     assert!(
         stdout.contains("probe evidence: configured, 3 receipts"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 scenario and 1 tradeoff rule are configured"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("optional ledger history can record the decision"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("probe: artifacts/perfgate/parser/probes-baseline.json"),
         "stdout: {stdout}"
     );
 }

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: decision example pack
+Current PR: decision suggestion reasons
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -72,8 +72,8 @@ surface change requires an accepted spec and explicit proof.
 | 506 | Baseline maturity doctor | merged | `perfgate baseline doctor`, CLI tests |
 | 508 | Signal maturity doctor | merged | `perfgate doctor signal`, CLI tests |
 | 510 | Calibration patch output | merged | `perfgate calibrate --emit-patch`, CLI tests |
-| 511 | Decision example pack | current | examples/fixtures and optional `decision examples` |
-| 512 | Decision suggestion reasons | pending | `perfgate decision suggest`, CLI tests |
+| 511 | Decision example pack | merged | examples/fixtures and optional `decision examples` |
+| 512 | Decision suggestion reasons | current | `perfgate decision suggest`, CLI tests |
 | 513 | Canary freshness matrix | pending | `docs/status/CANARY_MATRIX.md` |
 | 514 | Server backup/restore smoke | pending | server/CLI tests |
 | 515 | Server retention and migration policy | pending | server docs/status |
@@ -476,7 +476,7 @@ base advisory `calibrate` command remains usable.
 
 ## Work item: decision-example-pack
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: decision-suggestion-reasons
@@ -536,7 +536,7 @@ commands and fixtures remain unchanged.
 
 ## Work item: decision-suggestion-reasons
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: product-claims
@@ -553,13 +553,38 @@ Reason output should name metric movement, direction, threshold result, noise
 result, artifacts, probe/scenario/tradeoff evidence when present, missing
 evidence, and next command.
 
+### Non-goals
+
+- Do not change decision receipt schemas.
+- Do not make structured decisions mandatory.
+- Do not make ledger upload part of correctness.
+
+### Acceptance
+
+- `decision suggest` prints a `Why` section for every recommendation.
+- Metric reason lines include movement, metric direction, and threshold status.
+- Noisy evidence explains paired-mode recommendation.
+- Structured-decision-ready output names scenario/tradeoff evidence and keeps
+  ledger history optional.
+- Artifact output lists compare, probe, and decision index paths with missing
+  markers where applicable.
+
 ### Proof commands
 
 ```bash
-cargo +1.95.0 test -p perfgate-cli --all-features decision
+cargo +1.95.0 fmt --all -- --check
+cargo +1.95.0 test -p perfgate-cli --test cli_decision_suggest_tests --all-features
+cargo +1.95.0 test -p perfgate-cli --all-features decision_suggest
+cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
+cargo +1.95.0 run -p xtask -- docs-source-check
 cargo +1.95.0 run -p xtask -- schema-compat
 git diff --check
 ```
+
+### Rollback
+
+Revert the additional `Why` and `Artifacts` output plus focused tests. Existing
+`decision suggest` status classification remains the fallback behavior.
 
 ## Work item: canary-freshness-matrix
 


### PR DESCRIPTION
Summary: Adds explicit Why and Artifacts sections to perfgate decision suggest. Reason output now names metric movement, direction, threshold status, noise evidence, compare/probe/decision-index artifacts, missing compare evidence, structured-decision readiness, and optional ledger history without changing receipt schemas, CLI command names, action behavior, or making server ledger required. Validation: cargo +1.95.0 fmt --all -- --check; cargo +1.95.0 test -p perfgate-cli --test cli_decision_suggest_tests --all-features; cargo +1.95.0 test -p perfgate-cli --all-features decision_suggest; cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings; cargo +1.95.0 run -p xtask -- docs-source-check; cargo +1.95.0 run -p xtask -- schema-compat; cargo +1.95.0 run -p xtask -- docs-check; cargo +1.95.0 run -p xtask -- product-claims-check; cargo +1.95.0 run -p xtask -- doc-test; git diff --check.