### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "14550",
+  "message": "14681",
   "color": "orange"
 }


### PR DESCRIPTION
Summary:
- Refresh generated badge endpoint JSON from current main.
- Supersedes stale bot PR #513, which was generated before the latest docs/status merge.

Validation:
- rtk cargo +1.95.0 run -p xtask -- badges --check
- rtk cargo +1.95.0 run -p xtask -- docs-check
- rtk git diff --check