### PR TITLE
server: add ledger backup/restore smoke

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "canary-freshness-matrix"
-current_pr = "docs(status): add canary freshness matrix"
+current_work_item = "server-backup-restore-smoke"
+current_pr = "server: add ledger backup/restore smoke"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -195,14 +195,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "canary-freshness-matrix"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "server-backup-restore-smoke"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-server/src/storage/memory.rs
+++ b/crates/perfgate-server/src/storage/memory.rs
@@ -1463,4 +1463,207 @@ mod tests {
         assert_eq!(page.events[0].resource_id, "v4");
         assert_eq!(page.events[1].resource_id, "v3");
     }
+
+    #[tokio::test]
+    async fn backup_restore_smoke_preserves_latest_history_audit_and_dry_run() {
+        let source = InMemoryStore::new();
+        source
+            .create(&record_at("p", "bench", "v1", day(1)))
+            .await
+            .unwrap();
+        source
+            .create(&record_at("p", "bench", "v2", day(3)))
+            .await
+            .unwrap();
+        source
+            .create(&record_at("other", "bench", "v1", day(9)))
+            .await
+            .unwrap();
+        source
+            .create_verdict(&verdict_at("p", "bench", VerdictStatus::Pass, day(2)))
+            .await
+            .unwrap();
+        source
+            .create_verdict(&verdict_at("p", "bench", VerdictStatus::Warn, day(4)))
+            .await
+            .unwrap();
+        source
+            .create_decision(&decision_at(
+                "p",
+                Some("memory-for-runtime"),
+                MetricStatus::Pass,
+                VerdictStatus::Pass,
+                vec!["runtime_for_memory"],
+                false,
+                day(1),
+            ))
+            .await
+            .unwrap();
+        source
+            .create_decision(&decision_at(
+                "p",
+                Some("memory-for-runtime"),
+                MetricStatus::Warn,
+                VerdictStatus::Warn,
+                vec!["memory_for_runtime"],
+                true,
+                day(5),
+            ))
+            .await
+            .unwrap();
+        source
+            .log_event(&audit_at(
+                "p",
+                "operator",
+                AuditAction::Create,
+                AuditResourceType::Decision,
+                "decision-old",
+                day(1),
+            ))
+            .await
+            .unwrap();
+        source
+            .log_event(&audit_at(
+                "p",
+                "operator",
+                AuditAction::Delete,
+                AuditResourceType::Decision,
+                "decision-dry-run",
+                day(6),
+            ))
+            .await
+            .unwrap();
+
+        let baseline_summaries = source
+            .list("p", &ListBaselinesQuery::default())
+            .await
+            .unwrap()
+            .baselines;
+        let mut backup_baselines = Vec::new();
+        for summary in baseline_summaries {
+            backup_baselines.push(
+                source
+                    .get("p", &summary.benchmark, &summary.version)
+                    .await
+                    .unwrap()
+                    .expect("listed baseline should resolve to full record"),
+            );
+        }
+        let backup_verdicts = source
+            .list_verdicts("p", &ListVerdictsQuery::default())
+            .await
+            .unwrap()
+            .verdicts;
+        let backup_decisions = source
+            .list_decisions("p", &ListDecisionsQuery::default())
+            .await
+            .unwrap()
+            .decisions;
+        let backup_audit = source
+            .list_events(&ListAuditEventsQuery {
+                project: Some("p".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .events;
+
+        let restored = InMemoryStore::new();
+        for baseline in &backup_baselines {
+            restored.create(baseline).await.unwrap();
+        }
+        for verdict in &backup_verdicts {
+            restored.create_verdict(verdict).await.unwrap();
+        }
+        for decision in &backup_decisions {
+            restored.create_decision(decision).await.unwrap();
+        }
+        for event in &backup_audit {
+            restored.log_event(event).await.unwrap();
+        }
+
+        let source_latest_baseline = source.get_latest("p", "bench").await.unwrap().unwrap();
+        let restored_latest_baseline = restored.get_latest("p", "bench").await.unwrap().unwrap();
+        assert_eq!(
+            restored_latest_baseline.version,
+            source_latest_baseline.version
+        );
+        assert_eq!(
+            restored_latest_baseline.content_hash,
+            source_latest_baseline.content_hash
+        );
+        assert!(
+            restored
+                .get_latest("other", "bench")
+                .await
+                .unwrap()
+                .is_none(),
+            "backup scoped to project p should not restore other projects"
+        );
+
+        let source_verdict_ids: Vec<_> = source
+            .list_verdicts("p", &ListVerdictsQuery::default())
+            .await
+            .unwrap()
+            .verdicts
+            .into_iter()
+            .map(|record| record.id)
+            .collect();
+        let restored_verdict_ids: Vec<_> = restored
+            .list_verdicts("p", &ListVerdictsQuery::default())
+            .await
+            .unwrap()
+            .verdicts
+            .into_iter()
+            .map(|record| record.id)
+            .collect();
+        assert_eq!(restored_verdict_ids, source_verdict_ids);
+
+        let source_latest_decision = source.latest_decision("p").await.unwrap().unwrap();
+        let restored_latest_decision = restored.latest_decision("p").await.unwrap().unwrap();
+        assert_eq!(restored_latest_decision.id, source_latest_decision.id);
+        assert_eq!(
+            restored_latest_decision.accepted_rules,
+            source_latest_decision.accepted_rules
+        );
+
+        let source_audit_ids: Vec<_> = source
+            .list_events(&ListAuditEventsQuery {
+                project: Some("p".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .events
+            .into_iter()
+            .map(|event| event.id)
+            .collect();
+        let restored_audit_ids: Vec<_> = restored
+            .list_events(&ListAuditEventsQuery {
+                project: Some("p".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .events
+            .into_iter()
+            .map(|event| event.id)
+            .collect();
+        assert_eq!(restored_audit_ids, source_audit_ids);
+
+        let prune = restored.prune_decisions("p", day(3), true).await.unwrap();
+        assert_eq!(prune.matched, 1);
+        assert_eq!(prune.deleted, 0);
+        assert!(prune.dry_run);
+        assert_eq!(
+            restored
+                .list_decisions("p", &ListDecisionsQuery::default())
+                .await
+                .unwrap()
+                .pagination
+                .total,
+            2,
+            "dry-run prune must not delete restored decision history"
+        );
+    }
 }

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: canary freshness matrix
+Current PR: server backup/restore smoke
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -74,12 +74,12 @@ surface change requires an accepted spec and explicit proof.
 | 510 | Calibration patch output | merged | `perfgate calibrate --emit-patch`, CLI tests |
 | 511 | Decision example pack | merged | examples/fixtures and optional `decision examples` |
 | 512 | Decision suggestion reasons | merged | `perfgate decision suggest`, CLI tests |
-| 513 | Canary freshness matrix | current | `docs/status/CANARY_MATRIX.md` |
-| 514 | Server backup/restore smoke | pending | server/CLI tests |
-| 515 | Server retention and migration policy | pending | server docs/status |
-| 516 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
-| 517 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 518 | Evidence maturity closeout | pending | handoff and goal archive |
+| 514 | Canary freshness matrix | merged | `docs/status/CANARY_MATRIX.md` |
+| 517 | Server backup/restore smoke | current | server/CLI tests |
+| 518 | Server retention and migration policy | pending | server docs/status |
+| 519 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
+| 520 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 521 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 
@@ -588,7 +588,7 @@ Revert the additional `Why` and `Artifacts` output plus focused tests. Existing
 
 ## Work item: canary-freshness-matrix
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: proof-freshness-claims
@@ -634,7 +634,7 @@ git diff --check
 
 ## Work item: server-backup-restore-smoke
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: server-retention-migration-policy, product-claims


### PR DESCRIPTION
Summary:
- Add an InMemoryStore backup/restore smoke that exports active baselines, verdict history, decision history, and audit events through existing list/get APIs.
- Restore that evidence into a fresh store and verify latest baseline, verdict history, latest decision, audit ordering, project scoping, and prune dry-run preservation.
- Advance the 0.19 lane pointer from canary freshness to server backup/restore smoke.

Validation:
- rtk cargo +1.95.0 fmt --all -- --check
- rtk cargo +1.95.0 test -p perfgate-server --all-features backup_restore_smoke_preserves_latest_history_audit_and_dry_run
- rtk cargo +1.95.0 test -p perfgate-server --all-features
- rtk cargo +1.95.0 test -p perfgate-cli --all-features server
- rtk cargo +1.95.0 run -p xtask -- schema-compat
- rtk cargo +1.95.0 run -p xtask -- docs-source-check
- rtk cargo +1.95.0 run -p xtask -- product-claims-check
- rtk git diff --check

Notes:
- Server ledger remains optional team history.
- This does not add a public restore command or make server mode part of local correctness.