### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "14681",
+  "message": "14694",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- refresh badges/ripr-plus.json to the current generated endpoint value after the ledger policy merge
- supersedes stale bot PR #519, which generated message 14648 instead of the current 14694

## Validation
- rtk cargo +1.95.0 run -p xtask -- badges --check
- rtk cargo +1.95.0 run -p xtask -- docs-check
- rtk git diff --check