### PR TITLE
test: cover repair-context scenarios

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.19.0"
-current_work_item = "server-retention-migration-policy"
-current_pr = "docs(server): define ledger retention and migration policy"
+current_work_item = "agent-repair-context-fixtures"
+current_pr = "test: cover repair-context scenarios"
 
 objective = """
 Make perfgate useful after week one. A team should be able to tell which
@@ -209,14 +209,14 @@ plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "server-retention-migration-policy"
-status = "current"
+status = "merged"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"
 
 [[work_item]]
 id = "agent-repair-context-fixtures"
-status = "pending"
+status = "current"
 proposal = "docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md"
 spec = "docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md"
 plan = "plans/0.19.0/evidence-maturity-adoption-intelligence.md"

--- a/crates/perfgate-cli/src/check_guidance.rs
+++ b/crates/perfgate-cli/src/check_guidance.rs
@@ -292,7 +292,13 @@ pub(super) fn classify_check_error(error: &anyhow::Error) -> FailureClass {
     }
 
     let message = error.to_string().to_ascii_lowercase();
-    if message.contains("no benchmarks")
+    if message.contains("program not found")
+        || message.contains("failed to run iteration")
+        || message.contains("failed to run benchmark")
+        || message.contains("run command")
+    {
+        FailureClass::SetupCommandFailed
+    } else if message.contains("no benchmarks")
         || message.contains("not found in config")
         || message.contains("either --bench or --all")
     {
@@ -773,6 +779,12 @@ mod tests {
     fn classify_check_error_recognizes_config_read_failure() {
         let err = anyhow::anyhow!("read perfgate.toml failed");
         assert_eq!(classify_check_error(&err), FailureClass::SetupMissingConfig);
+    }
+
+    #[test]
+    fn classify_check_error_keeps_missing_program_as_command_failure() {
+        let err = anyhow::anyhow!("failed to run iteration 1: bench-tool: program not found");
+        assert_eq!(classify_check_error(&err), FailureClass::SetupCommandFailed);
     }
 
     #[test]

--- a/crates/perfgate-cli/tests/cli_repair_context_agent_tests.rs
+++ b/crates/perfgate-cli/tests/cli_repair_context_agent_tests.rs
@@ -1,0 +1,272 @@
+//! Agent-facing repair-context fixture coverage.
+//!
+//! These tests keep the repair context useful as an agent-operable receipt
+//! without changing the `perfgate.repair_context.v1` schema.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+use tempfile::tempdir;
+
+mod common;
+use common::perfgate_cmd;
+
+#[cfg(unix)]
+fn success_command() -> Vec<&'static str> {
+    vec!["true"]
+}
+
+#[cfg(windows)]
+fn success_command() -> Vec<&'static str> {
+    vec!["cmd", "/c", "exit", "0"]
+}
+
+#[cfg(unix)]
+fn slow_command() -> Vec<&'static str> {
+    vec!["sh", "-c", "sleep 0.05"]
+}
+
+#[cfg(windows)]
+fn slow_command() -> Vec<&'static str> {
+    vec!["powershell", "-Command", "Start-Sleep -Milliseconds 50"]
+}
+
+fn failing_command() -> Vec<&'static str> {
+    vec!["perfgate-command-that-does-not-exist-for-agent-fixture"]
+}
+
+fn write_config(root: &Path, bench_name: &str, command: &[&str], threshold: f64) {
+    let command = command
+        .iter()
+        .map(|part| format!("\"{}\"", part.replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        root.join("perfgate.toml"),
+        format!(
+            r#"
+[defaults]
+repeat = 1
+warmup = 0
+threshold = {threshold}
+
+[[bench]]
+name = "{bench_name}"
+command = [{command}]
+"#
+        ),
+    )
+    .expect("write config");
+}
+
+fn write_baseline(root: &Path, bench_name: &str, wall_ms: u64) {
+    let baselines = root.join("baselines");
+    fs::create_dir_all(&baselines).expect("create baselines dir");
+    let receipt = serde_json::json!({
+        "schema": "perfgate.run.v1",
+        "tool": {"name": "perfgate", "version": "0.18.0"},
+        "run": {
+            "id": "baseline-run-id",
+            "started_at": "2026-05-18T00:00:00Z",
+            "ended_at": "2026-05-18T00:00:01Z",
+            "host": {"os": std::env::consts::OS, "arch": std::env::consts::ARCH}
+        },
+        "bench": {
+            "name": bench_name,
+            "command": ["echo", "baseline"],
+            "repeat": 1,
+            "warmup": 0
+        },
+        "samples": [
+            {"wall_ms": wall_ms, "exit_code": 0, "warmup": false, "timed_out": false}
+        ],
+        "stats": {
+            "wall_ms": {"median": wall_ms, "min": wall_ms, "max": wall_ms}
+        }
+    });
+    fs::write(
+        baselines.join(format!("{bench_name}.json")),
+        serde_json::to_string_pretty(&receipt).unwrap(),
+    )
+    .expect("write baseline");
+}
+
+fn read_repair_context(out_dir: &Path) -> Value {
+    let path = out_dir.join("repair_context.json");
+    let text = fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!(
+            "repair_context.json should exist at {}: {err}",
+            path.display()
+        )
+    });
+    serde_json::from_str(&text).expect("repair_context.json should be valid JSON")
+}
+
+fn command_contains(repair: &Value, needle: &str) -> bool {
+    repair["recommended_next_commands"]
+        .as_array()
+        .expect("recommended_next_commands array")
+        .iter()
+        .filter_map(|value| value.as_str())
+        .any(|command| command.contains(needle))
+}
+
+#[test]
+fn missing_baseline_repair_context_is_agent_operable() {
+    let temp_dir = tempdir().expect("temp dir");
+    let out_dir = temp_dir.path().join("artifacts");
+    write_config(
+        temp_dir.path(),
+        "agent-missing-baseline",
+        &success_command(),
+        0.20,
+    );
+
+    let output = perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .arg("check")
+        .arg("--config")
+        .arg("perfgate.toml")
+        .arg("--bench")
+        .arg("agent-missing-baseline")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .expect("run check");
+
+    assert!(
+        output.status.success(),
+        "missing baseline is a warning-only setup state: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Status: missing_baseline"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("setup is incomplete") || stderr.contains("Setup is incomplete"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("do not loosen thresholds"),
+        "stderr: {stderr}"
+    );
+
+    let repair = read_repair_context(&out_dir);
+    assert_eq!(repair["schema"], "perfgate.repair_context.v1");
+    assert_eq!(repair["benchmark"], "agent-missing-baseline");
+    assert_eq!(repair["status"], "warn");
+    assert!(repair.get("compare_receipt_path").is_none());
+    assert!(
+        repair["report_path"]
+            .as_str()
+            .unwrap()
+            .ends_with("report.json")
+    );
+    assert!(command_contains(&repair, "rerun current command"));
+    assert!(command_contains(&repair, "perfgate paired"));
+}
+
+#[test]
+fn regression_repair_context_preserves_compare_and_breached_metric() {
+    let temp_dir = tempdir().expect("temp dir");
+    let out_dir = temp_dir.path().join("artifacts");
+    write_config(temp_dir.path(), "agent-regression", &slow_command(), 0.01);
+    write_baseline(temp_dir.path(), "agent-regression", 1);
+
+    let output = perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .arg("check")
+        .arg("--config")
+        .arg("perfgate.toml")
+        .arg("--bench")
+        .arg("agent-regression")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .expect("run check");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "regression should fail policy: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Status: performance_regression"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("do not promote the current run"),
+        "stderr: {stderr}"
+    );
+
+    let repair = read_repair_context(&out_dir);
+    assert_eq!(repair["schema"], "perfgate.repair_context.v1");
+    assert_eq!(repair["benchmark"], "agent-regression");
+    assert_eq!(repair["status"], "fail");
+    assert!(
+        repair["compare_receipt_path"]
+            .as_str()
+            .unwrap()
+            .ends_with("compare.json")
+    );
+    let breached = repair["breached_metrics"]
+        .as_array()
+        .expect("breached metrics array");
+    assert!(
+        breached
+            .iter()
+            .any(|metric| metric["metric"] == "wall_ms" && metric["status"] == "fail"),
+        "breached metrics: {breached:?}"
+    );
+    assert!(command_contains(&repair, "perfgate explain --compare"));
+    assert!(command_contains(&repair, "perfgate compare --baseline"));
+}
+
+#[test]
+fn setup_command_failure_guidance_does_not_invent_repair_context() {
+    let temp_dir = tempdir().expect("temp dir");
+    let out_dir = temp_dir.path().join("artifacts");
+    write_config(
+        temp_dir.path(),
+        "agent-setup-failure",
+        &failing_command(),
+        0.20,
+    );
+
+    let output = perfgate_cmd()
+        .current_dir(temp_dir.path())
+        .arg("check")
+        .arg("--config")
+        .arg("perfgate.toml")
+        .arg("--bench")
+        .arg("agent-setup-failure")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .output()
+        .expect("run check");
+
+    assert!(
+        !output.status.success(),
+        "command failure should fail setup: stdout {}, stderr {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Status: setup_command_failed"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("do not loosen thresholds to fix a command that does not run"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !out_dir.join("repair_context.json").exists(),
+        "setup failure should not invent a repair context without check receipts"
+    );
+}

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.19.0
-Current PR: server retention and migration policy
+Current PR: repair-context scenario fixtures
 Linked proposal: [`PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence`](../../docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md)
 Linked specs: [`PERFGATE-SPEC-0009-evidence-maturity-contract`](../../docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md), [`PERFGATE-SPEC-0010-agent-repair-context-contract`](../../docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -76,10 +76,10 @@ surface change requires an accepted spec and explicit proof.
 | 512 | Decision suggestion reasons | merged | `perfgate decision suggest`, CLI tests |
 | 514 | Canary freshness matrix | merged | `docs/status/CANARY_MATRIX.md` |
 | 518 | Server backup/restore smoke | merged | server/CLI tests |
-| 520 | Server retention and migration policy | current | server docs/status |
-| 521 | Agent repair-context fixtures | pending | repair-context tests/fixtures |
-| 522 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 523 | Evidence maturity closeout | pending | handoff and goal archive |
+| 520 | Server retention and migration policy | merged | server docs/status |
+| 523 | Agent repair-context fixtures | current | repair-context tests/fixtures |
+| 524 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 525 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 
@@ -667,7 +667,7 @@ git diff --check
 
 ## Work item: server-retention-migration-policy
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked spec: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md
 Blocks: product-claims
@@ -693,7 +693,7 @@ git diff --check
 
 ## Work item: agent-repair-context-fixtures
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0006-evidence-maturity-adoption-intelligence.md
 Linked specs: docs/specs/PERFGATE-SPEC-0009-evidence-maturity-contract.md; docs/specs/PERFGATE-SPEC-0010-agent-repair-context-contract.md
 Blocks: product-claims

--- a/plans/0.19.0/evidence-maturity-adoption-intelligence.md
+++ b/plans/0.19.0/evidence-maturity-adoption-intelligence.md
@@ -77,9 +77,9 @@ surface change requires an accepted spec and explicit proof.
 | 514 | Canary freshness matrix | merged | `docs/status/CANARY_MATRIX.md` |
 | 518 | Server backup/restore smoke | merged | server/CLI tests |
 | 520 | Server retention and migration policy | merged | server docs/status |
-| 523 | Agent repair-context fixtures | current | repair-context tests/fixtures |
-| 524 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
-| 525 | Evidence maturity closeout | pending | handoff and goal archive |
+| 524 | Agent repair-context fixtures | current | repair-context tests/fixtures |
+| 525 | Proof freshness tiers and claims | pending | `docs/status/PRODUCT_CLAIMS.md`, support docs |
+| 526 | Evidence maturity closeout | pending | handoff and goal archive |
 
 ## Work item: implementation-plan
 


### PR DESCRIPTION
## Summary
- add agent-facing repair_context fixtures for missing-baseline setup, policy regression, and setup-command failure
- keep missing executables classified as setup_command_failed instead of falling through to setup_missing_config
- advance the 0.19 evidence-maturity plan and active goal to the repair-context fixture slice

## Validation
- rtk cargo +1.95.0 fmt --all -- --check
- rtk cargo +1.95.0 test -p perfgate-cli --all-features --test cli_repair_context_agent_tests
- rtk cargo +1.95.0 test -p perfgate-cli --all-features check
- rtk cargo +1.95.0 test -p perfgate-cli --all-features decision
- rtk cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- rtk cargo +1.95.0 run -p xtask -- schema-compat
- rtk cargo +1.95.0 run -p xtask -- docs-check
- rtk proxy cargo +1.95.0 run -p xtask -- doc-test
- rtk cargo +1.95.0 run -p xtask -- docs-source-check
- rtk cargo +1.95.0 run -p xtask -- product-claims-check
- rtk git diff --check

## Boundaries
- no repair-context schema change
- no server ledger requirement
- no public crate changes