### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "14694",
+  "message": "14692",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- refresh badges/ripr-plus.json to the current generated endpoint value after #524
- supersedes stale bot PR #523, which still points at 14648

## Validation
- rtk cargo +1.95.0 run -p xtask -- badges --check
- rtk cargo +1.95.0 run -p xtask -- docs-check
- rtk git diff --check