### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "14646",
+  "message": "14715",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- Regenerates `badges/ripr-plus.json` from current `main` after the prior generated badge PR remained stale.

## Validation
- `rtk cargo +1.95.0 run -p xtask -- badges`
- `rtk cargo +1.95.0 run -p xtask -- badges --check`