### PR TITLE
docs: explain rollout profiles and promotion path

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "policy-profile-catalog"
-current_pr = "policy-profile-catalog"
+current_work_item = "rollout-profile-guidance"
+current_pr = "rollout-profile-guidance"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -110,11 +110,11 @@ status = "merged"
 
 [[work_item]]
 id = "policy-profile-catalog"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "rollout-profile-guidance"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "promotion-readiness-doctor"

--- a/docs/ADOPTION_LEVELS.md
+++ b/docs/ADOPTION_LEVELS.md
@@ -16,6 +16,11 @@ You do not need to configure every level on day one. The normal path is level 1
 first, level 2 when the repo wants branch protection, level 3 when simple pass
 or fail is not enough, and level 4 when a team needs retained history.
 
+When a benchmark has enough maturity to consider CI policy, use the
+[policy rollout profile guide](POLICY_ROLLOUT.md). It explains how to keep a
+signal advisory, promote it one benchmark at a time, quarantine untrustworthy
+evidence, and avoid making server ledger mode part of local correctness.
+
 ## Level 1: Local Benchmark Gate
 
 Use this when a repository has one or more repeatable benchmark commands and

--- a/docs/POLICY_ROLLOUT.md
+++ b/docs/POLICY_ROLLOUT.md
@@ -1,0 +1,164 @@
+# Policy Rollout Profiles
+
+Policy rollout is the step after evidence maturity. Use it when a team already
+has one or more perfgate benchmarks and needs to decide which signals should
+stay advisory, which are candidates for blocking policy, and which should be
+quarantined or retired.
+
+The rule is:
+
+```text
+smoke -> advisory -> gate_candidate -> required_gate
+```
+
+Promotion is deliberate. A mature baseline is useful evidence, not automatic
+approval to block pull requests.
+
+## Inspect Profiles
+
+List the reviewable starting points:
+
+```bash
+perfgate policy profiles
+```
+
+Inspect one profile:
+
+```bash
+perfgate policy profiles --profile rust-cli-standard
+perfgate policy profiles --profile rust-workspace-advisory
+perfgate policy profiles --profile node-command-advisory
+perfgate policy profiles --profile python-command-advisory
+perfgate policy profiles --profile http-local-smoke
+perfgate policy profiles --profile generic-command-advisory
+perfgate policy profiles --profile agent-heavy-repo
+perfgate policy profiles --profile server-ledger-optional
+```
+
+Profiles are metadata. They do not edit `perfgate.toml`, promote baselines,
+loosen thresholds, make checks blocking, or require server ledger mode.
+
+## Choose Starting Posture
+
+Use the smallest posture that answers the review question:
+
+| Posture | Use when | Do not infer |
+|---------|----------|--------------|
+| `smoke` | the command proves setup, startup, or first-hour wiring | the workload is safe to block PRs |
+| `advisory` | the signal is useful but not proven enough to enforce | failures can be ignored forever |
+| `gate_candidate` | evidence looks mature enough for review | the gate is already approved |
+| `required_gate` | reviewers explicitly approved blocking policy | every future failure is a code regression |
+| `quarantined` | host, noise, benchmark intent, or proof freshness is untrustworthy | the benchmark is permanently useless |
+| `retired` | the workload no longer helps active review | old receipts should be deleted |
+
+Start advisory unless the workload is already well understood. Promote one
+benchmark at a time.
+
+## Promotion Checklist
+
+Before a benchmark moves toward `gate_candidate`, check:
+
+```text
+baseline exists
+baseline is mature enough for the workload
+signal is stable, or paired mode is selected
+host context is compatible or intentionally scoped
+calibration was reviewed or explicitly deferred
+the workload is suitable for the intended policy
+proof freshness is current or explicitly bounded as recent
+reviewers can reproduce the result locally
+```
+
+Before a benchmark becomes `required_gate`, require human review. The review
+should show:
+
+```text
+current posture
+proposed posture
+baseline maturity
+signal maturity
+host compatibility
+calibration status
+proof freshness
+decision or tradeoff readiness
+local reproduction command
+what not to do
+```
+
+## Use The Existing Maturity Commands
+
+Policy rollout should be based on receipts, not confidence by naming.
+
+Check baseline maturity:
+
+```bash
+perfgate baseline doctor --config perfgate.toml
+```
+
+Check signal maturity:
+
+```bash
+perfgate doctor signal --config perfgate.toml
+```
+
+Emit a reviewable calibration patch when enough samples exist:
+
+```bash
+perfgate calibrate --config perfgate.toml --bench parser --emit-patch
+```
+
+Reproduce the gate locally:
+
+```bash
+perfgate check --config perfgate.toml --all --require-baseline
+```
+
+If repeated runs disagree, keep the benchmark advisory, increase samples, or
+use paired mode before promoting.
+
+## Profile Guidance
+
+| Profile | Starting posture | Good fit | Promotion caution |
+|---------|------------------|----------|-------------------|
+| `rust-cli-standard` | advisory, then one `gate_candidate` command | small Rust CLIs with fast command workloads | startup smoke does not prove steady-state throughput |
+| `rust-workspace-advisory` | advisory | larger workspaces with broad integration signal | compile and test setup can dominate the measurement |
+| `node-command-advisory` | advisory | dedicated Node benchmark scripts | JIT warmup and package-manager setup can hide true signal |
+| `python-command-advisory` | advisory | dedicated Python benchmark modules or scripts | interpreter startup and environment setup need review |
+| `http-local-smoke` | smoke or advisory | local endpoint checks and isolated services | remote services and startup timing should not block by default |
+| `generic-command-advisory` | advisory | language-neutral commands with stable local input | unknown noise is not a required-gate foundation |
+| `agent-heavy-repo` | advisory with review-required policy changes | repos where agents inspect receipts and propose patches | agents must not loosen thresholds or promote baselines alone |
+| `server-ledger-optional` | advisory ledger history | teams that want retained decision history | ledger mode is optional team history, not correctness |
+
+## Quarantine Or Retire
+
+Quarantine a benchmark when evidence becomes untrustworthy:
+
+```text
+high noise
+host mismatch
+stale proof
+broken benchmark command
+benchmark intent drift
+external service variance
+```
+
+Retire a benchmark when it no longer answers an active review question. Keep
+the history if it helps audits or release notes, but do not let retired
+benchmarks affect current policy.
+
+## Reviewer Rules
+
+Reviewers should approve policy changes only when the evidence says what the
+team thinks it says:
+
+- promote one benchmark at a time;
+- keep noisy workloads advisory;
+- use paired mode when host drift changes the verdict;
+- use structured decisions for real tradeoffs;
+- require local reproduction for blocking gates;
+- treat missing baselines as setup, not regression;
+- do not loosen thresholds to make a red check green; and
+- do not make server ledger mode required for local correctness.
+
+The useful question is not whether perfgate can run the command. It is whether
+the result should become team policy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ Codex execution state stay reviewable.
 - First-hour adoption path: [`FIRST_HOUR.md`](FIRST_HOUR.md)
 - Benchmark recipe selection: [`BENCHMARK_RECIPES.md`](BENCHMARK_RECIPES.md)
 - Adoption levels: [`ADOPTION_LEVELS.md`](ADOPTION_LEVELS.md)
+- Policy rollout profiles: [`POLICY_ROLLOUT.md`](POLICY_ROLLOUT.md)
 - Performance decisions: [`PERFORMANCE_DECISIONS.md`](PERFORMANCE_DECISIONS.md)
 - Decision outcome gallery:
   [`examples/decision-outcomes.md`](examples/decision-outcomes.md)

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: policy-profile-catalog
+Current PR: rollout-profile-guidance
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), `PERFGATE-SPEC-0012-agent-policy-change-guardrails` (planned)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -76,8 +76,8 @@ accepted spec and explicit proof.
 | 534 | Policy ergonomics proposal | merged | `docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md` |
 | 536 | Advisory-to-blocking promotion contract | merged | `docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md` |
 | 538 | Policy ergonomics implementation plan | merged | `plans/0.20.0/policy-ergonomics-team-rollout.md`, `.codex/goals/active.toml` |
-| TBD | Policy profile catalog | current | policy profile metadata and focused CLI tests |
-| TBD | Rollout profile guidance | pending | user-facing profile and promotion-path docs |
+| 540 | Policy profile catalog | merged | policy profile metadata and focused CLI tests |
+| TBD | Rollout profile guidance | current | user-facing profile and promotion-path docs |
 | TBD | Promotion readiness doctor | pending | `perfgate policy doctor --config perfgate.toml` |
 | TBD | Policy patch output | pending | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
 | TBD | Performance review packet | pending | report/comment artifact summary of policy posture and maturity |
@@ -145,7 +145,7 @@ and promotion contract remain accepted artifacts.
 
 ## Work item: policy-profile-catalog
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: rollout-profile-guidance, promotion-readiness-doctor
@@ -203,7 +203,7 @@ Revert profile metadata and focused tests.
 
 ## Work item: rollout-profile-guidance
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: promotion-readiness-doctor


### PR DESCRIPTION
## Summary
- Adds `docs/POLICY_ROLLOUT.md` as the user-facing rollout profile and promotion-path guide.
- Links policy rollout from the docs source-of-truth index and adoption levels.
- Advances the 0.20 active goal/plan from profile catalog to rollout profile guidance.

## Boundaries
- Docs-only.
- No policy behavior, config writes, baseline promotion, threshold changes, server-ledger requirement, receipt-schema change, or product-claim promotion.

## Validation
- `rtk cargo +1.95.0 run -p xtask -- docs-check`
- `rtk proxy cargo +1.95.0 run -p xtask -- doc-test`
- `rtk cargo +1.95.0 run -p xtask -- docs-source-check`
- `rtk cargo +1.95.0 run -p xtask -- product-claims-check`
- `rtk git diff --check`