### PR TITLE
policy: add promotion readiness doctor

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "rollout-profile-guidance"
-current_pr = "rollout-profile-guidance"
+current_work_item = "promotion-readiness-doctor"
+current_pr = "promotion-readiness-doctor"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -114,11 +114,11 @@ status = "merged"
 
 [[work_item]]
 id = "rollout-profile-guidance"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "promotion-readiness-doctor"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "policy-patch-output"

--- a/crates/perfgate-cli/src/baseline_doctor.rs
+++ b/crates/perfgate-cli/src/baseline_doctor.rs
@@ -17,7 +17,7 @@ const HIGH_NOISE_CV: f64 = 0.10;
 const STALE_BASELINE_DAYS: i64 = 30;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BaselineMaturity {
+pub(crate) enum BaselineMaturity {
     Missing,
     New,
     Immature,
@@ -29,7 +29,7 @@ enum BaselineMaturity {
 }
 
 impl BaselineMaturity {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Missing => "missing",
             Self::New => "new",
@@ -42,7 +42,7 @@ impl BaselineMaturity {
         }
     }
 
-    fn recommendation(self) -> &'static str {
+    pub(crate) fn recommendation(self) -> &'static str {
         match self {
             Self::Missing => "run a local check and promote only after reviewing the workload",
             Self::New => "keep advisory until more measured samples exist",
@@ -56,14 +56,14 @@ impl BaselineMaturity {
     }
 }
 
-struct BaselineDoctorRow {
-    bench: String,
-    path: String,
-    maturity: BaselineMaturity,
-    samples: Option<usize>,
-    cv: Option<f64>,
-    host: Option<String>,
-    age_days: Option<i64>,
+pub(crate) struct BaselineDoctorRow {
+    pub(crate) bench: String,
+    pub(crate) path: String,
+    pub(crate) maturity: BaselineMaturity,
+    pub(crate) samples: Option<usize>,
+    pub(crate) cv: Option<f64>,
+    pub(crate) host: Option<String>,
+    pub(crate) age_days: Option<i64>,
 }
 
 pub(crate) fn execute_baseline_doctor(
@@ -200,7 +200,10 @@ fn print_row(row: &BaselineDoctorRow) {
     println!("recommendation: {}", row.maturity.recommendation());
 }
 
-fn inspect_baseline(config: &ConfigFile, bench_name: &str) -> anyhow::Result<BaselineDoctorRow> {
+pub(crate) fn inspect_baseline(
+    config: &ConfigFile,
+    bench_name: &str,
+) -> anyhow::Result<BaselineDoctorRow> {
     let path = resolve_baseline_path(&None, bench_name, config);
     let path_text = path.to_string_lossy().to_string();
     if is_remote_storage_uri(&path_text) {
@@ -279,7 +282,10 @@ fn load_validated_baseline_config(config_path: &Path) -> anyhow::Result<ConfigFi
     Ok(config)
 }
 
-fn configured_benches(config: &ConfigFile, bench: Option<&str>) -> anyhow::Result<Vec<String>> {
+pub(crate) fn configured_benches(
+    config: &ConfigFile,
+    bench: Option<&str>,
+) -> anyhow::Result<Vec<String>> {
     if let Some(bench) = bench {
         if config
             .benches

--- a/crates/perfgate-cli/src/doctor.rs
+++ b/crates/perfgate-cli/src/doctor.rs
@@ -535,7 +535,7 @@ fn format_percent(value: f64) -> String {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SignalRecommendation {
+pub(crate) enum SignalRecommendation {
     SafeToGate,
     AdvisoryOnly,
     IncreaseSamples,
@@ -546,7 +546,7 @@ enum SignalRecommendation {
 }
 
 impl SignalRecommendation {
-    fn as_str(self) -> &'static str {
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::SafeToGate => "safe_to_gate",
             Self::AdvisoryOnly => "advisory_only",
@@ -558,7 +558,7 @@ impl SignalRecommendation {
         }
     }
 
-    fn meaning(self) -> &'static str {
+    pub(crate) fn meaning(self) -> &'static str {
         match self {
             Self::SafeToGate => "signal looks stable enough for required-baseline checks",
             Self::AdvisoryOnly => {
@@ -580,21 +580,21 @@ impl SignalRecommendation {
 }
 
 #[derive(Debug)]
-struct SignalDoctorRow {
-    bench: String,
-    run_path: PathBuf,
-    baseline_path: PathBuf,
-    compare_path: PathBuf,
-    run_found: bool,
-    baseline_found: bool,
-    baseline_remote: bool,
-    compare_found: bool,
-    samples: usize,
-    cv: Option<f64>,
-    host_stability: String,
-    baseline_age_days: Option<i64>,
-    recent_drift: String,
-    recommendation: SignalRecommendation,
+pub(crate) struct SignalDoctorRow {
+    pub(crate) bench: String,
+    pub(crate) run_path: PathBuf,
+    pub(crate) baseline_path: PathBuf,
+    pub(crate) compare_path: PathBuf,
+    pub(crate) run_found: bool,
+    pub(crate) baseline_found: bool,
+    pub(crate) baseline_remote: bool,
+    pub(crate) compare_found: bool,
+    pub(crate) samples: usize,
+    pub(crate) cv: Option<f64>,
+    pub(crate) host_stability: String,
+    pub(crate) baseline_age_days: Option<i64>,
+    pub(crate) recent_drift: String,
+    pub(crate) recommendation: SignalRecommendation,
 }
 
 pub(crate) fn execute_signal_doctor(args: SignalDoctorArgs) -> anyhow::Result<()> {
@@ -773,7 +773,7 @@ fn signal_next_commands(row: &SignalDoctorRow, config_path: &Path) -> Vec<String
     }
 }
 
-fn inspect_signal(
+pub(crate) fn inspect_signal(
     config: &ConfigFile,
     out_dir: &Path,
     bench_name: &str,

--- a/crates/perfgate-cli/src/policy.rs
+++ b/crates/perfgate-cli/src/policy.rs
@@ -1,6 +1,16 @@
 //! Policy rollout metadata and advisory policy surfaces.
 
-use clap::{Subcommand, ValueEnum};
+use clap::{Args, Subcommand, ValueEnum};
+use perfgate_types::ConfigFile;
+use perfgate_types::config::load_config_file;
+use perfgate_types::error::ConfigValidationError;
+use std::path::{Path, PathBuf};
+
+use crate::baseline_doctor::{
+    BaselineDoctorRow, BaselineMaturity, configured_benches, inspect_baseline,
+};
+use crate::doctor::{SignalDoctorRow, SignalRecommendation, inspect_signal, plural};
+use crate::{check_command, paired_command, resolve_configured_out_dir};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum PolicyProfileName {
@@ -45,6 +55,24 @@ pub enum PolicyAction {
         #[arg(long)]
         profile: Option<PolicyProfileName>,
     },
+
+    /// Report advisory policy promotion readiness without changing config.
+    Doctor(PolicyDoctorArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct PolicyDoctorArgs {
+    /// Path to the config file (TOML or JSON).
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate.
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Limit promotion readiness output to one configured benchmark.
+    #[arg(long)]
+    pub bench: Option<String>,
 }
 
 #[derive(Debug)]
@@ -287,6 +315,433 @@ pub fn render_policy_profiles(filter: Option<PolicyProfileName>) -> String {
     out
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PolicyPosture {
+    Smoke,
+    Advisory,
+    GateCandidate,
+    Quarantined,
+}
+
+impl PolicyPosture {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Smoke => "smoke",
+            Self::Advisory => "advisory",
+            Self::GateCandidate => "gate_candidate",
+            Self::Quarantined => "quarantined",
+        }
+    }
+}
+
+#[derive(Default)]
+struct PolicyDoctorCounts {
+    smoke: usize,
+    advisory: usize,
+    gate_candidate: usize,
+    quarantined: usize,
+}
+
+impl PolicyDoctorCounts {
+    fn record(&mut self, posture: PolicyPosture) {
+        match posture {
+            PolicyPosture::Smoke => self.smoke += 1,
+            PolicyPosture::Advisory => self.advisory += 1,
+            PolicyPosture::GateCandidate => self.gate_candidate += 1,
+            PolicyPosture::Quarantined => self.quarantined += 1,
+        }
+    }
+}
+
+pub fn execute_policy_doctor(args: PolicyDoctorArgs) -> anyhow::Result<()> {
+    let config = load_config_file(&args.config)?;
+    config
+        .validate()
+        .map_err(ConfigValidationError::ConfigFile)?;
+    let benches = configured_benches(&config, args.bench.as_deref())?;
+    let out_dir = resolve_configured_out_dir(args.out_dir.as_ref(), Some(&config));
+
+    println!("perfgate policy doctor");
+    println!("Config: {}", args.config.display());
+    println!();
+
+    if benches.is_empty() {
+        println!("No benchmarks are configured.");
+        println!("Next:");
+        println!(
+            "  edit {} and add a reviewed [[bench]] command",
+            args.config.display()
+        );
+        println!("Do not:");
+        println!(
+            "  promote baselines or policy until the benchmark measures the workload you care about"
+        );
+        println!();
+        println!(
+            "Advisory only: no config, baseline, threshold, policy, or server setting was changed."
+        );
+        return Ok(());
+    }
+
+    let mut counts = PolicyDoctorCounts::default();
+    for bench in &benches {
+        let baseline = inspect_baseline(&config, bench)?;
+        let signal = inspect_signal(&config, &out_dir, bench)?;
+        let recommended = recommended_posture(&baseline, &signal);
+        counts.record(recommended);
+        print_policy_doctor_row(&config, &args.config, &baseline, &signal, recommended);
+    }
+
+    println!();
+    println!(
+        "Summary: {} gate_candidate, {} advisory, {} smoke, {} quarantined",
+        counts.gate_candidate, counts.advisory, counts.smoke, counts.quarantined
+    );
+    println!();
+    println!("Do not:");
+    println!("  do not make a benchmark blocking just because it is mature");
+    println!("  do not loosen thresholds or promote baselines from this advisory output");
+    println!("  do not require server ledger mode for local correctness");
+    println!();
+    println!(
+        "Advisory only: no config, baseline, threshold, policy, or server setting was changed."
+    );
+
+    Ok(())
+}
+
+fn print_policy_doctor_row(
+    config: &ConfigFile,
+    config_path: &Path,
+    baseline: &BaselineDoctorRow,
+    signal: &SignalDoctorRow,
+    recommended: PolicyPosture,
+) {
+    let current = current_posture(baseline);
+
+    println!("bench: {}", baseline.bench);
+    println!("current posture: {}", current.as_str());
+    println!("recommended posture: {}", recommended.as_str());
+    println!("baseline maturity: {}", baseline.maturity.as_str());
+    println!("signal confidence: {}", signal.recommendation.as_str());
+    println!("host compatibility: {}", host_compatibility(signal));
+    println!("calibration status: {}", calibration_status(signal));
+    println!("proof freshness: {}", proof_freshness(baseline, signal));
+    println!(
+        "decision readiness: {}",
+        decision_readiness(config, &baseline.bench)
+    );
+    println!("artifacts:");
+    println!(
+        "  run: {}{}",
+        signal.run_path.display(),
+        if signal.run_found { "" } else { " (missing)" }
+    );
+    if signal.baseline_remote {
+        println!(
+            "  baseline: {} (remote, not probed)",
+            signal.baseline_path.display()
+        );
+    } else {
+        println!(
+            "  baseline: {}{}",
+            signal.baseline_path.display(),
+            if signal.baseline_found {
+                ""
+            } else {
+                " (missing)"
+            }
+        );
+    }
+    println!(
+        "  compare: {}{}",
+        signal.compare_path.display(),
+        if signal.compare_found {
+            ""
+        } else {
+            " (missing)"
+        }
+    );
+    println!("why:");
+    for reason in policy_reasons(baseline, signal, recommended) {
+        println!("  - {reason}");
+    }
+    println!("missing:");
+    for missing in policy_missing_requirements(baseline, signal, recommended) {
+        println!("  - {missing}");
+    }
+    println!("next:");
+    for command in policy_next_commands(config_path, baseline, signal, recommended) {
+        println!("  {command}");
+    }
+    println!("do not:");
+    for item in policy_do_not(recommended) {
+        println!("  - {item}");
+    }
+    println!();
+}
+
+fn current_posture(baseline: &BaselineDoctorRow) -> PolicyPosture {
+    match baseline.maturity {
+        BaselineMaturity::Missing => PolicyPosture::Smoke,
+        _ => PolicyPosture::Advisory,
+    }
+}
+
+fn recommended_posture(baseline: &BaselineDoctorRow, signal: &SignalDoctorRow) -> PolicyPosture {
+    match baseline.maturity {
+        BaselineMaturity::Missing => return PolicyPosture::Advisory,
+        BaselineMaturity::HostMismatched | BaselineMaturity::Stale => {
+            return PolicyPosture::Quarantined;
+        }
+        BaselineMaturity::HighNoise => return PolicyPosture::Advisory,
+        BaselineMaturity::New | BaselineMaturity::Immature | BaselineMaturity::Remote => {
+            return PolicyPosture::Advisory;
+        }
+        BaselineMaturity::Mature => {}
+    }
+
+    match signal.recommendation {
+        SignalRecommendation::SafeToGate => PolicyPosture::GateCandidate,
+        SignalRecommendation::CheckHostMismatch | SignalRecommendation::RefreshBaseline => {
+            PolicyPosture::Quarantined
+        }
+        SignalRecommendation::UsePairedMode
+        | SignalRecommendation::AdvisoryOnly
+        | SignalRecommendation::IncreaseSamples
+        | SignalRecommendation::NoDecisionYet => PolicyPosture::Advisory,
+    }
+}
+
+fn host_compatibility(signal: &SignalDoctorRow) -> String {
+    if matches!(
+        signal.recommendation,
+        SignalRecommendation::CheckHostMismatch
+    ) {
+        format!("host_mismatch ({})", signal.host_stability)
+    } else {
+        format!("compatible_or_not_checked ({})", signal.host_stability)
+    }
+}
+
+fn calibration_status(signal: &SignalDoctorRow) -> &'static str {
+    if signal.cv.is_some_and(|cv| cv > 0.10) {
+        "paired mode or calibration review required before promotion"
+    } else if signal.samples >= 7 && signal.cv.is_some() {
+        "review recommended before required_gate"
+    } else {
+        "insufficient evidence for reviewed calibration"
+    }
+}
+
+fn proof_freshness(baseline: &BaselineDoctorRow, signal: &SignalDoctorRow) -> String {
+    match baseline.maturity {
+        BaselineMaturity::Missing => "unproven (baseline missing)".to_string(),
+        BaselineMaturity::Stale => "stale (baseline older than maturity window)".to_string(),
+        BaselineMaturity::Remote => {
+            "unproven locally (remote baseline history not probed)".to_string()
+        }
+        _ if signal.run_found && signal.compare_found => {
+            "current (local run and compare receipts present)".to_string()
+        }
+        _ if baseline.age_days.is_some() => format!(
+            "recent baseline receipt ({} day{} old), compare receipt {}",
+            baseline.age_days.unwrap_or_default(),
+            plural(baseline.age_days.unwrap_or_default() as usize),
+            if signal.compare_found {
+                "present"
+            } else {
+                "missing"
+            }
+        ),
+        _ => "unproven (receipt freshness unavailable)".to_string(),
+    }
+}
+
+fn decision_readiness(config: &ConfigFile, bench_name: &str) -> &'static str {
+    let scenario_for_bench = config
+        .scenarios
+        .iter()
+        .any(|scenario| scenario.bench == bench_name);
+    match (scenario_for_bench, config.tradeoffs.is_empty()) {
+        (true, false) => "scenario and tradeoff evidence configured",
+        (true, true) => "scenario evidence configured; add tradeoff policy only for real tradeoffs",
+        (false, false) => "tradeoff policy exists; connect scenario evidence before relying on it",
+        (false, true) => {
+            "simple gate first; structured decisions are optional until a tradeoff appears"
+        }
+    }
+}
+
+fn policy_reasons(
+    baseline: &BaselineDoctorRow,
+    signal: &SignalDoctorRow,
+    recommended: PolicyPosture,
+) -> Vec<String> {
+    let mut reasons = Vec::new();
+    reasons.push(format!("baseline {}", baseline.maturity.as_str()));
+    reasons.push(format!(
+        "signal {}: {}",
+        signal.recommendation.as_str(),
+        signal.recommendation.meaning()
+    ));
+    if let Some(samples) = baseline
+        .samples
+        .or(Some(signal.samples))
+        .filter(|samples| *samples > 0)
+    {
+        reasons.push(format!(
+            "{samples} measured sample{} available",
+            plural(samples)
+        ));
+    }
+    if let Some(cv) = baseline.cv.or(signal.cv) {
+        reasons.push(format!("observed CV {}", format_percent(cv)));
+    }
+    match recommended {
+        PolicyPosture::GateCandidate => {
+            reasons.push("evidence can be reviewed for gate_candidate, not required_gate".into());
+        }
+        PolicyPosture::Quarantined => {
+            reasons.push(
+                "policy should pause until host, freshness, or setup evidence is repaired".into(),
+            );
+        }
+        PolicyPosture::Advisory => {
+            reasons.push(
+                "evidence should remain advisory until missing requirements are resolved".into(),
+            );
+        }
+        PolicyPosture::Smoke => {
+            reasons.push("use this only for setup confidence until evidence exists".into());
+        }
+    }
+    reasons
+}
+
+fn policy_missing_requirements(
+    baseline: &BaselineDoctorRow,
+    signal: &SignalDoctorRow,
+    recommended: PolicyPosture,
+) -> Vec<&'static str> {
+    let mut missing = Vec::new();
+    match baseline.maturity {
+        BaselineMaturity::Missing => missing.push("baseline promotion after workload review"),
+        BaselineMaturity::New | BaselineMaturity::Immature => {
+            missing.push("more measured samples before blocking")
+        }
+        BaselineMaturity::HighNoise => missing.push("paired-mode or calibration review"),
+        BaselineMaturity::HostMismatched => missing.push("compatible runner-class evidence"),
+        BaselineMaturity::Stale => missing.push("fresh baseline review"),
+        BaselineMaturity::Remote => missing.push("server history review before gating"),
+        BaselineMaturity::Mature => {}
+    }
+    match signal.recommendation {
+        SignalRecommendation::SafeToGate => {}
+        SignalRecommendation::AdvisoryOnly => missing.push("compare receipt for current evidence"),
+        SignalRecommendation::IncreaseSamples => missing.push("signal sample count"),
+        SignalRecommendation::UsePairedMode => missing.push("paired-mode evidence"),
+        SignalRecommendation::RefreshBaseline => missing.push("baseline refresh"),
+        SignalRecommendation::CheckHostMismatch => missing.push("host-compatible rerun"),
+        SignalRecommendation::NoDecisionYet => missing.push("complete setup receipts"),
+    }
+    if recommended == PolicyPosture::GateCandidate {
+        missing.push("required-gate reviewer approval");
+        missing.push("reviewable policy patch");
+    }
+    if missing.is_empty() {
+        missing.push("none for advisory gate_candidate review; required_gate still needs approval");
+    }
+    missing
+}
+
+fn policy_next_commands(
+    config_path: &Path,
+    baseline: &BaselineDoctorRow,
+    signal: &SignalDoctorRow,
+    recommended: PolicyPosture,
+) -> Vec<String> {
+    match baseline.maturity {
+        BaselineMaturity::Missing => {
+            return vec![
+                check_command(config_path, Some(&baseline.bench), false),
+                format!(
+                    "perfgate baseline promote --config {} --bench {}",
+                    config_path.display(),
+                    baseline.bench
+                ),
+            ];
+        }
+        BaselineMaturity::HighNoise => {
+            return vec![
+                format!(
+                    "perfgate calibrate --config {} --bench {} --emit-patch",
+                    config_path.display(),
+                    baseline.bench
+                ),
+                paired_command(Some(&baseline.bench)),
+            ];
+        }
+        BaselineMaturity::HostMismatched | BaselineMaturity::Stale => {
+            return vec![
+                "rerun on the intended runner class and review the refreshed baseline".to_string(),
+                check_command(config_path, Some(&baseline.bench), true),
+            ];
+        }
+        BaselineMaturity::New | BaselineMaturity::Immature | BaselineMaturity::Remote => {}
+        BaselineMaturity::Mature => {}
+    }
+
+    match (recommended, signal.recommendation) {
+        (PolicyPosture::GateCandidate, _) => vec![
+            check_command(config_path, Some(&baseline.bench), true),
+            format!("review promotion evidence for {}", baseline.bench),
+        ],
+        (_, SignalRecommendation::UsePairedMode) => vec![
+            format!(
+                "perfgate calibrate --config {} --bench {} --emit-patch",
+                config_path.display(),
+                baseline.bench
+            ),
+            paired_command(Some(&baseline.bench)),
+        ],
+        (_, SignalRecommendation::NoDecisionYet) => vec![
+            check_command(config_path, Some(&baseline.bench), false),
+            format!(
+                "perfgate baseline doctor --config {} --bench {}",
+                config_path.display(),
+                baseline.bench
+            ),
+        ],
+        _ => vec![check_command(config_path, Some(&baseline.bench), true)],
+    }
+}
+
+fn policy_do_not(recommended: PolicyPosture) -> Vec<&'static str> {
+    match recommended {
+        PolicyPosture::GateCandidate => vec![
+            "do not make this a required gate without reviewer approval",
+            "do not treat gate_candidate as already blocking",
+        ],
+        PolicyPosture::Quarantined => vec![
+            "do not force this benchmark through CI while evidence is untrustworthy",
+            "do not loosen thresholds to hide quarantine reasons",
+        ],
+        PolicyPosture::Advisory => vec![
+            "do not make advisory evidence blocking by default",
+            "do not promote baselines or thresholds without review",
+        ],
+        PolicyPosture::Smoke => vec![
+            "do not infer workload performance from setup smoke alone",
+            "do not require server ledger mode for local correctness",
+        ],
+    }
+}
+
+fn format_percent(value: f64) -> String {
+    format!("{:.1}%", value * 100.0)
+}
+
 fn render_profile(out: &mut String, profile: &PolicyProfile) {
     out.push_str(&format!("Profile: {}\n", profile.name));
     out.push_str(&format!("Summary: {}\n", profile.summary));
@@ -319,6 +774,7 @@ pub fn execute_policy_action(action: PolicyAction) -> anyhow::Result<()> {
             print!("{}", render_policy_profiles(profile));
             Ok(())
         }
+        PolicyAction::Doctor(args) => execute_policy_doctor(args),
     }
 }
 

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -447,7 +447,8 @@ fn cli_help_policy() {
         .stdout(predicate::str::contains(
             "Inspect advisory policy rollout profiles",
         ))
-        .stdout(predicate::str::contains("profiles"));
+        .stdout(predicate::str::contains("profiles"))
+        .stdout(predicate::str::contains("doctor"));
 }
 
 #[test]
@@ -460,6 +461,20 @@ fn cli_help_policy_profiles() {
             "List reviewable policy rollout profiles",
         ))
         .stdout(predicate::str::contains("--profile"));
+}
+
+#[test]
+fn cli_help_policy_doctor() {
+    perfgate_cmd()
+        .args(["policy", "doctor", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Report advisory policy promotion readiness",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--bench"));
 }
 
 #[test]
@@ -696,6 +711,14 @@ fn snapshot_help_policy_profiles() {
     insta::assert_snapshot!(
         "help_policy_profiles",
         help_output(&["policy", "profiles", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_policy_doctor() {
+    insta::assert_snapshot!(
+        "help_policy_doctor",
+        help_output(&["policy", "doctor", "--help"])
     );
 }
 

--- a/crates/perfgate-cli/tests/cli_policy_tests.rs
+++ b/crates/perfgate-cli/tests/cli_policy_tests.rs
@@ -1,9 +1,139 @@
 //! Integration tests for advisory policy rollout surfaces.
 
 use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
 
 mod common;
 use common::perfgate_cmd;
+
+#[cfg(unix)]
+fn success_command() -> Vec<&'static str> {
+    vec!["true"]
+}
+
+#[cfg(windows)]
+fn success_command() -> Vec<&'static str> {
+    vec!["cmd", "/c", "exit", "0"]
+}
+
+fn write_config(dir: &Path) {
+    let command = success_command()
+        .iter()
+        .map(|part| format!("\"{}\"", part))
+        .collect::<Vec<_>>()
+        .join(", ");
+    fs::write(
+        dir.join("perfgate.toml"),
+        format!(
+            r#"[defaults]
+repeat = 7
+warmup = 0
+baseline_dir = "baselines"
+out_dir = "artifacts/perfgate"
+
+[[bench]]
+name = "policy-bench"
+command = [{command}]
+"#
+        ),
+    )
+    .expect("write config");
+}
+
+fn write_run_receipt(path: &Path, bench: &str, sample_count: usize, cv: f64) {
+    let started_at = chrono::Utc::now() - chrono::Duration::days(1);
+    let samples = (0..sample_count)
+        .map(|_| {
+            serde_json::json!({
+                "wall_ms": 100,
+                "exit_code": 0,
+                "warmup": false,
+                "timed_out": false
+            })
+        })
+        .collect::<Vec<_>>();
+    let receipt = serde_json::json!({
+        "schema": "perfgate.run.v1",
+        "tool": { "name": "perfgate", "version": "0.20.0" },
+        "run": {
+            "id": format!("{bench}-run"),
+            "started_at": started_at.to_rfc3339(),
+            "ended_at": (started_at + chrono::Duration::seconds(1)).to_rfc3339(),
+            "host": {
+                "os": std::env::consts::OS,
+                "arch": std::env::consts::ARCH
+            }
+        },
+        "bench": {
+            "name": bench,
+            "command": success_command(),
+            "repeat": sample_count as u32,
+            "warmup": 0
+        },
+        "samples": samples,
+        "stats": {
+            "wall_ms": {
+                "median": 100,
+                "min": 98,
+                "max": 102,
+                "mean": 100.0,
+                "stddev": 100.0 * cv
+            }
+        }
+    });
+    fs::create_dir_all(path.parent().expect("receipt parent")).expect("create receipt parent");
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&receipt).expect("serialize receipt"),
+    )
+    .expect("write receipt");
+}
+
+fn write_compare_receipt(path: &Path, bench: &str, cv: f64) {
+    let compare = serde_json::json!({
+        "schema": "perfgate.compare.v1",
+        "tool": { "name": "perfgate", "version": "0.20.0" },
+        "bench": {
+            "name": bench,
+            "command": success_command(),
+            "repeat": 7,
+            "warmup": 0
+        },
+        "baseline_ref": { "path": format!("baselines/{bench}.json"), "run_id": "baseline-run" },
+        "current_ref": { "path": format!("artifacts/perfgate/{bench}/run.json"), "run_id": "current-run" },
+        "budgets": {
+            "wall_ms": {
+                "threshold": 0.20,
+                "warn_threshold": 0.10,
+                "direction": "lower"
+            }
+        },
+        "deltas": {
+            "wall_ms": {
+                "baseline": 100.0,
+                "current": 101.0,
+                "ratio": 1.01,
+                "pct": 0.01,
+                "regression": 0.01,
+                "cv": cv,
+                "status": "pass"
+            }
+        },
+        "verdict": {
+            "status": "pass",
+            "counts": { "pass": 1, "warn": 0, "fail": 0, "skip": 0 },
+            "reasons": []
+        }
+    });
+    fs::create_dir_all(path.parent().expect("compare parent")).expect("create compare parent");
+    fs::write(
+        path,
+        serde_json::to_string_pretty(&compare).expect("serialize compare"),
+    )
+    .expect("write compare");
+}
 
 #[test]
 fn policy_profiles_lists_reviewable_catalog() {
@@ -50,4 +180,110 @@ fn policy_profiles_rejects_unknown_profile() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn policy_doctor_keeps_missing_baseline_as_advisory_setup() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["policy", "doctor", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("perfgate policy doctor"))
+        .stdout(predicate::str::contains("bench: policy-bench"))
+        .stdout(predicate::str::contains("current posture: smoke"))
+        .stdout(predicate::str::contains("recommended posture: advisory"))
+        .stdout(predicate::str::contains("baseline maturity: missing"))
+        .stdout(predicate::str::contains(
+            "signal confidence: no_decision_yet",
+        ))
+        .stdout(predicate::str::contains(
+            "baseline promotion after workload review",
+        ))
+        .stdout(predicate::str::contains(
+            "perfgate baseline promote --config perfgate.toml --bench policy-bench",
+        ))
+        .stdout(predicate::str::contains(
+            "Advisory only: no config, baseline, threshold, policy, or server setting was changed.",
+        ));
+}
+
+#[test]
+fn policy_doctor_reports_mature_signal_as_gate_candidate_not_required_gate() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_run_receipt(
+        &dir.path().join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_run_receipt(
+        &dir.path().join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_compare_receipt(
+        &dir.path()
+            .join("artifacts/perfgate/policy-bench/compare.json"),
+        "policy-bench",
+        0.03,
+    );
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["policy", "doctor", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("current posture: advisory"))
+        .stdout(predicate::str::contains(
+            "recommended posture: gate_candidate",
+        ))
+        .stdout(predicate::str::contains("baseline maturity: mature"))
+        .stdout(predicate::str::contains("signal confidence: safe_to_gate"))
+        .stdout(predicate::str::contains("required-gate reviewer approval"))
+        .stdout(predicate::str::contains("reviewable policy patch"))
+        .stdout(predicate::str::contains(
+            "do not make this a required gate without reviewer approval",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 1 gate_candidate, 0 advisory, 0 smoke, 0 quarantined",
+        ));
+}
+
+#[test]
+fn policy_doctor_keeps_noisy_signal_advisory_with_paired_guidance() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_run_receipt(
+        &dir.path().join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.20,
+    );
+    write_run_receipt(
+        &dir.path().join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.20,
+    );
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args(["policy", "doctor", "--config", "perfgate.toml"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("recommended posture: advisory"))
+        .stdout(predicate::str::contains("baseline maturity: high_noise"))
+        .stdout(predicate::str::contains(
+            "paired-mode or calibration review",
+        ))
+        .stdout(predicate::str::contains("perfgate paired"))
+        .stdout(predicate::str::contains(
+            "do not make advisory evidence blocking by default",
+        ));
 }

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy_doctor.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy_doctor.snap
@@ -1,18 +1,16 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 706
-expression: "help_output(&[\"policy\", \"--help\"])"
+assertion_line: 719
+expression: "help_output(&[\"policy\", \"doctor\", \"--help\"])"
 ---
-Inspect advisory policy rollout profiles and promotion metadata
+Report advisory policy promotion readiness without changing config
 
-Usage: perfgate policy [OPTIONS] <COMMAND>
-
-Commands:
-  profiles List reviewable policy rollout profiles without changing config
-  doctor Report advisory policy promotion readiness without changing config
-  help Print this message or the help of the given subcommand(s)
+Usage: perfgate policy doctor [OPTIONS]
 
 Options:
+      --config <CONFIG> Path to the config file (TOML or JSON) [default: perfgate.toml]
+      --out-dir <DIR> Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate
+      --bench <BENCH> Limit promotion readiness output to one configured benchmark
   -h, --help Print help
 
 Global Options:

--- a/docs/POLICY_ROLLOUT.md
+++ b/docs/POLICY_ROLLOUT.md
@@ -101,6 +101,19 @@ Check signal maturity:
 perfgate doctor signal --config perfgate.toml
 ```
 
+Check whether the evidence is ready for policy review:
+
+```bash
+perfgate policy doctor --config perfgate.toml
+perfgate policy doctor --config perfgate.toml --bench parser
+```
+
+`policy doctor` reports the current posture, recommended posture, baseline
+maturity, signal confidence, host compatibility, calibration status, proof
+freshness, decision readiness, missing requirements, artifacts, and next
+commands. It is advisory: it does not edit config, promote baselines, loosen
+thresholds, make a gate blocking, or require server ledger mode.
+
 Emit a reviewable calibration patch when enough samples exist:
 
 ```bash

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: rollout-profile-guidance
+Current PR: promotion-readiness-doctor
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), `PERFGATE-SPEC-0012-agent-policy-change-guardrails` (planned)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -77,8 +77,8 @@ accepted spec and explicit proof.
 | 536 | Advisory-to-blocking promotion contract | merged | `docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md` |
 | 538 | Policy ergonomics implementation plan | merged | `plans/0.20.0/policy-ergonomics-team-rollout.md`, `.codex/goals/active.toml` |
 | 540 | Policy profile catalog | merged | policy profile metadata and focused CLI tests |
-| TBD | Rollout profile guidance | current | user-facing profile and promotion-path docs |
-| TBD | Promotion readiness doctor | pending | `perfgate policy doctor --config perfgate.toml` |
+| 544 | Rollout profile guidance | merged | user-facing profile and promotion-path docs |
+| TBD | Promotion readiness doctor | current | `perfgate policy doctor --config perfgate.toml` |
 | TBD | Policy patch output | pending | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
 | TBD | Performance review packet | pending | report/comment artifact summary of policy posture and maturity |
 | TBD | GitHub Action posture summary | pending | Action summary posture and `action-check` fixtures |
@@ -203,7 +203,7 @@ Revert profile metadata and focused tests.
 
 ## Work item: rollout-profile-guidance
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: promotion-readiness-doctor
@@ -237,7 +237,7 @@ git diff --check
 
 ## Work item: promotion-readiness-doctor
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: policy-patch-output, review-packet, product-claims


### PR DESCRIPTION
## Summary
- add advisory perfgate policy doctor output for current/recommended posture, baseline maturity, signal confidence, host compatibility, calibration status, proof freshness, decision readiness, missing requirements, artifacts, next commands, and do-not guidance
- reuse existing baseline and signal maturity helpers inside the CLI crate instead of changing receipt or config schemas
- add focused policy CLI coverage and help snapshots, plus rollout doc and active-goal/plan pointers

## Boundaries
- no config writes
- no baseline promotion
- no threshold loosening
- no required-gate auto-promotion
- no server-ledger requirement

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --test cli_policy_tests --all-features
- cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features policy
- cargo +1.95.0 test -p perfgate-cli --all-features policy
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check