### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "14854",
+  "message": "14900",
   "color": "orange"
 }


### PR DESCRIPTION
Generated-only badge refresh after #546 and #545. Current main still reported generated endpoint drift; this branch was produced with cargo +1.95.0 run -p xtask -- badges and verified with cargo +1.95.0 run -p xtask -- badges --check.