### PR TITLE
policy: emit reviewable promotion patch

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "promotion-readiness-doctor"
-current_pr = "promotion-readiness-doctor"
+current_work_item = "policy-patch-output"
+current_pr = "policy-patch-output"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -118,11 +118,11 @@ status = "merged"
 
 [[work_item]]
 id = "promotion-readiness-doctor"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "policy-patch-output"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "review-packet"

--- a/crates/perfgate-cli/src/policy.rs
+++ b/crates/perfgate-cli/src/policy.rs
@@ -1,9 +1,9 @@
 //! Policy rollout metadata and advisory policy surfaces.
 
 use clap::{Args, Subcommand, ValueEnum};
-use perfgate_types::ConfigFile;
 use perfgate_types::config::load_config_file;
 use perfgate_types::error::ConfigValidationError;
+use perfgate_types::{ConfigFile, Metric, NoisePolicy};
 use std::path::{Path, PathBuf};
 
 use crate::baseline_doctor::{
@@ -58,6 +58,9 @@ pub enum PolicyAction {
 
     /// Report advisory policy promotion readiness without changing config.
     Doctor(PolicyDoctorArgs),
+
+    /// Emit a reviewable, non-mutating policy promotion patch.
+    EmitPatch(PolicyEmitPatchArgs),
 }
 
 #[derive(Debug, Args)]
@@ -73,6 +76,54 @@ pub struct PolicyDoctorArgs {
     /// Limit promotion readiness output to one configured benchmark.
     #[arg(long)]
     pub bench: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct PolicyEmitPatchArgs {
+    /// Path to the config file (TOML or JSON).
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate.
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Benchmark to prepare a reviewable policy patch for.
+    #[arg(long)]
+    pub bench: String,
+
+    /// Proposed rollout state for reviewer approval.
+    #[arg(long, value_enum)]
+    pub to: PolicyRolloutState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PolicyRolloutState {
+    #[value(name = "smoke")]
+    Smoke,
+    #[value(name = "advisory")]
+    Advisory,
+    #[value(name = "gate_candidate")]
+    GateCandidate,
+    #[value(name = "required_gate")]
+    RequiredGate,
+    #[value(name = "quarantined")]
+    Quarantined,
+    #[value(name = "retired")]
+    Retired,
+}
+
+impl PolicyRolloutState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Smoke => "smoke",
+            Self::Advisory => "advisory",
+            Self::GateCandidate => "gate_candidate",
+            Self::RequiredGate => "required_gate",
+            Self::Quarantined => "quarantined",
+            Self::Retired => "retired",
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -408,6 +459,180 @@ pub fn execute_policy_doctor(args: PolicyDoctorArgs) -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+pub fn execute_policy_emit_patch(args: PolicyEmitPatchArgs) -> anyhow::Result<()> {
+    let evidence = load_policy_evidence(&args.config, args.out_dir.as_ref(), &args.bench)?;
+    let current = current_posture(&evidence.baseline);
+    let recommended = recommended_posture(&evidence.baseline, &evidence.signal);
+    let suggestion = patch_budget_suggestion(&evidence.config, &args.bench);
+
+    println!("perfgate policy emit-patch");
+    println!("Config: {}", args.config.display());
+    println!("bench: {}", args.bench);
+    println!("current posture: {}", current.as_str());
+    println!("recommended posture: {}", recommended.as_str());
+    println!("proposed posture: {}", args.to.as_str());
+    println!();
+    println!("Evidence used:");
+    for reason in policy_reasons(&evidence.baseline, &evidence.signal, recommended) {
+        println!("  - {reason}");
+    }
+    println!();
+    println!("Missing or review-required:");
+    for missing in policy_missing_requirements(&evidence.baseline, &evidence.signal, recommended) {
+        println!("  - {missing}");
+    }
+    for note in target_review_notes(args.to, recommended) {
+        println!("  - {note}");
+    }
+    println!();
+    println!("Reviewable TOML fragment:");
+    println!(
+        "# Apply manually inside the existing [[bench]] named \"{}\".",
+        args.bench
+    );
+    println!(
+        "# Proposed policy posture: {}; current posture: {}; recommendation: {}.",
+        args.to.as_str(),
+        current.as_str(),
+        recommended.as_str()
+    );
+    println!(
+        "# This fragment reviews thresholds only; it does not make policy blocking by itself."
+    );
+    println!("[bench.budgets.wall_ms]");
+    println!("threshold = {:.2}", suggestion.threshold);
+    println!("warn_factor = {:.2}", suggestion.warn_factor);
+    println!("noise_threshold = {:.2}", suggestion.noise_threshold);
+    println!("noise_policy = \"{}\"", suggestion.noise_policy.as_str());
+    println!();
+    println!("What this patch does not prove:");
+    println!("  - reviewer approval for required_gate");
+    println!("  - workload suitability beyond the named benchmark");
+    println!("  - server ledger correctness or availability");
+    println!("  - that future CI failures are code regressions rather than setup, host, or noise");
+    println!();
+    println!("Rollback or demotion:");
+    println!(
+        "  - move posture back to advisory if noise, host mismatch, or benchmark intent drifts"
+    );
+    println!("  - quarantine the benchmark while collecting fresh evidence");
+    println!("  - retire benchmarks that no longer answer an active review question");
+    println!();
+    println!("Next:");
+    println!(
+        "  perfgate policy doctor --config {} --bench {}",
+        args.config.display(),
+        args.bench
+    );
+    if recommended == PolicyPosture::GateCandidate {
+        println!("  review this patch before making the benchmark a required gate");
+    } else {
+        println!("  resolve missing evidence before promoting beyond advisory");
+    }
+    println!("Do not:");
+    println!("  do not paste this as approval to loosen thresholds or bypass review");
+    println!("  do not make server ledger mode required for local correctness");
+    println!();
+    println!(
+        "Advisory only: no config, baseline, threshold, policy, or server setting was changed."
+    );
+
+    Ok(())
+}
+
+struct PolicyEvidence {
+    config: ConfigFile,
+    baseline: BaselineDoctorRow,
+    signal: SignalDoctorRow,
+}
+
+fn load_policy_evidence(
+    config_path: &Path,
+    out_dir: Option<&PathBuf>,
+    bench_name: &str,
+) -> anyhow::Result<PolicyEvidence> {
+    let config = load_config_file(config_path)?;
+    config
+        .validate()
+        .map_err(ConfigValidationError::ConfigFile)?;
+    let benches = configured_benches(&config, Some(bench_name))?;
+    let bench = benches
+        .first()
+        .expect("configured_benches returns one item for a valid bench");
+    let resolved_out_dir = resolve_configured_out_dir(out_dir, Some(&config));
+    let baseline = inspect_baseline(&config, bench)?;
+    let signal = inspect_signal(&config, &resolved_out_dir, bench)?;
+
+    Ok(PolicyEvidence {
+        config,
+        baseline,
+        signal,
+    })
+}
+
+struct PolicyBudgetSuggestion {
+    threshold: f64,
+    warn_factor: f64,
+    noise_threshold: f64,
+    noise_policy: NoisePolicy,
+}
+
+fn patch_budget_suggestion(config: &ConfigFile, bench_name: &str) -> PolicyBudgetSuggestion {
+    let bench = config.benches.iter().find(|bench| bench.name == bench_name);
+    let wall_budget = bench
+        .and_then(|bench| bench.budgets.as_ref())
+        .and_then(|budgets| budgets.get(&Metric::WallMs));
+
+    PolicyBudgetSuggestion {
+        threshold: wall_budget
+            .and_then(|budget| budget.threshold)
+            .or(config.defaults.threshold)
+            .unwrap_or(0.20),
+        warn_factor: wall_budget
+            .and_then(|budget| budget.warn_factor)
+            .or(config.defaults.warn_factor)
+            .unwrap_or(0.50),
+        noise_threshold: wall_budget
+            .and_then(|budget| budget.noise_threshold)
+            .or(config.defaults.noise_threshold)
+            .unwrap_or(0.08),
+        noise_policy: wall_budget
+            .and_then(|budget| budget.noise_policy)
+            .or(config.defaults.noise_policy)
+            .unwrap_or(NoisePolicy::Warn),
+    }
+}
+
+fn target_review_notes(
+    target: PolicyRolloutState,
+    recommended: PolicyPosture,
+) -> Vec<&'static str> {
+    let mut notes = Vec::new();
+    match target {
+        PolicyRolloutState::RequiredGate => {
+            notes.push("required_gate needs explicit reviewer approval");
+            notes.push("blocking CI must preserve local reproduction and artifact links");
+        }
+        PolicyRolloutState::GateCandidate => {
+            notes.push("gate_candidate is review-ready evidence, not blocking policy");
+        }
+        PolicyRolloutState::Quarantined => {
+            notes.push("quarantine should name the evidence that became untrustworthy");
+        }
+        PolicyRolloutState::Retired => {
+            notes
+                .push("retirement should preserve useful history without affecting current policy");
+        }
+        PolicyRolloutState::Smoke | PolicyRolloutState::Advisory => {
+            notes.push("advisory posture should continue surfacing evidence without blocking");
+        }
+    }
+    if target == PolicyRolloutState::RequiredGate && recommended != PolicyPosture::GateCandidate {
+        notes.push("requested target exceeds current evidence recommendation");
+    }
+    notes
 }
 
 fn print_policy_doctor_row(
@@ -775,6 +1000,7 @@ pub fn execute_policy_action(action: PolicyAction) -> anyhow::Result<()> {
             Ok(())
         }
         PolicyAction::Doctor(args) => execute_policy_doctor(args),
+        PolicyAction::EmitPatch(args) => execute_policy_emit_patch(args),
     }
 }
 

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -448,7 +448,8 @@ fn cli_help_policy() {
             "Inspect advisory policy rollout profiles",
         ))
         .stdout(predicate::str::contains("profiles"))
-        .stdout(predicate::str::contains("doctor"));
+        .stdout(predicate::str::contains("doctor"))
+        .stdout(predicate::str::contains("emit-patch"));
 }
 
 #[test]
@@ -475,6 +476,21 @@ fn cli_help_policy_doctor() {
         .stdout(predicate::str::contains("--config"))
         .stdout(predicate::str::contains("--out-dir"))
         .stdout(predicate::str::contains("--bench"));
+}
+
+#[test]
+fn cli_help_policy_emit_patch() {
+    perfgate_cmd()
+        .args(["policy", "emit-patch", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Emit a reviewable, non-mutating policy promotion patch",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--bench"))
+        .stdout(predicate::str::contains("--to"));
 }
 
 #[test]
@@ -719,6 +735,14 @@ fn snapshot_help_policy_doctor() {
     insta::assert_snapshot!(
         "help_policy_doctor",
         help_output(&["policy", "doctor", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_policy_emit_patch() {
+    insta::assert_snapshot!(
+        "help_policy_emit_patch",
+        help_output(&["policy", "emit-patch", "--help"])
     );
 }
 

--- a/crates/perfgate-cli/tests/cli_policy_tests.rs
+++ b/crates/perfgate-cli/tests/cli_policy_tests.rs
@@ -287,3 +287,92 @@ fn policy_doctor_keeps_noisy_signal_advisory_with_paired_guidance() {
             "do not make advisory evidence blocking by default",
         ));
 }
+
+#[test]
+fn policy_emit_patch_prints_reviewable_fragment_without_writing_config() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_run_receipt(
+        &dir.path().join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_run_receipt(
+        &dir.path().join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_compare_receipt(
+        &dir.path()
+            .join("artifacts/perfgate/policy-bench/compare.json"),
+        "policy-bench",
+        0.03,
+    );
+    let before = fs::read_to_string(dir.path().join("perfgate.toml")).expect("read config");
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args([
+            "policy",
+            "emit-patch",
+            "--config",
+            "perfgate.toml",
+            "--bench",
+            "policy-bench",
+            "--to",
+            "gate_candidate",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("perfgate policy emit-patch"))
+        .stdout(predicate::str::contains("proposed posture: gate_candidate"))
+        .stdout(predicate::str::contains("Reviewable TOML fragment"))
+        .stdout(predicate::str::contains("[bench.budgets.wall_ms]"))
+        .stdout(predicate::str::contains("threshold = 0.20"))
+        .stdout(predicate::str::contains("noise_policy = \"warn\""))
+        .stdout(predicate::str::contains(
+            "gate_candidate is review-ready evidence, not blocking policy",
+        ))
+        .stdout(predicate::str::contains(
+            "Advisory only: no config, baseline, threshold, policy, or server setting was changed.",
+        ));
+
+    let after = fs::read_to_string(dir.path().join("perfgate.toml")).expect("read config");
+    assert_eq!(before, after, "policy emit-patch must not write config");
+}
+
+#[test]
+fn policy_emit_patch_marks_required_gate_as_review_required() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args([
+            "policy",
+            "emit-patch",
+            "--config",
+            "perfgate.toml",
+            "--bench",
+            "policy-bench",
+            "--to",
+            "required_gate",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("proposed posture: required_gate"))
+        .stdout(predicate::str::contains(
+            "required_gate needs explicit reviewer approval",
+        ))
+        .stdout(predicate::str::contains(
+            "requested target exceeds current evidence recommendation",
+        ))
+        .stdout(predicate::str::contains(
+            "baseline promotion after workload review",
+        ))
+        .stdout(predicate::str::contains(
+            "resolve missing evidence before promoting beyond advisory",
+        ));
+}

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 706
+assertion_line: 722
 expression: "help_output(&[\"policy\", \"--help\"])"
 ---
 Inspect advisory policy rollout profiles and promotion metadata
@@ -10,6 +10,7 @@ Usage: perfgate policy [OPTIONS] <COMMAND>
 Commands:
   profiles List reviewable policy rollout profiles without changing config
   doctor Report advisory policy promotion readiness without changing config
+  emit-patch Emit a reviewable, non-mutating policy promotion patch
   help Print this message or the help of the given subcommand(s)
 
 Options:

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy_emit_patch.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy_emit_patch.snap
@@ -1,0 +1,20 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 743
+expression: "help_output(&[\"policy\", \"emit-patch\", \"--help\"])"
+---
+Emit a reviewable, non-mutating policy promotion patch
+
+Usage: perfgate policy emit-patch [OPTIONS] --bench <BENCH> --to <TO>
+
+Options:
+      --config <CONFIG> Path to the config file (TOML or JSON) [default: perfgate.toml]
+      --out-dir <DIR> Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate
+      --bench <BENCH> Benchmark to prepare a reviewable policy patch for
+      --to <TO> Proposed rollout state for reviewer approval [possible values: smoke, advisory, gate_candidate, required_gate, quarantined, retired]
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/docs/POLICY_ROLLOUT.md
+++ b/docs/POLICY_ROLLOUT.md
@@ -114,6 +114,17 @@ freshness, decision readiness, missing requirements, artifacts, and next
 commands. It is advisory: it does not edit config, promote baselines, loosen
 thresholds, make a gate blocking, or require server ledger mode.
 
+Emit a reviewable policy patch:
+
+```bash
+perfgate policy emit-patch --config perfgate.toml --bench parser --to gate_candidate
+```
+
+`policy emit-patch` prints a TOML fragment, evidence reasons, missing
+requirements, review notes, and demotion guidance. It does not write
+`perfgate.toml`; a reviewer must apply any policy change deliberately. Use
+`--to required_gate` only when the team is ready to review blocking behavior.
+
 Emit a reviewable calibration patch when enough samples exist:
 
 ```bash

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: promotion-readiness-doctor
+Current PR: policy-patch-output
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), `PERFGATE-SPEC-0012-agent-policy-change-guardrails` (planned)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -78,8 +78,8 @@ accepted spec and explicit proof.
 | 538 | Policy ergonomics implementation plan | merged | `plans/0.20.0/policy-ergonomics-team-rollout.md`, `.codex/goals/active.toml` |
 | 540 | Policy profile catalog | merged | policy profile metadata and focused CLI tests |
 | 544 | Rollout profile guidance | merged | user-facing profile and promotion-path docs |
-| TBD | Promotion readiness doctor | current | `perfgate policy doctor --config perfgate.toml` |
-| TBD | Policy patch output | pending | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
+| 546 | Promotion readiness doctor | merged | `perfgate policy doctor --config perfgate.toml` |
+| TBD | Policy patch output | current | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
 | TBD | Performance review packet | pending | report/comment artifact summary of policy posture and maturity |
 | TBD | GitHub Action posture summary | pending | Action summary posture and `action-check` fixtures |
 | TBD | Agent policy guardrail spec | pending | `PERFGATE-SPEC-0012-agent-policy-change-guardrails` |
@@ -237,7 +237,7 @@ git diff --check
 
 ## Work item: promotion-readiness-doctor
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: policy-patch-output, review-packet, product-claims
@@ -288,7 +288,7 @@ git diff --check
 
 ## Work item: policy-patch-output
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: review-packet, action-posture-summary


### PR DESCRIPTION
## Summary
- add perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state> as a non-mutating policy promotion surface
- reuse policy doctor evidence to print current/recommended/proposed posture, reasons, missing/review-required items, a reviewable TOML fragment, non-inferences, rollback/demotion guidance, and next commands
- add focused CLI coverage proving mature evidence emits a patch without writing config and equired_gate stays review-required when evidence is missing
- update rollout docs and 0.20 plan/goal pointers

## Boundaries
- no config writes
- no baseline promotion
- no threshold loosening
- no required-gate auto-promotion
- no receipt schema change
- no server-ledger requirement

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --test cli_policy_tests --all-features
- cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features policy
- cargo +1.95.0 test -p perfgate-cli --all-features policy
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check