### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "14900",
+  "message": "14969",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- refresh generated public badge endpoint metadata from current main

## Validation
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check

## Notes
- Supersedes stale #548; current generation updates ripr-plus from 14900 to 14969.