### PR TITLE
policy: add performance review packet

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "policy-patch-output"
-current_pr = "policy-patch-output"
+current_work_item = "review-packet"
+current_pr = "review-packet"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -122,11 +122,11 @@ status = "merged"
 
 [[work_item]]
 id = "policy-patch-output"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "review-packet"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "action-posture-summary"

--- a/crates/perfgate-cli/src/policy.rs
+++ b/crates/perfgate-cli/src/policy.rs
@@ -3,14 +3,15 @@
 use clap::{Args, Subcommand, ValueEnum};
 use perfgate_types::config::load_config_file;
 use perfgate_types::error::ConfigValidationError;
-use perfgate_types::{ConfigFile, Metric, NoisePolicy};
+use perfgate_types::{CompareReceipt, ConfigFile, Metric, NoisePolicy};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::baseline_doctor::{
     BaselineDoctorRow, BaselineMaturity, configured_benches, inspect_baseline,
 };
 use crate::doctor::{SignalDoctorRow, SignalRecommendation, inspect_signal, plural};
-use crate::{check_command, paired_command, resolve_configured_out_dir};
+use crate::{atomic_write, check_command, paired_command, read_json, resolve_configured_out_dir};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub enum PolicyProfileName {
@@ -61,6 +62,9 @@ pub enum PolicyAction {
 
     /// Emit a reviewable, non-mutating policy promotion patch.
     EmitPatch(PolicyEmitPatchArgs),
+
+    /// Render a compact performance review packet without changing policy.
+    ReviewPacket(PolicyReviewPacketArgs),
 }
 
 #[derive(Debug, Args)]
@@ -95,6 +99,25 @@ pub struct PolicyEmitPatchArgs {
     /// Proposed rollout state for reviewer approval.
     #[arg(long, value_enum)]
     pub to: PolicyRolloutState,
+}
+
+#[derive(Debug, Args)]
+pub struct PolicyReviewPacketArgs {
+    /// Path to the config file (TOML or JSON).
+    #[arg(long, default_value = "perfgate.toml")]
+    pub config: PathBuf,
+
+    /// Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate.
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Benchmark to render the policy review packet for.
+    #[arg(long)]
+    pub bench: String,
+
+    /// Write the Markdown packet to a file instead of stdout.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -542,6 +565,21 @@ pub fn execute_policy_emit_patch(args: PolicyEmitPatchArgs) -> anyhow::Result<()
     Ok(())
 }
 
+pub fn execute_policy_review_packet(args: PolicyReviewPacketArgs) -> anyhow::Result<()> {
+    let evidence = load_policy_evidence(&args.config, args.out_dir.as_ref(), &args.bench)?;
+    let out_dir = resolve_configured_out_dir(args.out_dir.as_ref(), Some(&evidence.config));
+    let packet = render_policy_review_packet(&args.config, &out_dir, &evidence)?;
+
+    if let Some(out) = args.out {
+        write_policy_review_packet(&out, &packet)?;
+        println!("Wrote policy review packet: {}", out.display());
+    } else {
+        print!("{packet}");
+    }
+
+    Ok(())
+}
+
 struct PolicyEvidence {
     config: ConfigFile,
     baseline: BaselineDoctorRow,
@@ -603,6 +641,186 @@ fn patch_budget_suggestion(config: &ConfigFile, bench_name: &str) -> PolicyBudge
             .or(config.defaults.noise_policy)
             .unwrap_or(NoisePolicy::Warn),
     }
+}
+
+fn render_policy_review_packet(
+    config_path: &Path,
+    out_dir: &Path,
+    evidence: &PolicyEvidence,
+) -> anyhow::Result<String> {
+    let baseline = &evidence.baseline;
+    let signal = &evidence.signal;
+    let current = current_posture(baseline);
+    let recommended = recommended_posture(baseline, signal);
+    let compare = read_compare_if_present(signal)?;
+    let gate_verdict = gate_verdict(signal, compare.as_ref());
+    let local_reproduction = check_command(
+        config_path,
+        Some(&baseline.bench),
+        baseline.maturity != BaselineMaturity::Missing,
+    );
+    let policy_patch = format!(
+        "perfgate policy emit-patch --config {} --bench {} --to {}",
+        config_path.display(),
+        baseline.bench,
+        rollout_state_for_posture(recommended).as_str()
+    );
+    let report_path = artifact_path(out_dir, &baseline.bench, "report.json");
+    let comment_path = artifact_path(out_dir, &baseline.bench, "comment.md");
+    let repair_context_path = artifact_path(out_dir, &baseline.bench, "repair_context.json");
+
+    let mut out = String::new();
+    out.push_str("# perfgate performance review packet\n\n");
+    out.push_str("This packet summarizes existing receipts for review. Receipts remain the source of truth.\n\n");
+    out.push_str("## Status\n\n");
+    out.push_str(&format!("- Config: `{}`\n", config_path.display()));
+    out.push_str(&format!("- Bench: `{}`\n", baseline.bench));
+    out.push_str(&format!("- Gate verdict: `{gate_verdict}`\n"));
+    out.push_str(&format!("- Current posture: `{}`\n", current.as_str()));
+    out.push_str(&format!(
+        "- Recommended posture: `{}`\n",
+        recommended.as_str()
+    ));
+    out.push_str(&format!(
+        "- Baseline maturity: `{}`\n",
+        baseline.maturity.as_str()
+    ));
+    out.push_str(&format!(
+        "- Signal confidence: `{}` - {}\n",
+        signal.recommendation.as_str(),
+        signal.recommendation.meaning()
+    ));
+    out.push_str(&format!(
+        "- Calibration status: {}\n",
+        calibration_status(signal)
+    ));
+    out.push_str(&format!(
+        "- Host compatibility: {}\n",
+        host_compatibility(signal)
+    ));
+    out.push_str(&format!(
+        "- Decision suggestion: {}\n",
+        decision_readiness(&evidence.config, &baseline.bench)
+    ));
+    out.push_str(&format!(
+        "- Proof freshness: {}\n",
+        proof_freshness(baseline, signal)
+    ));
+
+    out.push_str("\n## Artifacts\n\n");
+    push_artifact_line(&mut out, "run", &signal.run_path, signal.run_found);
+    if signal.baseline_remote {
+        out.push_str(&format!(
+            "- baseline: `{}` (remote, not probed)\n",
+            signal.baseline_path.display()
+        ));
+    } else {
+        push_artifact_line(
+            &mut out,
+            "baseline",
+            &signal.baseline_path,
+            signal.baseline_found,
+        );
+    }
+    push_artifact_line(
+        &mut out,
+        "compare",
+        &signal.compare_path,
+        signal.compare_found,
+    );
+    push_artifact_line(&mut out, "report", &report_path, report_path.exists());
+    push_artifact_line(&mut out, "comment", &comment_path, comment_path.exists());
+    push_artifact_line(
+        &mut out,
+        "repair context",
+        &repair_context_path,
+        repair_context_path.exists(),
+    );
+
+    out.push_str("\n## Why\n\n");
+    for reason in policy_reasons(baseline, signal, recommended) {
+        out.push_str(&format!("- {reason}\n"));
+    }
+
+    out.push_str("\n## Missing Or Review-Required\n\n");
+    for missing in policy_missing_requirements(baseline, signal, recommended) {
+        out.push_str(&format!("- {missing}\n"));
+    }
+
+    out.push_str("\n## Reviewer Commands\n\n");
+    out.push_str(&format!("- Reproduce locally: `{local_reproduction}`\n"));
+    out.push_str(&format!("- Review policy patch: `{policy_patch}`\n"));
+    for command in policy_next_commands(config_path, baseline, signal, recommended) {
+        out.push_str(&format!("- Next: `{command}`\n"));
+    }
+
+    out.push_str("\n## Do Not\n\n");
+    for item in policy_do_not(recommended) {
+        out.push_str(&format!("- {item}\n"));
+    }
+    out.push_str("- do not loosen thresholds or promote baselines from this packet alone\n");
+    out.push_str("- do not require server ledger mode for local correctness\n");
+
+    out.push_str("\n## Non-Inferences\n\n");
+    out.push_str("- This packet does not change config, baselines, thresholds, policy, or server settings.\n");
+    out.push_str("- It does not approve `required_gate`; reviewer approval is still required.\n");
+    out.push_str("- It does not replace run, compare, report, comment, repair context, or decision receipts.\n");
+
+    Ok(out)
+}
+
+fn write_policy_review_packet(path: &Path, packet: &str) -> anyhow::Result<()> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)?;
+    }
+    atomic_write(path, packet.as_bytes())
+}
+
+fn read_compare_if_present(signal: &SignalDoctorRow) -> anyhow::Result<Option<CompareReceipt>> {
+    if signal.compare_found {
+        Ok(Some(read_json(&signal.compare_path)?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn gate_verdict(signal: &SignalDoctorRow, compare: Option<&CompareReceipt>) -> String {
+    if let Some(compare) = compare {
+        return compare.verdict.status.as_str().to_string();
+    }
+    if !signal.baseline_found && !signal.baseline_remote {
+        return "setup_incomplete_missing_baseline".to_string();
+    }
+    "no_compare_receipt_yet".to_string()
+}
+
+fn rollout_state_for_posture(posture: PolicyPosture) -> PolicyRolloutState {
+    match posture {
+        PolicyPosture::Smoke => PolicyRolloutState::Smoke,
+        PolicyPosture::Advisory => PolicyRolloutState::Advisory,
+        PolicyPosture::GateCandidate => PolicyRolloutState::GateCandidate,
+        PolicyPosture::Quarantined => PolicyRolloutState::Quarantined,
+    }
+}
+
+fn artifact_path(out_dir: &Path, bench_name: &str, filename: &str) -> PathBuf {
+    let per_bench = out_dir.join(bench_name).join(filename);
+    if per_bench.exists() {
+        per_bench
+    } else {
+        out_dir.join(filename)
+    }
+}
+
+fn push_artifact_line(out: &mut String, label: &str, path: &Path, exists: bool) {
+    out.push_str(&format!(
+        "- {label}: `{}`{}\n",
+        path.display(),
+        if exists { "" } else { " (missing)" }
+    ));
 }
 
 fn target_review_notes(
@@ -1001,6 +1219,7 @@ pub fn execute_policy_action(action: PolicyAction) -> anyhow::Result<()> {
         }
         PolicyAction::Doctor(args) => execute_policy_doctor(args),
         PolicyAction::EmitPatch(args) => execute_policy_emit_patch(args),
+        PolicyAction::ReviewPacket(args) => execute_policy_review_packet(args),
     }
 }
 

--- a/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+++ b/crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
@@ -449,7 +449,8 @@ fn cli_help_policy() {
         ))
         .stdout(predicate::str::contains("profiles"))
         .stdout(predicate::str::contains("doctor"))
-        .stdout(predicate::str::contains("emit-patch"));
+        .stdout(predicate::str::contains("emit-patch"))
+        .stdout(predicate::str::contains("review-packet"));
 }
 
 #[test]
@@ -491,6 +492,21 @@ fn cli_help_policy_emit_patch() {
         .stdout(predicate::str::contains("--out-dir"))
         .stdout(predicate::str::contains("--bench"))
         .stdout(predicate::str::contains("--to"));
+}
+
+#[test]
+fn cli_help_policy_review_packet() {
+    perfgate_cmd()
+        .args(["policy", "review-packet", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Render a compact performance review packet",
+        ))
+        .stdout(predicate::str::contains("--config"))
+        .stdout(predicate::str::contains("--out-dir"))
+        .stdout(predicate::str::contains("--bench"))
+        .stdout(predicate::str::contains("--out"));
 }
 
 #[test]
@@ -743,6 +759,14 @@ fn snapshot_help_policy_emit_patch() {
     insta::assert_snapshot!(
         "help_policy_emit_patch",
         help_output(&["policy", "emit-patch", "--help"])
+    );
+}
+
+#[test]
+fn snapshot_help_policy_review_packet() {
+    insta::assert_snapshot!(
+        "help_policy_review_packet",
+        help_output(&["policy", "review-packet", "--help"])
     );
 }
 

--- a/crates/perfgate-cli/tests/cli_policy_tests.rs
+++ b/crates/perfgate-cli/tests/cli_policy_tests.rs
@@ -376,3 +376,110 @@ fn policy_emit_patch_marks_required_gate_as_review_required() {
             "resolve missing evidence before promoting beyond advisory",
         ));
 }
+
+#[test]
+fn policy_review_packet_renders_mature_gate_candidate_without_writing_config() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_run_receipt(
+        &dir.path().join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_run_receipt(
+        &dir.path().join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_compare_receipt(
+        &dir.path()
+            .join("artifacts/perfgate/policy-bench/compare.json"),
+        "policy-bench",
+        0.03,
+    );
+    fs::write(
+        dir.path()
+            .join("artifacts/perfgate/policy-bench/report.json"),
+        "{}",
+    )
+    .expect("write report artifact");
+    fs::write(
+        dir.path()
+            .join("artifacts/perfgate/policy-bench/comment.md"),
+        "comment",
+    )
+    .expect("write comment artifact");
+    let before = fs::read_to_string(dir.path().join("perfgate.toml")).expect("read config");
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args([
+            "policy",
+            "review-packet",
+            "--config",
+            "perfgate.toml",
+            "--bench",
+            "policy-bench",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "# perfgate performance review packet",
+        ))
+        .stdout(predicate::str::contains("- Gate verdict: `pass`"))
+        .stdout(predicate::str::contains(
+            "- Recommended posture: `gate_candidate`",
+        ))
+        .stdout(predicate::str::contains(
+            "- Baseline maturity: `mature`",
+        ))
+        .stdout(predicate::str::contains(
+            "- Signal confidence: `safe_to_gate`",
+        ))
+        .stdout(predicate::str::contains(
+            "- Reproduce locally: `perfgate check --config perfgate.toml --bench policy-bench --require-baseline`",
+        ))
+        .stdout(predicate::str::contains(
+            "- Review policy patch: `perfgate policy emit-patch --config perfgate.toml --bench policy-bench --to gate_candidate`",
+        ))
+        .stdout(predicate::str::contains(
+            "This packet does not change config, baselines, thresholds, policy, or server settings.",
+        ));
+
+    let after = fs::read_to_string(dir.path().join("perfgate.toml")).expect("read config");
+    assert_eq!(before, after, "policy review-packet must not write config");
+}
+
+#[test]
+fn policy_review_packet_can_write_markdown_artifact_for_setup_state() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    let out = dir
+        .path()
+        .join("artifacts/perfgate/policy-bench/policy-review.md");
+
+    perfgate_cmd()
+        .current_dir(dir.path())
+        .args([
+            "policy",
+            "review-packet",
+            "--config",
+            "perfgate.toml",
+            "--bench",
+            "policy-bench",
+            "--out",
+            out.to_str().expect("utf8 temp path"),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote policy review packet"));
+
+    let packet = fs::read_to_string(out).expect("read review packet");
+    assert!(packet.contains("- Gate verdict: `setup_incomplete_missing_baseline`"));
+    assert!(packet.contains("- Current posture: `smoke`"));
+    assert!(packet.contains("- Recommended posture: `advisory`"));
+    assert!(packet.contains("baseline promotion after workload review"));
+    assert!(packet.contains("do not loosen thresholds or promote baselines"));
+}

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
-assertion_line: 722
+assertion_line: 738
 expression: "help_output(&[\"policy\", \"--help\"])"
 ---
 Inspect advisory policy rollout profiles and promotion metadata
@@ -11,6 +11,7 @@ Commands:
   profiles List reviewable policy rollout profiles without changing config
   doctor Report advisory policy promotion readiness without changing config
   emit-patch Emit a reviewable, non-mutating policy promotion patch
+  review-packet Render a compact performance review packet without changing policy
   help Print this message or the help of the given subcommand(s)
 
 Options:

--- a/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy_review_packet.snap
+++ b/crates/perfgate-cli/tests/snapshots/cli_help_snapshot_tests__help_policy_review_packet.snap
@@ -1,0 +1,20 @@
+---
+source: crates/perfgate-cli/tests/cli_help_snapshot_tests.rs
+assertion_line: 767
+expression: "help_output(&[\"policy\", \"review-packet\", \"--help\"])"
+---
+Render a compact performance review packet without changing policy
+
+Usage: perfgate policy review-packet [OPTIONS] --bench <BENCH>
+
+Options:
+      --config <CONFIG> Path to the config file (TOML or JSON) [default: perfgate.toml]
+      --out-dir <DIR> Output directory containing recent artifacts. Defaults to [defaults].out_dir or artifacts/perfgate
+      --bench <BENCH> Benchmark to render the policy review packet for
+      --out <OUT> Write the Markdown packet to a file instead of stdout
+  -h, --help Print help
+
+Global Options:
+      --baseline-server <BASELINE_SERVER> URL of the baseline server (e.g., http://localhost:3000/api/v1) Can also be set via PERFGATE_SERVER_URL environment variable
+      --api-key <API_KEY> API key for authentication with the baseline server. Can also be set via PERFGATE_API_KEY environment variable
+      --project <PROJECT> Project name for multi-tenancy. Can also be set via PERFGATE_PROJECT environment variable

--- a/docs/POLICY_ROLLOUT.md
+++ b/docs/POLICY_ROLLOUT.md
@@ -125,6 +125,20 @@ requirements, review notes, and demotion guidance. It does not write
 `perfgate.toml`; a reviewer must apply any policy change deliberately. Use
 `--to required_gate` only when the team is ready to review blocking behavior.
 
+Render a compact review packet for a reviewer:
+
+```bash
+perfgate policy review-packet --config perfgate.toml --bench parser
+perfgate policy review-packet --config perfgate.toml --bench parser --out artifacts/perfgate/parser/policy-review.md
+```
+
+`policy review-packet` gathers verdict, current and recommended posture,
+baseline maturity, signal confidence, calibration status, host compatibility,
+decision suggestion, proof freshness, artifact paths, local reproduction,
+policy patch command, and do-not guidance into Markdown. It summarizes existing
+receipts; it does not replace them, approve `required_gate`, edit config,
+promote baselines, loosen thresholds, or require server ledger mode.
+
 Emit a reviewable calibration patch when enough samples exist:
 
 ```bash

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: policy-patch-output
+Current PR: review-packet
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), `PERFGATE-SPEC-0012-agent-policy-change-guardrails` (planned)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -79,8 +79,8 @@ accepted spec and explicit proof.
 | 540 | Policy profile catalog | merged | policy profile metadata and focused CLI tests |
 | 544 | Rollout profile guidance | merged | user-facing profile and promotion-path docs |
 | 546 | Promotion readiness doctor | merged | `perfgate policy doctor --config perfgate.toml` |
-| TBD | Policy patch output | current | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
-| TBD | Performance review packet | pending | report/comment artifact summary of policy posture and maturity |
+| 549 | Policy patch output | merged | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
+| TBD | Performance review packet | current | report/comment artifact summary of policy posture and maturity |
 | TBD | GitHub Action posture summary | pending | Action summary posture and `action-check` fixtures |
 | TBD | Agent policy guardrail spec | pending | `PERFGATE-SPEC-0012-agent-policy-change-guardrails` |
 | TBD | Agent policy fixtures | pending | policy guardrail fixtures for review-required changes |
@@ -288,7 +288,7 @@ git diff --check
 
 ## Work item: policy-patch-output
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: review-packet, action-posture-summary
@@ -327,7 +327,7 @@ git diff --check
 
 ## Work item: review-packet
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: action-posture-summary, agent-policy-guardrails


### PR DESCRIPTION
## Summary
- add perfgate policy review-packet to render a compact Markdown review packet from existing policy evidence
- include verdict, posture, baseline/signal maturity, calibration, host, decision, proof freshness, artifacts, reproduction, patch command, and do-not guidance
- update policy rollout docs plus 0.20 plan/active-goal pointers for the review-packet slice

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --test cli_policy_tests --all-features
- cargo +1.95.0 test -p perfgate-cli --test cli_help_snapshot_tests --all-features policy
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 test -p perfgate-cli --all-features report
- cargo +1.95.0 test -p perfgate-cli --all-features check
- cargo +1.95.0 run -p xtask -- schema-compat
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

## Boundaries
- no receipt schema change
- no config mutation or write mode
- no baseline promotion, threshold loosening, or server-ledger requirement
- no Action behavior change in this PR