### PR TITLE
action: surface policy posture in summary

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "review-packet"
-current_pr = "review-packet"
+current_work_item = "action-posture-summary"
+current_pr = "action-posture-summary"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -126,11 +126,11 @@ status = "merged"
 
 [[work_item]]
 id = "review-packet"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "action-posture-summary"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "agent-policy-guardrails"

--- a/action.yml
+++ b/action.yml
@@ -433,6 +433,109 @@ runs:
             ;;
         esac
 
+    - name: Append perfgate policy posture summary
+      if: always() && steps.run_check.outputs.exit_code != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+          exit 0
+        fi
+
+        out="${{ steps.resolve_out_dir.outputs.out_dir }}"
+        exit_code="${{ steps.run_check.outputs.exit_code }}"
+        verdict="${{ steps.run_check.outputs.verdict }}"
+        review_required="${{ steps.handle_review_required.outputs.review_required }}"
+        review_reason="${{ steps.handle_review_required.outputs.review_required_reason }}"
+
+        policy_args=(policy doctor --config "${{ inputs.config }}")
+        if [[ -n "${out}" ]]; then
+          policy_args+=(--out-dir "${out}")
+        fi
+        if [[ "${{ inputs.all }}" != "true" && -n "${{ inputs.bench }}" ]]; then
+          policy_args+=(--bench "${{ inputs.bench }}")
+        fi
+
+        review_packet_args=()
+        if [[ "${{ inputs.all }}" != "true" && -n "${{ inputs.bench }}" ]]; then
+          review_packet_args=(policy review-packet --config "${{ inputs.config }}" --bench "${{ inputs.bench }}")
+          if [[ -n "${out}" ]]; then
+            review_packet_args+=(--out-dir "${out}")
+          fi
+        fi
+
+        format_command() {
+          local formatted=""
+          local quoted=""
+          local arg
+
+          for arg in "$@"; do
+            if [[ -n "${formatted}" ]]; then
+              formatted+=" "
+            fi
+            printf -v quoted "%q" "${arg}"
+            formatted+="${quoted}"
+          done
+
+          printf "%s" "${formatted}"
+        }
+
+        policy_output="$(mktemp)"
+        policy_status="available"
+        if ! perfgate "${policy_args[@]}" > "${policy_output}" 2>&1; then
+          policy_status="unavailable"
+        fi
+
+        policy_line="$(format_command perfgate "${policy_args[@]}")"
+        review_packet_line=""
+        if [[ "${#review_packet_args[@]}" -gt 0 ]]; then
+          review_packet_line="$(format_command perfgate "${review_packet_args[@]}")"
+        fi
+
+        {
+          echo "### perfgate policy posture"
+          echo
+          echo "Blocking behavior: this action preserves existing perfgate exit-code behavior; maturity guidance is advisory unless your config already makes it blocking."
+          if [[ "${{ inputs.require_baseline }}" == "true" ]]; then
+            echo "Blocking gate: required-baseline mode is enabled."
+          else
+            echo "Advisory signal: missing baselines remain setup guidance unless this workflow enables required-baseline mode."
+          fi
+          if [[ -n "${verdict}" ]]; then
+            echo "Gate verdict: \`${verdict}\` (check exit code \`${exit_code}\`)."
+          else
+            echo "Gate verdict: unavailable (check exit code \`${exit_code}\`)."
+          fi
+          if [[ "${review_required}" == "true" ]]; then
+            echo "Policy review required: ${review_reason}"
+          fi
+          echo
+          echo "Policy doctor command:"
+          echo
+          printf '%s\n' '```bash'
+          echo "${policy_line}"
+          printf '%s\n' '```'
+          if [[ -n "${review_packet_line}" ]]; then
+            echo
+            echo "Review packet command:"
+            echo
+            printf '%s\n' '```bash'
+            echo "${review_packet_line}"
+            printf '%s\n' '```'
+          fi
+          echo
+          echo "Policy doctor output (${policy_status}):"
+          echo
+          printf '%s\n' '```text'
+          cat "${policy_output}"
+          printf '%s\n' '```'
+          echo
+          echo "Do not: make advisory maturity output blocking, loosen thresholds, promote baselines, or require server ledger mode from this summary alone."
+        } >> "${GITHUB_STEP_SUMMARY}"
+
+        rm -f "${policy_output}"
+
     - name: Print perfgate failure summary
       if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0') || (inputs.decision == 'true' && steps.handle_review_required.outputs.exit_code != '' && steps.handle_review_required.outputs.exit_code != '0'))
       shell: bash

--- a/docs/examples/action-failure-summaries.md
+++ b/docs/examples/action-failure-summaries.md
@@ -9,6 +9,32 @@ and the shell wiring is checked by `cargo +1.95.0 run -p xtask -- action-check`.
 The exact artifact paths can vary by configuration. A useful summary must still
 name the verdict, point to receipts, and show a local reproduction command.
 
+## Policy Posture
+
+Use this when the Action has run `perfgate check` and needs to show whether the
+evidence is advisory, a maturity warning, a promotion candidate, or already
+blocking because existing config says so. This summary does not change the
+Action result.
+
+```text
+Policy posture:
+Blocking behavior: this action preserves existing perfgate exit-code behavior; maturity guidance is advisory unless your config already makes it blocking.
+Advisory signal: missing baselines remain setup guidance unless this workflow enables required-baseline mode.
+Gate verdict: `pass` (check exit code `0`).
+Policy doctor command:
+  perfgate policy doctor --config perfgate.toml --out-dir artifacts/perfgate --bench parser
+Review packet command:
+  perfgate policy review-packet --config perfgate.toml --bench parser --out-dir artifacts/perfgate
+Policy doctor output:
+  recommended posture: gate_candidate
+  missing: required-gate reviewer approval
+Do not: make advisory maturity output blocking, loosen thresholds, promote baselines, or require server ledger mode from this summary alone.
+```
+
+The reviewer should treat `gate_candidate` as review-ready evidence, not as an
+approved required gate. Promotion still requires a deliberate policy patch and
+review.
+
 ## Missing Baseline
 
 Use this when the first CI run has not promoted a baseline yet.

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: review-packet
+Current PR: action-posture-summary
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), `PERFGATE-SPEC-0012-agent-policy-change-guardrails` (planned)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -80,8 +80,8 @@ accepted spec and explicit proof.
 | 544 | Rollout profile guidance | merged | user-facing profile and promotion-path docs |
 | 546 | Promotion readiness doctor | merged | `perfgate policy doctor --config perfgate.toml` |
 | 549 | Policy patch output | merged | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
-| TBD | Performance review packet | current | report/comment artifact summary of policy posture and maturity |
-| TBD | GitHub Action posture summary | pending | Action summary posture and `action-check` fixtures |
+| 553 | Performance review packet | merged | report/comment artifact summary of policy posture and maturity |
+| TBD | GitHub Action posture summary | current | Action summary posture and `action-check` fixtures |
 | TBD | Agent policy guardrail spec | pending | `PERFGATE-SPEC-0012-agent-policy-change-guardrails` |
 | TBD | Agent policy fixtures | pending | policy guardrail fixtures for review-required changes |
 | TBD | Proof freshness claim discipline | pending | product-claims proof freshness enforcement for policy promotion |
@@ -327,7 +327,7 @@ git diff --check
 
 ## Work item: review-packet
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: action-posture-summary, agent-policy-guardrails
@@ -363,7 +363,7 @@ git diff --check
 
 ## Work item: action-posture-summary
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: policy-claims-freshness, rollout-canary-plan

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1086,6 +1086,85 @@ fn collect_action_check_errors(action: &str, cli_manifest: &str) -> Vec<String> 
         );
     }
 
+    let Some(policy_summary_run) = action.step_run("Append perfgate policy posture summary") else {
+        errors.push(
+            "action.yml must append advisory policy posture to GITHUB_STEP_SUMMARY".to_string(),
+        );
+        return errors;
+    };
+    let policy_summary_lines = active_shell_lines(policy_summary_run);
+    if !raw_action.contains("if: always() && steps.run_check.outputs.exit_code != ''")
+        || !policy_summary_lines
+            .iter()
+            .any(|line| line == "out=\"${{ steps.resolve_out_dir.outputs.out_dir }}\"")
+        || !policy_summary_lines.iter().any(|line| {
+            line == "policy_args=(policy doctor --config \"${{ inputs.config }}\")"
+        })
+        || !policy_summary_lines.iter().any(|line| {
+            line == "review_packet_args=(policy review-packet --config \"${{ inputs.config }}\" --bench \"${{ inputs.bench }}\")"
+        })
+    {
+        errors.push(
+            "action.yml policy posture summary must run policy doctor and expose the review packet command".to_string(),
+        );
+    }
+    if !policy_summary_lines.iter().any(|line| {
+        line == "echo \"Blocking behavior: this action preserves existing perfgate exit-code behavior; maturity guidance is advisory unless your config already makes it blocking.\""
+    }) || !policy_summary_lines.iter().any(|line| {
+        line == "echo \"Advisory signal: missing baselines remain setup guidance unless this workflow enables required-baseline mode.\""
+    }) || !policy_summary_lines
+        .iter()
+        .any(|line| line == "echo \"Blocking gate: required-baseline mode is enabled.\"")
+    {
+        errors.push(
+            "action.yml policy posture summary must distinguish advisory and blocking posture"
+                .to_string(),
+        );
+    }
+    if !policy_summary_lines.iter().any(|line| {
+        line == "review_required=\"${{ steps.handle_review_required.outputs.review_required }}\""
+    }) || !policy_summary_lines
+        .iter()
+        .any(|line| line == "echo \"Policy review required: ${review_reason}\"")
+    {
+        errors.push(
+            "action.yml policy posture summary must surface review-required posture".to_string(),
+        );
+    }
+    if policy_summary_lines
+        .iter()
+        .any(|line| line.starts_with("echo \"```"))
+        || !policy_summary_lines
+            .iter()
+            .any(|line| line == "printf '%s\\n' '```bash'")
+        || !policy_summary_lines
+            .iter()
+            .any(|line| line == "printf '%s\\n' '```text'")
+        || !policy_summary_lines
+            .iter()
+            .any(|line| line == "printf '%s\\n' '```'")
+    {
+        errors.push(
+            "action.yml policy posture summary must emit Markdown code fences without Bash command substitution"
+                .to_string(),
+        );
+    }
+    if !policy_summary_lines
+        .iter()
+        .any(|line| line == "echo \"### perfgate policy posture\"")
+        || !policy_summary_lines
+            .iter()
+            .any(|line| line == "} >> \"${GITHUB_STEP_SUMMARY}\"")
+        || !policy_summary_lines.iter().any(|line| {
+            line == "echo \"Do not: make advisory maturity output blocking, loosen thresholds, promote baselines, or require server ledger mode from this summary alone.\""
+        })
+    {
+        errors.push(
+            "action.yml policy posture summary must write guarded posture guidance to GITHUB_STEP_SUMMARY"
+                .to_string(),
+        );
+    }
+
     let Some(failure_summary_run) = action.step_run("Print perfgate failure summary") else {
         errors.push(
             "action.yml must print a local reproduction command when perfgate fails".to_string(),
@@ -1346,6 +1425,19 @@ fn collect_action_summary_example_errors(summary_examples: &str) -> Vec<String> 
         ("server upload failure", "server upload failure"),
         ("review-required fail policy", "review_required: \"fail\""),
         ("windows path guidance", "Windows Path Or Shell Quoting"),
+        ("policy posture summary", "Policy posture:"),
+        (
+            "policy doctor command",
+            "perfgate policy doctor --config perfgate.toml",
+        ),
+        (
+            "policy review packet command",
+            "perfgate policy review-packet --config perfgate.toml",
+        ),
+        (
+            "advisory posture guardrail",
+            "make advisory maturity output blocking",
+        ),
     ];
     for (name, phrase) in required_copy {
         if !summary_examples.contains(phrase) {
@@ -6611,6 +6703,24 @@ runs:
         if [[ -f "${out}/decision.md" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
           cat "${out}/decision.md"
         fi
+    - name: Append perfgate policy posture summary
+      if: always() && steps.run_check.outputs.exit_code != ''
+      run: |
+        out="${{ steps.resolve_out_dir.outputs.out_dir }}"
+        review_required="${{ steps.handle_review_required.outputs.review_required }}"
+        policy_args=(policy doctor --config "${{ inputs.config }}")
+        review_packet_args=(policy review-packet --config "${{ inputs.config }}" --bench "${{ inputs.bench }}")
+        {
+          echo "### perfgate policy posture"
+          echo "Blocking behavior: this action preserves existing perfgate exit-code behavior; maturity guidance is advisory unless your config already makes it blocking."
+          echo "Advisory signal: missing baselines remain setup guidance unless this workflow enables required-baseline mode."
+          echo "Blocking gate: required-baseline mode is enabled."
+          echo "Policy review required: ${review_reason}"
+          printf '%s\n' '```bash'
+          printf '%s\n' '```text'
+          printf '%s\n' '```'
+          echo "Do not: make advisory maturity output blocking, loosen thresholds, promote baselines, or require server ledger mode from this summary alone."
+        } >> "${GITHUB_STEP_SUMMARY}"
     - name: Print perfgate failure summary
       if: always() && ((steps.run_check.outputs.exit_code != '0' && steps.run_check.outputs.policy_failure_deferred != 'true') || (inputs.decision == 'true' && steps.run_decision.outputs.exit_code != '' && steps.run_decision.outputs.exit_code != '0') || (inputs.decision == 'true' && steps.handle_review_required.outputs.exit_code != '' && steps.handle_review_required.outputs.exit_code != '0'))
       run: |
@@ -6720,6 +6830,23 @@ pkg-fmt = "zip"
     }
 
     #[test]
+    fn action_summary_examples_reject_missing_policy_posture_copy() {
+        let examples = include_str!("../../docs/examples/action-failure-summaries.md").replace(
+            "perfgate policy doctor --config perfgate.toml",
+            "perfgate doctor",
+        );
+        let errors = collect_action_summary_example_errors(&examples);
+
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("policy doctor command")),
+            "errors should mention missing policy posture copy: {:?}",
+            errors
+        );
+    }
+
+    #[test]
     fn action_check_rejects_missing_decision_input() {
         let action = valid_action_install_surface().replace(
             "  decision:\n    description: \"Run structured decision evaluation\"\n    default: \"false\"\n",
@@ -6730,6 +6857,21 @@ pkg-fmt = "zip"
         assert!(
             errors.iter().any(|error| error.contains("decision input")),
             "errors should mention missing decision input: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn action_check_rejects_missing_policy_posture_summary_step() {
+        let action = valid_action_install_surface().replace(
+            "    - name: Append perfgate policy posture summary",
+            "    - name: Append posture summary",
+        );
+        let errors = collect_action_check_errors(&action, valid_cli_binstall_metadata());
+
+        assert!(
+            errors.iter().any(|error| error.contains("policy posture")),
+            "errors should mention missing policy posture summary: {:?}",
             errors
         );
     }


### PR DESCRIPTION
## Summary
- append a non-blocking perfgate policy posture section to the GitHub step summary after check/decision handling
- surface policy doctor output, blocking/advisory posture, review-required state, and a single-bench review-packet command
- extend action-check and golden summary examples so posture copy cannot drift

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p xtask --all-features action_check
- cargo +1.95.0 test -p xtask --all-features action_summary_examples
- cargo +1.95.0 run -p xtask -- action-check
- cargo +1.95.0 clippy -p xtask --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- schema-compat
- git diff --check

## Boundaries
- no new Action inputs or outputs
- no change to blocking behavior or exit-code policy
- no receipt schema change
- no config writes, baseline promotion, threshold loosening, or server-ledger requirement