### PR TITLE
test: cover agent policy guardrail scenarios

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "agent-policy-guardrails"
-current_pr = "agent-policy-guardrails"
+current_work_item = "agent-policy-fixtures"
+current_pr = "agent-policy-fixtures"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -135,11 +135,11 @@ status = "merged"
 
 [[work_item]]
 id = "agent-policy-guardrails"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "agent-policy-fixtures"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "policy-claims-freshness"

--- a/crates/perfgate-cli/src/policy.rs
+++ b/crates/perfgate-cli/src/policy.rs
@@ -754,6 +754,25 @@ fn render_policy_review_packet(
         out.push_str(&format!("- Next: `{command}`\n"));
     }
 
+    let agent_guardrails = agent_policy_guardrails(
+        &evidence.config,
+        baseline,
+        signal,
+        recommended,
+        compare.as_ref(),
+    );
+    out.push_str("\n## Agent Guardrails\n\n");
+    out.push_str(&format!("- Scenario: `{}`\n", agent_guardrails.scenario));
+    out.push_str(&format!("- Allowed: {}\n", agent_guardrails.allowed));
+    out.push_str(&format!(
+        "- Review required: {}\n",
+        agent_guardrails.review_required
+    ));
+    out.push_str(&format!(
+        "- Forbidden by default: {}\n",
+        agent_guardrails.forbidden_by_default
+    ));
+
     out.push_str("\n## Do Not\n\n");
     for item in policy_do_not(recommended) {
         out.push_str(&format!("- {item}\n"));
@@ -821,6 +840,100 @@ fn push_artifact_line(out: &mut String, label: &str, path: &Path, exists: bool) 
         path.display(),
         if exists { "" } else { " (missing)" }
     ));
+}
+
+struct AgentPolicyGuardrails {
+    scenario: &'static str,
+    allowed: &'static str,
+    review_required: &'static str,
+    forbidden_by_default: &'static str,
+}
+
+fn agent_policy_guardrails(
+    config: &ConfigFile,
+    baseline: &BaselineDoctorRow,
+    signal: &SignalDoctorRow,
+    recommended: PolicyPosture,
+    compare: Option<&CompareReceipt>,
+) -> AgentPolicyGuardrails {
+    if baseline.maturity == BaselineMaturity::Missing {
+        return AgentPolicyGuardrails {
+            scenario: "missing_baseline",
+            allowed: "rerun the check and inspect run/report artifacts",
+            review_required: "baseline promotion after workload review",
+            forbidden_by_default: "do not promote a missing baseline blindly or loosen thresholds",
+        };
+    }
+
+    if baseline.maturity == BaselineMaturity::Stale
+        || signal.recommendation == SignalRecommendation::RefreshBaseline
+    {
+        return AgentPolicyGuardrails {
+            scenario: "stale_proof",
+            allowed: "refresh proof or rerun on the intended runner class",
+            review_required: "claim promotion or required_gate changes from refreshed proof",
+            forbidden_by_default: "do not cite stale proof as current support for blocking policy",
+        };
+    }
+
+    if baseline.maturity == BaselineMaturity::HighNoise
+        || signal.recommendation == SignalRecommendation::UsePairedMode
+    {
+        return AgentPolicyGuardrails {
+            scenario: "noisy_signal",
+            allowed: "recommend paired mode, more samples, or calibration review",
+            review_required: "policy promotion or threshold changes",
+            forbidden_by_default: "do not treat noisy evidence as a confirmed regression or required gate",
+        };
+    }
+
+    if has_tradeoff_evidence(config, &baseline.bench) && compare_has_policy_movement(compare) {
+        return AgentPolicyGuardrails {
+            scenario: "tradeoff_candidate",
+            allowed: "run decision suggest or bundle decision evidence",
+            review_required: "accepting a tradeoff or recording team history",
+            forbidden_by_default: "do not accept bounded regressions without decision evidence and reviewer approval",
+        };
+    }
+
+    if compare_has_policy_movement(compare) {
+        return AgentPolicyGuardrails {
+            scenario: "regression",
+            allowed: "reproduce locally and inspect compare/report artifacts",
+            review_required: "baseline refresh, threshold loosening, or tradeoff acceptance",
+            forbidden_by_default: "do not update the baseline or loosen thresholds to make CI green",
+        };
+    }
+
+    if recommended == PolicyPosture::GateCandidate {
+        return AgentPolicyGuardrails {
+            scenario: "mature_promotion_candidate",
+            allowed: "emit a gate_candidate patch with reasons",
+            review_required: "required_gate approval",
+            forbidden_by_default: "do not treat gate_candidate as already blocking",
+        };
+    }
+
+    AgentPolicyGuardrails {
+        scenario: "advisory_policy_review",
+        allowed: "inspect artifacts, rerun commands, and summarize posture",
+        review_required: "any config write, profile change, baseline promotion, or ledger requirement",
+        forbidden_by_default: "do not infer absent evidence or make advisory output blocking",
+    }
+}
+
+fn has_tradeoff_evidence(config: &ConfigFile, bench_name: &str) -> bool {
+    let scenario_for_bench = config
+        .scenarios
+        .iter()
+        .any(|scenario| scenario.bench == bench_name);
+    scenario_for_bench && !config.tradeoffs.is_empty()
+}
+
+fn compare_has_policy_movement(compare: Option<&CompareReceipt>) -> bool {
+    compare
+        .map(|compare| matches!(compare.verdict.status.as_str(), "warn" | "fail"))
+        .unwrap_or(false)
 }
 
 fn target_review_notes(

--- a/crates/perfgate-cli/tests/cli_policy_tests.rs
+++ b/crates/perfgate-cli/tests/cli_policy_tests.rs
@@ -19,6 +19,10 @@ fn success_command() -> Vec<&'static str> {
 }
 
 fn write_config(dir: &Path) {
+    write_config_with_extra(dir, "");
+}
+
+fn write_config_with_extra(dir: &Path, extra: &str) {
     let command = success_command()
         .iter()
         .map(|part| format!("\"{}\"", part))
@@ -36,6 +40,7 @@ out_dir = "artifacts/perfgate"
 [[bench]]
 name = "policy-bench"
 command = [{command}]
+{extra}
 "#
         ),
     )
@@ -43,7 +48,17 @@ command = [{command}]
 }
 
 fn write_run_receipt(path: &Path, bench: &str, sample_count: usize, cv: f64) {
-    let started_at = chrono::Utc::now() - chrono::Duration::days(1);
+    write_run_receipt_with_age(path, bench, sample_count, cv, 1);
+}
+
+fn write_run_receipt_with_age(
+    path: &Path,
+    bench: &str,
+    sample_count: usize,
+    cv: f64,
+    age_days: i64,
+) {
+    let started_at = chrono::Utc::now() - chrono::Duration::days(age_days);
     let samples = (0..sample_count)
         .map(|_| {
             serde_json::json!({
@@ -92,6 +107,20 @@ fn write_run_receipt(path: &Path, bench: &str, sample_count: usize, cv: f64) {
 }
 
 fn write_compare_receipt(path: &Path, bench: &str, cv: f64) {
+    write_compare_receipt_with_status(path, bench, cv, "pass", 0.01);
+}
+
+fn write_compare_receipt_with_status(path: &Path, bench: &str, cv: f64, status: &str, pct: f64) {
+    let counts = match status {
+        "fail" => serde_json::json!({ "pass": 0, "warn": 0, "fail": 1, "skip": 0 }),
+        "warn" => serde_json::json!({ "pass": 0, "warn": 1, "fail": 0, "skip": 0 }),
+        _ => serde_json::json!({ "pass": 1, "warn": 0, "fail": 0, "skip": 0 }),
+    };
+    let reasons = if status == "pass" {
+        serde_json::json!([])
+    } else {
+        serde_json::json!(["wall_ms regression exceeds policy"])
+    };
     let compare = serde_json::json!({
         "schema": "perfgate.compare.v1",
         "tool": { "name": "perfgate", "version": "0.20.0" },
@@ -113,18 +142,18 @@ fn write_compare_receipt(path: &Path, bench: &str, cv: f64) {
         "deltas": {
             "wall_ms": {
                 "baseline": 100.0,
-                "current": 101.0,
-                "ratio": 1.01,
-                "pct": 0.01,
-                "regression": 0.01,
+                "current": 100.0 * (1.0 + pct),
+                "ratio": 1.0 + pct,
+                "pct": pct,
+                "regression": pct,
                 "cv": cv,
-                "status": "pass"
+                "status": status
             }
         },
         "verdict": {
-            "status": "pass",
-            "counts": { "pass": 1, "warn": 0, "fail": 0, "skip": 0 },
-            "reasons": []
+            "status": status,
+            "counts": counts,
+            "reasons": reasons
         }
     });
     fs::create_dir_all(path.parent().expect("compare parent")).expect("create compare parent");
@@ -482,4 +511,200 @@ fn policy_review_packet_can_write_markdown_artifact_for_setup_state() {
     assert!(packet.contains("- Recommended posture: `advisory`"));
     assert!(packet.contains("baseline promotion after workload review"));
     assert!(packet.contains("do not loosen thresholds or promote baselines"));
+}
+
+fn policy_review_packet_stdout(dir: &Path) -> String {
+    let output = perfgate_cmd()
+        .current_dir(dir)
+        .args([
+            "policy",
+            "review-packet",
+            "--config",
+            "perfgate.toml",
+            "--bench",
+            "policy-bench",
+        ])
+        .output()
+        .expect("run policy review-packet");
+    assert!(
+        output.status.success(),
+        "review packet should succeed: stderr {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("stdout utf8")
+}
+
+fn write_mature_policy_artifacts(dir: &Path, status: &str) {
+    write_run_receipt(
+        &dir.join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_run_receipt(
+        &dir.join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    let pct = if status == "pass" { 0.01 } else { 0.25 };
+    write_compare_receipt_with_status(
+        &dir.join("artifacts/perfgate/policy-bench/compare.json"),
+        "policy-bench",
+        0.03,
+        status,
+        pct,
+    );
+}
+
+#[test]
+fn policy_review_packet_agent_guardrail_missing_baseline() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+
+    let packet = policy_review_packet_stdout(dir.path());
+
+    assert!(packet.contains("## Agent Guardrails"));
+    assert!(packet.contains("- Scenario: `missing_baseline`"));
+    assert!(packet.contains("- Allowed: rerun the check and inspect run/report artifacts"));
+    assert!(packet.contains("- Review required: baseline promotion after workload review"));
+    assert!(packet.contains(
+        "- Forbidden by default: do not promote a missing baseline blindly or loosen thresholds"
+    ));
+}
+
+#[test]
+fn policy_review_packet_agent_guardrail_noisy_signal() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_run_receipt(
+        &dir.path().join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.20,
+    );
+    write_run_receipt(
+        &dir.path().join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.20,
+    );
+
+    let packet = policy_review_packet_stdout(dir.path());
+
+    assert!(packet.contains("- Scenario: `noisy_signal`"));
+    assert!(
+        packet.contains("- Allowed: recommend paired mode, more samples, or calibration review")
+    );
+    assert!(packet.contains("- Review required: policy promotion or threshold changes"));
+    assert!(packet.contains(
+        "- Forbidden by default: do not treat noisy evidence as a confirmed regression or required gate"
+    ));
+}
+
+#[test]
+fn policy_review_packet_agent_guardrail_mature_promotion_candidate() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_mature_policy_artifacts(dir.path(), "pass");
+
+    let packet = policy_review_packet_stdout(dir.path());
+
+    assert!(packet.contains("- Scenario: `mature_promotion_candidate`"));
+    assert!(packet.contains("- Allowed: emit a gate_candidate patch with reasons"));
+    assert!(packet.contains("- Review required: required_gate approval"));
+    assert!(
+        packet.contains("- Forbidden by default: do not treat gate_candidate as already blocking")
+    );
+}
+
+#[test]
+fn policy_review_packet_agent_guardrail_regression() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_mature_policy_artifacts(dir.path(), "fail");
+
+    let packet = policy_review_packet_stdout(dir.path());
+
+    assert!(packet.contains("- Gate verdict: `fail`"));
+    assert!(packet.contains("- Scenario: `regression`"));
+    assert!(packet.contains("- Allowed: reproduce locally and inspect compare/report artifacts"));
+    assert!(packet.contains(
+        "- Review required: baseline refresh, threshold loosening, or tradeoff acceptance"
+    ));
+    assert!(packet.contains(
+        "- Forbidden by default: do not update the baseline or loosen thresholds to make CI green"
+    ));
+}
+
+#[test]
+fn policy_review_packet_agent_guardrail_tradeoff_candidate() {
+    let dir = tempdir().expect("tempdir");
+    write_config_with_extra(
+        dir.path(),
+        r#"
+[[scenario]]
+name = "release"
+bench = "policy-bench"
+weight = 1.0
+
+[[tradeoff]]
+name = "memory_for_runtime"
+if_failed = "max_rss_kb"
+downgrade_to = "warn"
+
+[[tradeoff.require]]
+metric = "wall_ms"
+min_improvement_ratio = 1.05
+"#,
+    );
+    write_mature_policy_artifacts(dir.path(), "fail");
+
+    let packet = policy_review_packet_stdout(dir.path());
+
+    assert!(packet.contains("- Decision suggestion: scenario and tradeoff evidence configured"));
+    assert!(packet.contains("- Scenario: `tradeoff_candidate`"));
+    assert!(packet.contains("- Allowed: run decision suggest or bundle decision evidence"));
+    assert!(packet.contains("- Review required: accepting a tradeoff or recording team history"));
+    assert!(packet.contains(
+        "- Forbidden by default: do not accept bounded regressions without decision evidence and reviewer approval"
+    ));
+}
+
+#[test]
+fn policy_review_packet_agent_guardrail_stale_proof() {
+    let dir = tempdir().expect("tempdir");
+    write_config(dir.path());
+    write_run_receipt_with_age(
+        &dir.path().join("baselines/policy-bench.json"),
+        "policy-bench",
+        7,
+        0.03,
+        45,
+    );
+    write_run_receipt(
+        &dir.path().join("artifacts/perfgate/policy-bench/run.json"),
+        "policy-bench",
+        7,
+        0.03,
+    );
+    write_compare_receipt(
+        &dir.path()
+            .join("artifacts/perfgate/policy-bench/compare.json"),
+        "policy-bench",
+        0.03,
+    );
+
+    let packet = policy_review_packet_stdout(dir.path());
+
+    assert!(packet.contains("- Baseline maturity: `stale`"));
+    assert!(packet.contains("- Proof freshness: stale"));
+    assert!(packet.contains("- Scenario: `stale_proof`"));
+    assert!(packet.contains("- Allowed: refresh proof or rerun on the intended runner class"));
+    assert!(packet.contains(
+        "- Review required: claim promotion or required_gate changes from refreshed proof"
+    ));
+    assert!(packet.contains(
+        "- Forbidden by default: do not cite stale proof as current support for blocking policy"
+    ));
 }

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: agent-policy-guardrails
+Current PR: agent-policy-fixtures
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), [`PERFGATE-SPEC-0012-agent-policy-change-guardrails`](../../docs/specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -82,8 +82,8 @@ accepted spec and explicit proof.
 | 549 | Policy patch output | merged | `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <state>` |
 | 553 | Performance review packet | merged | report/comment artifact summary of policy posture and maturity |
 | 557 | GitHub Action posture summary | merged | Action summary posture and `action-check` fixtures |
-| TBD | Agent policy guardrail spec | current | `PERFGATE-SPEC-0012-agent-policy-change-guardrails` |
-| TBD | Agent policy fixtures | pending | policy guardrail fixtures for review-required changes |
+| 559 | Agent policy guardrail spec | merged | `PERFGATE-SPEC-0012-agent-policy-change-guardrails` |
+| TBD | Agent policy fixtures | current | policy guardrail fixtures for review-required changes |
 | TBD | Proof freshness claim discipline | pending | product-claims proof freshness enforcement for policy promotion |
 | TBD | External policy rollout canary plan | pending | status canary rerun plan for policy ergonomics |
 | TBD | Public policy rollout canary | pending | one real canary proving advisory-to-promotion path |
@@ -391,7 +391,7 @@ git diff --check
 
 ## Work item: agent-policy-guardrails
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked specs: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md; docs/specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md
 Blocks: agent-policy-fixtures
@@ -432,7 +432,7 @@ git diff --check
 
 ## Work item: agent-policy-fixtures
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked specs: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md; docs/specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md
 Blocks: policy-claims-freshness


### PR DESCRIPTION
## Summary
- add an Agent Guardrails section to policy review packets so agents can distinguish allowed, review-required, and forbidden policy actions
- cover missing baseline, noisy signal, mature promotion candidate, regression, tradeoff candidate, and stale proof scenarios
- update the active 0.20 plan and goal pointers after the guardrail spec landed

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate-cli --all-features policy
- cargo +1.95.0 test -p perfgate-cli --all-features check
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- schema-compat
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

## Boundaries
- no receipt schema change
- no Action input, alias, or exit-code behavior change
- no automatic baseline promotion, threshold loosening, policy write, tradeoff acceptance, or server-ledger requirement
- review packets summarize existing receipts; receipts remain the source of truth