### PR TITLE
docs(status): enforce proof freshness for policy claims

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-18"
 milestone = "0.20.0"
-current_work_item = "agent-policy-fixtures"
-current_pr = "agent-policy-fixtures"
+current_work_item = "policy-claims-freshness"
+current_pr = "policy-claims-freshness"
 
 objective = """
 Make perfgate safe for teams to promote mature performance evidence into
@@ -139,11 +139,11 @@ status = "merged"
 
 [[work_item]]
 id = "agent-policy-fixtures"
-status = "current"
+status = "merged"
 
 [[work_item]]
 id = "policy-claims-freshness"
-status = "pending"
+status = "current"
 
 [[work_item]]
 id = "rollout-canary-plan"

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -38,6 +38,9 @@ freshness definitions live in [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md).
 | PG-CLAIM-0025 | perfgate tracks adoption canary freshness without overclaiming one canary shape. | advisory | status docs, canaries | next-canary-refresh |
 | PG-CLAIM-0026 | perfgate documents optional ledger backup, restore, retention, and migration expectations. | advisory | server docs, tests, status | next-server-ledger-change |
 | PG-CLAIM-0027 | perfgate has fixture-backed agent repair-context guidance for common repair scenarios. | advisory | repair_context.json, CLI guidance, tests | next-agent-repair-contract-change |
+| PG-CLAIM-0028 | perfgate supports advisory policy rollout profiles, promotion readiness, and non-mutating policy patches. | supported | CLI, docs, config | next-policy-ergonomics-change |
+| PG-CLAIM-0029 | perfgate surfaces policy posture in review packets and Action summaries without changing configured behavior. | supported | CLI, action, artifacts | next-policy-ergonomics-change |
+| PG-CLAIM-0030 | perfgate has fixture-backed agent policy guardrails for review-required policy changes. | advisory | CLI guidance, specs, tests | next-agent-policy-change |
 
 ## PG-CLAIM-0001: Reviewable performance decisions
 
@@ -830,3 +833,105 @@ Known limits:
   requirements.
 
 Review after: next-agent-repair-contract-change
+
+## PG-CLAIM-0028: Advisory policy rollout profiles
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, docs, config
+Linked docs: [`POLICY_ROLLOUT.md`](../POLICY_ROLLOUT.md), [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+cargo +1.95.0 run -p xtask -- docs-source-check
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+
+Linked tests:
+
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`policy.rs`](../../crates/perfgate-cli/src/policy.rs)
+
+Artifacts:
+
+- `perfgate policy profiles`
+- `perfgate policy doctor --config perfgate.toml`
+- `perfgate policy emit-patch --config perfgate.toml --bench <bench> --to <posture>`
+
+Known limits:
+
+- Policy profiles are starting points, not automatic benchmark selection.
+- Promotion readiness and emitted patches are advisory and non-mutating.
+- `required_gate` still requires deliberate review and policy application.
+
+Review after: next-policy-ergonomics-change
+
+## PG-CLAIM-0029: Review packet and Action policy posture
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, GitHub Action, artifacts
+Linked docs: [`POLICY_ROLLOUT.md`](../POLICY_ROLLOUT.md), [`examples/action-failure-summaries.md`](../examples/action-failure-summaries.md), [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+cargo +1.95.0 run -p xtask -- action-check
+cargo +1.95.0 run -p xtask -- schema-compat
+```
+
+Linked tests:
+
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`xtask/src/main.rs`](../../xtask/src/main.rs)
+
+Artifacts:
+
+- `perfgate policy review-packet --config perfgate.toml --bench <bench>`
+- Action summary policy posture block
+- local reproduction and policy doctor commands in review surfaces
+
+Known limits:
+
+- Review packets summarize receipts; they do not replace receipts as source of
+  truth.
+- Action posture summaries preserve existing configured exit-code behavior.
+- Advisory maturity output does not become blocking from the summary alone.
+
+Review after: next-policy-ergonomics-change
+
+## PG-CLAIM-0030: Agent policy guardrails
+
+Tier: advisory
+Proof freshness: current
+Surface: CLI guidance, specs, tests
+Linked docs: [`PERFGATE-SPEC-0012-agent-policy-change-guardrails`](../specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md), [`POLICY_ROLLOUT.md`](../POLICY_ROLLOUT.md), [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+cargo +1.95.0 test -p perfgate-cli --all-features check
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+
+Linked tests:
+
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`check_guidance.rs`](../../crates/perfgate-cli/src/check_guidance.rs)
+
+Artifacts:
+
+- policy review-packet `Agent Guardrails` section
+- missing-baseline, noisy-signal, mature-promotion, regression,
+  tradeoff-candidate, and stale-proof guardrail fixtures
+
+Known limits:
+
+- Agent guardrails do not make agents policy authorities.
+- Agents may inspect, rerun, summarize, and propose reviewable patches, but
+  baseline promotion, threshold loosening, required-gate changes, tradeoff
+  acceptance, and ledger requirements remain review-required.
+- Fresh guardrail fixtures do not prove every agent workflow or external repo.
+
+Review after: next-agent-policy-change

--- a/docs/status/PROOF_FRESHNESS.md
+++ b/docs/status/PROOF_FRESHNESS.md
@@ -29,6 +29,28 @@ use the weakest relevant state in its language:
 - `unproven` gaps should stay in "known limits" or canary matrices, not in
   positive claim text.
 
+## Claim Promotion Discipline
+
+Policy rollout claims should carry an explicit `Proof freshness:` field before
+they are promoted or used as support for team policy. The product-claims check
+accepts only these freshness states:
+
+```text
+current
+recent
+stale
+superseded
+unproven
+```
+
+`stable` and `supported` claims cannot use `stale`, `superseded`, or
+`unproven` as their proof freshness. Refresh the proof, lower the claim
+language, or keep the gap in "Known limits" instead.
+
+Freshness still does not make advisory guidance blocking. A current maturity or
+policy-rollout claim can support a recommendation, but required gates still
+need a deliberate policy patch and reviewer approval.
+
 ## Non-Inferences
 
 - Fresh proof for one repo shape does not prove every repo shape.

--- a/plans/0.20.0/policy-ergonomics-team-rollout.md
+++ b/plans/0.20.0/policy-ergonomics-team-rollout.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-18
 Milestone: 0.20.0
-Current PR: agent-policy-fixtures
+Current PR: policy-claims-freshness
 Linked proposal: [`PERFGATE-PROP-0007-policy-ergonomics-team-rollout`](../../docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md)
 Linked specs: [`PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract`](../../docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md), [`PERFGATE-SPEC-0012-agent-policy-change-guardrails`](../../docs/specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -83,8 +83,8 @@ accepted spec and explicit proof.
 | 553 | Performance review packet | merged | report/comment artifact summary of policy posture and maturity |
 | 557 | GitHub Action posture summary | merged | Action summary posture and `action-check` fixtures |
 | 559 | Agent policy guardrail spec | merged | `PERFGATE-SPEC-0012-agent-policy-change-guardrails` |
-| TBD | Agent policy fixtures | current | policy guardrail fixtures for review-required changes |
-| TBD | Proof freshness claim discipline | pending | product-claims proof freshness enforcement for policy promotion |
+| 562 | Agent policy fixtures | merged | policy guardrail fixtures for review-required changes |
+| TBD | Proof freshness claim discipline | current | product-claims proof freshness enforcement for policy promotion |
 | TBD | External policy rollout canary plan | pending | status canary rerun plan for policy ergonomics |
 | TBD | Public policy rollout canary | pending | one real canary proving advisory-to-promotion path |
 | TBD | Policy ergonomics closeout | pending | handoff and archived active goal |
@@ -432,7 +432,7 @@ git diff --check
 
 ## Work item: agent-policy-fixtures
 
-Status: current
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked specs: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md; docs/specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md
 Blocks: policy-claims-freshness
@@ -465,7 +465,7 @@ git diff --check
 
 ## Work item: policy-claims-freshness
 
-Status: pending
+Status: current
 Linked proposal: docs/proposals/PERFGATE-PROP-0007-policy-ergonomics-team-rollout.md
 Linked spec: docs/specs/PERFGATE-SPEC-0011-advisory-to-blocking-promotion-contract.md
 Blocks: rollout-canary-plan, policy-rollout-canary

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5082,6 +5082,28 @@ fn collect_product_claim_errors(
             )),
         }
 
+        if let Some(freshness) = claim_field(&claim.body, "Proof freshness") {
+            match freshness.as_str() {
+                "current" | "recent" | "stale" | "superseded" | "unproven" => {}
+                value => errors.push(format!(
+                    "{} line {} uses unknown proof freshness `{}`",
+                    claim.id, claim.line, value
+                )),
+            }
+
+            if matches!(tier.as_deref(), Some("stable" | "supported"))
+                && matches!(freshness.as_str(), "stale" | "superseded" | "unproven")
+            {
+                errors.push(format!(
+                    "{} line {} uses `{}` proof freshness for a `{}` claim; refresh proof or lower the claim language",
+                    claim.id,
+                    claim.line,
+                    freshness,
+                    tier.as_deref().unwrap_or("unknown")
+                ));
+            }
+        }
+
         if claim_field(&claim.body, "Surface").is_none() {
             errors.push(format!(
                 "{} line {} is missing `Surface:`",
@@ -6220,6 +6242,85 @@ Review after: before-release
                 .iter()
                 .any(|error| error.contains("references `PERFGATE-SPEC-0007` as planned")),
             "expected stale planned spec error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn product_claims_check_accepts_supported_claim_with_current_freshness() {
+        let content = r###"# Product Claims
+
+## PG-CLAIM-0001: Policy posture
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, docs
+Linked gates: product-claims-check
+Proof commands:
+
+```bash
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+
+Review after: next-policy-change
+"###;
+
+        let errors = collect_product_claim_errors(content, &BTreeSet::new());
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn product_claims_check_rejects_unknown_proof_freshness() {
+        let content = r###"# Product Claims
+
+## PG-CLAIM-0001: Policy posture
+
+Tier: advisory
+Proof freshness: fresh-ish
+Surface: CLI, docs
+Linked gates: product-claims-check
+Proof commands:
+
+```bash
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+
+Review after: next-policy-change
+"###;
+
+        let errors = collect_product_claim_errors(content, &BTreeSet::new());
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("unknown proof freshness")),
+            "expected proof freshness error, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn product_claims_check_rejects_supported_claim_with_stale_freshness() {
+        let content = r###"# Product Claims
+
+## PG-CLAIM-0001: Policy posture
+
+Tier: supported
+Proof freshness: stale
+Surface: CLI, docs
+Linked gates: product-claims-check
+Proof commands:
+
+```bash
+cargo +1.95.0 run -p xtask -- product-claims-check
+```
+
+Review after: next-policy-change
+"###;
+
+        let errors = collect_product_claim_errors(content, &BTreeSet::new());
+        assert!(
+            errors.iter().any(|error| {
+                error.contains("uses `stale` proof freshness for a `supported` claim")
+            }),
+            "expected stale supported-claim error, got {errors:?}"
         );
     }
 


### PR DESCRIPTION
## Summary
- add product-claims checker validation for explicit proof freshness states
- prevent stable/supported claims from using stale, superseded, or unproven freshness as their proof basis
- map 0.20 policy rollout, review-packet/action posture, and agent policy guardrail claims with current freshness and conservative limits
- advance the active 0.20 goal from agent-policy-fixtures to policy-claims-freshness

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p xtask product_claims_check
- cargo +1.95.0 clippy -p xtask --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check