### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "15138",
+  "message": "15463",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- refresh generated `badges/ripr-plus.json` from current `main`
- replaces superseded #579, which carried stale generated value `15092`

## Validation
- `cargo +1.95.0 run -p xtask -- badges`
- `cargo +1.95.0 run -p xtask -- badges --check`

## Boundaries
- generated badge endpoint only
- no product semantics, release state, receipt schema, or public API changes