### PR TITLE
plans(0.21): mark hyperfine intake merged

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-19"
 milestone = "0.21.0"
-current_work_item = "hyperfine-json-adapter"
-current_pr = "ingest/hyperfine-json-adapter"
+current_work_item = "criterion-adapter"
+current_pr = "TBD"
 
 objective = """
 Make perfgate useful for teams that already have benchmark ecosystems by
@@ -119,7 +119,7 @@ status = "merged"
 
 [[work_item]]
 id = "hyperfine-json-adapter"
-status = "in_progress"
+status = "merged"
 
 [[work_item]]
 id = "criterion-adapter"

--- a/plans/0.21.0/evidence-intake-adoption-packs.md
+++ b/plans/0.21.0/evidence-intake-adoption-packs.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-19
 Milestone: 0.21.0
-Current PR: ingest/hyperfine-json-adapter
+Current PR: TBD (next: criterion-adapter)
 Linked proposal: [`PERFGATE-PROP-0008-evidence-intake-adoption-packs`](../../docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md)
 Linked specs: [`PERFGATE-SPEC-0013-evidence-source-contract`](../../docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -70,7 +70,7 @@ schema-compat proof.
 | 576 | Evidence source contract | merged | `docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md` |
 | 578 | Implementation plan and active goal | merged | `plans/0.21.0/evidence-intake-adoption-packs.md`, `.codex/goals/active.toml` |
 | 580 | Generic command JSON adapter | merged | CLI adapter/import surface, fixtures, docs |
-| TBD | hyperfine JSON adapter | in progress | hyperfine fixtures, unit/direction/sample mapping |
+| 585 | hyperfine JSON adapter | merged | hyperfine fixtures, unit/direction/sample mapping |
 | TBD | Criterion adapter | pending | Criterion fixtures and non-inference docs |
 | TBD | pytest-benchmark JSON adapter | pending | Python benchmark fixtures and environment limits |
 | TBD | k6 summary JSON adapter | pending | HTTP/load-test fixtures and capacity non-inferences |
@@ -182,7 +182,7 @@ unchanged.
 
 ## Work item: hyperfine-json-adapter
 
-Status: in progress
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md
 Linked spec: docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md
 Blocks: imported-evidence-maturity, adoption-pack-catalog


### PR DESCRIPTION
## Summary
- mark the hyperfine JSON adapter as merged in the 0.21 plan and active goal
- move the active work pointer to the next planned slice, `criterion-adapter`

## Validation
- `cargo +1.95.0 run -p xtask -- docs-source-check`
- `cargo +1.95.0 run -p xtask -- docs-check`
- `cargo +1.95.0 run -p xtask -- product-claims-check`
- `git diff --check`

## Boundaries
- source-of-truth pointer sync only
- no product behavior, receipt schema, public API, or release-state change