### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "15463",
+  "message": "15554",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- refresh badges/ripr-plus.json from current main after the hyperfine intake merge and pointer sync
- replace stale generated badge PR #587, which carried an older value

## Validation
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check