### PR TITLE
ingest: harden Criterion adapter

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -5,7 +5,7 @@ owner = "codex"
 created = "2026-05-19"
 milestone = "0.21.0"
 current_work_item = "criterion-adapter"
-current_pr = "TBD"
+current_pr = "ingest/criterion-adapter"
 
 objective = """
 Make perfgate useful for teams that already have benchmark ecosystems by
@@ -123,7 +123,7 @@ status = "merged"
 
 [[work_item]]
 id = "criterion-adapter"
-status = "pending"
+status = "in_progress"
 
 [[work_item]]
 id = "pytest-benchmark-json-adapter"

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -1335,7 +1335,7 @@ pub struct IngestArgs {
     #[arg(long)]
     pub format: Option<String>,
 
-    /// Path to the input file (or directory for criterion)
+    /// Path to the input file
     #[arg(long)]
     pub input: Option<PathBuf>,
 
@@ -3210,6 +3210,27 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 }
                 eprintln!(
                     "Non-inferences: hyperfine command timing may include shell, setup, cache, or compile overhead; imported evidence remains advisory until maturity and policy surfaces support promotion."
+                );
+            } else if format == IngestFormat::Criterion {
+                eprintln!(
+                    "Evidence source: criterion; clear wall-time fields were mapped to lower-is-better wall_ms."
+                );
+                if receipt.samples.is_empty() {
+                    eprintln!(
+                        "Sample model: summary-only; Criterion estimates.json does not provide raw per-sample evidence to perfgate."
+                    );
+                } else {
+                    eprintln!(
+                        "Sample model: Criterion measured samples were preserved where cargo-criterion JSONL or raw.csv provided them."
+                    );
+                }
+                if receipt.run.host.os == "unknown" || receipt.run.host.arch == "unknown" {
+                    eprintln!(
+                        "Host context: unknown; Criterion output does not prove host compatibility."
+                    );
+                }
+                eprintln!(
+                    "Non-inferences: Criterion statistics are not perfgate maturity policy; imported evidence remains advisory until baseline, signal, and policy surfaces support promotion."
                 );
             }
             Ok(())

--- a/crates/perfgate-cli/tests/cli_ingest_tests.rs
+++ b/crates/perfgate-cli/tests/cli_ingest_tests.rs
@@ -111,6 +111,125 @@ fn test_ingest_hyperfine_exit_code_mismatch_fails_actionably() {
 }
 
 #[test]
+fn test_ingest_criterion_jsonl_writes_run_receipt() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("criterion.jsonl");
+    let output_path = temp_dir.path().join("run.json");
+
+    fs::write(
+        &input_path,
+        r#"{"reason":"warmup","id":"ignored"}
+{"reason":"benchmark-complete","id":"parser/large","iteration_count":[10,20,30],"measured_values":[50000000.0,100000000.0,150000000.0],"unit":"ns","throughput":[{"per_iteration":5000,"unit":"elements"}],"mean":{"estimate":5000000.0,"lower_bound":4900000.0,"upper_bound":5100000.0,"unit":"ns"},"median":{"estimate":4950000.0,"lower_bound":4890000.0,"upper_bound":5010000.0,"unit":"ns"}}"#,
+    )
+    .expect("failed to write Criterion input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("--format")
+        .arg("criterion")
+        .arg("--input")
+        .arg(&input_path)
+        .arg("--out")
+        .arg(&output_path);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Evidence source: criterion"))
+        .stderr(predicate::str::contains("Criterion measured samples"))
+        .stderr(predicate::str::contains("Host context: unknown"))
+        .stderr(predicate::str::contains(
+            "Criterion statistics are not perfgate maturity policy",
+        ));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read ingest output"),
+    )
+    .expect("ingest output should be JSON");
+
+    assert_eq!(receipt["schema"], "perfgate.run.v1");
+    assert_eq!(receipt["bench"]["name"], "parser/large");
+    assert_eq!(receipt["bench"]["repeat"], 3);
+    assert_eq!(receipt["bench"]["work_units"], 5000);
+    assert_eq!(receipt["run"]["host"]["os"], "unknown");
+    assert_eq!(
+        receipt["bench"]["command"][0],
+        "(ingested Criterion benchmark)"
+    );
+    assert_eq!(receipt["samples"].as_array().map(Vec::len), Some(3));
+    assert_eq!(receipt["samples"][0]["wall_ms"], 5);
+    assert_eq!(receipt["stats"]["wall_ms"]["median"], 5);
+    assert_eq!(receipt["stats"]["wall_ms"]["mean"], 5.0);
+}
+
+#[test]
+fn test_ingest_criterion_estimates_marks_summary_only() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("estimates.json");
+    let output_path = temp_dir.path().join("run.json");
+
+    fs::write(
+        &input_path,
+        r#"{
+  "mean": {"point_estimate": 5000000.0},
+  "median": {"point_estimate": 4950000.0},
+  "std_dev": {"point_estimate": 200000.0}
+}"#,
+    )
+    .expect("failed to write Criterion estimates input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("--format")
+        .arg("criterion")
+        .arg("--input")
+        .arg(&input_path)
+        .arg("--name")
+        .arg("criterion-summary")
+        .arg("--out")
+        .arg(&output_path);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Sample model: summary-only"))
+        .stderr(predicate::str::contains(
+            "Criterion statistics are not perfgate maturity policy",
+        ));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read ingest output"),
+    )
+    .expect("ingest output should be JSON");
+
+    assert_eq!(receipt["bench"]["name"], "criterion-summary");
+    assert_eq!(receipt["bench"]["repeat"], 0);
+    assert_eq!(receipt["samples"].as_array().map(Vec::len), Some(0));
+    assert_eq!(receipt["stats"]["wall_ms"]["median"], 5);
+}
+
+#[test]
+fn test_ingest_criterion_unsupported_unit_fails_actionably() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("criterion-bad-unit.json");
+
+    fs::write(
+        &input_path,
+        r#"{"reason":"benchmark-complete","id":"bad","iteration_count":[1],"measured_values":[42.0],"unit":"cycles"}"#,
+    )
+    .expect("failed to write Criterion input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("--format")
+        .arg("criterion")
+        .arg("--input")
+        .arg(&input_path);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("unsupported or ambiguous"));
+}
+
+#[test]
 fn test_ingest_generic_command_json_writes_run_receipt() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let input_path = temp_dir.path().join("generic.json");

--- a/crates/perfgate/src/integrations/ingest/criterion.rs
+++ b/crates/perfgate/src/integrations/ingest/criterion.rs
@@ -1,23 +1,54 @@
-//! Parser for Criterion benchmark results.
+//! Parser for Criterion benchmark output.
 //!
-//! Criterion stores estimates in `target/criterion/<bench>/new/estimates.json`.
-//! The JSON structure contains `mean`, `median`, `std_dev` with `point_estimate`
-//! and `confidence_interval` sub-objects, all in nanoseconds.
+//! Prefer `cargo criterion --message-format=json` benchmark-complete messages
+//! or Criterion `raw.csv` files. `new/estimates.json` is accepted only as a
+//! summary-only fallback because Criterion documents those JSON files as
+//! private implementation details.
 
-use anyhow::Context;
-use perfgate_types::{RunReceipt, Sample, Stats};
+use anyhow::{Context, bail};
+use perfgate_types::{
+    BenchMeta, HostInfo, RUN_SCHEMA_V1, RunMeta, RunReceipt, Sample, Stats, ToolInfo, U64Summary,
+};
 use serde::Deserialize;
+use serde_json::Value;
+use time::OffsetDateTime;
+use uuid::Uuid;
 
-use super::{compute_u64_summary, make_receipt};
+use super::compute_u64_summary;
 
-/// A Criterion estimate entry (mean, median, std_dev, etc.).
+#[derive(Debug, Deserialize)]
+struct CargoCriterionMessage {
+    reason: String,
+    id: String,
+    iteration_count: Vec<u64>,
+    measured_values: Vec<f64>,
+    unit: String,
+    #[serde(default)]
+    throughput: Vec<CargoCriterionThroughput>,
+    #[serde(default)]
+    mean: Option<CargoCriterionEstimate>,
+    #[serde(default)]
+    median: Option<CargoCriterionEstimate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoCriterionThroughput {
+    per_iteration: u64,
+    #[serde(default)]
+    unit: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoCriterionEstimate {
+    estimate: f64,
+    unit: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct CriterionEstimate {
     point_estimate: f64,
-    // confidence_interval is available but we don't need it for basic ingest
 }
 
-/// Top-level Criterion estimates.json structure.
 #[derive(Debug, Deserialize)]
 struct CriterionEstimates {
     mean: CriterionEstimate,
@@ -27,44 +58,281 @@ struct CriterionEstimates {
     slope: Option<CriterionEstimate>,
 }
 
-/// Parse a Criterion `estimates.json` file into a `RunReceipt`.
+struct CriterionSamples {
+    name: String,
+    samples: Vec<Sample>,
+    stats: U64Summary,
+    work_units: Option<u64>,
+}
+
+/// Parse Criterion output into a `RunReceipt`.
 ///
-/// Criterion reports timing in nanoseconds. We convert to milliseconds
-/// for the `wall_ms` metric. Since Criterion provides summary statistics
-/// rather than raw samples, we synthesize a sample set from the mean value.
+/// Supported inputs:
+///
+/// - `cargo criterion --message-format=json` JSON or JSONL containing a
+///   `benchmark-complete` message;
+/// - Criterion `raw.csv`; and
+/// - Criterion `new/estimates.json` as a summary-only fallback.
 pub fn parse_criterion(input: &str, name: Option<&str>) -> anyhow::Result<RunReceipt> {
-    let estimates: CriterionEstimates =
-        serde_json::from_str(input).context("failed to parse Criterion estimates.json")?;
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        bail!("Criterion input is empty");
+    }
 
-    let bench_name = name.unwrap_or("criterion-bench").to_string();
+    if looks_like_raw_csv(trimmed) {
+        return raw_csv_to_receipt(trimmed, name);
+    }
 
-    // Criterion values are in nanoseconds; convert to milliseconds (u64).
-    // Use the slope estimate if available (more accurate for iterated benchmarks),
-    // otherwise fall back to mean.
-    let primary = estimates.slope.as_ref().unwrap_or(&estimates.mean);
-    let mean_ns = primary.point_estimate;
-    let median_ns = estimates.median.point_estimate;
-    let std_dev_ns = estimates.std_dev.point_estimate;
+    match serde_json::from_str::<Value>(trimmed) {
+        Ok(value) => criterion_json_value_to_receipt(value, name),
+        Err(_parse_error) if looks_like_jsonl(trimmed) => {
+            cargo_criterion_jsonl_to_receipt(trimmed, name)
+        }
+        Err(parse_error) => {
+            bail!(
+                "failed to parse Criterion output; expected cargo-criterion JSON/JSONL benchmark-complete output, Criterion raw.csv, or Criterion new/estimates.json: {parse_error}"
+            )
+        }
+    }
+}
 
-    // Convert ns to ms for u64 fields. For sub-millisecond benchmarks we clamp
-    // to 1ms minimum to avoid zero values in the u64 field.
-    let median_ms = ns_to_ms(median_ns);
+fn criterion_json_value_to_receipt(value: Value, name: Option<&str>) -> anyhow::Result<RunReceipt> {
+    if value.get("reason").and_then(Value::as_str) == Some("benchmark-complete") {
+        let message: CargoCriterionMessage = serde_json::from_value(value)
+            .context("failed to parse cargo-criterion benchmark-complete message")?;
+        return cargo_criterion_message_to_receipt(message, name);
+    }
 
-    // Synthesize samples from the summary statistics.
-    // We generate 5 synthetic samples centered around the mean with the reported std_dev.
-    let offsets = [-2.0, -1.0, 0.0, 1.0, 2.0];
+    let estimates: CriterionEstimates = serde_json::from_value(value).with_context(|| {
+        "unsupported Criterion JSON; expected reason=benchmark-complete or estimates.json with mean/median/std_dev"
+    })?;
+    estimates_to_receipt(estimates, name)
+}
+
+fn cargo_criterion_jsonl_to_receipt(input: &str, name: Option<&str>) -> anyhow::Result<RunReceipt> {
+    for (index, line) in input.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line)
+            .with_context(|| format!("failed to parse Criterion JSONL line {}", index + 1))?;
+        if value.get("reason").and_then(Value::as_str) == Some("benchmark-complete") {
+            let message: CargoCriterionMessage = serde_json::from_value(value)
+                .context("failed to parse cargo-criterion benchmark-complete message")?;
+            return cargo_criterion_message_to_receipt(message, name);
+        }
+    }
+
+    bail!("cargo-criterion JSONL contains no benchmark-complete message")
+}
+
+fn cargo_criterion_message_to_receipt(
+    message: CargoCriterionMessage,
+    name: Option<&str>,
+) -> anyhow::Result<RunReceipt> {
+    if message.reason != "benchmark-complete" {
+        bail!(
+            "cargo-criterion message reason must be benchmark-complete, got {}",
+            message.reason
+        );
+    }
+    if message.measured_values.is_empty() {
+        bail!("cargo-criterion benchmark-complete message contains no measured_values");
+    }
+    if message.measured_values.len() != message.iteration_count.len() {
+        bail!(
+            "cargo-criterion measured_values length ({}) does not match iteration_count length ({})",
+            message.measured_values.len(),
+            message.iteration_count.len()
+        );
+    }
+
     let mut wall_values = Vec::new();
     let mut samples = Vec::new();
+    for (index, measured_value) in message.measured_values.iter().enumerate() {
+        let iterations = message.iteration_count[index];
+        if iterations == 0 {
+            bail!(
+                "cargo-criterion iteration_count at sample {} must be greater than zero",
+                index + 1
+            );
+        }
+        let per_iteration = *measured_value / iterations as f64;
+        let wall_ms = measurement_to_wall_ms(per_iteration, &message.unit, "measured_values")?;
+        wall_values.push(wall_ms);
+        samples.push(sample(wall_ms));
+    }
 
-    for &offset in &offsets {
-        let ns = mean_ns + offset * std_dev_ns;
-        let ms = ns_to_ms(ns.max(0.0));
-        wall_values.push(ms);
-        samples.push(Sample {
-            wall_ms: ms,
-            exit_code: 0,
-            warmup: false,
-            timed_out: false,
+    let mut stats = compute_u64_summary(&wall_values);
+    if let Some(median) = &message.median {
+        stats.median = estimate_to_wall_ms(median, "median")?;
+    }
+    if let Some(mean) = &message.mean {
+        stats.mean = Some(estimate_to_wall_ms_f64(mean, "mean")?);
+    }
+
+    let work_units = message.throughput.first().map(|throughput| {
+        let _unit = throughput.unit.as_deref();
+        throughput.per_iteration
+    });
+
+    let samples = CriterionSamples {
+        name: name.unwrap_or(&message.id).to_string(),
+        samples,
+        stats,
+        work_units,
+    };
+    Ok(samples_to_receipt(samples))
+}
+
+fn raw_csv_to_receipt(input: &str, name: Option<&str>) -> anyhow::Result<RunReceipt> {
+    let mut lines = input.lines().filter(|line| !line.trim().is_empty());
+    let header = lines.next().context("Criterion raw.csv is empty")?;
+    validate_raw_csv_header(header)?;
+
+    let mut identity: Option<String> = None;
+    let mut wall_values = Vec::new();
+    let mut samples = Vec::new();
+    let mut work_units: Option<u64> = None;
+
+    for (line_index, line) in lines.enumerate() {
+        let fields: Vec<&str> = line.split(',').map(str::trim).collect();
+        if fields.len() != 8 {
+            bail!(
+                "Criterion raw.csv line {} has {} fields; expected 8",
+                line_index + 2,
+                fields.len()
+            );
+        }
+
+        let row_identity = raw_csv_identity(fields[0], fields[1], fields[2]);
+        if let Some(existing) = &identity {
+            if existing != &row_identity {
+                bail!(
+                    "Criterion raw.csv contains multiple benchmark identities ('{}' and '{}'); import one benchmark file at a time",
+                    existing,
+                    row_identity
+                );
+            }
+        } else {
+            identity = Some(row_identity);
+        }
+
+        if work_units.is_none() && !fields[3].is_empty() {
+            let parsed = fields[3].parse::<u64>().with_context(|| {
+                format!(
+                    "Criterion raw.csv line {} throughput_num is not an integer",
+                    line_index + 2
+                )
+            })?;
+            work_units = Some(parsed);
+        }
+
+        let measured = fields[5].parse::<f64>().with_context(|| {
+            format!(
+                "Criterion raw.csv line {} sample_measured_value is not a number",
+                line_index + 2
+            )
+        })?;
+        let unit = fields[6];
+        let iterations = fields[7].parse::<u64>().with_context(|| {
+            format!(
+                "Criterion raw.csv line {} iteration_count is not an integer",
+                line_index + 2
+            )
+        })?;
+        if iterations == 0 {
+            bail!(
+                "Criterion raw.csv line {} iteration_count must be greater than zero",
+                line_index + 2
+            );
+        }
+
+        let per_iteration = measured / iterations as f64;
+        let wall_ms = measurement_to_wall_ms(per_iteration, unit, "sample_measured_value")?;
+        wall_values.push(wall_ms);
+        samples.push(sample(wall_ms));
+    }
+
+    if samples.is_empty() {
+        bail!("Criterion raw.csv contains no sample rows");
+    }
+
+    let samples = CriterionSamples {
+        name: name
+            .map(str::to_string)
+            .or(identity)
+            .unwrap_or_else(|| "criterion-bench".to_string()),
+        stats: compute_u64_summary(&wall_values),
+        samples,
+        work_units,
+    };
+    Ok(samples_to_receipt(samples))
+}
+
+fn estimates_to_receipt(
+    estimates: CriterionEstimates,
+    name: Option<&str>,
+) -> anyhow::Result<RunReceipt> {
+    let primary = estimates.slope.as_ref().unwrap_or(&estimates.mean);
+    let mean_ms = ns_to_ms_f64(primary.point_estimate, "mean")?;
+    let median_ms = ns_to_ms(estimates.median.point_estimate, "median")?;
+    let stddev_ms = ns_to_ms_f64(estimates.std_dev.point_estimate, "std_dev")?;
+
+    let stats = U64Summary {
+        median: median_ms,
+        min: median_ms,
+        max: median_ms,
+        mean: Some(mean_ms),
+        stddev: Some(stddev_ms),
+    };
+
+    let samples = CriterionSamples {
+        name: name.unwrap_or("criterion-bench").to_string(),
+        samples: Vec::new(),
+        stats,
+        work_units: None,
+    };
+    Ok(samples_to_receipt(samples))
+}
+
+fn samples_to_receipt(input: CriterionSamples) -> RunReceipt {
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    RunReceipt {
+        schema: RUN_SCHEMA_V1.to_string(),
+        tool: ToolInfo {
+            name: "perfgate-ingest".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        run: RunMeta {
+            id: Uuid::new_v4().to_string(),
+            started_at: timestamp.clone(),
+            ended_at: timestamp,
+            host: HostInfo {
+                os: "unknown".to_string(),
+                arch: "unknown".to_string(),
+                cpu_count: None,
+                memory_bytes: None,
+                hostname_hash: None,
+            },
+        },
+        bench: BenchMeta {
+            name: input.name,
+            cwd: None,
+            command: vec!["(ingested Criterion benchmark)".to_string()],
+            repeat: input.samples.len() as u32,
+            warmup: 0,
+            work_units: input.work_units,
+            timeout_ms: None,
+        },
+        samples: input.samples,
+        stats: Stats {
+            wall_ms: input.stats,
             cpu_ms: None,
             page_faults: None,
             ctx_switches: None,
@@ -74,25 +342,129 @@ pub fn parse_criterion(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
             network_packets: None,
             energy_uj: None,
             binary_bytes: None,
-            stdout: None,
-            stderr: None,
-        });
+            throughput_per_s: None,
+        },
     }
+}
 
-    let mut stats = compute_u64_summary(&wall_values);
-    // Override median with the actual Criterion median
-    stats.median = median_ms;
-    // Override mean/stddev with precise floating-point values (ns -> ms).
-    // IMPORTANT: Use f64 division here, NOT ns_to_ms(). See the GOTCHA on
-    // ns_to_ms — integer truncation would lose the sub-ms precision that
-    // budget evaluation and significance testing rely on.
-    stats.mean = Some(mean_ns / 1_000_000.0);
-    stats.stddev = Some(std_dev_ns / 1_000_000.0);
+fn validate_raw_csv_header(header: &str) -> anyhow::Result<()> {
+    let fields: Vec<&str> = header.split(',').map(str::trim).collect();
+    let expected = [
+        "group",
+        "function",
+        "value",
+        "throughput_num",
+        "throughput_type",
+        "sample_measured_value",
+        "unit",
+        "iteration_count",
+    ];
+    if fields != expected {
+        bail!(
+            "Criterion raw.csv header is not supported; expected {}",
+            expected.join(",")
+        );
+    }
+    Ok(())
+}
 
-    let wall_stats = stats;
+fn raw_csv_identity(group: &str, function: &str, value: &str) -> String {
+    let parts: Vec<&str> = [group, function, value]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect();
+    if parts.is_empty() {
+        "criterion-bench".to_string()
+    } else {
+        parts.join("/")
+    }
+}
 
-    let full_stats = Stats {
-        wall_ms: wall_stats,
+fn looks_like_raw_csv(input: &str) -> bool {
+    input
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| {
+            line.trim_start_matches('\u{feff}')
+                .starts_with("group,function,value,")
+        })
+        .unwrap_or(false)
+}
+
+fn looks_like_jsonl(input: &str) -> bool {
+    let mut non_empty = input.lines().filter(|line| !line.trim().is_empty());
+    matches!(
+        (non_empty.next(), non_empty.next()),
+        (Some(first), Some(_)) if first.trim_start().starts_with('{')
+    )
+}
+
+fn estimate_to_wall_ms(estimate: &CargoCriterionEstimate, field: &str) -> anyhow::Result<u64> {
+    measurement_to_wall_ms(estimate.estimate, &estimate.unit, field)
+}
+
+fn estimate_to_wall_ms_f64(estimate: &CargoCriterionEstimate, field: &str) -> anyhow::Result<f64> {
+    measurement_to_wall_ms_f64(estimate.estimate, &estimate.unit, field)
+}
+
+fn measurement_to_wall_ms(value: f64, unit: &str, field: &str) -> anyhow::Result<u64> {
+    let ms = measurement_to_wall_ms_f64(value, unit, field)?;
+    f64_to_u64_ms(ms, field)
+}
+
+fn measurement_to_wall_ms_f64(value: f64, unit: &str, field: &str) -> anyhow::Result<f64> {
+    if !value.is_finite() || value < 0.0 {
+        bail!("Criterion field '{field}' must be finite and non-negative");
+    }
+    match normalize_unit(unit).as_str() {
+        "ns" | "nanosecond" | "nanoseconds" => Ok(value / 1_000_000.0),
+        "us" | "microsecond" | "microseconds" => Ok(value / 1_000.0),
+        "ms" | "millisecond" | "milliseconds" => Ok(value),
+        "s" | "sec" | "second" | "seconds" => Ok(value * 1000.0),
+        _ => bail!(
+            "Criterion unit '{}' is unsupported or ambiguous; expected ns, us, ms, or seconds wall-time units",
+            unit
+        ),
+    }
+}
+
+fn ns_to_ms(ns: f64, field: &str) -> anyhow::Result<u64> {
+    f64_to_u64_ms(ns_to_ms_f64(ns, field)?, field)
+}
+
+fn ns_to_ms_f64(ns: f64, field: &str) -> anyhow::Result<f64> {
+    if !ns.is_finite() || ns < 0.0 {
+        bail!("Criterion field '{field}' must be finite and non-negative");
+    }
+    Ok(ns / 1_000_000.0)
+}
+
+fn f64_to_u64_ms(ms: f64, field: &str) -> anyhow::Result<u64> {
+    if !ms.is_finite() || ms < 0.0 {
+        bail!("Criterion field '{field}' must be finite and non-negative");
+    }
+    if ms > u64::MAX as f64 {
+        bail!("Criterion field '{field}' is too large for perfgate.run.v1");
+    }
+    if ms < 1.0 && ms > 0.0 {
+        Ok(1)
+    } else {
+        Ok(ms.round() as u64)
+    }
+}
+
+fn normalize_unit(unit: &str) -> String {
+    unit.trim()
+        .to_ascii_lowercase()
+        .replace(['-', '/', ' '], "_")
+}
+
+fn sample(wall_ms: u64) -> Sample {
+    Sample {
+        wall_ms,
+        exit_code: 0,
+        warmup: false,
+        timed_out: false,
         cpu_ms: None,
         page_faults: None,
         ctx_switches: None,
@@ -102,27 +474,8 @@ pub fn parse_criterion(input: &str, name: Option<&str>) -> anyhow::Result<RunRec
         network_packets: None,
         energy_uj: None,
         binary_bytes: None,
-        throughput_per_s: None,
-    };
-
-    Ok(make_receipt(&bench_name, samples, full_stats))
-}
-
-/// Integer ns-to-ms conversion for sample `wall_ms` values (u64).
-///
-/// GOTCHA: This intentionally truncates to integer milliseconds -- it is only
-/// appropriate for per-sample u64 fields where sub-ms precision is not needed.
-/// For stats fields (mean, stddev) you MUST use floating-point division
-/// (`ns / 1_000_000.0`) to preserve sub-millisecond precision. Using this
-/// function for stats would silently destroy the fractional component that
-/// downstream budget evaluation and significance testing depend on.
-fn ns_to_ms(ns: f64) -> u64 {
-    let ms = ns / 1_000_000.0;
-    if ms < 1.0 && ms > 0.0 {
-        // Sub-millisecond: round to nearest, minimum 1
-        1
-    } else {
-        ms.round() as u64
+        stdout: None,
+        stderr: None,
     }
 }
 
@@ -130,6 +483,15 @@ fn ns_to_ms(ns: f64) -> u64 {
 mod tests {
     use super::*;
     use perfgate_types::RUN_SCHEMA_V1;
+
+    const CARGO_CRITERION_JSONL: &str = r#"{"reason":"warmup","id":"ignored"}
+{"reason":"benchmark-complete","id":"parser/large","iteration_count":[10,20,30],"measured_values":[50000000.0,100000000.0,150000000.0],"unit":"ns","throughput":[{"per_iteration":5000,"unit":"elements"}],"mean":{"estimate":5000000.0,"lower_bound":4900000.0,"upper_bound":5100000.0,"unit":"ns"},"median":{"estimate":4950000.0,"lower_bound":4890000.0,"upper_bound":5010000.0,"unit":"ns"}}"#;
+
+    const CRITERION_RAW_CSV: &str = r#"group,function,value,throughput_num,throughput_type,sample_measured_value,unit,iteration_count
+Parser,large,,5000,elements,50000000,ns,10
+Parser,large,,5000,elements,100000000,ns,20
+Parser,large,,5000,elements,150000000,ns,30
+"#;
 
     const CRITERION_ESTIMATES: &str = r#"{
         "mean": {
@@ -162,84 +524,112 @@ mod tests {
     }"#;
 
     #[test]
-    fn parse_criterion_basic() {
+    fn parse_cargo_criterion_jsonl_preserves_measured_samples() {
+        let receipt = parse_criterion(CARGO_CRITERION_JSONL, None).unwrap();
+
+        assert_eq!(receipt.schema, RUN_SCHEMA_V1);
+        assert_eq!(receipt.bench.name, "parser/large");
+        assert_eq!(
+            receipt.bench.command,
+            vec!["(ingested Criterion benchmark)"]
+        );
+        assert_eq!(receipt.bench.repeat, 3);
+        assert_eq!(receipt.bench.work_units, Some(5000));
+        assert_eq!(receipt.samples.len(), 3);
+        assert_eq!(
+            receipt
+                .samples
+                .iter()
+                .map(|sample| sample.wall_ms)
+                .collect::<Vec<_>>(),
+            vec![5, 5, 5]
+        );
+        assert_eq!(receipt.stats.wall_ms.median, 5);
+        assert_eq!(receipt.stats.wall_ms.mean, Some(5.0));
+        assert_eq!(receipt.run.host.os, "unknown");
+        assert_eq!(receipt.run.host.arch, "unknown");
+    }
+
+    #[test]
+    fn parse_cargo_criterion_json_object_accepts_name_override() {
+        let input = CARGO_CRITERION_JSONL
+            .lines()
+            .nth(1)
+            .expect("benchmark-complete line");
+        let receipt = parse_criterion(input, Some("parser-renamed")).unwrap();
+
+        assert_eq!(receipt.bench.name, "parser-renamed");
+        assert_eq!(receipt.samples.len(), 3);
+    }
+
+    #[test]
+    fn parse_criterion_raw_csv_preserves_sample_rows() {
+        let receipt = parse_criterion(CRITERION_RAW_CSV, None).unwrap();
+
+        assert_eq!(receipt.bench.name, "Parser/large");
+        assert_eq!(receipt.bench.repeat, 3);
+        assert_eq!(receipt.bench.work_units, Some(5000));
+        assert_eq!(
+            receipt
+                .samples
+                .iter()
+                .map(|sample| sample.wall_ms)
+                .collect::<Vec<_>>(),
+            vec![5, 5, 5]
+        );
+        assert_eq!(receipt.run.host.os, "unknown");
+    }
+
+    #[test]
+    fn parse_criterion_estimates_is_summary_only() {
         let receipt = parse_criterion(CRITERION_ESTIMATES, Some("my-bench")).unwrap();
+
         assert_eq!(receipt.schema, RUN_SCHEMA_V1);
         assert_eq!(receipt.bench.name, "my-bench");
-        assert_eq!(receipt.samples.len(), 5);
-        // 5_000_000 ns = 5 ms
-        assert_eq!(receipt.stats.wall_ms.median, 5); // 4_950_000 ns ~ 5ms
-        assert!(receipt.stats.wall_ms.min <= receipt.stats.wall_ms.max);
+        assert_eq!(receipt.bench.repeat, 0);
+        assert!(receipt.samples.is_empty());
+        assert_eq!(receipt.stats.wall_ms.median, 5);
+        assert_eq!(receipt.stats.wall_ms.mean, Some(5.0));
+        assert_eq!(receipt.stats.wall_ms.stddev, Some(0.2));
+        assert_eq!(receipt.run.host.os, "unknown");
     }
 
     #[test]
-    fn parse_criterion_default_name() {
-        let receipt = parse_criterion(CRITERION_ESTIMATES, None).unwrap();
-        assert_eq!(receipt.bench.name, "criterion-bench");
+    fn parse_criterion_rejects_measured_value_iteration_mismatch() {
+        let input = r#"{"reason":"benchmark-complete","id":"bad","iteration_count":[1],"measured_values":[1.0,2.0],"unit":"ns"}"#;
+        let err = parse_criterion(input, None).unwrap_err();
+        assert!(err.to_string().contains("measured_values length"));
     }
 
     #[test]
-    fn parse_criterion_with_slope() {
-        let input = r#"{
-            "mean": {
-                "point_estimate": 10000000.0,
-                "standard_error": 100000.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 9800000.0, "upper_bound": 10200000.0}
-            },
-            "median": {
-                "point_estimate": 9900000.0,
-                "standard_error": 50000.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 9800000.0, "upper_bound": 10000000.0}
-            },
-            "std_dev": {
-                "point_estimate": 500000.0,
-                "standard_error": 25000.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 450000.0, "upper_bound": 550000.0}
-            },
-            "slope": {
-                "point_estimate": 9500000.0,
-                "standard_error": 80000.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 9340000.0, "upper_bound": 9660000.0}
-            }
-        }"#;
-
-        let receipt = parse_criterion(input, Some("slope-bench")).unwrap();
-        assert_eq!(receipt.bench.name, "slope-bench");
-        // Should use slope (9.5ms) rather than mean (10ms) for sample generation
-        assert_eq!(receipt.samples.len(), 5);
+    fn parse_criterion_rejects_zero_iteration_count() {
+        let input = r#"{"reason":"benchmark-complete","id":"bad","iteration_count":[0],"measured_values":[1.0],"unit":"ns"}"#;
+        let err = parse_criterion(input, None).unwrap_err();
+        assert!(err.to_string().contains("iteration_count"));
     }
 
     #[test]
-    fn parse_criterion_submillisecond() {
-        // 500 ns mean, 50 ns stddev
-        let input = r#"{
-            "mean": {
-                "point_estimate": 500.0,
-                "standard_error": 5.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 490.0, "upper_bound": 510.0}
-            },
-            "median": {
-                "point_estimate": 498.0,
-                "standard_error": 3.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 492.0, "upper_bound": 504.0}
-            },
-            "std_dev": {
-                "point_estimate": 50.0,
-                "standard_error": 2.0,
-                "confidence_interval": {"confidence_level": 0.95, "lower_bound": 46.0, "upper_bound": 54.0}
-            }
-        }"#;
-
-        let receipt = parse_criterion(input, Some("fast-bench")).unwrap();
-        // Sub-millisecond values should clamp to 1ms minimum
-        for sample in &receipt.samples {
-            assert!(sample.wall_ms >= 1);
-        }
+    fn parse_criterion_rejects_unsupported_unit() {
+        let input = r#"{"reason":"benchmark-complete","id":"bad","iteration_count":[1],"measured_values":[42.0],"unit":"cycles"}"#;
+        let err = parse_criterion(input, None).unwrap_err();
+        assert!(err.to_string().contains("unsupported or ambiguous"));
     }
 
     #[test]
-    fn parse_criterion_invalid_json() {
-        let result = parse_criterion("not json", Some("x"));
-        assert!(result.is_err());
+    fn parse_criterion_rejects_raw_csv_with_multiple_identities() {
+        let input = r#"group,function,value,throughput_num,throughput_type,sample_measured_value,unit,iteration_count
+Parser,large,,,elements,50000000,ns,10
+Parser,small,,,elements,100000000,ns,20
+"#;
+        let err = parse_criterion(input, None).unwrap_err();
+        assert!(err.to_string().contains("multiple benchmark identities"));
+    }
+
+    #[test]
+    fn parse_criterion_rejects_jsonl_without_benchmark_complete() {
+        let input = r#"{"reason":"warmup","id":"parser"}
+{"reason":"group-complete","group_name":"parser","benchmarks":["parser/large"]}"#;
+        let err = parse_criterion(input, None).unwrap_err();
+        assert!(err.to_string().contains("no benchmark-complete"));
     }
 }

--- a/docs/EVIDENCE_INTAKE.md
+++ b/docs/EVIDENCE_INTAKE.md
@@ -4,8 +4,8 @@ perfgate can sit above existing benchmark tools. The benchmark tool still
 measures; perfgate imports the result into reviewable receipts, maturity, policy,
 and Action surfaces.
 
-The first intake format is reviewable generic command JSON. It is intended for
-teams that already run a script and can emit a small JSON artifact.
+The foundational intake format is reviewable generic command JSON. It is
+intended for teams that already run a script and can emit a small JSON artifact.
 
 ## Generic Command JSON
 
@@ -140,5 +140,59 @@ Do not infer:
 - hyperfine command timing excludes shell, setup, cache, or compile overhead;
 - missing host context proves host compatibility;
 - user and system time remain separate after import;
+- the first imported result should become a baseline; or
+- successful import means the benchmark should block CI.
+
+## Criterion
+
+Criterion remains the Rust measurement tool. perfgate imports clear wall-time
+evidence from Criterion-compatible outputs and keeps the result advisory until
+normal maturity and policy surfaces support promotion.
+
+Preferred input is cargo-criterion's JSON message stream:
+
+```bash
+cargo criterion --message-format=json > artifacts/criterion.jsonl
+perfgate ingest --format criterion --input artifacts/criterion.jsonl --name parser-large --out artifacts/perfgate/run.json
+```
+
+perfgate also accepts Criterion `raw.csv` files for a single benchmark:
+
+```bash
+perfgate ingest --format criterion --input target/criterion/parser/new/raw.csv --name parser-large --out artifacts/perfgate/run.json
+```
+
+Then run the same maturity and policy surfaces:
+
+```bash
+perfgate baseline doctor --config perfgate.toml
+perfgate doctor signal --config perfgate.toml
+perfgate policy doctor --config perfgate.toml --bench parser-large
+perfgate policy review-packet --config perfgate.toml --bench parser-large --out artifacts/perfgate/review-packet.md
+```
+
+Mapping:
+
+```text
+Criterion source kind        -> criterion
+cargo-criterion measured_values / iteration_count -> raw wall_ms samples
+Criterion raw.csv sample_measured_value / iteration_count -> raw wall_ms samples
+mean/median estimates       -> wall_ms summary fields where present
+throughput per_iteration    -> bench.work_units where present
+host                         -> unknown
+```
+
+Criterion `new/estimates.json` can be imported as a summary-only fallback, but
+Criterion documents those JSON files as private implementation details in its
+[CSV output guide](https://bheisler.github.io/criterion.rs/book/user_guide/csv_output.html).
+Prefer cargo-criterion JSON messages or `raw.csv` when reviewable sample
+evidence is needed.
+
+Do not infer:
+
+- Criterion confidence intervals are the same as perfgate maturity policy;
+- summary-only `estimates.json` has raw sample/noise support;
+- missing host context proves host compatibility;
+- Criterion throughput units are fully preserved in `perfgate.run.v1`;
 - the first imported result should become a baseline; or
 - successful import means the benchmark should block CI.

--- a/plans/0.21.0/evidence-intake-adoption-packs.md
+++ b/plans/0.21.0/evidence-intake-adoption-packs.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-19
 Milestone: 0.21.0
-Current PR: TBD (next: criterion-adapter)
+Current PR: `ingest/criterion-adapter`
 Linked proposal: [`PERFGATE-PROP-0008-evidence-intake-adoption-packs`](../../docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md)
 Linked specs: [`PERFGATE-SPEC-0013-evidence-source-contract`](../../docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -71,7 +71,7 @@ schema-compat proof.
 | 578 | Implementation plan and active goal | merged | `plans/0.21.0/evidence-intake-adoption-packs.md`, `.codex/goals/active.toml` |
 | 580 | Generic command JSON adapter | merged | CLI adapter/import surface, fixtures, docs |
 | 585 | hyperfine JSON adapter | merged | hyperfine fixtures, unit/direction/sample mapping |
-| TBD | Criterion adapter | pending | Criterion fixtures and non-inference docs |
+| TBD | Criterion adapter | in progress | Criterion fixtures and non-inference docs |
 | TBD | pytest-benchmark JSON adapter | pending | Python benchmark fixtures and environment limits |
 | TBD | k6 summary JSON adapter | pending | HTTP/load-test fixtures and capacity non-inferences |
 | TBD | Custom JSON/CSV mapping | pending | explicit field mapping and fail-closed errors |
@@ -213,7 +213,7 @@ git diff --check
 
 ## Work item: criterion-adapter
 
-Status: pending
+Status: in progress
 Linked proposal: docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md
 Linked spec: docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md
 Blocks: rust-adoption-pack, external-rust-canary


### PR DESCRIPTION
## Summary
- import Criterion evidence from cargo-criterion benchmark-complete JSON/JSONL and Criterion raw.csv with real measured samples
- keep estimates.json as summary-only fallback, mark Criterion host context unknown, and add CLI non-inference guidance
- document Criterion intake and update the 0.21 lane pointers for the active Criterion slice

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate --all-features ingest
- cargo +1.95.0 test -p perfgate-cli --all-features ingest
- cargo +1.95.0 test -p perfgate-cli --all-features doctor
- cargo +1.95.0 test -p perfgate-cli --all-features help
- cargo +1.95.0 clippy -p perfgate --all-targets --all-features -- -D warnings
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- schema-compat
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check