### PR TITLE
plans(0.21): mark Criterion intake merged

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-19"
 milestone = "0.21.0"
-current_work_item = "criterion-adapter"
-current_pr = "ingest/criterion-adapter"
+current_work_item = "pytest-benchmark-json-adapter"
+current_pr = "TBD"
 
 objective = """
 Make perfgate useful for teams that already have benchmark ecosystems by
@@ -123,7 +123,7 @@ status = "merged"
 
 [[work_item]]
 id = "criterion-adapter"
-status = "in_progress"
+status = "merged"
 
 [[work_item]]
 id = "pytest-benchmark-json-adapter"

--- a/plans/0.21.0/evidence-intake-adoption-packs.md
+++ b/plans/0.21.0/evidence-intake-adoption-packs.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-19
 Milestone: 0.21.0
-Current PR: `ingest/criterion-adapter`
+Current PR: TBD (next: pytest-benchmark-json-adapter)
 Linked proposal: [`PERFGATE-PROP-0008-evidence-intake-adoption-packs`](../../docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md)
 Linked specs: [`PERFGATE-SPEC-0013-evidence-source-contract`](../../docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -71,7 +71,7 @@ schema-compat proof.
 | 578 | Implementation plan and active goal | merged | `plans/0.21.0/evidence-intake-adoption-packs.md`, `.codex/goals/active.toml` |
 | 580 | Generic command JSON adapter | merged | CLI adapter/import surface, fixtures, docs |
 | 585 | hyperfine JSON adapter | merged | hyperfine fixtures, unit/direction/sample mapping |
-| TBD | Criterion adapter | in progress | Criterion fixtures and non-inference docs |
+| 591 | Criterion adapter | merged | Criterion fixtures and non-inference docs |
 | TBD | pytest-benchmark JSON adapter | pending | Python benchmark fixtures and environment limits |
 | TBD | k6 summary JSON adapter | pending | HTTP/load-test fixtures and capacity non-inferences |
 | TBD | Custom JSON/CSV mapping | pending | explicit field mapping and fail-closed errors |
@@ -213,7 +213,7 @@ git diff --check
 
 ## Work item: criterion-adapter
 
-Status: in progress
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md
 Linked spec: docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md
 Blocks: rust-adoption-pack, external-rust-canary


### PR DESCRIPTION
## Summary
- mark the Criterion adapter slice as merged after #591
- advance the active 0.21 work item to pytest-benchmark-json-adapter
- keep the evidence-intake lane active

## Validation
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check