### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "15554",
+  "message": "15782",
   "color": "orange"
 }


### PR DESCRIPTION
## Summary
- refresh generated ripr+ badge endpoint from current main after #592

## Validation
- cargo +1.95.0 run -p xtask -- badges --check
- git diff --check