### PR TITLE
ingest: harden pytest-benchmark adapter

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -5,7 +5,7 @@ owner = "codex"
 created = "2026-05-19"
 milestone = "0.21.0"
 current_work_item = "pytest-benchmark-json-adapter"
-current_pr = "TBD"
+current_pr = "ingest/pytest-benchmark-adapter"
 
 objective = """
 Make perfgate useful for teams that already have benchmark ecosystems by
@@ -127,7 +127,7 @@ status = "merged"
 
 [[work_item]]
 id = "pytest-benchmark-json-adapter"
-status = "pending"
+status = "in_progress"
 
 [[work_item]]
 id = "k6-summary-json-adapter"

--- a/crates/perfgate-cli/src/main.rs
+++ b/crates/perfgate-cli/src/main.rs
@@ -3232,6 +3232,27 @@ fn run_command(cmd: Command, server_flags: ServerFlags) -> anyhow::Result<()> {
                 eprintln!(
                     "Non-inferences: Criterion statistics are not perfgate maturity policy; imported evidence remains advisory until baseline, signal, and policy surfaces support promotion."
                 );
+            } else if format == IngestFormat::PytestBenchmark {
+                eprintln!(
+                    "Evidence source: pytest_benchmark_json; seconds were mapped to lower-is-better wall_ms and pytest ops were mapped to higher-is-better throughput_per_s when present."
+                );
+                if receipt.samples.is_empty() {
+                    eprintln!(
+                        "Sample model: summary-only; pytest-benchmark JSON without stats.data does not provide raw sample evidence to perfgate."
+                    );
+                } else {
+                    eprintln!(
+                        "Sample model: pytest-benchmark stats.data entries were preserved as measured wall_ms samples."
+                    );
+                }
+                if receipt.run.host.os == "unknown" || receipt.run.host.arch == "unknown" {
+                    eprintln!(
+                        "Host context: unknown or partial; do not infer host compatibility from this import."
+                    );
+                }
+                eprintln!(
+                    "Non-inferences: passing pytest tests are correctness evidence, not performance maturity; imported evidence remains advisory until baseline, signal, and policy surfaces support promotion."
+                );
             }
             Ok(())
         }

--- a/crates/perfgate-cli/tests/cli_ingest_tests.rs
+++ b/crates/perfgate-cli/tests/cli_ingest_tests.rs
@@ -230,6 +230,179 @@ fn test_ingest_criterion_unsupported_unit_fails_actionably() {
 }
 
 #[test]
+fn test_ingest_pytest_benchmark_writes_run_receipt() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("pytest-benchmark.json");
+    let output_path = temp_dir.path().join("run.json");
+
+    fs::write(
+        &input_path,
+        r#"{
+  "machine_info": {
+    "system": "Linux",
+    "machine": "x86_64",
+    "cpu": {"count": 8},
+    "python_implementation": "CPython",
+    "python_version": "3.11.0"
+  },
+  "benchmarks": [
+    {
+      "name": "test_parser",
+      "fullname": "tests/test_perf.py::test_parser",
+      "options": {"timer": "perf_counter", "warmup": false},
+      "stats": {
+        "min": 0.010,
+        "max": 0.014,
+        "mean": 0.012,
+        "stddev": 0.001,
+        "rounds": 3,
+        "iterations": 1,
+        "median": 0.012,
+        "ops": 83.333333,
+        "data": [0.010, 0.012, 0.014]
+      }
+    }
+  ],
+  "version": "4.0.0"
+}"#,
+    )
+    .expect("failed to write pytest-benchmark input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("--format")
+        .arg("pytest-benchmark")
+        .arg("--input")
+        .arg(&input_path)
+        .arg("--out")
+        .arg(&output_path);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains(
+            "Evidence source: pytest_benchmark_json",
+        ))
+        .stderr(predicate::str::contains(
+            "pytest-benchmark stats.data entries were preserved",
+        ))
+        .stderr(predicate::str::contains(
+            "passing pytest tests are correctness evidence",
+        ));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read ingest output"),
+    )
+    .expect("ingest output should be JSON");
+
+    assert_eq!(receipt["schema"], "perfgate.run.v1");
+    assert_eq!(receipt["bench"]["name"], "tests/test_perf.py::test_parser");
+    assert_eq!(
+        receipt["bench"]["command"][0],
+        "(ingested pytest-benchmark JSON)"
+    );
+    assert_eq!(receipt["bench"]["repeat"], 3);
+    assert_eq!(receipt["run"]["host"]["os"], "Linux");
+    assert_eq!(receipt["run"]["host"]["arch"], "x86_64");
+    assert_eq!(receipt["run"]["host"]["cpu_count"], 8);
+    assert_eq!(receipt["samples"].as_array().map(Vec::len), Some(3));
+    assert_eq!(receipt["samples"][0]["wall_ms"], 10);
+    assert_eq!(receipt["stats"]["wall_ms"]["mean"], 12.0);
+    assert_eq!(receipt["stats"]["throughput_per_s"]["median"], 83.333333);
+}
+
+#[test]
+fn test_ingest_pytest_benchmark_summary_only_marks_limited_noise() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("pytest-summary.json");
+    let output_path = temp_dir.path().join("run.json");
+
+    fs::write(
+        &input_path,
+        r#"{
+  "benchmarks": [
+    {
+      "name": "test_summary",
+      "stats": {
+        "min": 0.010,
+        "max": 0.020,
+        "mean": 0.015,
+        "stddev": 0.002,
+        "rounds": 12,
+        "iterations": 1,
+        "median": 0.015
+      }
+    }
+  ]
+}"#,
+    )
+    .expect("failed to write pytest-benchmark summary input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("--format")
+        .arg("pytest")
+        .arg("--input")
+        .arg(&input_path)
+        .arg("--out")
+        .arg(&output_path);
+
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains("Sample model: summary-only"))
+        .stderr(predicate::str::contains("Host context: unknown or partial"));
+
+    let receipt: Value = serde_json::from_str(
+        &fs::read_to_string(&output_path).expect("failed to read ingest output"),
+    )
+    .expect("ingest output should be JSON");
+
+    assert_eq!(receipt["bench"]["name"], "test_summary");
+    assert_eq!(receipt["bench"]["repeat"], 12);
+    assert_eq!(receipt["samples"].as_array().map(Vec::len), Some(0));
+    assert_eq!(receipt["run"]["host"]["os"], "unknown");
+    assert_eq!(receipt["stats"]["wall_ms"]["median"], 15);
+}
+
+#[test]
+fn test_ingest_pytest_benchmark_data_rounds_mismatch_fails_actionably() {
+    let temp_dir = tempdir().expect("failed to create temp dir");
+    let input_path = temp_dir.path().join("pytest-bad-data.json");
+
+    fs::write(
+        &input_path,
+        r#"{
+  "benchmarks": [
+    {
+      "name": "bad",
+      "stats": {
+        "min": 0.010,
+        "max": 0.020,
+        "mean": 0.015,
+        "stddev": 0.002,
+        "rounds": 3,
+        "iterations": 1,
+        "median": 0.015,
+        "data": [0.010, 0.020]
+      }
+    }
+  ]
+}"#,
+    )
+    .expect("failed to write pytest-benchmark input");
+
+    let mut cmd = perfgate_cmd();
+    cmd.arg("ingest")
+        .arg("--format")
+        .arg("pytest-benchmark")
+        .arg("--input")
+        .arg(&input_path);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("data length"));
+}
+
+#[test]
 fn test_ingest_generic_command_json_writes_run_receipt() {
     let temp_dir = tempdir().expect("failed to create temp dir");
     let input_path = temp_dir.path().join("generic.json");

--- a/crates/perfgate/src/integrations/ingest/pytest.rs
+++ b/crates/perfgate/src/integrations/ingest/pytest.rs
@@ -1,16 +1,67 @@
 //! Parser for pytest-benchmark JSON output.
 //!
-//! pytest-benchmark stores results in `.benchmarks/*.json` with a structure
-//! containing `benchmarks[]` with `name`, `stats` (min, max, mean, median,
-//! stddev, rounds, iterations), etc. All timing values are in seconds.
+//! pytest-benchmark JSON reports timing values in seconds. When `stats.data`
+//! is present, perfgate preserves those raw timing samples as `wall_ms`
+//! samples. Without `stats.data`, the import is summary-only; perfgate does not
+//! synthesize samples from min/max/mean.
 
-use anyhow::Context;
-use perfgate_types::{RunReceipt, Sample, Stats};
+use anyhow::{Context, bail};
+use perfgate_types::{
+    BenchMeta, F64Summary, HostInfo, RUN_SCHEMA_V1, RunMeta, RunReceipt, Sample, Stats, ToolInfo,
+    U64Summary,
+};
 use serde::Deserialize;
+use serde_json::Value;
+use time::OffsetDateTime;
+use uuid::Uuid;
 
-use super::{compute_u64_summary, make_receipt};
+use super::compute_u64_summary;
 
-/// Statistics from a single pytest-benchmark entry.
+#[derive(Debug, Deserialize)]
+struct PytestOutput {
+    #[serde(default)]
+    machine_info: Option<MachineInfo>,
+    benchmarks: Vec<PytestBenchmark>,
+    #[serde(default)]
+    version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MachineInfo {
+    #[serde(default)]
+    system: Option<String>,
+    #[serde(default)]
+    machine: Option<String>,
+    #[serde(default)]
+    processor: Option<String>,
+    #[serde(default)]
+    python_implementation: Option<String>,
+    #[serde(default)]
+    python_version: Option<String>,
+    #[serde(default)]
+    cpu: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PytestBenchmark {
+    name: String,
+    #[serde(default)]
+    fullname: Option<String>,
+    #[serde(default)]
+    group: Option<String>,
+    #[serde(default)]
+    options: Option<PytestOptions>,
+    stats: PytestStats,
+}
+
+#[derive(Debug, Deserialize)]
+struct PytestOptions {
+    #[serde(default)]
+    warmup: Option<bool>,
+    #[serde(default)]
+    timer: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct PytestStats {
     min: f64,
@@ -18,27 +69,21 @@ struct PytestStats {
     mean: f64,
     median: f64,
     stddev: f64,
-    rounds: u64,
-}
-
-/// A single benchmark entry from pytest-benchmark JSON.
-#[derive(Debug, Deserialize)]
-struct PytestBenchmark {
-    name: String,
-    stats: PytestStats,
-}
-
-/// Top-level pytest-benchmark JSON structure.
-#[derive(Debug, Deserialize)]
-struct PytestOutput {
-    benchmarks: Vec<PytestBenchmark>,
+    #[serde(default)]
+    rounds: Option<u64>,
+    #[serde(default)]
+    iterations: Option<u64>,
+    #[serde(default)]
+    data: Option<Vec<f64>>,
+    #[serde(default)]
+    ops: Option<f64>,
 }
 
 /// Parse a pytest-benchmark JSON file into a `RunReceipt`.
 ///
-/// If the JSON contains multiple benchmarks, only the first is used.
-/// All timing values in the input are in seconds and are converted
-/// to milliseconds for the `wall_ms` metric.
+/// If the JSON contains multiple benchmarks, only the first benchmark is used.
+/// Use `--name` at the CLI layer to make that selection explicit in the
+/// resulting receipt.
 pub fn parse_pytest_benchmark(input: &str, name: Option<&str>) -> anyhow::Result<RunReceipt> {
     let output: PytestOutput =
         serde_json::from_str(input).context("failed to parse pytest-benchmark JSON")?;
@@ -47,105 +92,321 @@ pub fn parse_pytest_benchmark(input: &str, name: Option<&str>) -> anyhow::Result
         .benchmarks
         .first()
         .context("pytest-benchmark JSON contains no benchmarks")?;
+    validate_stats(&bench.stats)?;
 
     let bench_name = name
-        .map(|n| n.to_string())
+        .map(str::to_string)
+        .or_else(|| bench.fullname.clone())
         .unwrap_or_else(|| bench.name.clone());
 
-    let stats = &bench.stats;
+    let samples = raw_samples(&bench.stats)?;
+    let wall_summary = wall_summary(&bench.stats, &samples)?;
+    let throughput = bench.stats.ops.map(throughput_summary).transpose()?;
 
-    // pytest-benchmark times are in seconds; convert to milliseconds.
-    // Generate synthetic samples: we create `rounds` samples spread around the
-    // mean with the reported stddev. If rounds is large, we cap at 30 samples.
-    let num_samples = stats.rounds.min(30) as usize;
-    let num_samples = num_samples.max(1);
+    Ok(make_pytest_receipt(PytestReceiptInput {
+        name: bench_name,
+        group: bench.group.clone(),
+        samples,
+        stats: Stats {
+            wall_ms: wall_summary,
+            cpu_ms: None,
+            page_faults: None,
+            ctx_switches: None,
+            max_rss_kb: None,
+            io_read_bytes: None,
+            io_write_bytes: None,
+            network_packets: None,
+            energy_uj: None,
+            binary_bytes: None,
+            throughput_per_s: throughput,
+        },
+        host: host_info(output.machine_info.as_ref()),
+        python_runtime: python_runtime(output.machine_info.as_ref()),
+        repeat: repeat_count(&bench.stats),
+        warmup: warmup_count(bench.options.as_ref()),
+        source_version: output.version,
+        timer: bench
+            .options
+            .as_ref()
+            .and_then(|options| options.timer.clone()),
+    }))
+}
 
-    let mut wall_values = Vec::new();
-    let mut samples = Vec::new();
+struct PytestReceiptInput {
+    name: String,
+    group: Option<String>,
+    samples: Vec<Sample>,
+    stats: Stats,
+    host: HostInfo,
+    python_runtime: Option<String>,
+    repeat: u32,
+    warmup: u32,
+    source_version: Option<String>,
+    timer: Option<String>,
+}
 
-    if num_samples == 1 {
-        let ms = seconds_to_ms(stats.mean);
-        wall_values.push(ms);
-        samples.push(make_sample(ms));
-    } else {
-        // Generate evenly-spaced samples between min and max
-        for i in 0..num_samples {
-            let t = if num_samples > 1 {
-                let frac = i as f64 / (num_samples - 1) as f64;
-                stats.min + frac * (stats.max - stats.min)
-            } else {
-                stats.mean
-            };
-            let ms = seconds_to_ms(t);
-            wall_values.push(ms);
-            samples.push(make_sample(ms));
+fn validate_stats(stats: &PytestStats) -> anyhow::Result<()> {
+    for (field, value) in [
+        ("min", stats.min),
+        ("max", stats.max),
+        ("mean", stats.mean),
+        ("median", stats.median),
+        ("stddev", stats.stddev),
+    ] {
+        validate_seconds(value, field)?;
+    }
+
+    if stats.min > stats.max {
+        bail!("pytest-benchmark stats min must be <= max");
+    }
+
+    if let Some(rounds) = stats.rounds
+        && rounds == 0
+    {
+        bail!("pytest-benchmark stats rounds must be greater than zero when present");
+    }
+
+    if let Some(iterations) = stats.iterations
+        && iterations == 0
+    {
+        bail!("pytest-benchmark stats iterations must be greater than zero when present");
+    }
+
+    if let Some(data) = &stats.data {
+        if data.is_empty() {
+            bail!("pytest-benchmark stats.data must be non-empty when present");
+        }
+        for (index, value) in data.iter().enumerate() {
+            validate_seconds(*value, &format!("data[{}]", index))?;
+        }
+        if let Some(rounds) = stats.rounds
+            && rounds as usize != data.len()
+        {
+            bail!(
+                "pytest-benchmark stats.data length ({}) does not match rounds ({})",
+                data.len(),
+                rounds
+            );
         }
     }
 
-    let mut computed = compute_u64_summary(&wall_values);
-    // Override with the actual pytest-benchmark statistics.
-    // median/min/max are u64 so integer seconds_to_ms() is fine.
-    computed.median = seconds_to_ms(stats.median);
-    computed.min = seconds_to_ms(stats.min);
-    computed.max = seconds_to_ms(stats.max);
-    // IMPORTANT: Use f64 arithmetic here, NOT seconds_to_ms(). See the
-    // GOTCHA on seconds_to_ms — integer truncation would lose sub-ms
-    // precision that budget evaluation and significance testing rely on.
-    computed.mean = Some(stats.mean * 1000.0);
-    computed.stddev = Some(stats.stddev * 1000.0);
+    if let Some(ops) = stats.ops {
+        validate_non_negative_finite(ops, "ops")?;
+    }
 
-    let full_stats = Stats {
-        wall_ms: computed,
-        cpu_ms: None,
-        page_faults: None,
-        ctx_switches: None,
-        max_rss_kb: None,
-        io_read_bytes: None,
-        io_write_bytes: None,
-        network_packets: None,
-        energy_uj: None,
-        binary_bytes: None,
-        throughput_per_s: None,
+    Ok(())
+}
+
+fn raw_samples(stats: &PytestStats) -> anyhow::Result<Vec<Sample>> {
+    let Some(data) = &stats.data else {
+        return Ok(Vec::new());
     };
 
-    Ok(make_receipt(&bench_name, samples, full_stats))
+    data.iter()
+        .map(|seconds| {
+            let wall_ms = seconds_to_u64_ms(*seconds, "data")?;
+            Ok(Sample {
+                wall_ms,
+                exit_code: 0,
+                // pytest-benchmark reports measured data; warmup settings are
+                // preserved on bench metadata instead of marking measured
+                // samples as warmup samples.
+                warmup: false,
+                timed_out: false,
+                cpu_ms: None,
+                page_faults: None,
+                ctx_switches: None,
+                max_rss_kb: None,
+                io_read_bytes: None,
+                io_write_bytes: None,
+                network_packets: None,
+                energy_uj: None,
+                binary_bytes: None,
+                stdout: None,
+                stderr: None,
+            })
+        })
+        .collect()
 }
 
-fn make_sample(wall_ms: u64) -> Sample {
-    Sample {
-        wall_ms,
-        exit_code: 0,
-        warmup: false,
-        timed_out: false,
-        cpu_ms: None,
-        page_faults: None,
-        ctx_switches: None,
-        max_rss_kb: None,
-        io_read_bytes: None,
-        io_write_bytes: None,
-        network_packets: None,
-        energy_uj: None,
-        binary_bytes: None,
-        stdout: None,
-        stderr: None,
+fn wall_summary(stats: &PytestStats, samples: &[Sample]) -> anyhow::Result<U64Summary> {
+    let sample_wall_values: Vec<u64> = samples.iter().map(|sample| sample.wall_ms).collect();
+    let mut summary = if sample_wall_values.is_empty() {
+        U64Summary {
+            median: seconds_to_u64_ms(stats.median, "median")?,
+            min: seconds_to_u64_ms(stats.min, "min")?,
+            max: seconds_to_u64_ms(stats.max, "max")?,
+            mean: None,
+            stddev: None,
+        }
+    } else {
+        compute_u64_summary(&sample_wall_values)
+    };
+
+    summary.median = seconds_to_u64_ms(stats.median, "median")?;
+    summary.min = seconds_to_u64_ms(stats.min, "min")?;
+    summary.max = seconds_to_u64_ms(stats.max, "max")?;
+    summary.mean = Some(seconds_to_f64_ms(stats.mean, "mean")?);
+    summary.stddev = Some(seconds_to_f64_ms(stats.stddev, "stddev")?);
+    Ok(summary)
+}
+
+fn throughput_summary(ops: f64) -> anyhow::Result<F64Summary> {
+    validate_non_negative_finite(ops, "ops")?;
+    Ok(F64Summary {
+        median: ops,
+        min: ops,
+        max: ops,
+        mean: Some(ops),
+        stddev: None,
+    })
+}
+
+fn make_pytest_receipt(input: PytestReceiptInput) -> RunReceipt {
+    let now = OffsetDateTime::now_utc();
+    let timestamp = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+
+    let mut command = vec!["(ingested pytest-benchmark JSON)".to_string()];
+    if let Some(version) = input.source_version {
+        command.push(format!("pytest-benchmark {version}"));
+    }
+    if let Some(python_runtime) = input.python_runtime {
+        command.push(format!("python={python_runtime}"));
+    }
+    if let Some(timer) = input.timer {
+        command.push(format!("timer={timer}"));
+    }
+    if let Some(group) = input.group {
+        command.push(format!("group={group}"));
+    }
+
+    RunReceipt {
+        schema: RUN_SCHEMA_V1.to_string(),
+        tool: ToolInfo {
+            name: "perfgate-ingest".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+        run: RunMeta {
+            id: Uuid::new_v4().to_string(),
+            started_at: timestamp.clone(),
+            ended_at: timestamp,
+            host: input.host,
+        },
+        bench: BenchMeta {
+            name: input.name,
+            cwd: None,
+            command,
+            repeat: input.repeat,
+            warmup: input.warmup,
+            work_units: None,
+            timeout_ms: None,
+        },
+        samples: input.samples,
+        stats: input.stats,
     }
 }
 
-/// Integer seconds-to-ms conversion for sample `wall_ms` values (u64).
-///
-/// GOTCHA: This intentionally truncates to integer milliseconds -- it is only
-/// appropriate for per-sample u64 fields where sub-ms precision is not needed.
-/// For stats fields (mean, stddev) use direct `f64` arithmetic (`value * 1000.0`)
-/// to preserve sub-millisecond precision. Using this function for stats would
-/// silently destroy the fractional component that downstream budget evaluation
-/// and significance testing depend on.
-fn seconds_to_ms(s: f64) -> u64 {
-    let ms = s * 1000.0;
-    if ms < 1.0 && ms > 0.0 {
+fn host_info(machine_info: Option<&MachineInfo>) -> HostInfo {
+    let Some(machine_info) = machine_info else {
+        return unknown_host();
+    };
+
+    HostInfo {
+        os: machine_info
+            .system
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string()),
+        arch: machine_info
+            .machine
+            .clone()
+            .or_else(|| machine_info.processor.clone())
+            .unwrap_or_else(|| "unknown".to_string()),
+        cpu_count: cpu_count(machine_info.cpu.as_ref()),
+        memory_bytes: None,
+        hostname_hash: None,
+    }
+}
+
+fn unknown_host() -> HostInfo {
+    HostInfo {
+        os: "unknown".to_string(),
+        arch: "unknown".to_string(),
+        cpu_count: None,
+        memory_bytes: None,
+        hostname_hash: None,
+    }
+}
+
+fn cpu_count(cpu: Option<&Value>) -> Option<u32> {
+    let cpu = cpu?;
+    let value = cpu
+        .get("count")
+        .or_else(|| cpu.get("logical_count"))
+        .or_else(|| cpu.get("cpu_count"))?;
+    value
+        .as_u64()
+        .and_then(|value| u32::try_from(value).ok())
+        .or_else(|| value.as_str().and_then(|value| value.parse::<u32>().ok()))
+}
+
+fn python_runtime(machine_info: Option<&MachineInfo>) -> Option<String> {
+    let machine_info = machine_info?;
+    match (
+        machine_info.python_implementation.as_deref(),
+        machine_info.python_version.as_deref(),
+    ) {
+        (Some(implementation), Some(version)) => Some(format!("{implementation} {version}")),
+        (Some(implementation), None) => Some(implementation.to_string()),
+        (None, Some(version)) => Some(version.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn repeat_count(stats: &PytestStats) -> u32 {
+    stats
+        .data
+        .as_ref()
+        .map(|data| data.len() as u32)
+        .or_else(|| stats.rounds.and_then(|rounds| u32::try_from(rounds).ok()))
+        .unwrap_or(0)
+}
+
+fn warmup_count(options: Option<&PytestOptions>) -> u32 {
+    if options.and_then(|options| options.warmup).unwrap_or(false) {
         1
     } else {
-        ms.round() as u64
+        0
     }
+}
+
+fn validate_seconds(value: f64, field: &str) -> anyhow::Result<()> {
+    validate_non_negative_finite(value, field)
+}
+
+fn validate_non_negative_finite(value: f64, field: &str) -> anyhow::Result<()> {
+    if !value.is_finite() || value < 0.0 {
+        bail!("pytest-benchmark field '{field}' must be finite and non-negative");
+    }
+    Ok(())
+}
+
+fn seconds_to_u64_ms(seconds: f64, field: &str) -> anyhow::Result<u64> {
+    let ms = seconds_to_f64_ms(seconds, field)?;
+    if ms > u64::MAX as f64 {
+        bail!("pytest-benchmark field '{field}' is too large for perfgate.run.v1");
+    }
+    if ms < 1.0 && ms > 0.0 {
+        Ok(1)
+    } else {
+        Ok(ms.round() as u64)
+    }
+}
+
+fn seconds_to_f64_ms(seconds: f64, field: &str) -> anyhow::Result<f64> {
+    validate_seconds(seconds, field)?;
+    Ok(seconds * 1000.0)
 }
 
 #[cfg(test)]
@@ -153,7 +414,7 @@ mod tests {
     use super::*;
     use perfgate_types::RUN_SCHEMA_V1;
 
-    const PYTEST_JSON: &str = r#"{
+    const PYTEST_JSON_WITH_DATA: &str = r#"{
         "machine_info": {
             "node": "test-host",
             "processor": "x86_64",
@@ -162,25 +423,16 @@ mod tests {
             "python_version": "3.11.0",
             "python_compiler": "GCC 12.2.0",
             "release": "6.1.0",
-            "system": "Linux"
-        },
-        "commit_info": {
-            "id": "abc123"
+            "system": "Linux",
+            "cpu": {"count": 8}
         },
         "benchmarks": [
             {
-                "group": null,
+                "group": "parser",
                 "name": "test_sort",
                 "fullname": "tests/test_perf.py::test_sort",
-                "params": null,
-                "param": null,
-                "extra_info": {},
                 "options": {
-                    "disable_gc": false,
                     "timer": "perf_counter",
-                    "min_rounds": 5,
-                    "max_time": 1.0,
-                    "min_time": 0.000005,
                     "warmup": false
                 },
                 "stats": {
@@ -188,19 +440,11 @@ mod tests {
                     "max": 0.0312,
                     "mean": 0.0256,
                     "stddev": 0.0021,
-                    "rounds": 10,
+                    "rounds": 3,
                     "iterations": 1,
                     "median": 0.0250,
-                    "iqr": 0.0030,
-                    "q1": 0.0240,
-                    "q3": 0.0270,
-                    "iqr_outliers": 0,
-                    "stddev_outliers": 1,
-                    "outliers": "1;0",
-                    "ld15iqr": 0.0234,
-                    "hd15iqr": 0.0312,
                     "ops": 39.0625,
-                    "total": 0.256
+                    "data": [0.0234, 0.0250, 0.0312]
                 }
             }
         ],
@@ -208,86 +452,149 @@ mod tests {
         "version": "4.0.0"
     }"#;
 
+    const PYTEST_JSON_SUMMARY_ONLY: &str = r#"{
+        "benchmarks": [
+            {
+                "name": "test_summary",
+                "stats": {
+                    "min": 0.010,
+                    "max": 0.020,
+                    "mean": 0.015,
+                    "stddev": 0.002,
+                    "rounds": 1000,
+                    "iterations": 1,
+                    "median": 0.015,
+                    "ops": 66.666666
+                }
+            }
+        ]
+    }"#;
+
     #[test]
-    fn parse_pytest_basic() {
-        let receipt = parse_pytest_benchmark(PYTEST_JSON, Some("sort-bench")).unwrap();
+    fn parses_raw_data_without_synthesizing_samples() {
+        let receipt = parse_pytest_benchmark(PYTEST_JSON_WITH_DATA, None).unwrap();
+
         assert_eq!(receipt.schema, RUN_SCHEMA_V1);
-        assert_eq!(receipt.bench.name, "sort-bench");
-        // 10 rounds -> 10 samples
-        assert_eq!(receipt.samples.len(), 10);
-        // median 0.025s = 25ms (rounded)
+        assert_eq!(receipt.bench.name, "tests/test_perf.py::test_sort");
+        assert_eq!(
+            receipt.bench.command,
+            vec![
+                "(ingested pytest-benchmark JSON)".to_string(),
+                "pytest-benchmark 4.0.0".to_string(),
+                "python=CPython 3.11.0".to_string(),
+                "timer=perf_counter".to_string(),
+                "group=parser".to_string(),
+            ]
+        );
+        assert_eq!(receipt.bench.repeat, 3);
+        assert_eq!(receipt.bench.warmup, 0);
+        assert_eq!(receipt.samples.len(), 3);
+        assert_eq!(
+            receipt
+                .samples
+                .iter()
+                .map(|sample| sample.wall_ms)
+                .collect::<Vec<_>>(),
+            vec![23, 25, 31]
+        );
         assert_eq!(receipt.stats.wall_ms.median, 25);
         assert_eq!(receipt.stats.wall_ms.min, 23);
         assert_eq!(receipt.stats.wall_ms.max, 31);
+        assert_eq!(receipt.stats.wall_ms.mean, Some(25.6));
+        assert_eq!(receipt.stats.wall_ms.stddev, Some(2.1));
+        assert_eq!(
+            receipt.stats.throughput_per_s.as_ref().unwrap().median,
+            39.0625
+        );
+        assert_eq!(receipt.run.host.os, "Linux");
+        assert_eq!(receipt.run.host.arch, "x86_64");
+        assert_eq!(receipt.run.host.cpu_count, Some(8));
+        assert_eq!(receipt.run.host.hostname_hash, None);
     }
 
     #[test]
-    fn parse_pytest_default_name() {
-        let receipt = parse_pytest_benchmark(PYTEST_JSON, None).unwrap();
-        assert_eq!(receipt.bench.name, "test_sort");
+    fn accepts_name_override() {
+        let receipt = parse_pytest_benchmark(PYTEST_JSON_WITH_DATA, Some("parser-sort")).unwrap();
+
+        assert_eq!(receipt.bench.name, "parser-sort");
     }
 
     #[test]
-    fn parse_pytest_sample_count_capped() {
-        // If rounds is very large, should cap at 30
+    fn summary_only_does_not_create_synthetic_samples() {
+        let receipt = parse_pytest_benchmark(PYTEST_JSON_SUMMARY_ONLY, None).unwrap();
+
+        assert_eq!(receipt.bench.name, "test_summary");
+        assert_eq!(receipt.bench.repeat, 1000);
+        assert!(receipt.samples.is_empty());
+        assert_eq!(receipt.stats.wall_ms.median, 15);
+        assert_eq!(receipt.stats.wall_ms.mean, Some(15.0));
+        assert_eq!(
+            receipt.stats.throughput_per_s.as_ref().unwrap().median,
+            66.666666
+        );
+        assert_eq!(receipt.run.host.os, "unknown");
+        assert_eq!(receipt.run.host.arch, "unknown");
+    }
+
+    #[test]
+    fn rejects_data_rounds_mismatch() {
         let input = r#"{
             "benchmarks": [
                 {
-                    "name": "test_big",
+                    "name": "bad",
                     "stats": {
                         "min": 0.010,
                         "max": 0.020,
                         "mean": 0.015,
                         "stddev": 0.002,
-                        "rounds": 1000,
+                        "rounds": 3,
+                        "iterations": 1,
+                        "median": 0.015,
+                        "data": [0.010, 0.020]
+                    }
+                }
+            ]
+        }"#;
+        let err = parse_pytest_benchmark(input, None).unwrap_err();
+        assert!(err.to_string().contains("data length"));
+    }
+
+    #[test]
+    fn rejects_non_finite_or_negative_stats() {
+        let input = r#"{
+            "benchmarks": [
+                {
+                    "name": "bad",
+                    "stats": {
+                        "min": -0.010,
+                        "max": 0.020,
+                        "mean": 0.015,
+                        "stddev": 0.002,
+                        "rounds": 3,
                         "iterations": 1,
                         "median": 0.015
                     }
                 }
             ]
         }"#;
-        let receipt = parse_pytest_benchmark(input, None).unwrap();
-        assert_eq!(receipt.samples.len(), 30);
+        let err = parse_pytest_benchmark(input, None).unwrap_err();
+        assert!(err.to_string().contains("finite and non-negative"));
     }
 
     #[test]
-    fn parse_pytest_single_round() {
-        let input = r#"{
-            "benchmarks": [
-                {
-                    "name": "test_single",
-                    "stats": {
-                        "min": 0.100,
-                        "max": 0.100,
-                        "mean": 0.100,
-                        "stddev": 0.0,
-                        "rounds": 1,
-                        "iterations": 1,
-                        "median": 0.100
-                    }
-                }
-            ]
-        }"#;
-        let receipt = parse_pytest_benchmark(input, None).unwrap();
-        assert_eq!(receipt.samples.len(), 1);
-        assert_eq!(receipt.samples[0].wall_ms, 100);
+    fn rejects_empty_benchmarks() {
+        let err = parse_pytest_benchmark(r#"{"benchmarks": []}"#, None).unwrap_err();
+        assert!(err.to_string().contains("contains no benchmarks"));
     }
 
     #[test]
-    fn parse_pytest_empty_benchmarks() {
-        let input = r#"{"benchmarks": []}"#;
-        let result = parse_pytest_benchmark(input, None);
-        assert!(result.is_err());
+    fn rejects_invalid_json() {
+        let err = parse_pytest_benchmark("not json", None).unwrap_err();
+        assert!(err.to_string().contains("failed to parse"));
     }
 
     #[test]
-    fn parse_pytest_invalid_json() {
-        let result = parse_pytest_benchmark("not json", None);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn parse_pytest_submillisecond() {
+    fn clamps_submillisecond_nonzero_samples_to_one_ms() {
         let input = r#"{
             "benchmarks": [
                 {
@@ -297,17 +604,24 @@ mod tests {
                         "max": 0.0003,
                         "mean": 0.0002,
                         "stddev": 0.00005,
-                        "rounds": 5,
+                        "rounds": 2,
                         "iterations": 100,
-                        "median": 0.0002
+                        "median": 0.0002,
+                        "data": [0.0001, 0.0003]
                     }
                 }
             ]
         }"#;
         let receipt = parse_pytest_benchmark(input, None).unwrap();
-        // All sub-millisecond values should clamp to 1
-        for sample in &receipt.samples {
-            assert!(sample.wall_ms >= 1, "wall_ms was {} < 1", sample.wall_ms);
-        }
+        assert_eq!(
+            receipt
+                .samples
+                .iter()
+                .map(|sample| sample.wall_ms)
+                .collect::<Vec<_>>(),
+            vec![1, 1]
+        );
+        assert_eq!(receipt.stats.wall_ms.median, 1);
+        assert_eq!(receipt.stats.wall_ms.mean, Some(0.2));
     }
 }

--- a/docs/EVIDENCE_INTAKE.md
+++ b/docs/EVIDENCE_INTAKE.md
@@ -196,3 +196,58 @@ Do not infer:
 - Criterion throughput units are fully preserved in `perfgate.run.v1`;
 - the first imported result should become a baseline; or
 - successful import means the benchmark should block CI.
+
+## pytest-benchmark JSON
+
+pytest-benchmark remains the Python measurement tool. perfgate imports its JSON
+as Python benchmark evidence while keeping correctness test success separate
+from performance maturity.
+
+Generate JSON from an existing pytest benchmark run:
+
+```bash
+pytest --benchmark-json=artifacts/pytest-benchmark.json
+perfgate ingest --format pytest-benchmark --input artifacts/pytest-benchmark.json --name parser-py --out artifacts/perfgate/run.json
+```
+
+Then run the same maturity and policy surfaces:
+
+```bash
+perfgate baseline doctor --config perfgate.toml
+perfgate doctor signal --config perfgate.toml
+perfgate policy doctor --config perfgate.toml --bench parser-py
+perfgate policy review-packet --config perfgate.toml --bench parser-py --out artifacts/perfgate/review-packet.md
+```
+
+Mapping:
+
+```text
+pytest-benchmark source kind -> pytest_benchmark_json
+stats.data[]                 -> raw wall_ms samples when present
+stats min/median/mean/max/stddev -> wall_ms summary fields
+stats.ops                    -> throughput_per_s point summary when present
+machine_info.system          -> run.host.os when present
+machine_info.machine/processor -> run.host.arch when present
+machine_info.cpu.count       -> run.host.cpu_count when present
+machine_info python fields   -> bench.command metadata when present
+host                         -> unknown for missing fields
+```
+
+If `stats.data` is missing, perfgate imports the summary fields without creating
+synthetic samples. The receipt remains useful for baseline comparison, but noise
+and maturity guidance is weaker until raw samples are available.
+
+Use pytest-benchmark's documented JSON output flag
+[`--benchmark-json`](https://pytest-benchmark.readthedocs.io/en/latest/usage.html)
+to create the source artifact.
+
+Do not infer:
+
+- passing pytest tests are performance maturity evidence;
+- pytest-benchmark `ops` is a full sample distribution after import;
+- summary-only JSON has raw sample/noise support;
+- Python interpreter/runtime details have dedicated structured policy semantics
+  in `perfgate.run.v1`;
+- missing host fields prove host compatibility;
+- the first imported result should become a baseline; or
+- successful import means the benchmark should block CI.

--- a/plans/0.21.0/evidence-intake-adoption-packs.md
+++ b/plans/0.21.0/evidence-intake-adoption-packs.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-19
 Milestone: 0.21.0
-Current PR: TBD (next: pytest-benchmark-json-adapter)
+Current PR: ingest/pytest-benchmark-adapter
 Linked proposal: [`PERFGATE-PROP-0008-evidence-intake-adoption-packs`](../../docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md)
 Linked specs: [`PERFGATE-SPEC-0013-evidence-source-contract`](../../docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -72,7 +72,7 @@ schema-compat proof.
 | 580 | Generic command JSON adapter | merged | CLI adapter/import surface, fixtures, docs |
 | 585 | hyperfine JSON adapter | merged | hyperfine fixtures, unit/direction/sample mapping |
 | 591 | Criterion adapter | merged | Criterion fixtures and non-inference docs |
-| TBD | pytest-benchmark JSON adapter | pending | Python benchmark fixtures and environment limits |
+| TBD | pytest-benchmark JSON adapter | in progress | Python benchmark fixtures and environment limits |
 | TBD | k6 summary JSON adapter | pending | HTTP/load-test fixtures and capacity non-inferences |
 | TBD | Custom JSON/CSV mapping | pending | explicit field mapping and fail-closed errors |
 | TBD | Imported evidence maturity integration | pending | baseline doctor, signal doctor, calibration/policy surfaces |
@@ -243,7 +243,7 @@ git diff --check
 
 ## Work item: pytest-benchmark-json-adapter
 
-Status: pending
+Status: in progress
 Linked proposal: docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md
 Linked spec: docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md
 Blocks: python-adoption-pack, external-non-rust-canary


### PR DESCRIPTION
## Summary
- preserve pytest-benchmark stats.data as measured wall_ms samples instead of synthesizing samples from summaries
- map pytest summary fields, ops throughput, host context, and Python/runtime metadata into existing perfgate.run.v1 surfaces without schema churn
- document pytest-benchmark intake, non-inferences, and maturity/policy follow-up commands; mark the 0.21 pytest adapter slice in progress

## Validation
- cargo +1.95.0 fmt --all -- --check
- cargo +1.95.0 test -p perfgate --all-features ingest
- cargo +1.95.0 test -p perfgate-cli --all-features ingest
- cargo +1.95.0 test -p perfgate-cli --all-features doctor
- cargo +1.95.0 clippy -p perfgate --all-targets --all-features -- -D warnings
- cargo +1.95.0 clippy -p perfgate-cli --all-targets --all-features -- -D warnings
- cargo +1.95.0 run -p xtask -- schema-compat
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- git diff --check