### PR TITLE
plans(0.21): mark pytest intake merged

### DIFF
--- a/.codex/goals/active.toml
+++ b/.codex/goals/active.toml
@@ -4,8 +4,8 @@ status = "active"
 owner = "codex"
 created = "2026-05-19"
 milestone = "0.21.0"
-current_work_item = "pytest-benchmark-json-adapter"
-current_pr = "ingest/pytest-benchmark-adapter"
+current_work_item = "k6-summary-json-adapter"
+current_pr = "TBD"
 
 objective = """
 Make perfgate useful for teams that already have benchmark ecosystems by
@@ -127,7 +127,7 @@ status = "merged"
 
 [[work_item]]
 id = "pytest-benchmark-json-adapter"
-status = "in_progress"
+status = "merged"
 
 [[work_item]]
 id = "k6-summary-json-adapter"

--- a/plans/0.21.0/evidence-intake-adoption-packs.md
+++ b/plans/0.21.0/evidence-intake-adoption-packs.md
@@ -4,7 +4,7 @@ Status: active
 Owner: perfgate maintainers
 Created: 2026-05-19
 Milestone: 0.21.0
-Current PR: ingest/pytest-benchmark-adapter
+Current PR: TBD
 Linked proposal: [`PERFGATE-PROP-0008-evidence-intake-adoption-packs`](../../docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md)
 Linked specs: [`PERFGATE-SPEC-0013-evidence-source-contract`](../../docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md)
 Linked ADRs: [`PERFGATE-ADR-0002-receipts-first-performance-decisions`](../../docs/adr/PERFGATE-ADR-0002-receipts-first-performance-decisions.md)
@@ -72,7 +72,7 @@ schema-compat proof.
 | 580 | Generic command JSON adapter | merged | CLI adapter/import surface, fixtures, docs |
 | 585 | hyperfine JSON adapter | merged | hyperfine fixtures, unit/direction/sample mapping |
 | 591 | Criterion adapter | merged | Criterion fixtures and non-inference docs |
-| TBD | pytest-benchmark JSON adapter | in progress | Python benchmark fixtures and environment limits |
+| 597 | pytest-benchmark JSON adapter | merged | Python benchmark fixtures and environment limits |
 | TBD | k6 summary JSON adapter | pending | HTTP/load-test fixtures and capacity non-inferences |
 | TBD | Custom JSON/CSV mapping | pending | explicit field mapping and fail-closed errors |
 | TBD | Imported evidence maturity integration | pending | baseline doctor, signal doctor, calibration/policy surfaces |
@@ -243,7 +243,7 @@ git diff --check
 
 ## Work item: pytest-benchmark-json-adapter
 
-Status: in progress
+Status: merged
 Linked proposal: docs/proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md
 Linked spec: docs/specs/PERFGATE-SPEC-0013-evidence-source-contract.md
 Blocks: python-adoption-pack, external-non-rust-canary


### PR DESCRIPTION
## Summary
- mark the pytest-benchmark JSON adapter work item as merged after #597
- advance the active 0.21 goal to the k6 summary JSON adapter
- clear the stale current PR pointer before seeding perfgate-swarm

## Validation
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- doc-test
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- git diff --check

## Boundary
- no release, publish, signing, tag, alias, or package metadata changes