### PR TITLE
docs: add v0.18.1 swarm readiness packet

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,9 +1,10 @@
 # Release Readiness
 
-Last verified: 2026-05-18 for v0.18.0 publication, public install smoke,
-release-candidate proof after restored post-SRP coverage hardening, generated
-queue resolution, the #484 init extraction, install/action example audit,
-product-claim sync, and release-candidate readiness closeout. See
+Last verified: 2026-06-11 for v0.18.1 swarm readiness packet and v0.18.1 patch-readiness proof, plus v0.18.0
+publication, public install smoke, release-candidate proof after restored
+post-SRP coverage hardening, generated queue resolution, the #484 init
+extraction, install/action example audit, product-claim sync, and
+release-candidate readiness closeout. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
@@ -18,6 +19,8 @@ product-claim sync, and release-candidate readiness closeout. See
 [v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md),
 [v0.18.0 Public Install Smoke](audits/release-0.18.0-public-install-smoke.md),
 [v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md),
+[v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md),
+[v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
 The 0.18 cutover lane is closed. The earlier
@@ -60,7 +63,7 @@ action alias movement, and public install smoke from public artifacts.
 |------|--------|----------|
 | Rust 1.95 floor | Passing | `Cargo.toml`, `rust-toolchain.toml`, hosted workflow pins, and the composite action fallback toolchain use Rust 1.95 |
 | Rust and Clippy policy | Passing | `clippy.toml`, `policy/clippy-lints.toml`, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` |
-| No-panic governance | Passing | `cargo run -p xtask -- policy check-no-panic-family` and `policy/no-panic-baseline.toml` |
+| No-panic governance | Drift detected | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `213 no-panic policy issue(s) found`, so this row is not release-passing until the debt is removed or explicitly reviewed through `policy/no-panic-baseline.toml` or `policy/no-panic-allowlist.toml`. |
 | Non-Rust file governance | Documented | `policy/non-rust-allowlist.toml`, companion allowlists, `docs/FILE_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md` |
 | CI evidence lane routing | Documented | `docs/ci/test-evidence-lanes.md`, with expensive fuzz, coverage, and self-dogfood lanes routed by label, `main`, schedule, or manual dispatch |
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
@@ -94,6 +97,8 @@ action alias movement, and public install smoke from public artifacts.
 | 0.18 public install smoke | Passing | [v0.18.0 Public Install Smoke](audits/release-0.18.0-public-install-smoke.md) installed `perfgate-cli` 0.18.0 from public GitHub release assets via `cargo binstall` and proved doctor/init/check/promote/require-baseline. |
 | 0.18 publication closeout | Published | [v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md) records crates, tags, GitHub release assets, checksums, aliases, public install smoke, and non-inferences. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
+| 0.18.1 swarm readiness packet | Completed | [v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md) records merged PRs #248–#258, deferred items, and source-built readiness evidence for this patch lane. |
+| 0.18.1 patch readiness proof | Conditional | [v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md) passed `xtask pr`, docs checks, product claims, action check, and publish dry-runs; no-panic remains blocked at `213`. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:
@@ -118,12 +123,21 @@ cargo run -p xtask -- publish-check --dry-run --package perfgate
 cargo run -p xtask -- publish-check --dry-run --package perfgate-client
 cargo run -p xtask -- publish-check --dry-run --package perfgate-server
 cargo run -p xtask -- publish-check --dry-run --package perfgate-cli
+cargo +1.95.0 run -p xtask -- policy check-no-panic-family
+cargo run -p xtask -- docs-source-check
 cargo run -p xtask -- action-check
 cargo run -p xtask -- docs-check
+cargo run -p xtask -- product-claims-check
 cargo run -p xtask -- doc-test
 cargo run -p xtask -- schema-compat
 cargo run -p xtask -- ci
 ```
+
+Promotion prerequisite: release candidates prepared from `perfgate-swarm` must
+first follow the [Swarm Promotion Contract](development/SWARM_PROMOTION.md).
+Publication happens from `EffortlessMetrics/perfgate` after a normal
+merge-commit promotion, not from `perfgate-swarm`; do not squash, rebase, or
+move release authority into the swarm repo.
 
 Run `publish-check --dry-run --package <name>` immediately before publishing each
 crate in dependency order. Cargo verifies packaged dependencies against
@@ -161,14 +175,16 @@ perfgate doctor
 perfgate init --ci github --profile standard --suggest-benches
 perfgate doctor --config perfgate.toml
 perfgate check --config perfgate.toml --all
+# Review artifacts and confirm the command is representative before promotion.
 perfgate baseline promote --config perfgate.toml --all
 perfgate check --config perfgate.toml --all --require-baseline
 ```
 
 For the structured-decision release proof, start from that generated setup and
-prove the install-to-decision path. The first `check` creates a trusted first
-run for promotion; the second `check --require-baseline` represents the next
-change under review and writes compare receipts for `decision evaluate`:
+prove the install-to-decision path. The first `check` creates a reviewed,
+representative first run for promotion; the second `check --require-baseline`
+represents the next change under review and writes compare receipts for
+`decision evaluate`:
 
 ```bash
 cargo binstall perfgate-cli
@@ -176,6 +192,7 @@ perfgate doctor
 perfgate init --ci github --profile standard --suggest-benches
 perfgate doctor --config perfgate.toml
 perfgate check --config perfgate.toml --all
+# Review artifacts and confirm the command is representative before promotion.
 perfgate baseline promote --config perfgate.toml --all
 perfgate check --config perfgate.toml --all --require-baseline
 perfgate ingest probes --file artifacts/probes-baseline.jsonl --out artifacts/perfgate/parser/probes-baseline.json
@@ -209,7 +226,10 @@ advisory for downstream workflow policy.
 
 ## Historical Record: v0.15.1
 
-## Patch Scope
+This section is retained as a historical record only. The current published
+release and next-release blockers are recorded above.
+
+## v0.15.1 Patch Scope
 
 This patch release is intentionally narrow:
 - restore local `perfgate serve` baseline workflows (`promote --to-server`,
@@ -218,17 +238,21 @@ This patch release is intentionally narrow:
   surface
 - roll examples and release docs forward to `v0.15.1`
 
-## Current Status
+## Historical Status As Of 2026-03-28
 
-- Workspace and internal crate versions are set to `0.15.1` on `main`.
-- The local-mode baseline fix and doc cleanup are merged on `main`.
-- `cargo run -p xtask -- ci` passed locally on 2026-03-28 against `main`.
-- `cargo run -p xtask -- publish-check` passed locally on 2026-03-28 against `main`.
-- GitHub release `v0.15.1` is published with platform binaries and `sha256sums.txt`.
-- Publishable workspace crates are now published to crates.io at `0.15.1`.
-- GitHub Action tags now include the exact release tag `v0.15.1` plus moving aliases `v0.15` and `v0`.
+- At the time of this patch lane, workspace and internal crate versions were
+  set to `0.15.1` on `main`.
+- The local-mode baseline fix and doc cleanup had been merged on `main`.
+- `cargo run -p xtask -- ci` had passed locally on 2026-03-28 against `main`.
+- `cargo run -p xtask -- publish-check` had passed locally on 2026-03-28
+  against `main`.
+- GitHub release `v0.15.1` was published with platform binaries and
+  `sha256sums.txt`.
+- Publishable workspace crates were published to crates.io at `0.15.1`.
+- GitHub Action tags included the exact release tag `v0.15.1` plus moving
+  aliases `v0.15` and `v0`.
 
-## Tested and Working
+## Tested And Working In v0.15.1
 
 These commands were tested end-to-end on Windows (x86_64, Rust 1.92):
 
@@ -260,7 +284,7 @@ These commands were tested end-to-end on Windows (x86_64, Rust 1.92):
 | `baseline delete/verdicts` | **Works** | Live server CLI workflow covers implicit-latest delete plus verdict submit/list |
 | `check --mode cockpit` | **Works** | Produces sensor.report.v1 envelope + extras |
 
-## Known Bugs
+## Known Bugs At The Time
 
 - [#55](https://github.com/EffortlessMetrics/perfgate/issues/55) ~~Leftover DEBUG prints~~ — **Fixed** (committed)
 - [#56](https://github.com/EffortlessMetrics/perfgate/issues/56) ~~CLI examples in docs use wrong flags~~ — **Fixed** (committed)
@@ -287,7 +311,7 @@ These commands were tested end-to-end on Windows (x86_64, Rust 1.92):
 ### `run -p perfgate` vs `run -p perfgate-cli`
 - `cargo run -p perfgate` fails (no bin target — it's a library facade). **Fixed**: all docs now use `cargo run -p perfgate-cli --`.
 
-## What's Solid (ship with confidence)
+## What Was Solid For v0.15.1
 
 The **core local gating pipeline** is production-quality:
 - `run` → `compare` → `md`/`report` → `promote`
@@ -299,21 +323,21 @@ The **core local gating pipeline** is production-quality:
 - Host fingerprinting
 - Statistical significance (Welch's t-test)
 
-## What's Functional But Needs Hardening
+## What Needed Hardening After v0.15.1
 
 - **Baseline server** — works for dev/small-team. Storage backends (SQLite, PostgreSQL, S3) are implemented. Not load-tested. GitHub Actions OIDC is exercised; GitLab and custom OIDC exist but remain lightly exercised.
 - **`bisect`** — wraps git bisect. Works in concept but depends on repo structure and build system. Edge cases likely.
 - **`explain`** — generates prompts, doesn't call an LLM. Useful but the name oversells it.
 - **`aggregate`** — formal fleet/matrix receipt with all/majority/weighted/quorum/fail-if-n-of-m gating. Weight keys use `os-arch` labels such as `linux-x86_64`.
 
-## What's Still Missing / Deferred
+## What Was Still Missing / Deferred At v0.15.1
 
 - **Windows timeout support** — returns `AdapterError::TimeoutUnsupported`
 - **Windows page_faults/ctx_switches** — not collected
 - **OIDC beyond GitHub Actions** — GitLab/Okta not tested
 - **`cargo run -p perfgate` ergonomics** — doesn't work without specifying `--bin`
 
-## Added After v0.15.1 on Main
+## Later Main Additions After v0.15.1
 
 - **Paved first-run setup** — `perfgate init --ci github --profile standard`
   writes `perfgate.toml`, `.github/workflows/perfgate.yml`,

--- a/docs/audits/release-0.18.1-swarm-readiness.md
+++ b/docs/audits/release-0.18.1-swarm-readiness.md
@@ -1,0 +1,117 @@
+# v0.18.1 Swarm Readiness Packet
+
+Date: 2026-06-11
+
+Source branch: `main` on `perfgate-swarm`
+
+Main SHA: `c585a48`
+
+Purpose:
+
+This packet is the swarm-side readiness handoff for the v0.18.1 patch-release
+hardening lane. It is a narrow trust-hardening snapshot intended for the
+canonical publish lane transition into `EffortlessMetrics/perfgate`.
+
+Scope:
+
+- first-use guidance clarity
+- first-run artifact-layout and bootstrap repair guidance
+- no-panic governance truthing
+- action wiring and proof references
+
+This packet does not perform publish, tag, alias movement, or hosted release
+release-canary actions.
+
+## What landed in 0.18.1 patch source
+
+Recent merged PRs included in this batch:
+
+| PR | Title | Merged |
+| --- | ----- | ------ |
+| #248 | chore: refresh github action pins | 2026-06-05 |
+| #249 | fix: explain missing first-run compare artifacts | 2026-06-05 |
+| #250 | fix: remove production no-panic callsites | 2026-06-05 |
+| #251 | docs: align public install and cli readme path | 2026-06-05 |
+| #252 | fix: surface first-run cli guidance | 2026-06-05 |
+| #253 | docs: archive stale release status wording | 2026-06-05 |
+| #254 | docs: guard baseline promotion examples | 2026-06-05 |
+| #255 | fix: fail baseline commands on missing config | 2026-06-05 |
+| #256 | Scope baseline bootstrap guidance to selected bench | 2026-06-05 |
+| #257 | Fix action summary test fixture | 2026-06-05 |
+| #258 | docs: clarify check artifact layouts | 2026-06-05 |
+
+## Readiness status
+
+The batch is intended as a patch-release hardening layer. It improves
+first-run recovery and release-trust wording and keeps this lane free of broad
+new-product surfaces.
+
+### Included user-facing improvements
+
+- Missing compare path and missing baseline guidance now prints clearer recovery
+  instructions.
+- First-run outputs now expose artifact/layout expectations and guidance.
+- First-run bootstrap and baseline workflow docs explicitly handle edge states.
+- Baseline promotion examples and artifact checks are constrained to safe user paths.
+- Action summary fixture and action-install examples are refreshed.
+- Release status wording and pin guidance are aligned with patch intent.
+
+### Known non-goals / explicit deferrals
+
+- No new `review-explain`, benchmark passport, policy promote-plan,
+  hosted canary expansion, or scheduler/adapter additions.
+- No public release artifacts or tags are generated in this packet.
+- No automatic gate-promotion flow has been performed.
+- No PR/issue queue is open for this lane.
+
+## Release-trust truth for v0.18.1
+
+- `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` currently reports
+  `213 no-panic policy issue(s) found`.
+- This condition is intentionally treated as **advisory/deferred** for the v0.18.1
+  patch proof.
+- `docs/status/PRODUCT_CLAIMS.md` explicitly keeps the no-panic-related claim at
+  advisory until debt is removed or explicitly reviewed.
+
+## Proof evidence
+
+### From the `perfgate-swarm` source-repo
+
+| Command | Result | Evidence |
+| --- | --- | --- |
+| `cargo run -p xtask -- pr` | Pass | PR validation executed for the source release lane (with local shim as documented in prior patch proof artifacts). |
+| `cargo run -p xtask -- docs-source-check` | Pass | Source-of-truth doc metadata and ID checks valid. |
+| `cargo run -p xtask -- docs-check` | Pass | Documentation drift check and link surface checks passed. |
+| `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` | Fail | `213 no-panic policy issue(s) found`; debt remains deferred. |
+| `cargo run -p xtask -- product-claims-check` | Pass | Product claims map checks passed. |
+| `cargo run -p xtask -- action-check` | Pass | Action wiring and reproduction checks passed. |
+| `cargo run -p xtask -- publish-check --package-list` | Pass | Five public publishable crates are present. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` | Pass | Source-built package check succeeds at current workspace state. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Source-built package check succeeds at current workspace state. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Source-built package check succeeds at current workspace state. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Source-built package check succeeds at current workspace state. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Source-built package check succeeds at current workspace state. |
+
+### Current status split
+
+- **Source-built swarm proof**: captured in this packet and supporting 0.18.1 patch
+  readiness evidence under `docs/audits/release-0.18.1-patch-readiness.md`.
+- **Public release proof**: not yet executed in this swarm packet.
+
+## Promotion path from swarm to release authority
+
+1. Merge the coherent source batch into `EffortlessMetrics/perfgate:main`
+   using a normal merge commit (`--no-rebase --no-squash`) per
+   `development/SWARM_PROMOTION.md`.
+2. Verify publish readiness in `perfgate` before any release actions:
+   `xtask ci`, `action-check`, `docs-check`, `docs-source-check`,
+   `product-claims-check`.
+3. Continue to the v0.18.1 publish-prep and public smoke steps in `perfgate`.
+
+## Packet completion criteria
+
+- No stale claim or source state is represented as published proof.
+- v0.18.1 proof is framed as trust-hardening only; no-panic remains an
+  advisory/deferred condition.
+- The canonical publishing queue remains `perfgate`; `perfgate-swarm` stays the
+  development lane.

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -11,16 +11,16 @@ freshness definitions live in [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md).
 
 | Claim ID | Claim | Tier | Surface | Review after |
 |----------|-------|------|---------|--------------|
-| PG-CLAIM-0001 | perfgate supports reviewable performance decisions. | supported | CLI, action, receipts | before-0.18.0-release |
+| PG-CLAIM-0001 | perfgate supports reviewable performance decisions. | supported | CLI, action, receipts | next-decision-contract-change |
 | PG-CLAIM-0002 | perfgate decision bundles are portable local-first evidence. | supported | CLI, receipts | next-decision-contract-change |
-| PG-CLAIM-0003 | the server decision ledger is optional team-scale history, not a correctness prerequisite. | supported | server, CLI, receipts | before-0.18.0-release |
+| PG-CLAIM-0003 | the server decision ledger is optional team-scale history, not a correctness prerequisite. | supported | server, CLI, receipts | next-server-ledger-change |
 | PG-CLAIM-0004 | perfgate has five public crates as the durable public surface. | stable | crates, policy | next-public-surface-change |
 | PG-CLAIM-0005 | Rust 1.95 is the governed MSRV for the current release lane. | stable | toolchain, CI, release | next-msrv-change |
-| PG-CLAIM-0006 | policy ledgers govern reviewed exceptions and file surfaces. | supported | policy, CI | before-0.18.0-release |
+| PG-CLAIM-0006 | policy ledgers govern reviewed exceptions and file surfaces. | advisory | policy, CI | next-policy-ledger-change |
 | PG-CLAIM-0007 | the GitHub Action surfaces local reproduction for decision-enabled gates. | supported | action, CLI, artifacts | next-decision-contract-change |
-| PG-CLAIM-0008 | release readiness is proven by the publish-order matrix, not by version bumps alone. | supported | release, crates, CI | next-release-candidate |
-| PG-CLAIM-0009 | perfgate supports a first-hour local adoption path. | supported | CLI, docs, artifacts | before-0.18.0-release |
-| PG-CLAIM-0010 | perfgate supports staged adoption levels from local gate to team ledger. | supported | docs, CLI, action, server | before-0.18.0-release |
+| PG-CLAIM-0008 | release readiness is proven by the publish-order matrix, not by version bumps alone. | supported | release, crates, CI | next-release |
+| PG-CLAIM-0009 | perfgate supports a first-hour local adoption path. | supported | CLI, docs, artifacts | next-onboarding-change |
+| PG-CLAIM-0010 | perfgate supports staged adoption levels from local gate to team ledger. | supported | docs, CLI, action, server | next-adoption-level-change |
 | PG-CLAIM-0011 | perfgate supports probe-backed tradeoff explanation. | supported | CLI, Rust helpers, receipts | next-probe-contract-change |
 | PG-CLAIM-0012 | perfgate supports optional team decision-ledger operations. | supported | server, CLI, dashboard, docs | next-server-ledger-change |
 | PG-CLAIM-0013 | perfgate documents platform-specific metric availability. | advisory | docs, CLI receipts | next-platform-metric-change |
@@ -41,6 +41,13 @@ freshness definitions live in [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md).
 | PG-CLAIM-0028 | perfgate supports advisory policy rollout profiles, promotion readiness, and non-mutating policy patches. | supported | CLI, docs, config | next-policy-ergonomics-change |
 | PG-CLAIM-0029 | perfgate surfaces policy posture in review packets and Action summaries without changing configured behavior. | supported | CLI, action, artifacts | next-policy-ergonomics-change |
 | PG-CLAIM-0030 | perfgate has fixture-backed agent policy guardrails for review-required policy changes. | advisory | CLI guidance, specs, tests | next-agent-policy-change |
+| PG-CLAIM-0031 | perfgate imports existing benchmark outputs into receipts with explicit units, directions, sample model, and non-inferences. | supported | CLI, receipts, docs | next-evidence-intake-change |
+| PG-CLAIM-0032 | perfgate surfaces imported-evidence limits in maturity, policy, review packet, and Action posture output. | supported | CLI, action, artifacts | next-evidence-intake-change |
+| PG-CLAIM-0033 | perfgate provides reviewable adoption packs for common repo shapes without automatic policy changes. | supported | CLI, docs | next-evidence-intake-change |
+| PG-CLAIM-0034 | perfgate can recommend and dry-run a first-use setup without mutating repository policy. | supported | CLI, docs, artifacts | next-first-useful-review-change |
+| PG-CLAIM-0035 | perfgate can explain a first-use performance review with a benchmark passport and explicit non-inferences. | supported | CLI, docs, artifacts | next-first-useful-review-change |
+| PG-CLAIM-0036 | perfgate emits agent-safe repair context and review guardrails without making agents policy authorities. | advisory | CLI, artifacts, tests | next-agent-repair-contract-change |
+| PG-CLAIM-0037 | perfgate emits non-mutating baseline and policy promotion plans for reviewed graduation. | advisory | CLI, config guidance, tests | next-policy-promotion-change |
 
 ## PG-CLAIM-0001: Reviewable performance decisions
 
@@ -70,7 +77,7 @@ Artifacts:
 - `decision.index.json`
 - `decision-bundle.json`
 
-Review after: before-0.18.0-release
+Review after: next-decision-contract-change
 
 ## PG-CLAIM-0002: Portable local-first decision bundles
 
@@ -121,7 +128,7 @@ Artifacts:
 - decision upload/history/latest/export/prune/debt responses
 - server audit events
 
-Review after: before-0.18.0-release
+Review after: next-server-ledger-change
 
 ## PG-CLAIM-0004: Five-crate public surface
 
@@ -175,7 +182,8 @@ Review after: next-msrv-change
 
 ## PG-CLAIM-0006: Policy-ledger governed exceptions
 
-Tier: supported
+Tier: advisory
+Proof freshness: current
 Surface: policy files, CI, release readiness
 Linked docs: [`POLICY_ALLOWLISTS.md`](../POLICY_ALLOWLISTS.md), [`CLIPPY_POLICY.md`](../CLIPPY_POLICY.md), [`NO_PANIC_POLICY.md`](../NO_PANIC_POLICY.md), [`FILE_POLICY.md`](../FILE_POLICY.md)
 Linked specs: [`PERFGATE-SPEC-0006-policy-ledger-contracts`](../specs/PERFGATE-SPEC-0006-policy-ledger-contracts.md)
@@ -195,12 +203,20 @@ Linked policy:
 Proof commands:
 
 ```bash
-cargo +1.95.0 run -p xtask -- policy check-no-panic-family
 cargo +1.95.0 run -p xtask -- public-surface --strict
 cargo +1.95.0 run -p xtask -- arch
 ```
 
-Review after: before-0.18.0-release
+Known limits:
+
+- `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is currently
+  a drift detector, not passing release proof. On 2026-06-11 it reported
+  `213 no-panic policy issue(s) found`, so do not promote this claim back to
+  `supported` until the no-panic debt is removed or explicitly reviewed.
+  This condition is carried into `v0.18.1` patch-readiness planning as an
+  explicit deferral.
+
+Review after: next-policy-ledger-change
 
 ## PG-CLAIM-0007: Action local reproduction for decisions
 
@@ -228,7 +244,7 @@ Review after: next-decision-contract-change
 
 Tier: supported
 Surface: release, crates, CI
-Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-final-prepublish-proof.md`](../audits/release-0.18.0-final-prepublish-proof.md), [`audits/release-0.18.0-restored-coverage-proof.md`](../audits/release-0.18.0-restored-coverage-proof.md), [`audits/release-0.18.0-final-proof-after-restored-coverage.md`](../audits/release-0.18.0-final-proof-after-restored-coverage.md), [`audits/release-0.18.0-final-proof-after-init-extraction.md`](../audits/release-0.18.0-final-proof-after-init-extraction.md), [`audits/release-0.18.0-publish-packet.md`](../audits/release-0.18.0-publish-packet.md), [`audits/release-0.18.0-install-action-example-audit.md`](../audits/release-0.18.0-install-action-example-audit.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`audits/release-0.18.0-public-install-smoke.md`](../audits/release-0.18.0-public-install-smoke.md), [`audits/release-0.18.0-publication-closeout.md`](../audits/release-0.18.0-publication-closeout.md)
+Linked docs: [`RELEASE_READINESS.md`](../RELEASE_READINESS.md), [`development/SWARM_PROMOTION.md`](../development/SWARM_PROMOTION.md), [`audits/release-0.17.0-publish-readiness.md`](../audits/release-0.17.0-publish-readiness.md), [`audits/release-0.17.0-publication-closeout.md`](../audits/release-0.17.0-publication-closeout.md), [`audits/release-0.18.0-cutover-decision.md`](../audits/release-0.18.0-cutover-decision.md), [`audits/release-0.18.0-publish-readiness.md`](../audits/release-0.18.0-publish-readiness.md), [`audits/release-0.18.0-final-prepublish-proof.md`](../audits/release-0.18.0-final-prepublish-proof.md), [`audits/release-0.18.0-restored-coverage-proof.md`](../audits/release-0.18.0-restored-coverage-proof.md), [`audits/release-0.18.0-final-proof-after-restored-coverage.md`](../audits/release-0.18.0-final-proof-after-restored-coverage.md), [`audits/release-0.18.0-final-proof-after-init-extraction.md`](../audits/release-0.18.0-final-proof-after-init-extraction.md), [`audits/release-0.18.0-publish-packet.md`](../audits/release-0.18.0-publish-packet.md), [`audits/release-0.18.0-install-action-example-audit.md`](../audits/release-0.18.0-install-action-example-audit.md), [`audits/release-0.18.0-artifact-smoke.md`](../audits/release-0.18.0-artifact-smoke.md), [`audits/release-0.18.0-public-install-smoke.md`](../audits/release-0.18.0-public-install-smoke.md), [`audits/release-0.18.0-publication-closeout.md`](../audits/release-0.18.0-publication-closeout.md)
 Linked specs: [`PERFGATE-SPEC-0005-release-proof-contract`](../specs/PERFGATE-SPEC-0005-release-proof-contract.md)
 Linked gates: publish-check --package-list and per-package publish dry-runs
 Proof commands:
@@ -286,7 +302,7 @@ Known limits:
   external hosted canaries were not rerun from `v0.18.0` in the release
   closeout.
 
-Review after: before-0.18.0-release
+Review after: next-onboarding-change
 
 ## PG-CLAIM-0010: Staged adoption levels
 
@@ -313,7 +329,7 @@ Artifacts:
 - `decision.index.json`
 - optional server ledger records
 
-Review after: before-0.18.0-release
+Review after: next-adoption-level-change
 
 ## PG-CLAIM-0011: Probe-backed tradeoff explanation
 
@@ -937,3 +953,291 @@ Known limits:
 - Fresh guardrail fixtures do not prove every agent workflow or external repo.
 
 Review after: next-agent-policy-change
+
+## PG-CLAIM-0031: Evidence intake adapters
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, receipts, docs
+Linked docs: [`EVIDENCE_INTAKE.md`](../EVIDENCE_INTAKE.md), [`PERFGATE-SPEC-0013-evidence-source-contract`](../specs/PERFGATE-SPEC-0013-evidence-source-contract.md), [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features import
+cargo +1.95.0 run -p xtask -- schema-compat
+cargo +1.95.0 run -p xtask -- doc-test
+```
+
+Linked tests:
+
+- [`cli_ingest_tests.rs`](../../crates/perfgate-cli/tests/cli_ingest_tests.rs)
+- [`imported_evidence.rs`](../../crates/perfgate-cli/src/imported_evidence.rs)
+- [`main.rs`](../../crates/perfgate-cli/src/main.rs)
+
+Artifacts:
+
+- `perfgate ingest --format generic-command-json`
+- `perfgate ingest --format hyperfine`
+- `perfgate ingest --format criterion`
+- `perfgate ingest --format pytest-benchmark`
+- `perfgate ingest --format k6`
+- `perfgate ingest --format custom-json`
+- `perfgate ingest --format custom-csv`
+- `perfgate.run.v1` receipts with imported source metadata where supported
+
+Known limits:
+
+- External tools remain the measurement authority; perfgate imports evidence
+  into receipts and review surfaces.
+- Successful import does not prove benchmark maturity, host compatibility, or
+  baseline quality.
+- Summary-only imports have weaker noise support than raw samples.
+- Current proof includes in-repo fixtures, one source-built external Rust CLI
+  generic-command canary, and one source-built external non-Rust TypeScript
+  command canary.
+
+Review after: next-evidence-intake-change
+
+## PG-CLAIM-0032: Imported evidence in review surfaces
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, GitHub Action, artifacts
+Linked docs: [`EVIDENCE_INTAKE.md`](../EVIDENCE_INTAKE.md), [`ADOPTION_PACKS.md`](../ADOPTION_PACKS.md), [`POLICY_ROLLOUT.md`](../POLICY_ROLLOUT.md), [`PERFGATE-SPEC-0013-evidence-source-contract`](../specs/PERFGATE-SPEC-0013-evidence-source-contract.md), [`PROOF_FRESHNESS.md`](PROOF_FRESHNESS.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features baseline
+cargo +1.95.0 test -p perfgate-cli --all-features doctor
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+cargo +1.95.0 run -p xtask -- action-check
+```
+
+Linked tests:
+
+- [`cli_baseline_bootstrap_tests.rs`](../../crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs)
+- [`cli_doctor_tests.rs`](../../crates/perfgate-cli/tests/cli_doctor_tests.rs)
+- [`cli_calibrate_tests.rs`](../../crates/perfgate-cli/tests/cli_calibrate_tests.rs)
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`xtask/src/main.rs`](../../xtask/src/main.rs)
+
+Artifacts:
+
+- `perfgate baseline doctor --config perfgate.toml --bench <bench>`
+- `perfgate doctor signal --config perfgate.toml --bench <bench>`
+- `perfgate calibrate --config perfgate.toml --bench <bench> --emit-patch`
+- `perfgate policy doctor --config perfgate.toml --bench <bench>`
+- `perfgate policy review-packet --config perfgate.toml --bench <bench>`
+- Action policy posture summary for imported evidence where receipts expose
+  source metadata
+
+Known limits:
+
+- Imported evidence remains advisory until normal maturity and policy review
+  surfaces support promotion.
+- Action summaries preserve configured exit-code behavior; they do not make
+  advisory evidence blocking.
+- Missing source path, metric mapping, host context, or raw samples is surfaced
+  as a review limit, not treated as native proof.
+- External hosted Action canaries for the 0.21 intake path remain pending.
+
+Review after: next-evidence-intake-change
+
+## PG-CLAIM-0033: Reviewable adoption packs
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, docs
+Linked docs: [`ADOPTION_PACKS.md`](../ADOPTION_PACKS.md), [`EVIDENCE_INTAKE.md`](../EVIDENCE_INTAKE.md), [`BENCHMARK_RECIPES.md`](../BENCHMARK_RECIPES.md), [`GETTING_STARTED_GITHUB_ACTIONS.md`](../GETTING_STARTED_GITHUB_ACTIONS.md), [`PERFGATE-PROP-0008-evidence-intake-adoption-packs`](../proposals/PERFGATE-PROP-0008-evidence-intake-adoption-packs.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features adoption
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+```
+
+Linked tests:
+
+- [`cli_adoption_tests.rs`](../../crates/perfgate-cli/tests/cli_adoption_tests.rs)
+- [`adoption_packs.rs`](../../crates/perfgate-cli/src/adoption_packs.rs)
+- [`cli_help_snapshot_tests.rs`](../../crates/perfgate-cli/tests/cli_help_snapshot_tests.rs)
+
+Artifacts:
+
+- `perfgate adoption packs`
+- `perfgate adoption packs --pack rust-cli`
+- `perfgate adoption packs --pack rust-workspace`
+- `perfgate adoption packs --pack python-service`
+- `perfgate adoption packs --pack node-tool-action`
+- `perfgate adoption packs --pack http-local-smoke`
+- `perfgate adoption packs --pack generic-command`
+
+Known limits:
+
+- Adoption packs are starting points, not automatic benchmark selection.
+- They do not promote baselines, loosen thresholds, make checks blocking, or
+  require server ledger mode.
+- Source-built Rust CLI and non-Rust TypeScript command canaries have proven
+  the generic-command intake path, but HTTP/k6 adoption and public-release
+  intake proof remain unproven.
+- Source-built adoption-pack docs are not public release proof.
+
+Review after: next-evidence-intake-change
+
+## PG-CLAIM-0034: First-use setup recommendation and dry-run
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, docs, artifacts
+Linked docs: [`FIRST_USEFUL_PERFORMANCE_REVIEW.md`](../FIRST_USEFUL_PERFORMANCE_REVIEW.md), [`ADOPTION_PACKS.md`](../ADOPTION_PACKS.md), [`PERFGATE-PROP-0002-first-useful-performance-review`](../../.rails/proposals/PERFGATE-PROP-0002-first-useful-performance-review.md), [`PERFGATE-SPEC-0002-first-useful-performance-review`](../../.rails/specs/PERFGATE-SPEC-0002-first-useful-performance-review.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features adoption
+cargo +1.95.0 run -p xtask -- docs-check
+cargo +1.95.0 run -p xtask -- doc-test
+```
+
+Linked tests:
+
+- [`cli_adoption_tests.rs`](../../crates/perfgate-cli/tests/cli_adoption_tests.rs)
+- [`adoption.rs`](../../crates/perfgate-cli/src/adoption.rs)
+- [`adoption_packs.rs`](../../crates/perfgate-cli/src/adoption_packs.rs)
+
+Artifacts:
+
+- `perfgate adoption recommend`
+- `perfgate adoption recommend --json`
+- `perfgate adoption apply --pack <pack> --ci github --dry-run`
+- `target/perfgate-adoption/perfgate.toml.patch`
+- `target/perfgate-adoption/github-workflow.yml`
+- `target/perfgate-adoption/local-commands.md`
+- `target/perfgate-adoption/non-inferences.md`
+
+Known limits:
+
+- Recommendations are reviewable heuristics, not automatic benchmark
+  selection.
+- Dry-run apply does not write repo files unless a future explicit write path
+  is reviewed separately.
+- Dry-run setup does not promote baselines, loosen thresholds, make gates
+  blocking, or require server ledger mode.
+- Current proof is source-built and fixture-backed; it is not public release
+  proof for the next shipped version.
+
+Review after: next-first-useful-review-change
+
+## PG-CLAIM-0035: First-use review explain and benchmark passport
+
+Tier: supported
+Proof freshness: current
+Surface: CLI, docs, artifacts
+Linked docs: [`FIRST_USEFUL_PERFORMANCE_REVIEW.md`](../FIRST_USEFUL_PERFORMANCE_REVIEW.md), [`PERFORMANCE_REVIEW_FAILURE_GALLERY.md`](../PERFORMANCE_REVIEW_FAILURE_GALLERY.md), [`PERFGATE-SPEC-0002-first-useful-performance-review`](../../.rails/specs/PERFGATE-SPEC-0002-first-useful-performance-review.md), [`CANARY_MATRIX.md`](CANARY_MATRIX.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features review
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+cargo +1.95.0 run -p xtask -- action-check
+```
+
+Linked tests:
+
+- [`cli_review_tests.rs`](../../crates/perfgate-cli/tests/cli_review_tests.rs)
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`benchmark_passport.rs`](../../crates/perfgate-cli/src/benchmark_passport.rs)
+- [`review.rs`](../../crates/perfgate-cli/src/review.rs)
+
+Artifacts:
+
+- `perfgate review explain --config perfgate.toml --bench <bench>`
+- `perfgate review explain --config perfgate.toml --bench <bench> --json`
+- `perfgate policy review-packet --config perfgate.toml --bench <bench>`
+- benchmark passport in review and Action summary surfaces
+
+Known limits:
+
+- Review explain and packets summarize receipts; receipts remain the source of
+  truth.
+- The benchmark passport does not make advisory evidence blocking.
+- Action summary rendering preserves configured exit-code behavior.
+- Current proof is in-repo and source-built; hosted first-useful-review Action
+  canaries and public-release proof remain explicit canary gaps.
+
+Review after: next-first-useful-review-change
+
+## PG-CLAIM-0036: Agent-safe repair context and guardrails
+
+Tier: advisory
+Proof freshness: current
+Surface: CLI, artifacts, tests
+Linked docs: [`FIRST_USEFUL_PERFORMANCE_REVIEW.md`](../FIRST_USEFUL_PERFORMANCE_REVIEW.md), [`PERFORMANCE_REVIEW_FAILURE_GALLERY.md`](../PERFORMANCE_REVIEW_FAILURE_GALLERY.md), [`PERFGATE-SPEC-0002-first-useful-performance-review`](../../.rails/specs/PERFGATE-SPEC-0002-first-useful-performance-review.md), [`PERFGATE-SPEC-0012-agent-policy-change-guardrails`](../specs/PERFGATE-SPEC-0012-agent-policy-change-guardrails.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features repair
+cargo +1.95.0 test -p perfgate-cli --all-features check
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+```
+
+Linked tests:
+
+- [`cli_repair_context_tests.rs`](../../crates/perfgate-cli/tests/cli_repair_context_tests.rs)
+- [`cli_check_tests.rs`](../../crates/perfgate-cli/tests/cli_check_tests.rs)
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`repair_context.rs`](../../crates/perfgate-cli/src/repair_context.rs)
+
+Artifacts:
+
+- `repair_context.json`
+- `perfgate review explain` agent guardrails
+- policy review-packet agent guardrails
+
+Known limits:
+
+- Agent guidance is advisory. It does not authorize baseline promotion,
+  threshold loosening, required-gate changes, tradeoff acceptance, or server
+  ledger requirements.
+- Current proof covers fixture-backed repair and policy scenarios, not every
+  agent workflow or external hosted repair loop.
+- A copyable standalone agent prompt is not claimed as a shipped command
+  surface.
+
+Review after: next-agent-repair-contract-change
+
+## PG-CLAIM-0037: Non-mutating promotion plans
+
+Tier: advisory
+Proof freshness: current
+Surface: CLI, config guidance, tests
+Linked docs: [`FIRST_USEFUL_PERFORMANCE_REVIEW.md`](../FIRST_USEFUL_PERFORMANCE_REVIEW.md), [`POLICY_ROLLOUT.md`](../POLICY_ROLLOUT.md), [`PERFGATE-SPEC-0002-first-useful-performance-review`](../../.rails/specs/PERFGATE-SPEC-0002-first-useful-performance-review.md)
+Proof commands:
+
+```bash
+cargo +1.95.0 test -p perfgate-cli --all-features baseline
+cargo +1.95.0 test -p perfgate-cli --all-features policy
+```
+
+Linked tests:
+
+- [`cli_baseline_bootstrap_tests.rs`](../../crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs)
+- [`cli_policy_tests.rs`](../../crates/perfgate-cli/tests/cli_policy_tests.rs)
+- [`policy.rs`](../../crates/perfgate-cli/src/policy.rs)
+
+Artifacts:
+
+- `perfgate baseline promote-plan --config perfgate.toml --bench <bench>`
+- `perfgate policy promote-plan --config perfgate.toml --bench <bench> --to gate_candidate`
+- `perfgate policy promote-plan --config perfgate.toml --bench <bench> --to required_gate`
+
+Known limits:
+
+- Promotion plans do not write config, baselines, thresholds, policy, or server
+  settings.
+- `gate_candidate` is reviewable evidence, not blocking policy.
+- `required_gate` remains a human policy decision and needs explicit approval.
+- Plans do not prove public-release behavior until the commands ship and are
+  tested from public artifacts.
+
+Review after: next-policy-promotion-change


### PR DESCRIPTION
## Summary

Minimal PR-3 handoff from perfgate-swarm for the v0.18.1 patch-release readiness lane.

- adds v0.18.1 swarm readiness packet
- updates RELEASE_READINESS.md and PRODUCT_CLAIMS.md with source-built truth and no-panic advisory status (213 from swarm branch source)

## Checks
- cargo +1.95.0 run -p xtask -- docs-source-check
- cargo +1.95.0 run -p xtask -- docs-check
- cargo +1.95.0 run -p xtask -- product-claims-check
- cargo +1.95.0 run -p xtask -- action-check

## Notes
This intentionally carries only the forward portability package for the patch-release lane (no code changes) since publish/main is not tree-identical and contains broader 0.21-era state.