### PR TITLE
chore: promote v0.18.1 release readiness hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ layout guidance, and release-trust truthing. The latest public release remains
 - Clarified generated check artifacts and first-use output framing in docs and CLI
   examples.
 - Added no-panic drift truthing updates that keep v0.18.1 release claims explicit
-  about advisory debt at 213 callsite issues.
+  about advisory debt at 240 callsite issues.
 - Synced patch-readiness proof and release docs around the same constrained scope.
 - Refreshing publish-facing docs and proof references remains scoped to the v0.18.1
   patch lane and does not imply broader feature change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-No unreleased changes beyond the prepared 0.18.0 release-candidate notes below.
+No unreleased changes beyond the prepared 0.18.1 patch-candidate notes below.
 
-## [0.18.0] - Unreleased
+## [0.18.1] - Unreleased
 
-0.18.0 is prepared in source and release-candidate proof, but it is not yet
-published, tagged, or available through public install paths. The latest public
-release remains `v0.17.0` until the 0.18 publication closeout records crates.io,
-GitHub release, action alias, asset, and public install smoke proof.
+0.18.1 is prepared as a narrow patch release focused on first-run recovery, artifact
+layout guidance, and release-trust truthing. The latest public release remains
+`v0.18.0` until publication gates are complete.
+
+### Changed
+- Added first-run guidance refreshes around missing compare path, missing baseline
+  state, and compare-artifact interpretation.
+- Updated baseline bootstrap and bootstrap promotion UX to avoid ambiguous
+  no-op/error paths on sparse initial repos.
+- Clarified generated check artifacts and first-use output framing in docs and CLI
+  examples.
+- Added no-panic drift truthing updates that keep v0.18.1 release claims explicit
+  about advisory debt at 213 callsite issues.
+- Synced patch-readiness proof and release docs around the same constrained scope.
+- Refreshing publish-facing docs and proof references remains scoped to the v0.18.1
+  patch lane and does not imply broader feature change.
+- No production release tags, public installs, or action alias movement occurred in
+  this prep phase.
+
+## [0.18.0] - 2026-05-18
+
+0.18.0 is published to crates.io and GitHub releases as `v0.18.0` with `v0.18`
+and `v0` action aliases, plus public install smoke proof from public artifacts.
 
 ### Changed
 - Reconciled release-readiness docs with the published v0.17.0 state across

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
@@ -122,8 +122,8 @@ wiremock = "0.6"
 libc = "0.2.182"
 
 # Internal crates
-perfgate-types = { path = "crates/perfgate-types", version = "0.18.0" }
-perfgate-fake = { path = "crates/perfgate-fake", version = "0.18.0" }
-perfgate-server = { path = "crates/perfgate-server", version = "0.18.0" }
-perfgate-client = { path = "crates/perfgate-client", version = "0.18.0" }
-perfgate = { path = "crates/perfgate", version = "0.18.0" }
+perfgate-types = { path = "crates/perfgate-types", version = "0.18.1" }
+perfgate-fake = { path = "crates/perfgate-fake", version = "0.18.1" }
+perfgate-server = { path = "crates/perfgate-server", version = "0.18.1" }
+perfgate-client = { path = "crates/perfgate-client", version = "0.18.1" }
+perfgate = { path = "crates/perfgate", version = "0.18.1" }

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -63,7 +63,7 @@ action alias movement, and public install smoke from public artifacts.
 |------|--------|----------|
 | Rust 1.95 floor | Passing | `Cargo.toml`, `rust-toolchain.toml`, hosted workflow pins, and the composite action fallback toolchain use Rust 1.95 |
 | Rust and Clippy policy | Passing | `clippy.toml`, `policy/clippy-lints.toml`, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` |
-| No-panic governance | Drift detected | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `213 no-panic policy issue(s) found`, so this row is not release-passing until the debt is removed or explicitly reviewed through `policy/no-panic-baseline.toml` or `policy/no-panic-allowlist.toml`. |
+| No-panic governance | Drift detected | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `240 no-panic policy issue(s) found`, so this row is not release-passing until the debt is removed or explicitly reviewed through `policy/no-panic-baseline.toml` or `policy/no-panic-allowlist.toml`. |
 | Non-Rust file governance | Documented | `policy/non-rust-allowlist.toml`, companion allowlists, `docs/FILE_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md` |
 | CI evidence lane routing | Documented | `docs/ci/test-evidence-lanes.md`, with expensive fuzz, coverage, and self-dogfood lanes routed by label, `main`, schedule, or manual dispatch |
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
@@ -98,7 +98,7 @@ action alias movement, and public install smoke from public artifacts.
 | 0.18 publication closeout | Published | [v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md) records crates, tags, GitHub release assets, checksums, aliases, public install smoke, and non-inferences. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | 0.18.1 swarm readiness packet | Completed | [v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md) records merged PRs #248–#258, deferred items, and source-built readiness evidence for this patch lane. |
-| 0.18.1 patch readiness proof | Conditional | [v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md) passed `xtask pr`, docs checks, product claims, action check, and publish dry-runs; no-panic remains blocked at `213`. |
+| 0.18.1 patch readiness proof | Conditional | [v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md) passed `xtask pr`, docs checks, product claims, action check, and publish dry-runs; no-panic remains blocked at `240`. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:

--- a/docs/audits/release-0.18.1-patch-readiness.md
+++ b/docs/audits/release-0.18.1-patch-readiness.md
@@ -1,0 +1,60 @@
+# v0.18.1 Patch Readiness Proof
+
+Date: 2026-06-11
+
+Branch: `main` on `perfgate-swarm`
+
+Purpose:
+
+Record the source-side proof for the 0.18.1 patch hardening lane before
+promotion to the canonical publish repo.
+
+## Scope
+
+- First-run recovery and bootstrap guidance.
+- Artifact layout and baseline bootstrap diagnostics.
+- No-panic governance truthing posture.
+- Action behavior and install/example hygiene.
+- Publish-ready file-level/package scope checks prior to release authority migration.
+
+## Proof Evidence
+
+### Source-repo checks
+
+| Command | Result | Evidence |
+| --- | --- | --- |
+| `cargo run -p xtask -- pr` | Pass | PR validation command for release-lane source state passed. |
+| `cargo run -p xtask -- docs-source-check` | Pass | Source-of-truth doc metadata and ID checks valid. |
+| `cargo run -p xtask -- docs-check` | Pass | Documentation drift and link checks passed. |
+| `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` | Fail | `240 no-panic policy issue(s) found`; debt remains deferred. |
+| `cargo run -p xtask -- product-claims-check` | Pass | Product claims map checks passed with deferred no-panic posture. |
+| `cargo run -p xtask -- action-check` | Pass | GitHub Action wiring and reproduction command checks passed. |
+| `cargo run -p xtask -- publish-check --package-list` | Pass | Five publishable crates are listed. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` | Pass | Dry-run package verification passed. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Dry-run package verification passed. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Dry-run package verification passed. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Dry-run package verification passed. |
+| `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Dry-run package verification passed. |
+
+## Governance posture
+
+- `no-panic` remains advisory/deferred for this patch release and is explicitly
+  called out in:
+  - [`docs/RELEASE_READINESS.md`](../RELEASE_READINESS.md)
+  - [`docs/status/PRODUCT_CLAIMS.md`](../status/PRODUCT_CLAIMS.md)
+  - [`docs/audits/release-0.18.1-swarm-readiness.md`](release-0.18.1-swarm-readiness.md)
+
+## Deferred / non-goals for this patch lane
+
+- No public publication/tags/release artifacts are produced in swarm.
+- No `review explain`, benchmark passport, baseline promote-plan, policy promote-plan,
+  or hosted canary work is included.
+- No `review` or `policy` automation for automatic gate promotion.
+- Public install/action smoke is recorded only in canonical publish-lane or
+  post-publication packets.
+
+## Promotion note
+
+This proof is a source-side handoff. Canonical publication authority remains
+in `EffortlessMetrics/perfgate` and requires a normal merge commit from swarm
+per `development/SWARM_PROMOTION.md`.

--- a/docs/audits/release-0.18.1-publish-packet.md
+++ b/docs/audits/release-0.18.1-publish-packet.md
@@ -1,0 +1,66 @@
+# v0.18.1 Publish Packet
+
+Date: 2026-06-11
+
+Purpose: define the canonical publishing command packet for v0.18.1. This packet
+is non-mutating and does not publish crates, move aliases, tag versions, create a
+GitHub release, or run public install smoke.
+
+Scope: patch-release candidate for first-use trust hardening only.
+
+## Release Boundary
+
+This packet is a pre-publish artifact and does not trigger irreversible release
+steps. Publish commands must only run after explicit release approval.
+
+## Expected Crates
+
+| Crate | Expected version | Expected URL after publish |
+| --- | --- | --- |
+| `perfgate-types` | `0.18.1` | `https://crates.io/crates/perfgate-types/0.18.1` |
+| `perfgate` | `0.18.1` | `https://crates.io/crates/perfgate/0.18.1` |
+| `perfgate-client` | `0.18.1` | `https://crates.io/crates/perfgate-client/0.18.1` |
+| `perfgate-server` | `0.18.1` | `https://crates.io/crates/perfgate-server/0.18.1` |
+| `perfgate-cli` | `0.18.1` | `https://crates.io/crates/perfgate-cli/0.18.1` |
+
+## Publish Order
+
+```text
+perfgate-types
+perfgate
+perfgate-client
+perfgate-server
+perfgate-cli
+```
+
+## Publish Commands
+
+```bash
+cargo +1.95.0 publish -p perfgate-types --locked
+cargo +1.95.0 info perfgate-types
+
+cargo +1.95.0 publish -p perfgate --locked
+cargo +1.95.0 info perfgate
+
+cargo +1.95.0 publish -p perfgate-client --locked
+cargo +1.95.0 info perfgate-client
+
+cargo +1.95.0 publish -p perfgate-server --locked
+cargo +1.95.0 info perfgate-server
+
+cargo +1.95.0 publish -p perfgate-cli --locked
+cargo +1.95.0 info perfgate-cli
+```
+
+For each `cargo info` result, confirm:
+
+- the crate resolves from crates.io,
+- version `0.18.1` is present,
+- same-release dependencies are visible where expected.
+
+## Non-Goals
+
+- No canary rewrites.
+- No hosted Action alias cutover until publication is complete.
+- No public install smoke claims before public artifacts exist.
+

--- a/docs/audits/release-0.18.1-publish-readiness.md
+++ b/docs/audits/release-0.18.1-publish-readiness.md
@@ -1,0 +1,58 @@
+# v0.18.1 Publish Readiness Proof
+
+Date: 2026-06-11
+
+Branch: `chore/0.18.1-release-prep` (canonical publish-prep branch)
+Version under test: `0.18.1`
+
+Purpose: validate that the v0.18.1 release candidate packages and verifies for
+the five public crates before any irreversible publication step. This proof does
+not publish crates, create tags, create a GitHub release, or move action aliases.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Rust toolchain | `cargo +1.95.0` |
+| Publishable crates | `perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli` |
+| Publication state | Dry-run only; no crates were uploaded |
+
+## Publish Dry-Run Matrix
+
+| Command | Result | Evidence summary |
+| --- | --- | --- |
+| `cargo +1.95.0 run -p xtask -- publish-check --package-list` | Pass | Static packaging checks passed and listed the five publishable crates. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types` | Pass | Packaged and verified `perfgate-types v0.18.1` in dry-run mode. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Packaged and verified `perfgate v0.18.1` in dry-run mode. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Packaged and verified `perfgate-client v0.18.1` in dry-run mode. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Packaged and verified `perfgate-server v0.18.1` in dry-run mode. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Packaged and verified `perfgate-cli v0.18.1` in dry-run mode. |
+
+## Publish Order
+
+If release-operator approval is granted later, publish in this order:
+
+```text
+perfgate-types
+perfgate
+perfgate-client
+perfgate-server
+perfgate-cli
+```
+
+This proof only validates packaging and verification. It is not approval to run
+the publish commands.
+
+## Known Gaps
+
+- Crates were not published.
+- No `v0.18.1` tag was created.
+- No `v0.18` or `v0` action alias movement was attempted.
+- No GitHub release was created.
+- Public install smoke remains blocked until public artifacts exist.
+
+## Known Deferred Proof
+
+- No-panic policy check remains a controlled drift (`213`) and is carried forward
+  as an explicit advisory/deferred condition in lane planning.
+

--- a/docs/audits/release-0.18.1-publish-readiness.md
+++ b/docs/audits/release-0.18.1-publish-readiness.md
@@ -53,6 +53,5 @@ the publish commands.
 
 ## Known Deferred Proof
 
-- No-panic policy check remains a controlled drift (`213`) and is carried forward
+- No-panic policy check remains a controlled drift (`240`) and is carried forward
   as an explicit advisory/deferred condition in lane planning.
-

--- a/docs/audits/release-0.18.1-release-notes-draft.md
+++ b/docs/audits/release-0.18.1-release-notes-draft.md
@@ -1,0 +1,44 @@
+# v0.18.1 Release Notes Draft
+
+Date: 2026-06-11
+
+Status: draft, unpublished
+
+Purpose: prepare patch-release notes for v0.18.1 (first-use trust hardening).
+This document does not imply publication or action alias movement.
+
+## Public State
+
+As of this draft:
+
+- latest published release remains `v0.18.0`;
+- crates.io latest public versions remain `0.18.0`;
+- no `v0.18.1`, `v0.18`, or `v0` alias movement is performed by this PR;
+- workspace version is prepared for `0.18.1` verification.
+
+## Highlights
+
+- Updated first-run and first-check failure messaging to make missing-baseline and
+  missing-compare states easier to recover from.
+- Improved check-artifact framing so users can identify `run.json`, `compare.json`,
+  and `report.json` outputs earlier.
+- Refreshed baseline bootstrap and promotion guidance for sparse or newly adopted
+  repos.
+- Added explicit no-panic release-trust posture (advisory/deferred at
+  `213` policy issues) so release claims match proof.
+- Refreshed release-readiness evidence and example references for the patch lane.
+
+## Remaining Release Proof Still Required
+
+Before this draft can become a publication closeout, the lane must still record:
+
+- public release artifacts and tag movement (`v0.18.1`, `v0.18`, `v0`);
+- public install smoke from public assets;
+- artifact and action alias verification after publication.
+
+## Non-Inferences
+
+- This draft does not publish crates.
+- This draft does not create or move tags.
+- This draft does not create a GitHub release.
+- This draft does not move `v0`, `v0.18`, or `v0.18.1`.

--- a/docs/audits/release-0.18.1-release-notes-draft.md
+++ b/docs/audits/release-0.18.1-release-notes-draft.md
@@ -25,7 +25,7 @@ As of this draft:
 - Refreshed baseline bootstrap and promotion guidance for sparse or newly adopted
   repos.
 - Added explicit no-panic release-trust posture (advisory/deferred at
-  `213` policy issues) so release claims match proof.
+  `240` policy issues) so release claims match proof.
 - Refreshed release-readiness evidence and example references for the patch lane.
 
 ## Remaining Release Proof Still Required

--- a/docs/audits/release-0.18.1-swarm-readiness.md
+++ b/docs/audits/release-0.18.1-swarm-readiness.md
@@ -67,7 +67,7 @@ new-product surfaces.
 ## Release-trust truth for v0.18.1
 
 - `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` currently reports
-  `213 no-panic policy issue(s) found`.
+  `240 no-panic policy issue(s) found`.
 - This condition is intentionally treated as **advisory/deferred** for the v0.18.1
   patch proof.
 - `docs/status/PRODUCT_CLAIMS.md` explicitly keeps the no-panic-related claim at
@@ -82,7 +82,7 @@ new-product surfaces.
 | `cargo run -p xtask -- pr` | Pass | PR validation executed for the source release lane (with local shim as documented in prior patch proof artifacts). |
 | `cargo run -p xtask -- docs-source-check` | Pass | Source-of-truth doc metadata and ID checks valid. |
 | `cargo run -p xtask -- docs-check` | Pass | Documentation drift check and link surface checks passed. |
-| `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` | Fail | `213 no-panic policy issue(s) found`; debt remains deferred. |
+| `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` | Fail | `240 no-panic policy issue(s) found`; debt remains deferred. |
 | `cargo run -p xtask -- product-claims-check` | Pass | Product claims map checks passed. |
 | `cargo run -p xtask -- action-check` | Pass | Action wiring and reproduction checks passed. |
 | `cargo run -p xtask -- publish-check --package-list` | Pass | Five public publishable crates are present. |

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -211,7 +211,7 @@ Known limits:
 
 - `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is currently
   a drift detector, not passing release proof. On 2026-06-11 it reported
-  `213 no-panic policy issue(s) found`, so do not promote this claim back to
+  `240 no-panic policy issue(s) found`, so do not promote this claim back to
   `supported` until the no-panic debt is removed or explicitly reviewed.
   This condition is carried into `v0.18.1` patch-readiness planning as an
   explicit deferral.


### PR DESCRIPTION
## Summary

This PR promotes the latest source readiness hardening from perfgate-swarm:

- no-panic governance evidence updated to 240 issues with explicit advisory/deferred posture
- v0.18.1 release proof/docs updates for publish-readiness/swap readiness
- added missing docs/audits/release-0.18.1-patch-readiness.md proof packet

This lane is patch-only trust-hardening for v0.18.1 and does not include product feature work.