### PR TITLE
chore: update 0.18.1 publish-readiness truth

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,6 @@
 # Release Readiness
 
-Last verified: 2026-06-11 for v0.18.1 swarm readiness packet and v0.18.1 patch-readiness proof, plus v0.18.0
+Last verified: 2026-06-11 for v0.18.1 swarm readiness packet, v0.18.1 patch-readiness proof, v0.18.1 publish packet/readiness proof, plus v0.18.0
 publication, public install smoke, release-candidate proof after restored
 post-SRP coverage hardening, generated queue resolution, the #484 init
 extraction, install/action example audit, product-claim sync, and
@@ -99,6 +99,11 @@ action alias movement, and public install smoke from public artifacts.
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
 | 0.18.1 swarm readiness packet | Completed | [v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md) records merged PRs #248–#258, deferred items, and source-built readiness evidence for this patch lane. |
 | 0.18.1 patch readiness proof | Conditional | [v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md) passed `xtask pr`, docs checks, product claims, action check, and publish dry-runs; no-panic remains blocked at `240`. |
+| 0.18.1 publish packet | Completed | [v0.18.1 Publish Packet](audits/release-0.18.1-publish-packet.md) defines canonical publish order, target versions, and post-dry-run pre-publication constraints. |
+| 0.18.1 publish readiness proof | Conditional | [v0.18.1 Publish Readiness Proof](audits/release-0.18.1-publish-readiness.md) passed all but `perfgate-cli` due dependency resolution on unpublished `perfgate 0.18.1`. |
+| 0.18.1 release notes draft | Prepared | [v0.18.1 Release Notes Draft](audits/release-0.18.1-release-notes-draft.md) captures final user-visible claims and remaining publish tasks. |
+| 0.18.1 public install smoke | Not Yet Executed | `0.18.1` is still unpublished on crates.io and no public release artifacts exist yet for install smoke evidence. |
+| 0.18.1 publication closeout | Not Yet Executed | Publication closeout remains pending until `v0.18.1` crates.io release, GitHub release, action aliases, and public install smoke are complete. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:

--- a/docs/audits/release-0.18.1-patch-readiness.md
+++ b/docs/audits/release-0.18.1-patch-readiness.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-11
 
-Branch: `main` on `perfgate-swarm`
+Branch: `chore/0.18.1-release-prep` on `perfgate-swarm`
 
 Purpose:
 

--- a/docs/audits/release-0.18.1-publish-readiness.md
+++ b/docs/audits/release-0.18.1-publish-readiness.md
@@ -26,7 +26,7 @@ not publish crates, create tags, create a GitHub release, or move action aliases
 | `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Packaged and verified `perfgate v0.18.1` in dry-run mode. |
 | `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Packaged and verified `perfgate-client v0.18.1` in dry-run mode. |
 | `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Packaged and verified `perfgate-server v0.18.1` in dry-run mode. |
-| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Packaged and verified `perfgate-cli v0.18.1` in dry-run mode. |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli` | Fail | Blocked by dependency resolution: `perfgate v0.18.1` is not yet published (crates.io resolves `perfgate` as `0.18.0`). |
 
 ## Publish Order
 
@@ -50,6 +50,8 @@ the publish commands.
 - No `v0.18` or `v0` action alias movement was attempted.
 - No GitHub release was created.
 - Public install smoke remains blocked until public artifacts exist.
+- `perfgate-cli` dry-run is expected to succeed only after `perfgate` has been
+  published at `0.18.1`.
 
 ## Known Deferred Proof
 

--- a/docs/audits/release-0.18.1-swarm-readiness.md
+++ b/docs/audits/release-0.18.1-swarm-readiness.md
@@ -2,9 +2,9 @@
 
 Date: 2026-06-11
 
-Source branch: `main` on `perfgate-swarm`
+Source branch: `chore/0.18.1-release-prep` on `perfgate-swarm`
 
-Main SHA: `c585a48`
+Main SHA: `a5f2893`
 
 Purpose:
 


### PR DESCRIPTION
## Summary
- Update v0.18.1 source readiness packets to reflect the actual lane branch (chore/0.18.1-release-prep) and merge-head SHA.
- Record publish readiness proof truth: publish-check --dry-run --package perfgate-cli is currently blocked by missing perfgate 0.18.1 on crates.io.
- Extend docs/RELEASE_READINESS.md with explicit v0.18.1 publish packet/readiness/progress rows so release state no longer overclaims.

## Proof Run
- rtk cargo run -p xtask -- docs-source-check
- rtk cargo run -p xtask -- docs-check
- rtk cargo run -p xtask -- product-claims-check
- rtk cargo run -p xtask -- action-check
- rtk cargo +1.95.0 run -p xtask -- publish-check --package-list
- rtk cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-types
- rtk cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate
- rtk cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client
- rtk cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server
- rtk cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli (fails: perfgate 0.18.1 missing on crates.io)
- rtk git diff --check