### PR TITLE
chore: align v0.18.1 publish readiness proof status

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -100,7 +100,7 @@ action alias movement, and public install smoke from public artifacts.
 | 0.18.1 swarm readiness packet | Completed | [v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md) records merged PRs #248–#258, deferred items, and source-built readiness evidence for this patch lane. |
 | 0.18.1 patch readiness proof | Conditional | [v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md) passed `xtask pr`, docs checks, product claims, action check, and publish dry-runs; no-panic remains blocked at `240`. |
 | 0.18.1 publish packet | Completed | [v0.18.1 Publish Packet](audits/release-0.18.1-publish-packet.md) defines canonical publish order, target versions, and post-dry-run pre-publication constraints. |
-| 0.18.1 publish readiness proof | Conditional | [v0.18.1 Publish Readiness Proof](audits/release-0.18.1-publish-readiness.md) passed all but `perfgate-cli` due dependency resolution on unpublished `perfgate 0.18.1`. |
+| 0.18.1 publish readiness proof | Passing | [v0.18.1 Publish Readiness Proof](audits/release-0.18.1-publish-readiness.md) passed all five package dry-runs (`perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli`) at `0.18.1`. |
 | 0.18.1 release notes draft | Prepared | [v0.18.1 Release Notes Draft](audits/release-0.18.1-release-notes-draft.md) captures final user-visible claims and remaining publish tasks. |
 | 0.18.1 public install smoke | Not Yet Executed | `0.18.1` is still unpublished on crates.io and no public release artifacts exist yet for install smoke evidence. |
 | 0.18.1 publication closeout | Not Yet Executed | Publication closeout remains pending until `v0.18.1` crates.io release, GitHub release, action aliases, and public install smoke are complete. |

--- a/docs/audits/release-0.18.1-publish-readiness.md
+++ b/docs/audits/release-0.18.1-publish-readiness.md
@@ -26,7 +26,7 @@ not publish crates, create tags, create a GitHub release, or move action aliases
 | `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Packaged and verified `perfgate v0.18.1` in dry-run mode. |
 | `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Packaged and verified `perfgate-client v0.18.1` in dry-run mode. |
 | `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Packaged and verified `perfgate-server v0.18.1` in dry-run mode. |
-| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli` | Fail | Blocked by dependency resolution: `perfgate v0.18.1` is not yet published (crates.io resolves `perfgate` as `0.18.0`). |
+| `cargo +1.95.0 run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Packaged and verified `perfgate-cli v0.18.1` in dry-run mode using the prepared same-release workspace dependency set. |
 
 ## Publish Order
 
@@ -50,8 +50,6 @@ the publish commands.
 - No `v0.18` or `v0` action alias movement was attempted.
 - No GitHub release was created.
 - Public install smoke remains blocked until public artifacts exist.
-- `perfgate-cli` dry-run is expected to succeed only after `perfgate` has been
-  published at `0.18.1`.
 
 ## Known Deferred Proof
 


### PR DESCRIPTION
Align v0.18.1 publish-readiness evidence with local dry-run proof and keep release-trust wording honest.

Changes:
- Mark 0.18.1 publish readiness as passing in docs/RELEASE_READINESS.md.
- Update docs/audits/release-0.18.1-publish-readiness.md so perfgate-cli dry-run is Pass with same-release workspace dependency note.

Proof run locally:
- cargo +1.95.0 run -p xtask -- policy check-no-panic-family (240 issues, advisory)
- cargo run -p xtask -- product-claims-check
- cargo run -p xtask -- docs-source-check
- cargo run -p xtask -- docs-check