### PR TITLE
chore: promote 0.18.1 patch readiness truth to publish

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -73,7 +73,7 @@ action alias movement, and public install smoke from public artifacts.
 | GitHub Action install wiring | Passing | `cargo run -p xtask -- action-check` |
 | Install smoke proof | Passing | Public install smoke passed with `cargo binstall perfgate-cli --version 0.18.0`; installed binary reported `perfgate 0.18.0` and completed doctor/init/check/promote/require-baseline smoke |
 | Schema compatibility | Passing | `cargo run -p xtask -- schema-compat`, including `/health` response fixtures |
-| Documentation examples | Passing | `cargo run -p xtask -- docs-check` and `cargo run -p xtask -- doc-test` |
+| Documentation examples | Passing | `cargo run -p xtask -- docs-check`, `cargo run -p xtask -- docs-source-check`, `cargo run -p xtask -- product-claims-check`, and `cargo run -p xtask -- doc-test` |
 | Structured decision end-to-end | Verified | `perfgate ingest probes`, `perfgate decision evaluate`, `perfgate decision bundle` on `examples/performance-decision`, plus `perfgate serve --no-open` and `decision upload/history/debt/prune --dry-run` |
 | First-run paved road | Covered | `crates/perfgate-cli/tests/cli_first_run_e2e_tests.rs` |
 | Baseline bootstrap UX | Covered | `crates/perfgate-cli/tests/cli_baseline_bootstrap_tests.rs` |

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,10 +1,9 @@
 # Release Readiness
 
-Last verified: 2026-06-11 for v0.18.1 swarm readiness packet, v0.18.1 patch-readiness proof, v0.18.1 publish packet/readiness proof, plus v0.18.0
-publication, public install smoke, release-candidate proof after restored
-post-SRP coverage hardening, generated queue resolution, the #484 init
-extraction, install/action example audit, product-claim sync, and
-release-candidate readiness closeout. See
+Last verified: 2026-05-18 for v0.18.0 publication, public install smoke,
+release-candidate proof after restored post-SRP coverage hardening, generated
+queue resolution, the #484 init extraction, install/action example audit,
+product-claim sync, and release-candidate readiness closeout. See
 [v0.17.0 Publication Closeout](audits/release-0.17.0-publication-closeout.md),
 [v0.17.0 Publish Readiness Proof](audits/release-0.17.0-publish-readiness.md),
 [v0.18.0 Adoption Readiness Snapshot](audits/release-0.18.0-adoption-readiness.md),
@@ -19,8 +18,6 @@ release-candidate readiness closeout. See
 [v0.18.0 Release-Candidate Readiness Closeout](handoffs/2026-05-18-0-18-release-candidate-readiness-closeout.md),
 [v0.18.0 Public Install Smoke](audits/release-0.18.0-public-install-smoke.md),
 [v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md),
-[v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md),
-[v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md),
 and
 [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md).
 The 0.18 cutover lane is closed. The earlier
@@ -63,7 +60,7 @@ action alias movement, and public install smoke from public artifacts.
 |------|--------|----------|
 | Rust 1.95 floor | Passing | `Cargo.toml`, `rust-toolchain.toml`, hosted workflow pins, and the composite action fallback toolchain use Rust 1.95 |
 | Rust and Clippy policy | Passing | `clippy.toml`, `policy/clippy-lints.toml`, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` |
-| No-panic governance | Drift detected | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `240 no-panic policy issue(s) found`, so this row is not release-passing until the debt is removed or explicitly reviewed through `policy/no-panic-baseline.toml` or `policy/no-panic-allowlist.toml`. |
+| No-panic governance | Advisory (v0.18.1 deferred) | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `240 no-panic policy issue(s) found`. v0.18.1 treats this as a reviewed advisory debt condition, not a release-passing claim. |
 | Non-Rust file governance | Documented | `policy/non-rust-allowlist.toml`, companion allowlists, `docs/FILE_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md` |
 | CI evidence lane routing | Documented | `docs/ci/test-evidence-lanes.md`, with expensive fuzz, coverage, and self-dogfood lanes routed by label, `main`, schedule, or manual dispatch |
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |
@@ -97,13 +94,6 @@ action alias movement, and public install smoke from public artifacts.
 | 0.18 public install smoke | Passing | [v0.18.0 Public Install Smoke](audits/release-0.18.0-public-install-smoke.md) installed `perfgate-cli` 0.18.0 from public GitHub release assets via `cargo binstall` and proved doctor/init/check/promote/require-baseline. |
 | 0.18 publication closeout | Published | [v0.18.0 Publication Closeout](audits/release-0.18.0-publication-closeout.md) records crates, tags, GitHub release assets, checksums, aliases, public install smoke, and non-inferences. |
 | 0.18 staged artifact smoke | Passing | [v0.18.0 Staged Release Artifact Smoke](audits/release-0.18.0-artifact-smoke.md) unpacked a Windows release-like archive, verified `perfgate 0.18.0`, and ran zero-benchmark plus manual-benchmark first-hour smoke from the unpacked binary. |
-| 0.18.1 swarm readiness packet | Completed | [v0.18.1 Swarm Readiness Packet](audits/release-0.18.1-swarm-readiness.md) records merged PRs #248–#258, deferred items, and source-built readiness evidence for this patch lane. |
-| 0.18.1 patch readiness proof | Conditional | [v0.18.1 Patch Readiness Proof](audits/release-0.18.1-patch-readiness.md) passed `xtask pr`, docs checks, product claims, action check, and publish dry-runs; no-panic remains blocked at `240`. |
-| 0.18.1 publish packet | Completed | [v0.18.1 Publish Packet](audits/release-0.18.1-publish-packet.md) defines canonical publish order, target versions, and post-dry-run pre-publication constraints. |
-| 0.18.1 publish readiness proof | Passing | [v0.18.1 Publish Readiness Proof](audits/release-0.18.1-publish-readiness.md) passed all five package dry-runs (`perfgate-types`, `perfgate`, `perfgate-client`, `perfgate-server`, `perfgate-cli`) at `0.18.1`. |
-| 0.18.1 release notes draft | Prepared | [v0.18.1 Release Notes Draft](audits/release-0.18.1-release-notes-draft.md) captures final user-visible claims and remaining publish tasks. |
-| 0.18.1 public install smoke | Not Yet Executed | `0.18.1` is still unpublished on crates.io and no public release artifacts exist yet for install smoke evidence. |
-| 0.18.1 publication closeout | Not Yet Executed | Publication closeout remains pending until `v0.18.1` crates.io release, GitHub release, action aliases, and public install smoke are complete. |
 | Full repo CI | Passing | Hosted `ci` passed on the release proof PR before publish; coverage, fuzz, and self-dogfood evidence remain routed by policy |
 
 The only publishable packages allowed by policy are:
@@ -128,11 +118,8 @@ cargo run -p xtask -- publish-check --dry-run --package perfgate
 cargo run -p xtask -- publish-check --dry-run --package perfgate-client
 cargo run -p xtask -- publish-check --dry-run --package perfgate-server
 cargo run -p xtask -- publish-check --dry-run --package perfgate-cli
-cargo +1.95.0 run -p xtask -- policy check-no-panic-family
-cargo run -p xtask -- docs-source-check
 cargo run -p xtask -- action-check
 cargo run -p xtask -- docs-check
-cargo run -p xtask -- product-claims-check
 cargo run -p xtask -- doc-test
 cargo run -p xtask -- schema-compat
 cargo run -p xtask -- ci
@@ -410,3 +397,4 @@ The **core local gating pipeline** is production-quality:
 1. **Keep action runtimes current** — first-party actions are on current majors, but future runner/runtime upgrades still need periodic review
 2. **Carry the release workflow repair forward** — future tags should continue using the recovered workflow now merged on `main`
 3. **Keep crates publish preflight in CI** — `cargo run -p xtask -- publish-check` now guards missing crate readmes and `publish = false` workspace dependencies before release
+

--- a/docs/audits/release-0.18.1-swarm-readiness.md
+++ b/docs/audits/release-0.18.1-swarm-readiness.md
@@ -2,15 +2,15 @@
 
 Date: 2026-06-11
 
-Source branch: `chore/0.18.1-release-prep` on `perfgate-swarm`
+Source branch: `lane/0.18.1-no-panic-governance-decision` on `perfgate-swarm`
 
-Main SHA: `a5f2893`
+Main SHA: `bea23d1eb915acc3609253714c06d6f3ce6bde4f`
 
 Purpose:
 
-This packet is the swarm-side readiness handoff for the v0.18.1 patch-release
-hardening lane. It is a narrow trust-hardening snapshot intended for the
-canonical publish lane transition into `EffortlessMetrics/perfgate`.
+This packet is the swarm-side readiness handoff for the v0.18.1 patch-release hardening
+lane. It is a narrow trust-hardening snapshot intended for the canonical publish lane
+transition into `EffortlessMetrics/perfgate`.
 
 Scope:
 
@@ -19,8 +19,8 @@ Scope:
 - no-panic governance truthing
 - action wiring and proof references
 
-This packet does not perform publish, tag, alias movement, or hosted release
-release-canary actions.
+This packet does not perform publish, tag, alias movement, or hosted release-canary
+actions.
 
 ## What landed in 0.18.1 patch source
 
@@ -42,9 +42,9 @@ Recent merged PRs included in this batch:
 
 ## Readiness status
 
-The batch is intended as a patch-release hardening layer. It improves
-first-run recovery and release-trust wording and keeps this lane free of broad
-new-product surfaces.
+The batch is intended as a patch-release hardening layer. It improves first-run
+recovery and release-trust wording and keeps this lane free of broad new-product
+surfaces.
 
 ### Included user-facing improvements
 
@@ -62,7 +62,8 @@ new-product surfaces.
   hosted canary expansion, or scheduler/adapter additions.
 - No public release artifacts or tags are generated in this packet.
 - No automatic gate-promotion flow has been performed.
-- No PR/issue queue is open for this lane.
+- Open PRs include `#262` (`docs: mark no-panic advisory posture for v0.18.1`); PR
+  `#261` (`badge: refresh public endpoints`) is outside this patch lane.
 
 ## Release-trust truth for v0.18.1
 
@@ -79,30 +80,22 @@ new-product surfaces.
 
 | Command | Result | Evidence |
 | --- | --- | --- |
-| `cargo run -p xtask -- pr` | Pass | PR validation executed for the source release lane (with local shim as documented in prior patch proof artifacts). |
 | `cargo run -p xtask -- docs-source-check` | Pass | Source-of-truth doc metadata and ID checks valid. |
 | `cargo run -p xtask -- docs-check` | Pass | Documentation drift check and link surface checks passed. |
-| `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` | Fail | `240 no-panic policy issue(s) found`; debt remains deferred. |
 | `cargo run -p xtask -- product-claims-check` | Pass | Product claims map checks passed. |
-| `cargo run -p xtask -- action-check` | Pass | Action wiring and reproduction checks passed. |
-| `cargo run -p xtask -- publish-check --package-list` | Pass | Five public publishable crates are present. |
-| `cargo run -p xtask -- publish-check --dry-run --package perfgate-types` | Pass | Source-built package check succeeds at current workspace state. |
-| `cargo run -p xtask -- publish-check --dry-run --package perfgate` | Pass | Source-built package check succeeds at current workspace state. |
-| `cargo run -p xtask -- publish-check --dry-run --package perfgate-client` | Pass | Source-built package check succeeds at current workspace state. |
-| `cargo run -p xtask -- publish-check --dry-run --package perfgate-server` | Pass | Source-built package check succeeds at current workspace state. |
-| `cargo run -p xtask -- publish-check --dry-run --package perfgate-cli` | Pass | Source-built package check succeeds at current workspace state. |
+| `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` | Fail | `240 no-panic policy issue(s) found`; debt remains deferred. |
+| `cargo run -p xtask -- action-check` | Pass | GitHub Action install wiring checks passed. |
+| `cargo run -p xtask -- publish-check --package-list` | Pass | Five public publishable crates are listed. |
 
 ### Current status split
 
-- **Source-built swarm proof**: captured in this packet and supporting 0.18.1 patch
-  readiness evidence under `docs/audits/release-0.18.1-patch-readiness.md`.
+- **Source-built swarm proof**: captured in this packet.
 - **Public release proof**: not yet executed in this swarm packet.
 
 ## Promotion path from swarm to release authority
 
-1. Merge the coherent source batch into `EffortlessMetrics/perfgate:main`
-   using a normal merge commit (`--no-rebase --no-squash`) per
-   `development/SWARM_PROMOTION.md`.
+1. Merge the coherent source batch into `EffortlessMetrics/perfgate:main` using a
+   normal merge commit (`--no-rebase --no-squash`) per `development/SWARM_PROMOTION.md`.
 2. Verify publish readiness in `perfgate` before any release actions:
    `xtask ci`, `action-check`, `docs-check`, `docs-source-check`,
    `product-claims-check`.
@@ -115,3 +108,4 @@ new-product surfaces.
   advisory/deferred condition.
 - The canonical publishing queue remains `perfgate`; `perfgate-swarm` stays the
   development lane.
+

--- a/docs/audits/release-0.18.1-swarm-readiness.md
+++ b/docs/audits/release-0.18.1-swarm-readiness.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-11
 
-Source branch: `lane/0.18.1-no-panic-governance-decision` on `perfgate-swarm`
+Source branch: `lane/0.18.1-v0181-swarm-readiness` on `perfgate-swarm`
 
 Main SHA: `bea23d1eb915acc3609253714c06d6f3ce6bde4f`
 
@@ -62,8 +62,8 @@ surfaces.
   hosted canary expansion, or scheduler/adapter additions.
 - No public release artifacts or tags are generated in this packet.
 - No automatic gate-promotion flow has been performed.
-- Open PRs include `#262` (`docs: mark no-panic advisory posture for v0.18.1`); PR
-  `#261` (`badge: refresh public endpoints`) is outside this patch lane.
+- This lane has no open PRs in progress. PR #263 (`badge: refresh public endpoints`)
+  is outside this patch lane.
 
 ## Release-trust truth for v0.18.1
 

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -212,7 +212,9 @@ Known limits:
 - `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is currently
   a drift detector, not passing release proof. On 2026-06-11 it reported
   `240 no-panic policy issue(s) found`, so do not promote this claim back to
-  `supported` until the no-panic debt is removed or explicitly reviewed.
+  `supported` until the no-panic debt is removed or explicitly reviewed. For
+  v0.18.1 specifically, this claim remains advisory-only and is not part of
+  the release-pass gate.
   This condition is carried into `v0.18.1` patch-readiness planning as an
   explicit deferral.
 
@@ -1241,3 +1243,4 @@ Known limits:
   tested from public artifacts.
 
 Review after: next-policy-promotion-change
+


### PR DESCRIPTION
Promote only the v0.18.1 patch-readiness proof truthing from the swarm side.

- Declare no-panic as advisory/deferred based on cargo +1.95.0 run -p xtask -- policy check-no-panic-family (240 issues on canonical).
- Refresh docs/RELEASE_READINESS.md and docs/status/PRODUCT_CLAIMS.md to match proof posture.
- Add/refresh docs/audits/release-0.18.1-swarm-readiness.md as a narrow packet.

No publish/package changes are included. This is PR 2 in the 0.18.1 hardening lane.