### PR TITLE
docs: sync v0.18.1 readiness truth

### DIFF
--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -61,7 +61,7 @@ action alias movement, and public install smoke from public artifacts.
 |------|--------|----------|
 | Rust 1.95 floor | Passing | `Cargo.toml`, `rust-toolchain.toml`, hosted workflow pins, and the composite action fallback toolchain use Rust 1.95 |
 | Rust and Clippy policy | Passing | `clippy.toml`, `policy/clippy-lints.toml`, and `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings` |
-| No-panic governance | Advisory (v0.18.1 deferred) | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `213 no-panic policy issue(s) found`. v0.18.1 treats this as reviewed advisory debt (not a release-pass condition). |
+| No-panic governance | Advisory (v0.18.1 deferred) | `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is the active drift detector. On 2026-06-11 it reported `240 no-panic policy issue(s) found`. v0.18.1 treats this as reviewed advisory debt (not a release-pass condition). |
 | Non-Rust file governance | Documented | `policy/non-rust-allowlist.toml`, companion allowlists, `docs/FILE_POLICY.md`, and `docs/POLICY_ALLOWLISTS.md` |
 | CI evidence lane routing | Documented | `docs/ci/test-evidence-lanes.md`, with expensive fuzz, coverage, and self-dogfood lanes routed by label, `main`, schedule, or manual dispatch |
 | Public package allowlist | Passing | `cargo run -p xtask -- public-surface --strict` |

--- a/docs/audits/release-0.18.1-swarm-readiness.md
+++ b/docs/audits/release-0.18.1-swarm-readiness.md
@@ -2,9 +2,9 @@
 
 Date: 2026-06-11
 
-Source branch: `lane/0.18.1-v0181-swarm-readiness` on `perfgate-swarm`
+Source branch: `main` on `perfgate-swarm`
 
-Main SHA: `bea23d1eb915acc3609253714c06d6f3ce6bde4f`
+Main SHA: `071aac4e5e0a`
 
 Purpose:
 
@@ -39,6 +39,11 @@ Recent merged PRs included in this batch:
 | #256 | Scope baseline bootstrap guidance to selected bench | 2026-06-05 |
 | #257 | Fix action summary test fixture | 2026-06-05 |
 | #258 | docs: clarify check artifact layouts | 2026-06-05 |
+| #260 | docs: v0.18.1 swarm readiness packet + clippy unblock | 2026-06-11 |
+| #262 | docs: mark no-panic advisory posture for v0.18.1 | 2026-06-11 |
+| #264 | docs: clarify no-panic advisory posture for v0.18.1 | 2026-06-11 |
+| #266 | chore: refresh v0.18.1 patch readiness packet proof artifacts | 2026-06-11 |
+| #268 | docs: sync readiness packet and badge endpoint drift | 2026-06-11 |
 
 ## Readiness status
 
@@ -62,8 +67,7 @@ surfaces.
   hosted canary expansion, or scheduler/adapter additions.
 - No public release artifacts or tags are generated in this packet.
 - No automatic gate-promotion flow has been performed.
-- This lane has no open PRs in progress. PR #263 (`badge: refresh public endpoints`)
-  is outside this patch lane.
+- No open PRs directly tied to this patch lane are pending after lane cleanup.
 
 ## Release-trust truth for v0.18.1
 

--- a/docs/status/PRODUCT_CLAIMS.md
+++ b/docs/status/PRODUCT_CLAIMS.md
@@ -211,7 +211,7 @@ Known limits:
 
 - `cargo +1.95.0 run -p xtask -- policy check-no-panic-family` is currently
   a drift detector, not passing release proof. On 2026-06-11 it reported
-  `213 no-panic policy issue(s) found`, so do not promote this claim back to
+  `240 no-panic policy issue(s) found`, so do not promote this claim back to
   `supported` until the no-panic debt is removed or explicitly reviewed. For
   v0.18.1 specifically, this claim remains advisory-only and is not part of
   the release-pass gate; this is documented as an explicit reviewed deferral in


### PR DESCRIPTION
Update v0.18.1 readiness documentation and evidence links for advisory no-panic.